### PR TITLE
Remove provisioning script using local yarn path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,6 +5,7 @@ A interation of the Colony Dapp sporting both a fully decentralized operating mo
 ## Prerequisites
 * `node` `v14.18.x` (Best use [nvm](https://github.com/nvm-sh/nvm))
 * `npm` `v8.x.x`
+* `yarn` `v1.22.x`
 * `jq` (See [install instructions](https://github.com/stedolan/jq/wiki/Installation))
 
 **Deprecated**

--- a/scripts/provision_submodules.sh
+++ b/scripts/provision_submodules.sh
@@ -36,7 +36,7 @@ REPUTATIONMONITOR="reputationMonitor"
 
 ROOT_PATH=$(pwd)
 
-YARN="${ROOT_PATH}/node_modules/.bin/yarn"
+YARN="yarn"
 
 log() {
   # Colors


### PR DESCRIPTION
## Description

The `provision_submodules.sh` was referencing a local `yarn` path that was not a dependency and thus not being installed. This now calls `yarn` directly, which should pick up the global path.

Resolves #17
