### PR TITLE
Add GraphQL Voyager

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "truffle": "truffle",
     "amplify": "amplify",
     "DEPRECATED:webpack:prod": "NODE_OPTIONS=\"--max-old-space-size=4096\" NODE_ENV=production webpack-cli --config webpack.prod.js",
-    "postinstall": "bash scripts/lambda-functions-dependencies.sh"
+    "postinstall": "bash scripts/lambda-functions-dependencies.sh",
+    "voyager": "ts-node temp-voyager/voyager"
   },
   "repository": {
     "type": "git",

--- a/temp-voyager/voyager.html
+++ b/temp-voyager/voyager.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/react@16/umd/react.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@16/umd/react-dom.production.min.js"></script>
+
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/graphql-voyager/dist/voyager.css"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/graphql-voyager/dist/voyager.min.js"></script>
+  </head>
+  <body>
+    <div id="voyager">Loading...</div>
+    <script>
+      function introspectionProvider(introspectionQuery) {
+        return fetch('http://localhost:20002/graphql', {
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': 'da2-fakeApiId123456',
+          },
+          body: JSON.stringify({ query: introspectionQuery }),
+        }).then((response) => response.json());
+      }
+
+      GraphQLVoyager.init(document.getElementById('voyager'), {
+        introspection: introspectionProvider,
+      });
+    </script>
+  </body>
+</html>

--- a/temp-voyager/voyager.ts
+++ b/temp-voyager/voyager.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+import path from 'path';
+
+const app = express();
+
+app.use('/', (_, res) => {
+  res.sendFile(path.resolve(__dirname, './voyager.html'));
+});
+
+app.listen(4567);
+
+// eslint-disable-next-line no-console
+console.log('GraphQL Voyager started at http://localhost:4567');


### PR DESCRIPTION
## Description

This PR adds a `voyager` script that spins up a GraphQL Voyager, a tool for visualising and inspecting GraphQL API schemas:
<img width="1476" alt="image" src="https://user-images.githubusercontent.com/112586815/199100753-c8466b45-b1d7-4442-be12-ee7598e55720.png">

It allows you to inspect the queries, mutations, input and return types as well as explore the relations between types. I found it quite handy when previously working with GraphQL APIs.

To run:
```
npm run voyager
```
