### PR TITLE
Fix generating local config files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "truffle": "truffle",
     "amplify": "amplify",
     "DEPRECATED:webpack:prod": "NODE_OPTIONS=\"--max-old-space-size=4096\" NODE_ENV=production webpack-cli --config webpack.prod.js",
+    "preinstall": "bash scripts/generate-temp-files.sh",
     "postinstall": "bash scripts/lambda-functions-dependencies.sh",
     "voyager": "ts-node temp-voyager/voyager"
   },

--- a/scripts/generate-temp-files.sh
+++ b/scripts/generate-temp-files.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+ENV_FILE=".env"
+AMPLIFY_CONFIG_LOCAL_AWS_INFO='./amplify/.config/local-aws-info.json'
+AMPLIFY_CONFIG_LOCAL_ENV_INFO='./amplify/.config/local-env-info.json'
+
+echo -e "Generating local specific, temporary files\n"
+
+# Setup the cdapp's env file
+if [ -f "$ENV_FILE" ]; then
+    echo "The CDapp .env file already exists, skip generating it"
+else
+    echo "Generating the \"CDapp's\" .env file"
+    cp .env.example $ENV_FILE
+fi
+
+# Setup the amplify's local aws config
+if [ -f "$AMPLIFY_CONFIG_LOCAL_AWS_INFO" ]; then
+  echo "Amplify's local AWS info config already exists, skip generating it"
+else
+  echo "Generating Amplify's local AWS info config"
+  # Please mind the spaces to format the JSON file nicely
+  # I've opted to use `echo` as opposed to `jq` since not all systems might have it
+  echo -e '{\n  "dev": {\n    "configLevel": "project", \n    "useProfile": true, \n    "profileName": "default"\n  }\n}' > $AMPLIFY_CONFIG_LOCAL_AWS_INFO
+fi
+
+# Setup the amplify's local env config
+if [ -f "$AMPLIFY_CONFIG_LOCAL_ENV_INFO" ]; then
+  echo "Amplify's local ENV info config already exists, skip generating it"
+else
+  echo "Generating Amplify's local ENV info config"
+  # Please mind the spaces to format the JSON file nicely
+  # I've opted to use `echo` as opposed to `jq` since not all systems might have it
+  echo -e "{\n  \"projectPath\": \"$(pwd)\",\n  \"defaultEditor\": \"vscode\",\n  \"envName\": \"dev\"\n}" > $AMPLIFY_CONFIG_LOCAL_ENV_INFO
+fi


### PR DESCRIPTION
This PR fixes lambda function creation _(well, actually fixes the whole `amplify` script, which would crash otherwise)_ when running `npm run amplify`

It does so, by generating some temporary, local, config files which `amplify` expects to exist prior to running.

Besides that, I've also made sure that if the CDapp doesn't have a local `.env` file already, it will generate one from the example file
