### PR TITLE
Introduce Colony Provider

### DIFF
--- a/src/components/common/ColonyHome/ColonyDomainDescription/ColonyDomainDescription.tsx
+++ b/src/components/common/ColonyHome/ColonyDomainDescription/ColonyDomainDescription.tsx
@@ -2,20 +2,20 @@ import React, { useCallback } from 'react';
 
 import ColorTag from '~shared/ColorTag';
 
-// import { Colony } from '~data/index';
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
-import { Colony } from '~types';
+import { useColonyContext } from '~hooks';
 
 import styles from './ColonyDomainDescription.css';
 
 interface Props {
-  colony: Colony;
   currentDomainId: number;
 }
 
-const displayName = 'commin.ColonyHome.ColonyDomainDescription';
+const displayName = 'common.ColonyHome.ColonyDomainDescription';
 
-const ColonyDomainDescription = ({ colony, currentDomainId }: Props) => {
+const ColonyDomainDescription = ({ currentDomainId }: Props) => {
+  const { colony } = useColonyContext();
+
   /*
    * @TODO a proper color transformation
    * This was just quickly thrown together to ensure it works
@@ -32,13 +32,15 @@ const ColonyDomainDescription = ({ colony, currentDomainId }: Props) => {
     return colorMap[domainColor];
   }, []);
 
-  if (currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID) {
+  if (!colony || currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID) {
     return null;
   }
+
   const { name, color, description } =
-    colony.domains.items.find(
-      ({ nativeId }) => Number(nativeId) === currentDomainId,
+    colony.domains?.items.find(
+      (domain) => Number(domain?.nativeId) === currentDomainId,
     ) || {};
+
   return (
     <div className={styles.main}>
       <div className={styles.name}>

--- a/src/components/common/ColonyHome/ColonyDomainSelector/ColonyDomainSelector.tsx
+++ b/src/components/common/ColonyHome/ColonyDomainSelector/ColonyDomainSelector.tsx
@@ -10,7 +10,7 @@ import DomainDropdown from '~shared/DomainDropdown';
 import { useColonyContext } from '~hooks';
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
 // import { oneTxMustBeUpgraded } from '~modules/dashboard/checks';
-import { Colony, Color, graphQlDomainColorMap } from '~types';
+import { Color, graphQlDomainColorMap } from '~types';
 
 import CreateDomainButton from './CreateDomainButton';
 
@@ -23,7 +23,6 @@ interface FormValues {
 interface Props {
   filteredDomainId?: number;
   onDomainChange?: (domainId: number) => any;
-  colony: Colony;
 }
 
 const displayName = 'common.ColonyHome.ColonyDomainSelector';
@@ -31,10 +30,10 @@ const displayName = 'common.ColonyHome.ColonyDomainSelector';
 const ColonyDomainSelector = ({
   filteredDomainId = COLONY_TOTAL_BALANCE_DOMAIN_ID,
   onDomainChange,
-  colony: { domains },
-  colony,
 }: Props) => {
-  const { canInteractWithColony } = useColonyContext();
+  const { colony, canInteractWithColony } = useColonyContext();
+  const { domains } = colony || {};
+
   // const { data } = useColonyExtensionsQuery({
   //   variables: { address: colonyAddress },
   // });
@@ -89,6 +88,10 @@ const ColonyDomainSelector = ({
     [getDomainColor],
   );
 
+  if (!colony) {
+    return null;
+  }
+
   return (
     <Form<FormValues>
       initialValues={{
@@ -103,9 +106,7 @@ const ColonyDomainSelector = ({
         onDomainChange={onDomainChange}
         onDomainEdit={canInteractWithColony ? handleEditDomain : undefined}
         footerComponent={
-          canInteractWithColony ? (
-            <CreateDomainButton colony={colony} />
-          ) : undefined
+          canInteractWithColony ? <CreateDomainButton /> : undefined
         }
         renderActiveOptionFn={renderActiveOption}
         showAllDomains

--- a/src/components/common/ColonyHome/ColonyDomainSelector/ColonyDomainSelector.tsx
+++ b/src/components/common/ColonyHome/ColonyDomainSelector/ColonyDomainSelector.tsx
@@ -7,7 +7,7 @@ import DomainDropdown from '~shared/DomainDropdown';
 // import { useDialog } from '~shared/Dialog';
 // import EditDomainDialog from '~dialogs/EditDomainDialog';
 
-import { useCanInteractWithColony } from '~hooks';
+import { useColonyContext } from '~hooks';
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
 // import { oneTxMustBeUpgraded } from '~modules/dashboard/checks';
 import { Colony, Color, graphQlDomainColorMap } from '~types';
@@ -34,7 +34,7 @@ const ColonyDomainSelector = ({
   colony: { domains },
   colony,
 }: Props) => {
-  const canInteractWithCurrentColony = useCanInteractWithColony(colony);
+  const { canInteractWithColony } = useColonyContext();
   // const { data } = useColonyExtensionsQuery({
   //   variables: { address: colonyAddress },
   // });
@@ -101,11 +101,9 @@ const ColonyDomainSelector = ({
         name="filteredDomainId"
         currentDomainId={filteredDomainId}
         onDomainChange={onDomainChange}
-        onDomainEdit={
-          canInteractWithCurrentColony ? handleEditDomain : undefined
-        }
+        onDomainEdit={canInteractWithColony ? handleEditDomain : undefined}
         footerComponent={
-          canInteractWithCurrentColony ? (
+          canInteractWithColony ? (
             <CreateDomainButton colony={colony} />
           ) : undefined
         }

--- a/src/components/common/ColonyHome/ColonyDomainSelector/CreateDomainButton.tsx
+++ b/src/components/common/ColonyHome/ColonyDomainSelector/CreateDomainButton.tsx
@@ -3,15 +3,12 @@ import { defineMessages, useIntl } from 'react-intl';
 
 import Icon from '~shared/Icon';
 // import { useDialog } from '~core/Dialog';
-
 // import CreateDomainDialog from '~dialogs/CreateDomainDialog';
-
-// import { Colony } from '~data/index';
-import { Colony } from '~types';
+import { useColonyContext } from '~hooks';
 
 import styles from './CreateDomainButton.css';
 
-const displayName = 'common.ColonuHome.ColonyDomainSelector.CreateDomainButton';
+const displayName = 'common.ColonyHome.ColonyDomainSelector.CreateDomainButton';
 
 const MSG = defineMessages({
   buttonCreateNewDomain: {
@@ -20,12 +17,11 @@ const MSG = defineMessages({
   },
 });
 
-interface Props {
-  colony: Colony;
-}
-
-const CreateDomainButton = ({ colony }: Props) => {
+const CreateDomainButton = () => {
   const { formatMessage } = useIntl();
+
+  const { colony } = useColonyContext();
+
   // const openCreateDomainDialog = useDialog(CreateDomainDialog);
 
   // const handleClick = useCallback<MouseEventHandler<HTMLButtonElement>>(

--- a/src/components/common/ColonyHome/ColonyExtensions/ColonyExtensions.tsx
+++ b/src/components/common/ColonyHome/ColonyExtensions/ColonyExtensions.tsx
@@ -2,34 +2,33 @@ import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import Heading from '~core/Heading';
-import { Colony, useColonyExtensionsQuery } from '~data/index';
+import { useColonyExtensionsQuery } from '~data/index';
 import { MiniSpinnerLoader } from '~core/Preloaders';
 import extensionData from '~data/staticData/extensionData';
-
-import styles from './ColonyExtensions.css';
 import NavLink from '~core/NavLink';
 import ExtensionStatus from '~dashboard/Extensions/ExtensionStatus';
+import { useColonyContext } from '~hooks';
+
+import styles from './ColonyExtensions.css';
+
+const displayName = 'dashboard.ColonyHome.ColonyExtensions';
 
 const MSG = defineMessages({
   title: {
-    id: 'dashboard.ColonyHome.ColonyExtensions.title',
+    id: `${displayName}.title`,
     defaultMessage: 'Enabled extensions',
   },
   loadingData: {
-    id: 'dashboard.ColonyHome.ColonyMembers.loadingData',
+    id: `${displayName}.loadingData`,
     defaultMessage: 'Loading extensions data ...',
   },
 });
 
-interface Props {
-  colony: Colony;
-}
+const ColonyExtensions = () => {
+  const { colony } = useColonyContext();
 
-const displayName = 'dashboard.ColonyHome.ColonyExtensions';
-
-const ColonyExtensions = ({ colony: { colonyName, colonyAddress } }: Props) => {
   const { data, loading } = useColonyExtensionsQuery({
-    variables: { address: colonyAddress },
+    variables: { address: colony?.colonyAddress },
   });
 
   if (loading) {
@@ -60,7 +59,7 @@ const ColonyExtensions = ({ colony: { colonyName, colonyAddress } }: Props) => {
               <li key={address} className={styles.extension}>
                 <NavLink
                   className={styles.invisibleLink}
-                  to={`/colony/${colonyName}/extensions/${extensionId}`}
+                  to={`/colony/${colony?.name}/extensions/${extensionId}`}
                   text={extensionData[extensionId].name}
                 />
                 <ExtensionStatus

--- a/src/components/common/ColonyHome/ColonyFinishDeployment/ColonyFinishDeployment.tsx
+++ b/src/components/common/ColonyHome/ColonyFinishDeployment/ColonyFinishDeployment.tsx
@@ -4,11 +4,12 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import Alert from '~core/Alert';
 import { ActionButton } from '~core/Button';
 
-import { Colony, useNetworkContracts } from '~data/index';
+import { useNetworkContracts } from '~data/index';
 import {
   useTransformer,
   useAppContext,
   useUserAccountRegistered,
+  useColonyContext,
 } from '~hooks';
 import { ActionTypes } from '~redux/index';
 import { mapPayload } from '~utils/actions';
@@ -18,30 +19,28 @@ import { getAllUserRoles } from '~modules/transformers';
 
 import styles from './ColonyFinishDeployment.css';
 
+const displayName = 'common.ColonyHome.ColonyFinishDeployment';
+
 const MSG = defineMessages({
   deploymentNotFinished: {
-    id: `dashboard.ColonyHome.ColonyFinishDeployment.deploymentNotFinished`,
+    id: `${displayName}.deploymentNotFinished`,
     defaultMessage: `Colony creation incomplete. Click to continue 👉`,
   },
   buttonFinishDeployment: {
-    id: `dashboard.ColonyHome.ColonyFinishDeployment.buttonFinishDeployment`,
+    id: `${displayName}.buttonFinishDeployment`,
     defaultMessage: `Finish Deployment`,
   },
 });
 
-type Props = {
-  colony: Colony;
-};
-
-const displayName = 'dashboard.ColonyHome.ColonyFinishDeployment';
-
-const ColonyFinishDeployment = ({
-  colony,
-  colony: { isDeploymentFinished, colonyAddress },
-}: Props) => {
+const ColonyFinishDeployment = () => {
   const { version: networkVersion } = useNetworkContracts();
   const { wallet } = useAppContext();
   const userHasAccountRegistered = useUserAccountRegistered();
+
+  const { colony } = useColonyContext();
+  const { colonyAddress } = colony || {};
+  /** @TODO: This should be a property of colony */
+  const isDeploymentFinished = false;
 
   const transform = useCallback(
     mapPayload(() => ({

--- a/src/components/common/ColonyHome/ColonyFundingWidget/ColonyFundingWidget.tsx
+++ b/src/components/common/ColonyHome/ColonyFundingWidget/ColonyFundingWidget.tsx
@@ -5,8 +5,9 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import Heading from '~shared/Heading';
 // import InfoPopover from '~shared/InfoPopover';
 import NavLink from '~shared/NavLink';
-// import { Colony, useTokenBalancesForDomainsQuery } from '~data/index';
-import { Colony, ColonyTokens } from '~types';
+// import { useTokenBalancesForDomainsQuery } from '~data/index';
+import { ColonyTokens } from '~types';
+import { useColonyContext } from '~hooks';
 
 import TokenBalanceItem from './TokenBalanceItem';
 
@@ -21,20 +22,24 @@ const MSG = defineMessages({
   },
 });
 
-interface Props {
-  colony: Colony;
-  // currentDomainId: number;
-}
+// interface Props {
+//   currentDomainId: number;
+// }
 
-const ColonyFundingWidget = ({
-  // currentDomainId,
-  colony: {
+const ColonyFundingWidget = (/* { currentDomainId }: Props */) => {
+  const { colony } = useColonyContext();
+
+  if (!colony) {
+    return null;
+  }
+
+  const {
     name,
     tokens,
     nativeToken: { tokenAddress: nativeTokenAddress },
     status,
-  },
-}: Props) => {
+  } = colony;
+
   // const {
   //   data,
   //   loading: isLoadingTokenBalances,

--- a/src/components/common/ColonyHome/ColonyHome.tsx
+++ b/src/components/common/ColonyHome/ColonyHome.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo, useState } from 'react';
-import { defineMessages } from 'react-intl';
 import {
   Outlet,
   Route,
@@ -7,21 +6,16 @@ import {
   useLocation,
   useParams,
 } from 'react-router-dom';
-import { useQuery, gql } from '@apollo/client';
 
-import LoadingTemplate from '~frame/LoadingTemplate';
 // import Extensions, { ExtensionDetails } from '~dashboard/Extensions';
 
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
-import { getFullColonyByName } from '~gql';
 // import { allAllowedExtensions } from '~data/staticData/';
 
 // import ColonyActions from '~dashboard/ColonyActions';
 // import ColonyEvents from '~dashboard/ColonyEvents';
 
 import ColonyHomeLayout from './ColonyHomeLayout';
-
-import styles from './ColonyHomeLayout.css';
 
 import {
   COLONY_EVENTS_ROUTE,
@@ -30,30 +24,17 @@ import {
   COLONY_EXTENSION_SETUP_ROUTE,
 } from '~routes/index';
 import NotFoundRoute from '~routes/NotFoundRoute';
+import { useColonyContext } from '~hooks';
 
 const displayName = 'common.ColonyHome';
 
-const MSG = defineMessages({
-  loadingText: {
-    id: `${displayName}.loadingText`,
-    defaultMessage: 'Loading Colony',
-  },
-});
-
 const ColonyHome = () => {
+  const { colony } = useColonyContext();
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { colonyName, extensionId } = useParams<{
-    colonyName: string;
+  const { extensionId } = useParams<{
     extensionId?: string;
   }>();
-
-  const { data, loading, error } = useQuery(gql(getFullColonyByName), {
-    variables: {
-      name: colonyName,
-    },
-  });
-
-  const [colony] = data?.getColonyByName?.items || [];
 
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
@@ -153,23 +134,9 @@ const ColonyHome = () => {
     return null;
   }, [colony, filteredDomainId]);
 
-  if (loading || (colony && colony.name !== colonyName)) {
-    return (
-      <div className={styles.loadingWrapper}>
-        <LoadingTemplate loadingText={MSG.loadingText} />
-      </div>
-    );
-  }
-
-  if (
-    !colonyName ||
-    error ||
-    !colony ||
-    colony instanceof Error
-    // || !isExtensionIdValid
-  ) {
-    return <NotFoundRoute />;
-  }
+  // if (!isExtensionIdValid) {
+  //   return <NotFoundRoute />;
+  // }
 
   return memoizedSwitch;
 };

--- a/src/components/common/ColonyHome/ColonyHomeLayout.css
+++ b/src/components/common/ColonyHome/ColonyHomeLayout.css
@@ -13,7 +13,11 @@
    * the width of the left subscribed colonies list
    */
   max-width: calc(100vw - (100vw - 100%));
-  grid-template-columns: [left] minmax(0, 1fr) [content] minmax(700px, 2fr) [sidebar] minmax(180px, 1fr);
+  grid-template-columns:
+    [left] minmax(0, 1fr) [content] minmax(700px, 2fr) [sidebar] minmax(
+      180px,
+      1fr
+    );
   column-gap: 80px;
 }
 
@@ -61,9 +65,4 @@
 
 .events {
   display: block;
-}
-
-.loadingWrapper {
-  height: 100%;
-  position: relative;
 }

--- a/src/components/common/ColonyHome/ColonyHomeLayout.css.d.ts
+++ b/src/components/common/ColonyHome/ColonyHomeLayout.css.d.ts
@@ -4,7 +4,6 @@ declare namespace ColonyHomeLayoutCssNamespace {
     domainsDropdownContainer: string;
     events: string;
     leftAside: string;
-    loadingWrapper: string;
     main: string;
     mainContent: string;
     mainContentGrid: string;

--- a/src/components/common/ColonyHome/ColonyHomeLayout.tsx
+++ b/src/components/common/ColonyHome/ColonyHomeLayout.tsx
@@ -2,8 +2,7 @@ import React, { ReactNode } from 'react';
 
 import NewActionButton from '~common/NewActionButton';
 import ColonyTotalFunds from '~common/ColonyTotalFunds';
-
-import { Colony } from '~types';
+import { useColonyContext } from '~hooks';
 
 import ColonyDomainSelector from './ColonyDomainSelector';
 import ColonyFundingWidget from './ColonyFundingWidget';
@@ -20,7 +19,6 @@ import ColonyDomainDescription from './ColonyDomainDescription';
 import styles from './ColonyHomeLayout.css';
 
 type Props = {
-  colony: Colony;
   filteredDomainId: number;
   onDomainChange?: (domainId: number) => void;
   /*
@@ -38,7 +36,6 @@ type Props = {
 const displayName = 'common.ColonyHome.ColonyHomeLayout';
 
 const ColonyHomeLayout = ({
-  colony,
   filteredDomainId,
   children,
   // ethDomainId,
@@ -48,30 +45,34 @@ const ColonyHomeLayout = ({
   showActions = true,
   onDomainChange = () => null,
 }: Props) => {
+  const { colony } = useColonyContext();
+
+  if (!colony) {
+    return null;
+  }
+
   return (
     <div className={styles.main}>
       <div
         className={showSidebar ? styles.mainContentGrid : styles.minimalGrid}
       >
         <aside className={styles.leftAside}>
-          <ColonyTitle colony={colony} />
-          {showNavigation && <ColonyNavigation colony={colony} />}
+          <ColonyTitle />
+          {showNavigation && <ColonyNavigation />}
         </aside>
         <div className={styles.mainContent}>
           {showControls && (
             <>
-              <ColonyTotalFunds colony={colony} />
+              <ColonyTotalFunds />
               <div className={styles.contentActionsPanel}>
                 <div className={styles.domainsDropdownContainer}>
                   <ColonyDomainSelector
                     filteredDomainId={filteredDomainId}
                     onDomainChange={onDomainChange}
-                    colony={colony}
                   />
                 </div>
                 {showActions && (
-                  <NewActionButton /* colony={colony} ethDomainId={ethDomainId} */
-                  />
+                  <NewActionButton /* ethDomainId={ethDomainId} */ />
                 )}
               </div>
             </>
@@ -80,26 +81,19 @@ const ColonyHomeLayout = ({
         </div>
         {showSidebar && (
           <aside className={styles.rightAside}>
-            <ColonyDomainDescription
-              colony={colony}
-              currentDomainId={filteredDomainId}
-            />
-            {/* <ColonyUnclaimedTransfers colony={colony} /> */}
+            <ColonyDomainDescription currentDomainId={filteredDomainId} />
+            {/* <ColonyUnclaimedTransfers /> */}
             <ColonyFundingWidget
-              colony={colony}
-              // currentDomainId={filteredDomainId}
+            // currentDomainId={filteredDomainId}
             />
-            <ColonyMembersWidget
-              colony={colony}
-              currentDomainId={filteredDomainId}
-            />
-            {/* <ColonyExtensions colony={colony} /> */}
+            <ColonyMembersWidget currentDomainId={filteredDomainId} />
+            {/* <ColonyExtensions /> */}
           </aside>
         )}
       </div>
-      {/* <ColonyUpgrade colony={colony} />
-      <ExtensionUpgrade colony={colony} />
-      <ColonyFinishDeployment colony={colony} /> */}
+      {/* <ColonyUpgrade />
+      <ExtensionUpgrade />
+      <ColonyFinishDeployment /> */}
     </div>
   );
 };

--- a/src/components/common/ColonyHome/ColonyMembersWidget/ColonyMembersWidget.tsx
+++ b/src/components/common/ColonyHome/ColonyMembersWidget/ColonyMembersWidget.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 // import { MiniSpinnerLoader } from '~shared/Preloaders';
 // import { Colony, useContributorsAndWatchersQuery } from '~data/index';
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
-import { Colony } from '~types';
+import { useColonyContext } from '~hooks';
 
 // import styles from './ColonyMembersWidget.css';
 import MembersSubsection from './MembersSubsection';
@@ -24,17 +24,20 @@ const displayName = 'common.ColonyHome.ColonyMembersWidget';
 // });
 
 interface Props {
-  colony: Colony;
   currentDomainId?: number;
   maxAvatars?: number;
 }
 
 const ColonyMembersWidget = ({
-  // colony: { colonyAddress, name },
-  colony,
   currentDomainId = COLONY_TOTAL_BALANCE_DOMAIN_ID,
   maxAvatars,
 }: Props) => {
+  const { colony } = useColonyContext();
+
+  if (!colony) {
+    return null;
+  }
+
   // const {
   //   data: members,
   //   loading: loadingMembers,

--- a/src/components/common/ColonyHome/ColonyNavigation/ColonyNavigation.tsx
+++ b/src/components/common/ColonyHome/ColonyNavigation/ColonyNavigation.tsx
@@ -1,46 +1,45 @@
 import React, { ComponentProps, useMemo } from 'react';
 import { defineMessages } from 'react-intl';
 
-import { Colony } from '~types';
+import { useColonyContext } from '~hooks';
 
 import NavItem from './NavItem';
 
 import styles from './ColonyNavigation.css';
 
+const displayName = 'common.ColonyHome.ColonyNavigation';
+
 const MSG = defineMessages({
   linkTextActions: {
-    id: 'dashboard.ColonyHome.ColonyNavigation.linkTextActions',
+    id: `${displayName}.linkTextActions`,
     defaultMessage: 'Actions',
   },
   linkTextEvents: {
-    id: 'dashboard.ColonyHome.ColonyNavigation.linkTextEvents',
+    id: `${displayName}.linkTextEvents`,
     defaultMessage: 'Events',
   },
   linkTextExtensions: {
-    id: 'dashboard.ColonyHome.ColonyNavigation.linkTextExtensions',
+    id: `${displayName}.linkTextExtensions`,
     defaultMessage: 'Extensions',
   },
   linkTextUnwrapTokens: {
-    id: 'dashboard.ColonyHome.ColonyNavigation.linkTextUnwrapTokens',
+    id: `${displayName}.linkTextUnwrapTokens`,
     defaultMessage: 'Unwrap Tokens',
   },
   linkTextClaimTokens: {
-    id: 'dashboard.ColonyHome.ColonyNavigation.linkTextClaimTokens',
+    id: `${displayName}.linkTextClaimTokens`,
     defaultMessage: 'Claim Tokens',
   },
   comingSoonMessage: {
-    id: 'dashboard.ColonyNavigation.comingSoonMessage',
+    id: `${displayName}.comingSoonMessage`,
     defaultMessage: 'Coming Soon',
   },
 });
 
-type Props = {
-  colony: Colony;
-};
+const ColonyNavigation = () => {
+  const { colony } = useColonyContext();
+  const { name } = colony || {};
 
-const displayName = 'dashboard.ColonyHome.ColonyNavigation';
-
-const ColonyNavigation = ({ colony: { name } }: Props) => {
   /*
    * @TODO actually determine these
    * This can be easily inferred from the subgraph queries
@@ -54,7 +53,11 @@ const ColonyNavigation = ({ colony: { name } }: Props) => {
   const hasNewExtensions = false;
 
   const items = useMemo<ComponentProps<typeof NavItem>[]>(() => {
-    const navigationItems: ComponentProps<typeof NavItem>[] = [
+    if (!name) {
+      return [];
+    }
+
+    const navigationItems = [
       {
         linkTo: `/colony/${name}`,
         showDot: hasNewActions,

--- a/src/components/common/ColonyHome/ColonySubscription/ColonySubscription.tsx
+++ b/src/components/common/ColonyHome/ColonySubscription/ColonySubscription.tsx
@@ -8,15 +8,14 @@ import MaskedAddress from '~shared/MaskedAddress';
 import InvisibleCopyableAddress from '~shared/InvisibleCopyableAddress';
 
 import { Colony } from '~types';
-import { useAppContext } from '~hooks';
-
+import { useAppContext, useColonyContext } from '~hooks';
 import { CREATE_USER_ROUTE } from '~routes/index';
 
 import ColonySubscriptionInfoPopover from './ColonySubscriptionInfoPopover';
 
 import styles from './ColonySubscription.css';
 
-const displayName = 'commmon.ColonyHome.ColonySubscription';
+const displayName = 'common.ColonyHome.ColonySubscription';
 
 const MSG = defineMessages({
   copyMessage: {
@@ -33,11 +32,10 @@ const MSG = defineMessages({
   },
 });
 
-interface Props {
-  colony: Colony;
-}
+const ColonySubscription = () => {
+  const { colony } = useColonyContext();
+  const { colonyAddress } = colony || {};
 
-const ColonySubscription = ({ colony: { colonyAddress }, colony }: Props) => {
   const { user } = useAppContext();
 
   const isSubscribed = !!(user?.watchlist?.items || []).find(
@@ -65,7 +63,6 @@ const ColonySubscription = ({ colony: { colonyAddress }, colony }: Props) => {
         )}
         {isSubscribed && (
           <ColonySubscriptionInfoPopover
-            colony={colony}
             onUnsubscribe={() => {
               // eslint-disable-next-line no-console
               console.log('Implement unsubscribe logic');

--- a/src/components/common/ColonyHome/ColonySubscription/ColonySubscriptionInfoPopover.tsx
+++ b/src/components/common/ColonyHome/ColonySubscription/ColonySubscriptionInfoPopover.tsx
@@ -5,24 +5,24 @@ import Popover from '~shared/Popover';
 import Button from '~shared/Button';
 import MaskedAddress from '~shared/MaskedAddress';
 import ColonyAvatar from '~shared/ColonyAvatar';
-
-import { Colony } from '~types';
+import { useColonyContext } from '~hooks';
 
 import styles from './ColonySubscriptionInfoPopover.css';
 
+const displayName = 'common.ColonyHome.ColonySubscriptionInfoPopover';
+
 const MSG = defineMessages({
   leaveColonyQuestion: {
-    id: 'dashboard.ColonyHome.ColonySubscriptionInfoPopover.leaveColonyQuestion',
+    id: `${displayName}.leaveColonyQuestion`,
     defaultMessage: 'Leave?',
   },
   nativeTokenTitle: {
-    id: 'dashboard.ColonyHome.ColonySubscriptionInfoPopover.nativeTokenTitle',
+    id: `${displayName}.nativeTokenTitle`,
     defaultMessage: 'Native Token Address',
   },
 });
 
 interface Props {
-  colony: Colony;
   onUnsubscribe?: () => void;
   children?: ReactNode;
   canUnsubscribe?: boolean;
@@ -30,85 +30,88 @@ interface Props {
 
 const ColonySubscriptionInfoPopover = ({
   children,
-  colony: {
-    colonyAddress,
-    name,
-    profile,
-    nativeToken: { tokenAddress },
-  },
-  colony,
   canUnsubscribe = true,
   onUnsubscribe = () => {},
-}: Props) => (
-  <Popover
-    renderContent={
-      <div className={styles.main}>
-        <div className={styles.colonyDetails}>
-          <div className={styles.colonyAvatar}>
-            <ColonyAvatar
-              colonyAddress={colonyAddress}
-              colony={colony}
-              size="s"
-            />
-          </div>
-          <div className={styles.colonyInfo}>
-            <span className={styles.colonyInfoTitle}>
-              {profile?.displayName || name}
-            </span>
-            <span className={styles.colonyInfoEns}>@{name}</span>
-            <span className={styles.colonyInfoAddress}>
-              <MaskedAddress address={colonyAddress} full />
-            </span>
-          </div>
-          {canUnsubscribe && (
-            <div className={styles.unsubscribeFromColony}>
-              <Button
-                appearance={{ theme: 'blue', size: 'small' }}
-                onClick={onUnsubscribe}
-              >
-                <FormattedMessage {...MSG.leaveColonyQuestion} />
-              </Button>
-            </div>
-          )}
-        </div>
-        <span className={styles.nativeTokenTitle}>
-          <FormattedMessage {...MSG.nativeTokenTitle} />
-        </span>
-        <span className={styles.nativeTokenAddress}>
-          <MaskedAddress
-            address={tokenAddress}
-            full
-            dataTest="nativeTokenAddress"
-          />
-        </span>
-      </div>
-    }
-    trigger="click"
-    showArrow={false}
-    placement="right"
-    popperOptions={{
-      modifiers: [
-        {
-          name: 'offset',
-          options: {
-            /*
-             * @NOTE Values are set manual, exactly as the ones provided in the figma spec.
-             *
-             * There's no logic to how they are calculated, so next time you need
-             * to change them you'll either have to go by exact specs, or change
-             * them until it "feels right" :)
-             */
-            offset: [100, -10],
-          },
-        },
-      ],
-    }}
-  >
-    {children}
-  </Popover>
-);
+}: Props) => {
+  const { colony } = useColonyContext();
 
-ColonySubscriptionInfoPopover.displayName =
-  'dashboard.ColonyHome.ColonySubscriptionInfoPopover';
+  if (!colony) {
+    return null;
+  }
+
+  const { colonyAddress, name, profile, nativeToken } = colony;
+  const { tokenAddress } = nativeToken;
+
+  return (
+    <Popover
+      renderContent={
+        <div className={styles.main}>
+          <div className={styles.colonyDetails}>
+            <div className={styles.colonyAvatar}>
+              <ColonyAvatar
+                colonyAddress={colonyAddress}
+                colony={colony}
+                size="s"
+              />
+            </div>
+            <div className={styles.colonyInfo}>
+              <span className={styles.colonyInfoTitle}>
+                {profile?.displayName || name}
+              </span>
+              <span className={styles.colonyInfoEns}>@{name}</span>
+              <span className={styles.colonyInfoAddress}>
+                <MaskedAddress address={colonyAddress} full />
+              </span>
+            </div>
+            {canUnsubscribe && (
+              <div className={styles.unsubscribeFromColony}>
+                <Button
+                  appearance={{ theme: 'blue', size: 'small' }}
+                  onClick={onUnsubscribe}
+                >
+                  <FormattedMessage {...MSG.leaveColonyQuestion} />
+                </Button>
+              </div>
+            )}
+          </div>
+          <span className={styles.nativeTokenTitle}>
+            <FormattedMessage {...MSG.nativeTokenTitle} />
+          </span>
+          <span className={styles.nativeTokenAddress}>
+            <MaskedAddress
+              address={tokenAddress}
+              full
+              dataTest="nativeTokenAddress"
+            />
+          </span>
+        </div>
+      }
+      trigger="click"
+      showArrow={false}
+      placement="right"
+      popperOptions={{
+        modifiers: [
+          {
+            name: 'offset',
+            options: {
+              /*
+               * @NOTE Values are set manual, exactly as the ones provided in the figma spec.
+               *
+               * There's no logic to how they are calculated, so next time you need
+               * to change them you'll either have to go by exact specs, or change
+               * them until it "feels right" :)
+               */
+              offset: [100, -10],
+            },
+          },
+        ],
+      }}
+    >
+      {children}
+    </Popover>
+  );
+};
+
+ColonySubscriptionInfoPopover.displayName = displayName;
 
 export default ColonySubscriptionInfoPopover;

--- a/src/components/common/ColonyHome/ColonyTitle/ColonyTitle.tsx
+++ b/src/components/common/ColonyHome/ColonyTitle/ColonyTitle.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { defineMessages } from 'react-intl';
 
 import Heading from '~shared/Heading';
-import ColonySubscription from '../ColonySubscription';
+import { useColonyContext } from '~hooks';
 
-import { Colony } from '~types';
+import ColonySubscription from '../ColonySubscription';
 
 import styles from './ColonyTitle.css';
 
@@ -17,11 +17,15 @@ const MSG = defineMessages({
   },
 });
 
-type Props = {
-  colony: Colony;
-};
+const ColonyTitle = () => {
+  const { colony } = useColonyContext();
 
-const ColonyTitle = ({ colony: { name, profile }, colony }: Props) => {
+  if (!colony) {
+    return null;
+  }
+
+  const { profile, name } = colony;
+
   return (
     <div className={styles.main}>
       <div className={styles.wrapper}>
@@ -37,7 +41,7 @@ const ColonyTitle = ({ colony: { name, profile }, colony }: Props) => {
           />
         </div>
         <div>
-          <ColonySubscription colony={colony} />
+          <ColonySubscription />
         </div>
       </div>
     </div>

--- a/src/components/common/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.tsx
+++ b/src/components/common/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.tsx
@@ -11,9 +11,9 @@ import { Tooltip } from '~shared/Popover';
 import Link from '~shared/Link';
 
 import { ActionTypes } from '~redux';
-import { useCanInteractWithColony } from '~hooks';
 import { mergePayload } from '~utils/actions';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
+import { useColonyContext } from '~hooks';
 
 import styles from './ColonyUnclaimedTransfers.css';
 
@@ -25,23 +25,23 @@ interface Props {
 
 const MSG = defineMessages({
   title: {
-    id: 'dashboard.ColonyHome.ColonyUnclaimedTransfers.title',
+    id: `${displayName}.title`,
     defaultMessage: 'Incoming funds',
   },
   claimButton: {
-    id: 'dashboard.ColonyHome.ColonyUnclaimedTransfers.claimButton',
+    id: `${displayName}.claimButton`,
     defaultMessage: 'Claim',
   },
   tooltip: {
-    id: 'dashboard.ColonyHome.ColonyUnclaimedTransfers.tooltip',
+    id: `${displayName}.tooltip`,
     defaultMessage: 'Click to claim incoming funds for this colony.',
   },
   more: {
-    id: 'dashboard.ColonyHome.ColonyUnclaimedTransfers.more',
+    id: `${displayName}.more`,
     defaultMessage: '+ {extraClaims} more',
   },
   unknownToken: {
-    id: 'dashboard.ColonyHome.ColonyUnclaimedTransfers.unknownToken',
+    id: `${displayName}.unknownToken`,
     defaultMessage: 'Unknown Token',
   },
 });
@@ -53,7 +53,7 @@ const ColonyUnclaimedTransfers = ({
   const { data, error } = useColonyTransfersQuery({
     variables: { address: colony.colonyAddress },
   });
-  const canInteractWithCurrentColony = useCanInteractWithColony(colony);
+  const { canInteractWithColony } = useColonyContext();
 
   const firstItem = data?.processedColony.unclaimedTransfers[0];
 
@@ -123,7 +123,7 @@ const ColonyUnclaimedTransfers = ({
               error={ActionTypes.CLAIM_TOKEN_ERROR}
               success={ActionTypes.CLAIM_TOKEN_SUCCESS}
               transform={transform}
-              disabled={!canInteractWithCurrentColony}
+              disabled={!canInteractWithColony}
             />
           </Tooltip>
         </li>

--- a/src/components/common/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.tsx
+++ b/src/components/common/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
-import { useColonyTransfersQuery, Colony, useTokenQuery } from '~data/index';
+import { useColonyTransfersQuery, useTokenQuery } from '~data/index';
 
 import { ActionButton } from '~shared/Button';
 import Heading from '~shared/Heading';
@@ -9,7 +9,6 @@ import NavLink from '~shared/NavLink';
 import Numeral from '~shared/Numeral';
 import { Tooltip } from '~shared/Popover';
 import Link from '~shared/Link';
-
 import { ActionTypes } from '~redux';
 import { mergePayload } from '~utils/actions';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
@@ -17,11 +16,7 @@ import { useColonyContext } from '~hooks';
 
 import styles from './ColonyUnclaimedTransfers.css';
 
-const displayName = 'dashboard.ColonyHome.ColonyUnclaimedTransfers';
-
-interface Props {
-  colony: Colony;
-}
+const displayName = 'common.ColonyHome.ColonyUnclaimedTransfers';
 
 const MSG = defineMessages({
   title: {
@@ -46,12 +41,12 @@ const MSG = defineMessages({
   },
 });
 
-const ColonyUnclaimedTransfers = ({
-  colony,
-  colony: { colonyAddress, colonyName },
-}: Props) => {
+const ColonyUnclaimedTransfers = () => {
+  const { colony } = useColonyContext();
+  const { colonyAddress, name } = colony || {};
+
   const { data, error } = useColonyTransfersQuery({
-    variables: { address: colony.colonyAddress },
+    variables: { address: colonyAddress },
   });
   const { canInteractWithColony } = useColonyContext();
 
@@ -76,7 +71,7 @@ const ColonyUnclaimedTransfers = ({
   return claimsLength ? (
     <div className={styles.main}>
       <Heading appearance={{ size: 'normal', weight: 'bold' }}>
-        <NavLink to={`/colony/${colonyName}/funds`}>
+        <NavLink to={`/colony/${name}/funds`}>
           <FormattedMessage {...MSG.title} />
         </NavLink>
       </Heading>
@@ -131,7 +126,7 @@ const ColonyUnclaimedTransfers = ({
           <li>
             <Link
               className={styles.manageFundsLink}
-              to={`/colony/${colonyName}/funds`}
+              to={`/colony/${name}/funds`}
               data-test="manageFunds"
             >
               <div className={styles.tokenItem}>

--- a/src/components/common/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
+++ b/src/components/common/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
@@ -6,9 +6,8 @@ import NetworkContractUpgradeDialog from '~dialogs/NetworkContractUpgradeDialog'
 import Alert from '~shared/Alert';
 import Button from '~shared/Button';
 import ExternalLink from '~shared/ExternalLink';
-
-import { Colony, useNetworkContracts } from '~data/index';
-import { useTransformer, useAppContext } from '~hooks';
+import { useNetworkContracts } from '~data/index';
+import { useTransformer, useAppContext, useColonyContext } from '~hooks';
 import { getNetworkRelaseLink } from '~utils/external';
 import {
   colonyMustBeUpgraded,
@@ -19,25 +18,23 @@ import { getAllUserRoles } from '~modules/transformers';
 
 import styles from './ColonyUpgrade.css';
 
+const displayName = 'common.ColonyHome.ColonyUpgrade';
+
 const MSG = defineMessages({
   upgradeRequired: {
-    id: `dashboard.ColonyHome.ColonyUpgrade.upgradeRequired`,
+    id: `${displayName}.upgradeRequired`,
     defaultMessage: `This colony uses a version of the network that is no
       longer supported. You must upgrade to continue using this application.`,
   },
   upgradeSuggested: {
-    id: `dashboard.ColonyHome.ColonyUpgrade.upgradeSuggested`,
+    id: `${displayName}.upgradeSuggested`,
     defaultMessage: `A new version of the Colony Network is available! {linkToRelease}`,
   },
 });
 
-type Props = {
-  colony: Colony;
-};
+const ColonyUpgrade = () => {
+  const { colony } = useColonyContext();
 
-const displayName = 'dashboard.ColonyHome.ColonyUpgrade';
-
-const ColonyUpgrade = ({ colony }: Props) => {
   const openUpgradeVersionDialog = useDialog(NetworkContractUpgradeDialog);
   const { version: networkVersion } = useNetworkContracts();
   const { user, wallet } = useAppContext();
@@ -109,7 +106,8 @@ const ColonyUpgrade = ({ colony }: Props) => {
                       <ExternalLink
                         text={{ id: 'text.learnMore' }}
                         href={getNetworkRelaseLink(
-                          parseInt(colony.version, 10) + 1,
+                          // parseInt(colony.version, 10) + 1,
+                          10,
                         )}
                       />
                     ),

--- a/src/components/common/ColonyHome/ExtensionUpgrade/ExtensionUpgrade.tsx
+++ b/src/components/common/ColonyHome/ExtensionUpgrade/ExtensionUpgrade.tsx
@@ -5,31 +5,30 @@ import { useParams } from 'react-router';
 
 import Alert from '~core/Alert';
 import Button from '~core/Button';
-import { Colony, useColonyExtensionsQuery } from '~data/index';
+import { useColonyExtensionsQuery } from '~data/index';
 import { oneTxMustBeUpgraded } from '~modules/dashboard/checks';
+import { useColonyContext } from '~hooks';
 
 import styles from './ExtensionUpgrade.css';
 
+const displayName = 'common.ColonyHome.ExtensionUpgrade';
+
 const MSG = defineMessages({
   upgradeMessage: {
-    id: `dashboard.ColonyHome.ExtensionUpgrade.upgradeMessage`,
+    id: `${displayName}.upgradeMessage`,
     defaultMessage: `This colony uses a version of the OneTx Payment Extension that is no longer supported. You must upgrade to continue using this application.`,
   },
   goToExtensionButton: {
-    id: `dashboard.ColonyHome.ExtensionUpgrade.goToExtensionButton`,
+    id: `${displayName}.goToExtensionButton`,
     defaultMessage: `Go to Extension`,
   },
 });
 
-type Props = {
-  colony: Colony;
-};
+const ExtensionUpgrade = () => {
+  const { colony } = useColonyContext();
+  const { colonyAddress, name } = colony || {};
 
-const displayName = 'dashboard.ColonyHome.ExtensionUpgrade';
-
-const ExtensionUpgrade = ({ colony: { colonyName, colonyAddress } }: Props) => {
-  const { colonyName: colonyNameEntry, extensionId } = useParams<{
-    colonyName: string;
+  const { extensionId } = useParams<{
     extensionId: string;
   }>();
 
@@ -37,8 +36,7 @@ const ExtensionUpgrade = ({ colony: { colonyName, colonyAddress } }: Props) => {
     variables: { address: colonyAddress },
   });
 
-  const isExtensionDetailsRoute =
-    colonyNameEntry === colonyName && extensionId === Extension.OneTxPayment;
+  const isExtensionDetailsRoute = extensionId === Extension.OneTxPayment;
 
   const oneTxPaymentExtension = data?.processedColony?.installedExtensions.find(
     ({ details, extensionId: extensionName }) =>
@@ -66,8 +64,7 @@ const ExtensionUpgrade = ({ colony: { colonyName, colonyAddress } }: Props) => {
               <Button
                 appearance={{ theme: 'primary', size: 'medium' }}
                 text={MSG.goToExtensionButton}
-                // eslint-disable-next-line max-len
-                linkTo={`/colony/${colonyName}/extensions/${Extension.OneTxPayment}`}
+                linkTo={`/colony/${name}/extensions/${Extension.OneTxPayment}`}
               />
             </div>
           )}

--- a/src/components/common/ColonyMembers/ColonyMembers.tsx
+++ b/src/components/common/ColonyMembers/ColonyMembers.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
-import { defineMessages } from 'react-intl';
-import { useQuery, gql } from '@apollo/client';
+// import { defineMessages } from 'react-intl';
 
 // import { ColonyVersion, Extension } from '@colony/colony-js';
 
 // import Button from '~core/Button';
 // import { useDialog } from '~core/Dialog';
 // import { BanUserDialog } from '~core/Comment';
-import LoadingTemplate from '~frame/LoadingTemplate';
 // import Members from '~dashboard/Members';
 // import PermissionManagementDialog from '~dialogs/PermissionManagementDialog';
 // import WrongNetworkDialog from '~dashboard/ColonyHome/WrongNetworkDialog';
@@ -25,67 +22,41 @@ import LoadingTemplate from '~frame/LoadingTemplate';
 // import { getAllUserRoles } from '~modules/transformers';
 // import { hasRoot, canAdminister } from '~modules/users/checks';
 // import { oneTxMustBeUpgraded } from '~modules/dashboard/checks';
-import NotFoundRoute from '~routes/NotFoundRoute';
 
-import { getFullColonyByName } from '~gql';
-import { useCanInteractWithColony } from '~hooks';
+// import { useColonyContext } from '~hooks';
 
 import styles from './ColonyMembers.css';
 
 const displayName = 'common.ColonyMembers';
 
-const MSG = defineMessages({
-  editPermissions: {
-    id: `${displayName}.editPermissions`,
-    defaultMessage: 'Edit permissions',
-  },
-  banAddress: {
-    id: `${displayName}.banAddress`,
-    defaultMessage: 'Ban address',
-  },
-  unbanAddress: {
-    id: `${displayName}.unbanAddress`,
-    defaultMessage: 'Unban address',
-  },
-  loadingText: {
-    id: `${displayName}.loadingText`,
-    defaultMessage: 'Loading Colony',
-  },
-});
+// const MSG = defineMessages({
+//   editPermissions: {
+//     id: `${displayName}.editPermissions`,
+//     defaultMessage: 'Edit permissions',
+//   },
+//   banAddress: {
+//     id: `${displayName}.banAddress`,
+//     defaultMessage: 'Ban address',
+//   },
+//   unbanAddress: {
+//     id: `${displayName}.unbanAddress`,
+//     defaultMessage: 'Unban address',
+//   },
+// });
 
 const ColonyMembers = () => {
-  const { colonyName } = useParams<{
-    colonyName: string;
-    extensionId?: string;
-  }>();
+  // const { extensionId } = useParams<{
+  //   extensionId?: string;
+  // }>();
 
-  const { data, loading, error } = useQuery(gql(getFullColonyByName), {
-    variables: {
-      name: colonyName,
-    },
-  });
+  // const { colony } = useColonyContext();
 
-  const [colony] = data?.getColonyByName?.items || [];
+  // const canInteractWithCurrentColony = useCanInteractWithColony(colony);
+  const canInteractWithCurrentColony = false;
 
-  const canInteractWithCurrentColony = useCanInteractWithColony(colony);
-
-  if (loading || (colony && colony.name !== colonyName)) {
-    return (
-      <div className={styles.loadingWrapper}>
-        <LoadingTemplate loadingText={MSG.loadingText} />
-      </div>
-    );
-  }
-
-  if (
-    !colonyName ||
-    error ||
-    !colony ||
-    colony instanceof Error
-    // || !isExtensionIdValid
-  ) {
-    return <NotFoundRoute />;
-  }
+  // if (!isExtensionIdValid) {
+  //   return <NotFoundRoute />;
+  // }
 
   return (
     <div className={styles.main}>

--- a/src/components/common/ColonyMembers/ColonyMembers.tsx
+++ b/src/components/common/ColonyMembers/ColonyMembers.tsx
@@ -22,8 +22,7 @@ import React from 'react';
 // import { getAllUserRoles } from '~modules/transformers';
 // import { hasRoot, canAdminister } from '~modules/users/checks';
 // import { oneTxMustBeUpgraded } from '~modules/dashboard/checks';
-
-// import { useColonyContext } from '~hooks';
+import { useColonyContext } from '~hooks';
 
 import styles from './ColonyMembers.css';
 
@@ -49,10 +48,7 @@ const ColonyMembers = () => {
   //   extensionId?: string;
   // }>();
 
-  // const { colony } = useColonyContext();
-
-  // const canInteractWithCurrentColony = useCanInteractWithColony(colony);
-  const canInteractWithCurrentColony = false;
+  const { canInteractWithColony } = useColonyContext();
 
   // if (!isExtensionIdValid) {
   //   return <NotFoundRoute />;
@@ -63,7 +59,7 @@ const ColonyMembers = () => {
       <div className={styles.mainContentGrid}>
         <div className={styles.mainContent}>
           Colony Members
-          {canInteractWithCurrentColony && <p>Colony can be interacted with</p>}
+          {canInteractWithColony && <p>Colony can be interacted with</p>}
         </div>
         <aside className={styles.rightAside} />
       </div>

--- a/src/components/common/ColonyTotalFunds/ColonyTotalFunds.tsx
+++ b/src/components/common/ColonyTotalFunds/ColonyTotalFunds.tsx
@@ -13,30 +13,31 @@ import IconTooltip from '~shared/IconTooltip';
 // } from '~data/index';
 import { Address } from '~types/index';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
-import { useCanInteractWithColony } from '~hooks';
 // import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
-
 import { Colony, ColonyTokens } from '~types';
+import { useColonyContext } from '~hooks';
 
 import ColonyTotalFundsPopover from './ColonyTotalFundsPopover';
 
 import styles from './ColonyTotalFunds.css';
 
+const displayName = 'dashboard.ColonyTotalFunds';
+
 const MSG = defineMessages({
   totalBalance: {
-    id: 'dashboard.ColonyTotalFunds.totalBalance',
+    id: `${displayName}.totalBalance`,
     defaultMessage: 'Colony total balance',
   },
   manageFundsLink: {
-    id: 'dashboard.ColonyTotalFunds.manageFundsLink',
+    id: `${displayName}.manageFundsLink`,
     defaultMessage: 'Manage Funds',
   },
   loadingData: {
-    id: 'dashboard.ColonyTotalFunds.loadingData',
+    id: `${displayName}.loadingData`,
     defaultMessage: 'Loading token information...',
   },
   tokenSelect: {
-    id: 'dashboard.ColonyTotalFunds.tokenSelect',
+    id: `${displayName}.tokenSelect`,
     defaultMessage: 'Select Tokens',
   },
 });
@@ -44,8 +45,6 @@ const MSG = defineMessages({
 type Props = {
   colony: Colony;
 };
-
-const displayName = 'dashboard.ColonyTotalFunds';
 
 const ColonyTotalFunds = ({
   colony: {
@@ -56,9 +55,8 @@ const ColonyTotalFunds = ({
     // version,
     // isNativeTokenLocked,
   },
-  colony,
 }: Props) => {
-  const canInteractWithCurrentColony = useCanInteractWithColony(colony);
+  const { canInteractWithColony } = useColonyContext();
   const [currentTokenAddress, setCurrentTokenAddress] =
     useState<Address>(nativeTokenAddress);
 
@@ -143,7 +141,7 @@ const ColonyTotalFunds = ({
       </div>
       <div className={styles.totalBalanceCopy}>
         <FormattedMessage {...MSG.totalBalance} />
-        {isSupportedColonyVersion && canInteractWithCurrentColony && (
+        {isSupportedColonyVersion && canInteractWithColony && (
           <Link
             className={styles.manageFundsLink}
             to={`/colony/${name}/funds`}

--- a/src/components/common/ColonyTotalFunds/ColonyTotalFunds.tsx
+++ b/src/components/common/ColonyTotalFunds/ColonyTotalFunds.tsx
@@ -8,20 +8,19 @@ import Numeral from '~shared/Numeral';
 // import { MiniSpinnerLoader } from '~shared/Preloaders';
 import IconTooltip from '~shared/IconTooltip';
 // import {
-//   Colony,
 //   useTokenBalancesForDomainsQuery,
 // } from '~data/index';
 import { Address } from '~types/index';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
 // import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
-import { Colony, ColonyTokens } from '~types';
+import { ColonyTokens } from '~types';
 import { useColonyContext } from '~hooks';
 
 import ColonyTotalFundsPopover from './ColonyTotalFundsPopover';
 
 import styles from './ColonyTotalFunds.css';
 
-const displayName = 'dashboard.ColonyTotalFunds';
+const displayName = 'common.ColonyTotalFunds';
 
 const MSG = defineMessages({
   totalBalance: {
@@ -42,23 +41,10 @@ const MSG = defineMessages({
   },
 });
 
-type Props = {
-  colony: Colony;
-};
-
-const ColonyTotalFunds = ({
-  colony: {
-    name,
-    tokens,
-    nativeToken: { tokenAddress: nativeTokenAddress },
-    status,
-    // version,
-    // isNativeTokenLocked,
-  },
-}: Props) => {
-  const { canInteractWithColony } = useColonyContext();
-  const [currentTokenAddress, setCurrentTokenAddress] =
-    useState<Address>(nativeTokenAddress);
+const ColonyTotalFunds = () => {
+  const { colony, canInteractWithColony } = useColonyContext();
+  const { name, tokens, nativeToken, status } = colony || {};
+  const { tokenAddress: nativeTokenAddress } = nativeToken || {};
 
   // const {
   //   data,
@@ -71,7 +57,13 @@ const ColonyTotalFunds = ({
   //   },
   // });
 
+  const [currentTokenAddress, setCurrentTokenAddress] = useState<Address>();
+
   useEffect(() => {
+    if (!nativeTokenAddress) {
+      return;
+    }
+
     setCurrentTokenAddress(nativeTokenAddress);
   }, [nativeTokenAddress]);
 

--- a/src/components/common/NewActionButton/NewActionButton.tsx
+++ b/src/components/common/NewActionButton/NewActionButton.tsx
@@ -36,8 +36,6 @@ import { SpinnerLoader } from '~shared/Preloaders';
 //   oneTxMustBeUpgraded,
 // } from '~modules/dashboard/checks';
 
-// import { Colony } from '~types';
-
 import styles from './NewActionButton.css';
 
 const displayName = 'commmon.ColonyHome.NewActionButton';
@@ -54,7 +52,6 @@ const MSG = defineMessages({
 });
 
 // interface Props {
-//   colony: Colony;
 //   ethDomainId?: number;
 // }
 

--- a/src/components/common/NewActionButton/NewActionButton.tsx
+++ b/src/components/common/NewActionButton/NewActionButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
+import { useColonyContext } from '~hooks';
 // import { Extension } from '@colony/colony-js';
 // import { useSelector } from 'react-redux';
 
@@ -35,8 +36,7 @@ import { SpinnerLoader } from '~shared/Preloaders';
 //   oneTxMustBeUpgraded,
 // } from '~modules/dashboard/checks';
 
-import { Colony } from '~types';
-import { useCanInteractWithColony } from '~hooks';
+// import { Colony } from '~types';
 
 import styles from './NewActionButton.css';
 
@@ -53,10 +53,10 @@ const MSG = defineMessages({
   },
 });
 
-interface Props {
-  colony: Colony;
-  // ethDomainId?: number;
-}
+// interface Props {
+//   colony: Colony;
+//   ethDomainId?: number;
+// }
 
 // interface RootState {
 //   users: {
@@ -66,8 +66,8 @@ interface Props {
 //   };
 // }
 
-const NewActionButton = ({ colony /* ethDomainId */ }: Props) => {
-  const canInteractWithCurrentColony = useCanInteractWithColony(colony);
+const NewActionButton = (/* { colony, ethDomainId }: Props */) => {
+  const canInteractWithColony = useColonyContext();
 
   // const { version: networkVersion } = useNetworkContracts();
 
@@ -274,7 +274,7 @@ const NewActionButton = ({ colony /* ethDomainId */ }: Props) => {
       {isLoadingData && <SpinnerLoader appearance={{ size: 'medium' }} />}
       {!isLoadingData && (
         <Tooltip
-          trigger={!canInteractWithCurrentColony ? 'hover' : null}
+          trigger={!canInteractWithColony ? 'hover' : null}
           content={
             <span className={styles.tooltipWrapper}>
               <FormattedMessage {...MSG.walletNotConnectedWarning} />
@@ -290,7 +290,7 @@ const NewActionButton = ({ colony /* ethDomainId */ }: Props) => {
             //   !colony?.isDeploymentFinished ||
             //   mustUpgradeOneTx
             // }
-            disabled={!canInteractWithCurrentColony}
+            disabled={!canInteractWithColony}
             data-test="newActionButton"
           />
         </Tooltip>

--- a/src/components/frame/ColonyBackText/ColonyBackText.tsx
+++ b/src/components/frame/ColonyBackText/ColonyBackText.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { gql, useQuery } from '@apollo/client';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import { useParams } from 'react-router-dom';
 
-import { getFullColonyByName } from '~gql';
+import { useColonyContext } from '~hooks';
 
 const componentDisplayName = 'frame.ColonyBackText';
 
@@ -19,22 +17,13 @@ const MSG = defineMessages({
 });
 
 const ColonyBackText = () => {
-  const { colonyName } = useParams<{ colonyName: string }>();
-  const { data } = useQuery(gql(getFullColonyByName), {
-    variables: {
-      name: colonyName,
-    },
-  });
-
-  const [colony] = data?.getColonyByName?.items || [];
+  const { colony } = useColonyContext();
 
   if (!colony) {
     return null;
   }
 
-  const {
-    profile: { displayName },
-  } = colony;
+  const { displayName } = colony.profile || {};
 
   return <FormattedMessage {...MSG.backText} values={{ displayName }} />;
 };

--- a/src/components/frame/RouteLayouts/UserNavigation/UserNavigation.tsx
+++ b/src/components/frame/RouteLayouts/UserNavigation/UserNavigation.tsx
@@ -1,19 +1,15 @@
 import React from 'react'; // useEffect // useMemo,
 import { defineMessages, useIntl } from 'react-intl';
-import { useParams } from 'react-router-dom';
-import { gql, useQuery } from '@apollo/client';
 
 // import Icon from '~shared/Icon';
 import MemberReputation from '~shared/MemberReputation';
 import { Tooltip } from '~shared/Popover';
-
 // import UserTokenActivationButton from '~users/UserTokenActivationButton';
 import AvatarDropdown from '~frame/AvatarDropdown';
 // import {
 //   useUserBalanceWithLockQuery,
 // } from '~data/index';
-import { useAppContext, useUserReputation } from '~hooks';
-import { getFullColonyByName } from '~gql';
+import { useAppContext, useColonyContext, useUserReputation } from '~hooks';
 // import { groupedTransactionsAndMessages } from '~redux/selectors';
 
 import Wallet from './Wallet';
@@ -30,14 +26,7 @@ const MSG = defineMessages({
 });
 
 const UserNavigation = () => {
-  /**
-   * TODO: Refactor after #67 is done
-   */
-  const { colonyName } = useParams<{ colonyName: string }>();
-  const { data } = useQuery(gql(getFullColonyByName), {
-    variables: { name: colonyName },
-  });
-  const [colony] = data?.getColonyByName?.items || [];
+  const { colony } = useColonyContext();
 
   const { wallet } = useAppContext();
   const { formatMessage } = useIntl();

--- a/src/context/ColonyContext.tsx
+++ b/src/context/ColonyContext.tsx
@@ -1,0 +1,72 @@
+import React, { createContext, useMemo, ReactNode } from 'react';
+import { gql, useQuery } from '@apollo/client';
+import { useParams } from 'react-router-dom';
+import { defineMessages } from 'react-intl';
+
+import { getFullColonyByName } from '~gql';
+import { Colony } from '~types';
+import LoadingTemplate from '~frame/LoadingTemplate';
+import NotFoundRoute from '~routes/NotFoundRoute';
+
+interface ColonyContextValue {
+  colony?: Colony;
+  loading: boolean;
+}
+
+const ColonyContext = createContext<ColonyContextValue>({
+  loading: false,
+});
+
+const displayName = 'ColonyContextProvider';
+
+const MSG = defineMessages({
+  loadingText: {
+    id: `${displayName}.loadingText`,
+    defaultMessage: 'Loading Colony',
+  },
+});
+
+export const ColonyContextProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const { colonyName } = useParams<{ colonyName: string }>();
+
+  const { data, loading, error } = useQuery(gql(getFullColonyByName), {
+    skip: !colonyName,
+    variables: {
+      name: colonyName ?? '',
+    },
+    fetchPolicy: 'network-only',
+  });
+
+  const [colony] = data?.getColonyByName?.items || [];
+
+  const colonyContext = useMemo<ColonyContextValue>(
+    () => ({ colony, loading }),
+    [colony, loading],
+  );
+
+  if (!colonyName) {
+    return null;
+  }
+
+  if (loading) {
+    return <LoadingTemplate loadingText={MSG.loadingText} />;
+  }
+
+  if (!colony || error) {
+    return <NotFoundRoute />;
+  }
+
+  return (
+    <ColonyContext.Provider value={colonyContext}>
+      {children}
+    </ColonyContext.Provider>
+  );
+};
+
+ColonyContext.displayName = displayName;
+
+export { ColonyContext };

--- a/src/context/ColonyContext.tsx
+++ b/src/context/ColonyContext.tsx
@@ -7,14 +7,17 @@ import { getFullColonyByName } from '~gql';
 import { Colony } from '~types';
 import LoadingTemplate from '~frame/LoadingTemplate';
 import NotFoundRoute from '~routes/NotFoundRoute';
+import { useCanInteractWithColony } from '~hooks';
 
 interface ColonyContextValue {
   colony?: Colony;
   loading: boolean;
+  canInteractWithColony: boolean;
 }
 
 const ColonyContext = createContext<ColonyContextValue>({
   loading: false,
+  canInteractWithColony: false,
 });
 
 const displayName = 'ColonyContextProvider';
@@ -43,9 +46,11 @@ export const ColonyContextProvider = ({
 
   const [colony] = data?.getColonyByName?.items || [];
 
+  const canInteractWithColony = useCanInteractWithColony(colony);
+
   const colonyContext = useMemo<ColonyContextValue>(
-    () => ({ colony, loading }),
-    [colony, loading],
+    () => ({ colony, loading, canInteractWithColony }),
+    [colony, loading, canInteractWithColony],
   );
 
   if (!colonyName) {

--- a/src/context/ColonyContext.tsx
+++ b/src/context/ColonyContext.tsx
@@ -41,7 +41,7 @@ export const ColonyContextProvider = ({
     variables: {
       name: colonyName ?? '',
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
   });
 
   const [colony] = data?.getColonyByName?.items || [];

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -11,6 +11,7 @@ export { UserSettingsClass as UserSettings };
 
 export { AppContext, AppContextProvider } from './AppContext';
 export { ColonyManagerClass as ColonyManager };
+export { ColonyContext, ColonyContextProvider } from './ColonyContext';
 
 export enum ContextModule {
   Wallet = 'wallet',

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -37,6 +37,7 @@ export { default as useUserSettings, SlotKey } from './useUserSettings';
 export { default as useWindowSize } from './useWindowSize';
 export { default as useAppContext } from './useAppContext';
 export { default as useUserReputation } from './useUserReputation';
+export { default as useColonyContext } from './useColonyContext';
 export * from './useCanInteractWithColony';
 
 /* Used in cases where we need to memoize the transformed output of any data.

--- a/src/hooks/useCanInteractWithColony.ts
+++ b/src/hooks/useCanInteractWithColony.ts
@@ -35,11 +35,10 @@ export const useCanInteractWithNetwork = (): boolean => {
 };
 
 /*
- * @TODO Eventually, this should be
- * - Encapsulated in `ColonyProvider`, once that gets added via #67
+ * @TODO Eventually, this should
  * - Include roles / permissions into the check
  */
-export const useCanInteractWithColony = (colony: Colony): boolean => {
+export const useCanInteractWithColony = (colony?: Colony): boolean => {
   const { wallet } = useAppContext();
   const canInteractWithNetwork = useCanInteractWithNetwork();
 

--- a/src/hooks/useColonyContext.ts
+++ b/src/hooks/useColonyContext.ts
@@ -1,0 +1,17 @@
+import { useContext } from 'react';
+
+import { ColonyContext } from '~context';
+
+const useColonyContext = () => {
+  const context = useContext(ColonyContext);
+
+  if (!context) {
+    throw new Error(
+      'This hook must be used within the "ColonyContext" provider',
+    );
+  }
+
+  return context;
+};
+
+export default useColonyContext;

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -51,6 +51,7 @@ import {
   // CLAIM_TOKEN_ROUTE,
 } from './routeConstants';
 import NotFoundRoute from './NotFoundRoute';
+import { ColonyContextProvider } from '~context/ColonyContext';
 
 // import WalletRequiredRoute from './WalletRequiredRoute';
 // import useTitle from '~hooks/useTitle';
@@ -112,15 +113,17 @@ const Routes = () => {
 
         <Route
           element={
-            <Default
-              routeProps={{
-                backText: ColonyBackText,
-                backRoute: ({ colonyName }) => `/colony/${colonyName}`,
-                hasSubscribedColonies: false,
-              }}
-            >
-              <Outlet />
-            </Default>
+            <ColonyContextProvider>
+              <Default
+                routeProps={{
+                  backText: ColonyBackText,
+                  backRoute: ({ colonyName }) => `/colony/${colonyName}`,
+                  hasSubscribedColonies: false,
+                }}
+              >
+                <Outlet />
+              </Default>
+            </ColonyContextProvider>
           }
         >
           <Route path={COLONY_FUNDING_ROUTE} element={<ColonyFunding />} />
@@ -133,9 +136,11 @@ const Routes = () => {
         <Route
           path={COLONY_HOME_ROUTE}
           element={
-            <Default routeProps={{ hasBackLink: false }}>
-              <ColonyHome />
-            </Default>
+            <ColonyContextProvider>
+              <Default routeProps={{ hasBackLink: false }}>
+                <ColonyHome />
+              </Default>
+            </ColonyContextProvider>
           }
         />
         {/* <WalletRequiredRoute


### PR DESCRIPTION
## Description

This PR introduces a new `ColonyContext` and related components. The main purpose is to streamline colony fetching, handling loading and error states and provide better typing.

All the components making the `getFullColonyByName` query or getting the colony via props have been refactored to use the new context.
Additionally, the boolean returned by `useCanInteractWithColony` hook is also exposed via that context. 

~~@rdig a couple of questions before I mark this as ready:~~
 - ~~Instead of "encapsulating" the logic from `useCanInteractWithColony` hook I just called it from the context - is that fine or should I move the logic entirely?~~
 - ~~There's a bunch of components that get colony passed as a prop. I held on for now with refactoring them to use context as it could lead to us having to write more code checking if `colony` returned by the context isn't undefined - whereas when the colony is passed via props this check would have already been done by the parent component. What's your thoughts on that?~~
 - ~~For the `getFullColonyByName` query, should I change the fetch policy to `network-only`? Or is it okay for it to returned cached colony data? Alternatively we could use `cache-and-network`.~~

Resolves #67 
