### PR TITLE
Make reputation monitor available on port 3001

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,9 +56,9 @@ You can access the Amplify / Mock Appsync GraphQL api playground at `http://loca
 
 In order for reputation to function within your dev environment, you will need to toggle it on first.
 
-Access the following URL to toggle the reputation monitor auto-mining on or off: `http://127.0.01:3001/reputation/monitor/toggle`
+Access the following URL to toggle the reputation monitor auto-mining on or off: `http://127.0.0.1:3001/reputation/monitor/toggle`
 
-You can also view the status of the reputation monitor using the following URL: `http://127.0.01:3001/reputation/monitor/status`
+You can also view the status of the reputation monitor using the following URL: `http://127.0.0.1:3001/reputation/monitor/status`
 
 ### Truffle
 

--- a/docker/colony-cdapp-dev-env-orchestration.yaml
+++ b/docker/colony-cdapp-dev-env-orchestration.yaml
@@ -20,6 +20,8 @@ services:
     image: colony-cdapp-dev-env/reputation-monitor:latest
     volumes:
       - '../amplify/mock-data:/colonyCDapp/amplify/mock-data'
+    ports:
+      - '3001:3001'
     depends_on:
       network-contracts:
         condition: service_healthy

--- a/docker/colony-cdapp-dev-env-reputation-monitor
+++ b/docker/colony-cdapp-dev-env-reputation-monitor
@@ -31,7 +31,7 @@ WORKDIR /colonyCDappBackend
 
 # Open up ports to the docker image
 # Reputation Oracle
-EXPOSE 3002
+EXPOSE 3001
 
 # Make the run script executable
 RUN chmod +x ./run.sh


### PR DESCRIPTION
## Description

The reputation monitor wasn't available in the CDapp. This PR puts it on 3001. I think while setting up the Docker environments there was some confusion between the miner/oracle (which remains on 3002) and this monitor (which is now on 3001), and this seems to work from my (very) cursory testing without breaking access to the oracle, but it's possible there's some subtlety's I'm unaware of.