### PR TITLE
Fix ganache address used for mining in local dev

### DIFF
--- a/docker/files/network/run.sh.base
+++ b/docker/files/network/run.sh.base
@@ -16,7 +16,7 @@ DISABLE_DOCKER=true yarn truffle migrate
 # Export deployed addresses
 
 ETHER_ROUTER_ADDRESS=$(jq -r .etherRouterAddress etherrouter-address.json)
-MINER_ACCOUNT_ADDRESS=$(jq -r '.addresses | to_entries | .[16] | .value' ganache-accounts.json)
+MINER_ACCOUNT_ADDRESS=$(jq -r '.addresses | to_entries | .[5] | .value' ganache-accounts.json)
 BROADCASTER_ACCOUNT_PRIVKEY=$(jq -r '.private_keys | to_entries | .[17] | .value' ganache-accounts.json)
 
 # Copy over colony network build artifacts to aid in development


### PR DESCRIPTION
It's specifically the address at [index 5](https://github.com/JoinColony/colonyDapp/blob/d9211aabff928e2d0f9fc8908adad492112b6f37/scripts/start_all.js#L46) in the array that's set up for mining, so that's the address that should be used.

In the current state, the environment (and miner) comes up, but the address being used for mining has no CLNY staked, and so is unable to mine.