### PR TITLE
Migrate Colony Creation Wizard to use React Hook Forms

### DIFF
--- a/src/components/common/CreateColonyWizard/ConfirmTransactions.tsx
+++ b/src/components/common/CreateColonyWizard/ConfirmTransactions.tsx
@@ -7,7 +7,7 @@ import { Message } from '~types';
 
 import styles from './ConfirmTransactions.css';
 
-const displayName = 'Wizard.ConfirmTransactions';
+const displayName = 'common.CreateColonyWizard.ConfirmTransactions';
 
 interface ConfirmTransactionsProps {
   transactionGroup?: TransactionOrMessageGroup;

--- a/src/components/common/CreateColonyWizard/CreateColonyCardRow.tsx
+++ b/src/components/common/CreateColonyWizard/CreateColonyCardRow.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Heading from '~shared/Heading';
 import { useAppContext } from '~hooks';
 
-import { FormValues } from './CreateColonyWizard';
+import { FormValues } from '../CreateColonyWizard';
 
 import styles from './CreateColonyCardRow.css';
 

--- a/src/components/common/CreateColonyWizard/StepColonyName.tsx
+++ b/src/components/common/CreateColonyWizard/StepColonyName.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { WizardStepProps } from '~shared/Wizard';
-import { Form, Input } from '~shared/Fields';
+import { HookForm as Form, HookFormInput as Input } from '~shared/Fields';
 import Heading from '~shared/Heading';
 import Button from '~shared/Button';
 import QuestionMarkTooltip from '~shared/QuestionMarkTooltip';
@@ -11,8 +11,11 @@ import { multiLineTextEllipsis } from '~utils/strings';
 import { DEFAULT_NETWORK_INFO } from '~constants';
 import { useAppContext, useMobile } from '~hooks';
 
-import { validationSchema } from './validation';
-import { FormValues, Step1 } from './CreateColonyWizard';
+import {
+  FormValues,
+  Step1,
+  colonyNameValidationSchema as validationSchema,
+} from '../CreateColonyWizard';
 
 import styles from './StepColonyName.css';
 
@@ -39,10 +42,6 @@ const MSG = defineMessages({
     id: `${displayName}.tooltip`,
     defaultMessage: `We use ENS to create a .{displayENSDomain} subdomain for your colony. You can use this to create a custom URL and invite people to join your colony.`,
   },
-  keyRequired: {
-    id: `${displayName}.keyRequired`,
-    defaultMessage: `{key} is a required field`,
-  },
 });
 
 type Props = Pick<
@@ -50,18 +49,24 @@ type Props = Pick<
   'wizardForm' | 'nextStep' | 'wizardValues'
 >;
 
-const StepColonyName = ({ wizardForm, nextStep, wizardValues }: Props) => {
+const formatting = {
+  colonyName: { lowercase: true, blocks: [255] },
+};
+
+const StepColonyName = ({
+  wizardForm: { initialValues: defaultValues },
+  nextStep,
+}: Props) => {
   const { user } = useAppContext();
   const username = user?.profile?.displayName || user?.name || '';
   const isMobile = useMobile();
-
   return (
-    <Form
+    <Form<Step1>
       onSubmit={nextStep}
       validationSchema={validationSchema}
-      {...wizardForm}
+      defaultValues={defaultValues}
     >
-      {({ isValid, isSubmitting, dirty }) => {
+      {({ formState: { isValid, isSubmitting } }) => {
         return (
           <section className={styles.main}>
             <Heading appearance={{ size: 'medium', weight: 'medium' }}>
@@ -105,7 +110,8 @@ const StepColonyName = ({ wizardForm, nextStep, wizardValues }: Props) => {
                 // eslint-disable-next-line max-len
                 extensionString={`.colony.${DEFAULT_NETWORK_INFO.displayENSDomain}`}
                 label={MSG.colonyUniqueURL}
-                formattingOptions={{ lowercase: true, blocks: [256] }}
+                formattingOptions={formatting.colonyName}
+                value={defaultValues.colonyName}
                 disabled={isSubmitting}
                 extra={
                   <QuestionMarkTooltip
@@ -130,11 +136,7 @@ const StepColonyName = ({ wizardForm, nextStep, wizardValues }: Props) => {
                   appearance={{ theme: 'primary', size: 'large' }}
                   type="submit"
                   data-test="claimColonyNameConfirm"
-                  disabled={
-                    !isValid ||
-                    (!dirty && !wizardValues.colonyName) ||
-                    isSubmitting
-                  }
+                  disabled={!isValid || isSubmitting}
                   loading={isSubmitting}
                   text={{ id: 'button.continue' }}
                 />

--- a/src/components/common/CreateColonyWizard/StepConfirmAllInput.tsx
+++ b/src/components/common/CreateColonyWizard/StepConfirmAllInput.tsx
@@ -9,8 +9,7 @@ import { ActionForm, FormStatus } from '~shared/Fields';
 import { mergePayload } from '~utils/actions';
 import { ActionTypes } from '~redux/index';
 
-import CardRow, { Row } from './CreateColonyCardRow';
-import { FormValues } from './CreateColonyWizard';
+import { FormValues, CardRow, Row } from '../CreateColonyWizard';
 
 import styles from './StepConfirmAllInput.css';
 

--- a/src/components/common/CreateColonyWizard/StepConfirmAllInput.tsx
+++ b/src/components/common/CreateColonyWizard/StepConfirmAllInput.tsx
@@ -4,7 +4,7 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import { WizardStepProps } from '~shared/Wizard';
 import Heading from '~shared/Heading';
 import Button from '~shared/Button';
-import { ActionForm, FormStatus } from '~shared/Fields';
+import { ActionHookForm as ActionForm } from '~shared/Fields';
 
 import { mergePayload } from '~utils/actions';
 import { ActionTypes } from '~redux/index';
@@ -67,14 +67,14 @@ const StepConfirmAllInput = ({ nextStep, wizardValues }: Props) => {
 
   return (
     <ActionForm
-      initialValues={{}}
+      defaultValues={{}}
       submit={ActionTypes.CREATE}
       success={ActionTypes.CREATE_SUCCESS}
       error={ActionTypes.CREATE_ERROR}
       transform={transform}
       onSuccess={() => nextStep(wizardValues)}
     >
-      {({ isSubmitting, status }) => (
+      {({ formState: { isSubmitting } }) => (
         <section className={styles.main}>
           <Heading
             appearance={{ size: 'medium', weight: 'bold', margin: 'none' }}
@@ -86,7 +86,6 @@ const StepConfirmAllInput = ({ nextStep, wizardValues }: Props) => {
           <div className={styles.finalContainer}>
             <CardRow cardOptions={options} values={wizardValues} />
           </div>
-          <FormStatus status={status} />
           <div className={styles.buttons}>
             <Button
               appearance={{ theme: 'primary', size: 'large' }}

--- a/src/components/common/CreateColonyWizard/StepConfirmTransactions.tsx
+++ b/src/components/common/CreateColonyWizard/StepConfirmTransactions.tsx
@@ -6,7 +6,6 @@ import { Navigate } from 'react-router-dom';
 import { WizardStepProps } from '~shared/Wizard';
 import NavLink from '~shared/NavLink';
 
-import { groupedTransactionsAndMessages } from '~redux/selectors';
 import {
   getGroupStatus,
   findTransactionGroupByKey,
@@ -15,10 +14,10 @@ import {
   TransactionOrMessageGroups,
 } from '~frame/GasStation/transactionGroup';
 import { TRANSACTION_STATUSES } from '~types';
+import { groupedTransactionsAndMessages } from '~redux/selectors';
 import { ActionTypes } from '~redux/index';
 
-import { FormValues } from './CreateColonyWizard';
-import ConfirmTransactions from './ConfirmTransactions';
+import { FormValues, ConfirmTransactions } from '../CreateColonyWizard';
 
 import styles from './StepConfirmTransactions.css';
 

--- a/src/components/common/CreateColonyWizard/StepTokenChoice.tsx
+++ b/src/components/common/CreateColonyWizard/StepTokenChoice.tsx
@@ -5,12 +5,11 @@ import { WizardStepProps } from '~shared/Wizard';
 import Heading from '~shared/Heading';
 import ExternalLink from '~shared/ExternalLink';
 import DecisionHub from '~shared/DecisionHub';
-import { Form } from '~shared/Fields';
+import { HookForm as Form } from '~shared/Fields';
 import { multiLineTextEllipsis } from '~utils/strings';
 import { SELECT_NATIVE_TOKEN_INFO as LEARN_MORE_URL } from '~constants';
-import { useMobile } from '~hooks';
 
-import { FormValues, Step2 } from './CreateColonyWizard';
+import { FormValues, Step2 } from '../CreateColonyWizard';
 
 import styles from './StepTokenChoice.css';
 
@@ -54,7 +53,7 @@ const MSG = defineMessages({
   },
   selectTokenSubtitle: {
     id: `${displayName}.existingTokenSubtitle`,
-    defaultMessage: 'Add in the list of examples: UNI, SUSHI, & AAVE',
+    defaultMessage: 'For example: UNI, SUSHI, & AAVE',
   },
   tooltipCreate: {
     id: `${displayName}.tooltipCreate`,
@@ -92,12 +91,10 @@ type Props = Pick<
 
 const StepTokenChoice = ({
   nextStep,
-  wizardForm,
-  wizardValues,
+  wizardForm: { initialValues: defaultValues },
+  wizardValues: { displayName: colonyName },
   setStepsValues,
 }: Props) => {
-  const isMobile = useMobile();
-
   const handleSubmit = (values: Step2) => {
     setStepsValues((stepsValues) => {
       const oldStep2: Partial<Step2> = stepsValues[1];
@@ -116,7 +113,7 @@ const StepTokenChoice = ({
   };
 
   return (
-    <Form onSubmit={handleSubmit} {...wizardForm}>
+    <Form<Step2> onSubmit={handleSubmit} defaultValues={defaultValues}>
       <section className={styles.content}>
         <div className={styles.title}>
           <Heading appearance={{ size: 'medium', weight: 'bold' }}>
@@ -129,8 +126,8 @@ const StepTokenChoice = ({
                  * inside a sentence that does not
                  */
                 colony: (
-                  <span title={wizardValues.displayName}>
-                    {multiLineTextEllipsis(wizardValues.displayName, 120)}
+                  <span title={colonyName}>
+                    {multiLineTextEllipsis(colonyName, 120)}
                   </span>
                 ),
               }}
@@ -150,7 +147,7 @@ const StepTokenChoice = ({
             text={MSG.subtitleWithExample}
           />
         </div>
-        <DecisionHub name="tokenChoice" options={options} isMobile={isMobile} />
+        <DecisionHub name="tokenChoice" options={options} />
         <div className={styles.titleAndButton}>
           <Heading
             appearance={{

--- a/src/components/common/CreateColonyWizard/index.ts
+++ b/src/components/common/CreateColonyWizard/index.ts
@@ -1,1 +1,10 @@
-export { default } from './CreateColonyWizard';
+export { default, FormValues, Step1, Step2, Step3 } from './CreateColonyWizard';
+export {
+  selectTokenValidationSchema,
+  createTokenValidationSchema,
+  colonyNameValidationSchema,
+} from './validation';
+export { default as TokenSelector } from './TokenSelector';
+export { LinkToOtherStep, switchTokenInputType } from './StepSelectToken';
+export { default as ConfirmTransactions } from './ConfirmTransactions';
+export { default as CardRow, Row } from './CreateColonyCardRow';

--- a/src/components/common/CreateColonyWizard/validation.ts
+++ b/src/components/common/CreateColonyWizard/validation.ts
@@ -1,20 +1,30 @@
 import { string, object } from 'yup';
 
-import { GetFullColonyByNameDocument } from '~gql';
+import { ADDRESS_ZERO, DEFAULT_NETWORK_TOKEN } from '~constants';
+import { GetFullColonyByNameDocument, GetTokenByAddressDocument } from '~gql';
 import { intl } from '~utils/intl';
+import { isAddress } from '~utils/web3';
 import { createYupTestFromQuery } from '~utils/yup/tests';
 
 /*
  * The colony name regex is composed of
  * ^[A-Za-z0-9] starts with upper case, lower case or numerals
- * [A-Za-z0-9_] can include upper case, lower case, numerals or underscore
+ * \w can include upper case, lower case, numerals or underscore
  * {0,254}$ match the preceding set at least 0 and at most 254 times from the end (so excluding the first char)
  */
-const COLONY_NAME_REGEX = `^[A-Za-z0-9][A-Za-z0-9_]{0,254}$`;
+const COLONY_NAME_REGEX = /^[A-Za-z0-9]\w{0,254}$/;
+
+const TOKEN_SYMBOL_REGEX = /^[A-Za-z0-9]{0,5}$/;
 
 const isNameTaken = createYupTestFromQuery({
   query: GetFullColonyByNameDocument,
   circuitBreaker: isValidName,
+});
+
+const doesTokenExist = createYupTestFromQuery({
+  query: GetTokenByAddressDocument,
+  circuitBreaker: isValidTokenAddress,
+  failIfPresent: false,
 });
 
 const { formatMessage } = intl({
@@ -22,9 +32,20 @@ const { formatMessage } = intl({
   'error.colonyURL': 'This is not a valid colony URL',
   'error.colonyNameRequired': 'Enter a name to continue',
   'error.colonyURLRequired': 'Enter a URL to continue',
+  'error.addressZeroError':
+    'You cannot use {symbol} token as a native token for colony.',
+  'error.tokenAddressRequired': 'Enter a token address to continue',
+  'error.invalidToken':
+    'Not a valid token. Only ERC20 tokens with 18 decimals are supported.',
+  'error.tokenNotFound':
+    'Token data not found. Please check the token contract address.',
+  'error.tokenNameRequired': 'Enter a token name to continue',
+  'error.tokenSymbolRequired': 'Enter a token symbol to continue',
+  'error.tokenNameLength': 'Token name should be 255 characters or fewer',
+  'error.tokenSymbol': 'Token symbol can only contain letters and numbers',
 });
 
-export const validationSchema = object({
+export const colonyNameValidationSchema = object({
   displayName: string().required(
     formatMessage({ id: 'error.colonyNameRequired' }),
   ),
@@ -32,8 +53,56 @@ export const validationSchema = object({
     .required(formatMessage({ id: 'error.colonyURLRequired' }))
     .test('isValidName', formatMessage({ id: 'error.colonyURL' }), isValidName)
     .test('isNameTaken', formatMessage({ id: 'error.urlTaken' }), isNameTaken),
-});
+}).defined();
+
+export const selectTokenValidationSchema = object({
+  tokenAddress: string()
+    .default('')
+    .required(formatMessage({ id: 'error.tokenAddressRequired' }))
+    .address(formatMessage({ id: 'error.invalidToken' }))
+    .notOneOf(
+      [ADDRESS_ZERO],
+      formatMessage(
+        { id: 'error.addressZeroError' },
+        {
+          symbol: DEFAULT_NETWORK_TOKEN.symbol,
+        },
+      ),
+    )
+    .test(
+      'doesTokenExist',
+      formatMessage({ id: 'error.tokenNotFound' }),
+      doesTokenExist,
+    ),
+  tokenName: string().default(''),
+  tokenSymbol: string().default(''),
+}).defined();
+
+export const createTokenValidationSchema = object({
+  tokenSymbol: string()
+    .default('')
+    .max(5)
+    .required(formatMessage({ id: 'error.tokenSymbolRequired' }))
+    .test(
+      'isValidTokenSymbol',
+      formatMessage({ id: 'error.tokenSymbol' }),
+      isValidTokenSymbol,
+    ),
+  tokenName: string()
+    .default('')
+    .max(255, formatMessage({ id: 'error.tokenNameLength' }))
+    .required(formatMessage({ id: 'error.tokenNameRequired' })),
+  tokenAddress: string().default(''),
+}).defined();
 
 function isValidName(name: string) {
   return name ? new RegExp(COLONY_NAME_REGEX).test(name) : true;
+}
+
+function isValidTokenSymbol(symbol: string) {
+  return symbol ? new RegExp(TOKEN_SYMBOL_REGEX).test(symbol) : true;
+}
+
+function isValidTokenAddress(address: string) {
+  return isAddress(address) && address !== ADDRESS_ZERO;
 }

--- a/src/components/common/CreateUserWizard/CreateUserWizard.tsx
+++ b/src/components/common/CreateUserWizard/CreateUserWizard.tsx
@@ -7,9 +7,12 @@ import ColonyButton from '~shared/Button';
 import WizardTemplate from '~frame/WizardTemplateColony';
 import withWizard from '~shared/Wizard/withWizard';
 
-import { FormValues, initialValues } from './validation';
-import StepUserName from './StepUserName';
-import StepUserEmail from './StepUserEmail';
+import {
+  FormValues,
+  initialValues,
+  StepUserName,
+  StepUserEmail,
+} from '../CreateUserWizard';
 
 import styles from './CreateUserWizard.css';
 

--- a/src/components/common/CreateUserWizard/StepUserEmail.tsx
+++ b/src/components/common/CreateUserWizard/StepUserEmail.tsx
@@ -8,12 +8,10 @@ import {
   FormValues,
   UserStepTemplate,
   ContinueWizard,
-} from '../CreateUserWizard';
-import {
   stepUserEmailValidationSchema as validationSchema,
   UserWizardStep1,
-} from './validation';
-import ConfirmEmail from './ConfirmEmail';
+  ConfirmEmail,
+} from '../CreateUserWizard';
 
 export const displayName = 'common.CreateUserWizard.StepUserEmail';
 

--- a/src/components/common/CreateUserWizard/StepUserName.tsx
+++ b/src/components/common/CreateUserWizard/StepUserName.tsx
@@ -2,22 +2,19 @@ import React from 'react';
 import { defineMessages } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 
-import { HookFormInput as Input } from '~shared/Fields';
+import { HookFormInput as Input, ActionHookForm } from '~shared/Fields';
 import { ActionTypes } from '~redux/index';
 import { WizardStepProps } from '~shared/Wizard';
 import { mergePayload } from '~utils/actions';
-import ActionHookForm from '~shared/Fields/Form/ActionHookForm';
 import { LANDING_PAGE_ROUTE } from '~routes';
 
 import {
   FormValues,
   ContinueWizard,
   UserStepTemplate,
-} from '../CreateUserWizard';
-import {
   stepUserNameValidationSchema as validationSchema,
   UserWizardStep2,
-} from './validation';
+} from '../CreateUserWizard';
 
 const displayName = 'common.CreateUserWizard.StepUserName';
 

--- a/src/components/common/CreateUserWizard/index.ts
+++ b/src/components/common/CreateUserWizard/index.ts
@@ -1,6 +1,12 @@
+export { default, ContinueWizard, UserStepTemplate } from './CreateUserWizard';
+export { default as StepUserName } from './StepUserName';
+export { default as StepUserEmail } from './StepUserEmail';
 export {
-  default,
   FormValues,
-  ContinueWizard,
-  UserStepTemplate,
-} from './CreateUserWizard';
+  initialValues,
+  stepUserEmailValidationSchema,
+  UserWizardStep1,
+  stepUserNameValidationSchema,
+  UserWizardStep2,
+} from './validation';
+export { default as ConfirmEmail } from './ConfirmEmail';

--- a/src/components/shared/DecisionHub/DecisionHub.tsx
+++ b/src/components/shared/DecisionHub/DecisionHub.tsx
@@ -9,19 +9,12 @@ interface Props {
   options: DecisionOptionType[];
   /** Html input `name` attribute */
   name: string;
-  /** Component renders mobile styles if true */
-  isMobile?: boolean;
 }
 
-const DecisionHub = ({ options, name, isMobile = false }: Props) => (
+const DecisionHub = ({ options, name }: Props) => (
   <div data-test="hubOptions">
     {options.map((option) => (
-      <DecisionOption
-        name={name}
-        option={option}
-        key={`row-${option.value}`}
-        isMobile={isMobile}
-      />
+      <DecisionOption name={name} option={option} key={`row-${option.value}`} />
     ))}
   </div>
 );

--- a/src/components/shared/DecisionHub/DecisionOption.tsx
+++ b/src/components/shared/DecisionHub/DecisionOption.tsx
@@ -1,13 +1,14 @@
-import React, { ButtonHTMLAttributes, useCallback } from 'react';
+import React, { ButtonHTMLAttributes } from 'react';
 import {
   MessageDescriptor,
   defineMessages,
   FormattedMessage,
 } from 'react-intl';
-import { useField } from 'formik';
+import { useFormContext } from 'react-hook-form';
 import { LinkProps } from 'react-router-dom';
 
 import { getMainClasses } from '~utils/css';
+import { useMobile } from '~hooks';
 
 import Icon from '../Icon';
 import Link from '../Link';
@@ -87,12 +88,15 @@ const DecisionOption = ({
   option: { title, subtitle, disabled, value },
   option,
   link,
-  isMobile = false,
 }: Props) => {
-  const [, , { setValue }] = useField(name);
-  const makeDecision = useCallback(() => {
-    if (!disabled && value && setValue) setValue(value);
-  }, [setValue, value, disabled]);
+  const { setValue } = useFormContext();
+  const isMobile = useMobile();
+
+  const makeDecision = () => {
+    if (!disabled && value) {
+      setValue(name, value);
+    }
+  };
 
   const Element = link ? Link : 'button';
   const elmProps = link

--- a/src/components/shared/Fields/Form/HookForm.tsx
+++ b/src/components/shared/Fields/Form/HookForm.tsx
@@ -6,23 +6,26 @@ import {
   UseFormReturn,
   SubmitHandler,
   SubmitErrorHandler,
+  FieldValues,
 } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Schema } from 'yup';
 
 const displayName = 'HookForm';
 
-export interface HookFormProps<FormData extends Record<string, any>> {
-  children: ((props: UseFormReturn) => React.ReactNode) | React.ReactNode;
+export interface HookFormProps<FormData extends FieldValues> {
+  children:
+    | ((props: UseFormReturn<FormData>) => React.ReactNode)
+    | React.ReactNode;
   onSubmit: SubmitHandler<FormData>;
   onError?: SubmitErrorHandler<FormData>;
   validationSchema?: Schema<FormData>;
-  defaultValues?: UseFormProps['defaultValues'];
-  mode?: UseFormProps['mode'];
-  options?: UseFormProps;
+  defaultValues?: UseFormProps<FormData>['defaultValues'];
+  mode?: UseFormProps<FormData>['mode'];
+  options?: UseFormProps<FormData>;
 }
 
-const HookForm = <FormData extends Record<string, any>>({
+const HookForm = <FormData extends FieldValues>({
   children,
   defaultValues,
   mode = 'onTouched',

--- a/src/components/shared/Fields/Input/HookForm/Input.tsx
+++ b/src/components/shared/Fields/Input/HookForm/Input.tsx
@@ -11,7 +11,7 @@ import { formatText } from '~utils/intl';
 import ConfusableWarning from '~shared/ConfusableWarning';
 
 import InputLabel from '../../InputLabel';
-import InputStatus from '../../InputStatus';
+import InputStatus from '../../InputStatus/HookForm';
 import { InputComponentAppearance } from '../../Input';
 
 import InputComponent from './InputComponent';
@@ -55,11 +55,17 @@ export interface HookFormInputProps
   /** Html `id` for label & input */
   id?: string;
 
+  /** Will show a loading status beneath input if true. Takes priority over error and status. */
+  isLoading?: boolean;
+
   /** Label text */
   label?: Message;
 
   /** Label text values for intl interpolation */
   labelValues?: SimpleMessageValues;
+
+  /** Text displayed after the word "Loading", i.e. "Loading{annotation}...". */
+  loadingAnnotation?: Message;
 
   /** Pass params to a max button - implemented only in Cleave options */
   maxButtonParams?: MaxButtonParams;
@@ -99,8 +105,10 @@ const HookFormInput = ({
   help,
   helpValues,
   id: idProp,
+  isLoading,
   label,
   labelValues,
+  loadingAnnotation,
   name,
   placeholder,
   placeholderValues,
@@ -145,10 +153,11 @@ const HookFormInput = ({
       <div className={styles.extensionContainer}>
         <InputComponent
           appearance={appearance}
-          aria-invalid={!!error && touched}
+          aria-invalid={!!error && !isLoading && touched}
           id={id}
           name={name}
           placeholder={formatText(placeholder, placeholderValues)}
+          inputValueLength={inputValue?.length || 0}
           {...restInputProps}
         />
         {extensionStringText && (
@@ -158,9 +167,11 @@ const HookFormInput = ({
       {!elementOnly && (
         <InputStatus
           appearance={appearance}
+          error={error}
+          isLoading={isLoading}
+          loadingAnnotation={loadingAnnotation}
           status={status}
           statusValues={statusValues}
-          error={error}
           touched={touched}
         />
       )}

--- a/src/components/shared/Fields/Input/HookForm/InputComponent.tsx
+++ b/src/components/shared/Fields/Input/HookForm/InputComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { getMainClasses } from '~utils/css';
@@ -22,6 +22,7 @@ const LengthWidget = ({ length, maxLength }: LengthWidgetProps) => (
 export interface HookFormInputComponentProps
   extends Omit<InputProps, 'placeholder'> {
   placeholder?: string;
+  inputValueLength: number;
 }
 
 const displayName = 'HookFormInputComponent';
@@ -55,6 +56,7 @@ const HookFormInputComponent = ({
   appearance,
   dataTest,
   formattingOptions,
+  inputValueLength: length,
   maxLength,
   maxButtonParams,
   name,
@@ -62,7 +64,6 @@ const HookFormInputComponent = ({
   onBlur,
   ...restInputProps
 }: HookFormInputComponentProps) => {
-  const [length, setLength] = useState<number>(0);
   const { register } = useFormContext();
   const {
     onChange: hookFormOnChange,
@@ -76,9 +77,6 @@ const HookFormInputComponent = ({
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     hookFormOnChange(e);
     onChange?.(e);
-    if (maxLength) {
-      setLength(e.target.value.length);
-    }
   };
 
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {

--- a/src/components/shared/Fields/InputStatus/HookForm/InputStatus.tsx
+++ b/src/components/shared/Fields/InputStatus/HookForm/InputStatus.tsx
@@ -1,0 +1,59 @@
+import { useIntl } from 'react-intl';
+import React from 'react';
+
+import { getMainClasses } from '~utils/css';
+import { formatText } from '~utils/intl';
+import { isNil } from '~utils/lodash';
+import { HookFormInputProps } from '~shared/Fields/Input/HookForm';
+import { Message } from '~types';
+
+import styles from '../InputStatus.css';
+
+interface HookFormInputStatusProps
+  extends Pick<
+    HookFormInputProps,
+    'appearance' | 'status' | 'statusValues' | 'isLoading' | 'loadingAnnotation'
+  > {
+  /** Error text (if applicable) */
+  error?: Message;
+
+  /** Has input field been touched? */
+  touched?: boolean;
+}
+
+const displayName = 'HookFormInputStatus';
+
+const HookFormInputStatus = ({
+  appearance = {},
+  error,
+  isLoading,
+  loadingAnnotation = '',
+  status,
+  statusValues,
+  touched,
+}: HookFormInputStatusProps) => {
+  const { formatMessage } = useIntl();
+  const errorText = formatText(error);
+  const statusText = formatText(status, statusValues);
+  const loadingText = formatMessage(
+    { id: 'status.loading' },
+    { optionalText: formatText(loadingAnnotation) },
+  );
+  const text = errorText || statusText;
+  const Element = appearance.direction === 'horizontal' ? 'span' : 'p';
+  return (
+    <Element
+      className={getMainClasses(appearance, styles, {
+        error: !!error && !isLoading,
+        hidden:
+          (!text && !isLoading) || (!!error && !isNil(touched) && !touched),
+      })}
+    >
+      {isLoading ? loadingText : text}
+    </Element>
+  );
+};
+
+HookFormInputStatus.displayName = displayName;
+
+export default HookFormInputStatus;

--- a/src/components/shared/Fields/InputStatus/HookForm/index.ts
+++ b/src/components/shared/Fields/InputStatus/HookForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from './InputStatus';

--- a/src/components/shared/Fields/index.ts
+++ b/src/components/shared/Fields/index.ts
@@ -8,6 +8,7 @@ export {
   Input as HookFormInput,
   InputComponent as HookFormInputComponent,
   FormattedInput as HookFormFormattedInput,
+  HookFormInputProps,
 } from './Input/HookForm';
 export { default as InputLabel } from './InputLabel';
 export { default as InputStatus } from './InputStatus';

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -404,5 +404,7 @@
     "tooltip.lockedToken": "This token is locked. Colony native tokens are locked and non-transferrable by default to avoid unwanted project token transfer outside of the colony.",
     "tooltip.forceToggle": "Toggle \"Force\" to bypass governance and perform this action immediately. This is only possible with the right permissions.",
 
-    "error.network": "There was a problem with the connection. Please try again"
+    "error.network": "There was a problem with the connection. Please try again",
+
+    "status.loading": "Loading{optionalText}..."
 }

--- a/src/utils/lodash.ts
+++ b/src/utils/lodash.ts
@@ -1,2 +1,3 @@
 export { default as once } from 'lodash/once';
 export { default as now } from 'lodash/now';
+export { default as isNil } from 'lodash/isNil';

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,0 +1,30 @@
+/* Use the NetworkInformation API to see user's network speed. More info: https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation */
+const getNetworkInfo = () => {
+  // @ts-ignore Property is experimental.
+  return window.navigator.connection;
+};
+
+const getConnectionType = () => {
+  const networkInfo = getNetworkInfo();
+  if (networkInfo) {
+    return networkInfo.effectiveType;
+  }
+
+  return null;
+};
+
+export const connectionIs4G = () => {
+  const connectionType = getConnectionType();
+
+  // Where we don't have access to the NetworkInformationAPI
+  if (!connectionType) {
+    return null;
+  }
+
+  if (connectionType === '4g') {
+    return true;
+  }
+
+  // If connection type is either 'slow-2g', '2g', '3g' -- the only remaining options.
+  return false;
+};


### PR DESCRIPTION
## Description

This PR migrates the Colony Creation wizard from Formik to React Hook Form. It should work the same as before, just now it's using the React Hook Form components.

**New stuff** ✨

* HookForm-specific `InputStatus`
* `utils/network`: some helpers to see what network speed the user has. May be useful to conditionally show a loading status based on this information. Faster connections may make a loading status redundant, e.g. if we're querying our own db, it's typically very fast and thus no need to display a loading status. The loading status also appears to flash in this case, because of the connection speed, which is also good to avoid.

**Changes** 🏗

* `ColonyCreationWizard`: now using React Hook Form components.
* Tidied up imports in `UserCreationWizard`

Resolves  #116
