### PR TITLE
Migrate UserProfile to React Hook Form

### DIFF
--- a/src/components/common/UserProfileEdit/UserAvatarUploader.css
+++ b/src/components/common/UserProfileEdit/UserAvatarUploader.css
@@ -1,3 +1,0 @@
-.inputStatus {
-  margin-top: 10px;
-}

--- a/src/components/common/UserProfileEdit/UserAvatarUploader.tsx
+++ b/src/components/common/UserProfileEdit/UserAvatarUploader.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
 
-import { FileReaderFile } from '~shared/FileUpload';
 import AvatarUploader from '~shared/AvatarUploader';
 import UserAvatar from '~shared/UserAvatar';
 
@@ -9,6 +8,7 @@ import { User } from '~types';
 import { useUpdateUserProfileMutation } from '~gql';
 import { useAppContext } from '~hooks';
 import { excludeTypenameKey } from '~utils/objects';
+import { FileReaderFile } from '~utils/fileReader/types';
 
 const displayName = 'common.UserProfileEdit.UserAvatarUploader';
 

--- a/src/components/shared/AvatarUploader/AvatarUploader.css
+++ b/src/components/shared/AvatarUploader/AvatarUploader.css
@@ -71,3 +71,7 @@
 .buttonContainer {
   margin-top: 25px;
 }
+
+.inputStatus {
+  margin-top: 10px;
+}

--- a/src/components/shared/AvatarUploader/AvatarUploader.css.d.ts
+++ b/src/components/shared/AvatarUploader/AvatarUploader.css.d.ts
@@ -6,6 +6,7 @@ declare namespace AvatarUploaderCssNamespace {
     dropzoneAccept: string;
     dropzoneNoButtonsVariant: string;
     filesContainer: string;
+    inputStatus: string;
     overlay: string;
   }
 }

--- a/src/components/shared/AvatarUploader/AvatarUploader.tsx
+++ b/src/components/shared/AvatarUploader/AvatarUploader.tsx
@@ -1,92 +1,72 @@
-import React, { ReactNode, useCallback, useRef } from 'react';
-import {
-  MessageDescriptor,
-  defineMessages,
-  FormattedMessage,
-} from 'react-intl';
-import { FetchResult } from '@apollo/client';
+import React, { useRef } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { ApolloError, FetchResult } from '@apollo/client';
 
-import { Formik } from 'formik';
-
+import { HookForm as Form, InputStatus } from '~shared/Fields';
 import FileUpload, { FileReaderFile } from '~shared/FileUpload';
-import { Appearance } from '~shared/Fields/Input/InputComponent';
+import { FileUploadProps } from '~shared/FileUpload/types';
+
+import Button from '../Button';
+import AvatarUploadItem from './AvatarUploadItem';
 
 import styles from './AvatarUploader.css';
 
-import Button from '../Button';
-
-import AvatarUploadItem from './AvatarUploadItem';
+const displayName = 'AvatarUploader';
 
 const MSG = defineMessages({
   dropNow: {
-    id: 'AvatarUploader.dropNow',
+    id: `${displayName}.dropNow`,
     defaultMessage: 'Drop now!',
   },
   notAllowed: {
-    id: 'AvatarUploader.notAllowed',
+    id: `${displayName}.notAllowed`,
     defaultMessage: 'Not allowed',
+  },
+  avatarFileError: {
+    id: `${displayName}.avatarFileError`,
+    defaultMessage: 'This filetype is not allowed or file is too big',
   },
 });
 
-export const ACCEPTED_MIME_TYPES = {
+const ACCEPTED_MIME_TYPES = {
   'image/svg+xml': [],
   'image/png': [],
 };
 
-export const ACCEPTED_MAX_FILE_SIZE = 1048576; // 1 Mb
+const ACCEPTED_MAX_FILE_SIZE = 1048576; // 1 Mb
 
-interface Props {
-  /** Only render the Uploader, no label */
-  elementOnly?: boolean;
-
-  /** Label to use */
-  label: string | MessageDescriptor;
-
-  /** Help text (will appear next to label text) */
-  help?: string | MessageDescriptor;
-
-  /** Placeholder to render when not uploading */
-  placeholder?: ReactNode;
-
-  /** Function to handle removal of the avatar (should set avatarURL to null from outside) */
-  remove: (...args: any[]) => Promise<any>;
-
-  /** Function to handle the actual uploading of the file */
-  upload: (fileData: FileReaderFile) => Promise<FetchResult>;
-
-  /** Function to handle an upload error from the outside */
-  handleError?: (...args: any[]) => Promise<any>;
-
+interface Props extends Partial<FileUploadProps> {
   /** Used to control the state of the remove button (don't fire the remove action if not avatar is set) */
   isSet?: boolean;
-
+  /** Function to handle an upload error from the outside */
+  handleError?: (...args: any[]) => Promise<any>;
+  /** Display choose / remove buttons beneath Avatar */
   hasButtons: boolean;
-
-  disabled?: boolean;
-
-  labelAppearance?: Appearance;
+  /** Function to handle removal of the avatar (should set avatarURL to null from outside) */
+  remove: (...args: any[]) => Promise<any>;
+  /** Function to handle the actual uploading of the file */
+  upload: (fileData: FileReaderFile) => Promise<FetchResult>;
+  /** Present if there was an error calling the mutation */
+  uploadError?: ApolloError;
 }
 
 const AvatarUploader = ({
-  elementOnly,
-  label,
-  help,
-  placeholder,
+  appearance,
   remove,
-  upload,
   hasButtons,
   disabled,
   isSet = true,
-  labelAppearance,
-  handleError,
+  uploadError,
+  ...uploaderProps
 }: Props) => {
   const dropzoneRef = useRef<{ open: () => void }>();
 
-  const choose = useCallback(() => {
-    if (dropzoneRef.current) {
+  const open = () => {
+    // will be null if disabled
+    if (typeof dropzoneRef.current?.open === 'function') {
       dropzoneRef.current.open();
     }
-  }, []);
+  };
 
   // FileUpload children are renderProps (functions)
   const renderOverlay = () => (
@@ -100,51 +80,68 @@ const AvatarUploader = ({
     dropzone: styles.dropzoneNoButtonsVariant,
   };
 
-  // Formik is used for state and error handling through FileUpload, nothing else
+  // Form is used for state and error handling through FileUpload, nothing else
   return (
-    <Formik onSubmit={() => {}} initialValues={{ avatarUploader: [] }}>
-      <form>
-        <FileUpload
-          elementOnly={elementOnly}
-          classNames={hasButtons ? styles : noButtonStyles}
-          dropzoneOptions={{
-            accept: ACCEPTED_MIME_TYPES,
-            maxSize: ACCEPTED_MAX_FILE_SIZE,
-            disabled,
-          }}
-          label={label}
-          labelAppearance={labelAppearance}
-          help={help}
-          maxFilesLimit={1}
-          name="avatarUploader"
-          renderPlaceholder={placeholder}
-          ref={dropzoneRef}
-          itemComponent={AvatarUploadItem}
-          upload={upload}
-          handleError={handleError}
-          dataTest="avatarUploaderDrop"
-        >
-          {renderOverlay()}
-        </FileUpload>
-        {hasButtons && (
-          <div className={styles.buttonContainer}>
-            <Button
-              appearance={{ theme: 'danger' }}
-              text={{ id: 'button.remove' }}
-              onClick={remove}
-              disabled={!isSet}
-              dataTest="avatarUploaderRemove"
-            />
-            <Button
-              text={{ id: 'button.choose' }}
-              onClick={choose}
-              dataTest="avatarUploaderChoose"
-            />
-          </div>
-        )}
-      </form>
-    </Formik>
+    <Form onSubmit={() => {}} defaultValues={{ avatarUploader: [] }}>
+      {({ formState: { errors }, reset }) => {
+        const name = 'avatarUploader';
+        const error = errors[name];
+        const hasError = !!uploadError || !!error;
+        const choose = () => {
+          reset();
+          // waits for form state to reset, which clears 'disabled'-ness in the event previous upload errored
+          setTimeout(open, 0);
+        };
+
+        return (
+          <>
+            <FileUpload
+              {...uploaderProps}
+              classNames={hasButtons ? styles : noButtonStyles}
+              dropzoneOptions={{
+                accept: ACCEPTED_MIME_TYPES,
+                maxSize: ACCEPTED_MAX_FILE_SIZE,
+                disabled,
+              }}
+              appearance={appearance}
+              maxFilesLimit={1}
+              name={name}
+              ref={dropzoneRef}
+              itemComponent={AvatarUploadItem}
+              dataTest="avatarUploaderDrop"
+            >
+              {renderOverlay()}
+            </FileUpload>
+            {hasButtons && (
+              <div className={styles.buttonContainer}>
+                <Button
+                  appearance={{ theme: 'danger' }}
+                  text={{ id: 'button.remove' }}
+                  onClick={remove}
+                  disabled={!isSet}
+                  dataTest="avatarUploaderRemove"
+                />
+                <Button
+                  text={{ id: 'button.choose' }}
+                  onClick={choose}
+                  dataTest="avatarUploaderChoose"
+                />
+              </div>
+            )}
+            {hasError && (
+              <div className={styles.inputStatus}>
+                <InputStatus
+                  appearance={appearance}
+                  error={MSG.avatarFileError}
+                />
+              </div>
+            )}
+          </>
+        );
+      }}
+    </Form>
   );
 };
 
+AvatarUploader.displayName = displayName;
 export default AvatarUploader;

--- a/src/components/shared/AvatarUploader/AvatarUploader.tsx
+++ b/src/components/shared/AvatarUploader/AvatarUploader.tsx
@@ -3,8 +3,9 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import { ApolloError, FetchResult } from '@apollo/client';
 
 import { HookForm as Form, InputStatus } from '~shared/Fields';
-import FileUpload, { FileReaderFile } from '~shared/FileUpload';
 import { FileUploadProps } from '~shared/FileUpload/types';
+import FileUpload from '~shared/FileUpload';
+import { FileReaderFile } from '~utils/fileReader/types';
 
 import Button from '../Button';
 import AvatarUploadItem from './AvatarUploadItem';

--- a/src/components/shared/CSVUploader/CSVUploader.tsx
+++ b/src/components/shared/CSVUploader/CSVUploader.tsx
@@ -75,7 +75,7 @@ const CSVUploader = ({
         accept: MIME_TYPES,
       }}
       customErrorMessage={error}
-      inputStatusAppearance={{ theme: 'minimal', textSpace: 'wrap' }}
+      appearance={{ theme: 'minimal', textSpace: 'wrap' }}
       itemComponent={CSVUploaderItem}
       handleError={handleUploadError}
       processingData={processingData}

--- a/src/components/shared/Fields/Checkbox/HookForm/Checkbox.tsx
+++ b/src/components/shared/Fields/Checkbox/HookForm/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { InputHTMLAttributes, useState } from 'react';
 import { nanoid } from 'nanoid';
 import { PopperOptions } from 'react-popper-tooltip';
 import { useFormContext } from 'react-hook-form';
@@ -6,14 +6,26 @@ import { useFormContext } from 'react-hook-form';
 import InputLabel from '~shared/Fields/InputLabel';
 import { Tooltip } from '~shared/Popover';
 import { getMainClasses } from '~utils/css';
+import { SimpleMessageValues } from '~types';
+import { formatText } from '~utils/intl';
 
-import { HookFormInputProps as InputProps } from '../../Input/HookForm';
+import { CoreInputProps } from '../../Input/HookForm';
 
 import styles from './Checkbox.css';
 
-interface Props extends InputProps {
+interface Appearance {
+  theme?: 'dark';
+  direction?: 'horizontal' | 'vertical';
+}
+
+export interface Props
+  extends Omit<CoreInputProps, 'placeholder' | 'placeholderValues'>,
+    Omit<InputHTMLAttributes<HTMLInputElement>, 'name' | 'placeholder'> {
+  appearance: Appearance;
   /**  Text for the checkbox tooltip */
   tooltipText?: string;
+  /** Text values for tooltip */
+  tooltipTextValues?: SimpleMessageValues;
   /** Options to pass to the underlying PopperJS element. See here for more: https://popper.js.org/docs/v2/constructors/#options. */
   tooltipPopperOptions?: PopperOptions;
 }
@@ -34,8 +46,10 @@ const HookFormCheckbox = ({
   onChange,
   value,
   tooltipText,
+  tooltipTextValues,
   tooltipPopperOptions,
   dataTest,
+  ...checkboxProps
 }: Props) => {
   const [inputId] = useState(nanoid());
   const { getValues, register } = useFormContext();
@@ -43,6 +57,7 @@ const HookFormCheckbox = ({
   const mainClasses = getMainClasses(appearance, styles);
   const classNames = className ? `${mainClasses} ${className}` : mainClasses;
 
+  const toolTipContent = formatText(tooltipText, tooltipTextValues);
   const showTooltip = disabled && tooltipText;
   const showLabel = !elementOnly && label;
 
@@ -64,6 +79,7 @@ const HookFormCheckbox = ({
       aria-disabled={disabled}
       aria-checked={isChecked}
       data-test={dataTest}
+      {...checkboxProps}
     />
   );
 
@@ -71,7 +87,7 @@ const HookFormCheckbox = ({
     <div className={classNames}>
       {showTooltip ? (
         <Tooltip
-          content={tooltipText}
+          content={toolTipContent}
           placement="bottom"
           popperOptions={tooltipPopperOptions}
         >

--- a/src/components/shared/Fields/Checkbox/index.ts
+++ b/src/components/shared/Fields/Checkbox/index.ts
@@ -1,2 +1,5 @@
 export { default } from './Checkbox';
-export { default as HookFormCheckbox } from './HookForm/Checkbox';
+export {
+  default as HookFormCheckbox,
+  Props as HookFormCheckboxProps,
+} from './HookForm/Checkbox';

--- a/src/components/shared/Fields/Input/HookForm/Input.tsx
+++ b/src/components/shared/Fields/Input/HookForm/Input.tsx
@@ -1,98 +1,39 @@
-import React, { InputHTMLAttributes, ReactNode, useState } from 'react';
+import React, { InputHTMLAttributes, useState } from 'react';
 import classnames from 'classnames';
-import { CleaveOptions } from 'cleave.js/options';
-import { MessageDescriptor } from 'react-intl';
 import { nanoid } from 'nanoid';
-import { SetValueConfig, useFormContext } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import { isConfusing } from '@colony/unicode-confusables-noascii';
+import { CleaveOptions } from 'cleave.js/options';
 
-import { Message, SimpleMessageValues } from '~types';
 import { formatText } from '~utils/intl';
 import ConfusableWarning from '~shared/ConfusableWarning';
+import { Message } from '~types';
 
 import InputLabel from '../../InputLabel';
 import InputStatus from '../../InputStatus/HookForm';
 import { InputComponentAppearance } from '../../Input';
-
 import InputComponent from './InputComponent';
+import { CoreInputProps, MaxButtonParams } from './types';
+
 import styles from '../Input.css';
 
-interface MaxButtonParams {
-  maxAmount: string;
-  options?: SetValueConfig;
-  customOnClickFn?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-}
-
 export interface HookFormInputProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'placeholder'> {
+  extends CoreInputProps,
+    Omit<InputHTMLAttributes<HTMLInputElement>, 'placeholder' | 'name'> {
   /** Appearance object */
   appearance?: InputComponentAppearance;
-
-  /** Testing */
-  dataTest?: string;
-
-  /** Set the input field to a disabled state */
-  disabled?: boolean;
-
-  /** Should display the input with the label hidden */
-  elementOnly?: boolean;
-
   /** Add extension of input to the right of it, i.e. for ENS name */
-  extensionString?: string | MessageDescriptor;
-
-  /** Extra node to render on the top right in the label */
-  extra?: ReactNode;
-
+  extensionString?: Message;
   /** Memomized options object for cleave.js formatting (see [this list](https://github.com/nosir/cleave.js/blob/master/doc/options.md)). Be sure to ensure the object is either memoized or defined outside of the component. */
   formattingOptions?: CleaveOptions;
-
-  /** Help text */
-  help?: Message;
-
-  /** Help text values for intl interpolation */
-  helpValues?: SimpleMessageValues;
-
-  /** Html `id` for label & input */
-  id?: string;
-
   /** Will show a loading status beneath input if true. Takes priority over error and status. */
   isLoading?: boolean;
-
-  /** Label text */
-  label?: Message;
-
-  /** Label text values for intl interpolation */
-  labelValues?: SimpleMessageValues;
-
   /** Text displayed after the word "Loading", i.e. "Loading{annotation}...". */
   loadingAnnotation?: Message;
-
   /** Pass params to a max button - implemented only in Cleave options */
   maxButtonParams?: MaxButtonParams;
-
-  /** Input field name (form variable) */
-  name: string;
-
-  /** External on change hook */
-  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
-
-  /** External on change hook */
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-
-  /** Placeholder text */
-  placeholder?: Message;
-
-  /** Placeholder text values for intl interpolation */
-  placeholderValues?: SimpleMessageValues;
-
   /** Show ConfusableWarning based on user input */
   showConfusable?: boolean;
-
-  /** Status text */
-  status?: Message;
-
-  /** Status text values for intl interpolation */
-  statusValues?: SimpleMessageValues;
 }
 
 const displayName = 'HookFormInput';

--- a/src/components/shared/Fields/Input/HookForm/index.ts
+++ b/src/components/shared/Fields/Input/HookForm/index.ts
@@ -4,3 +4,4 @@ export {
   default as InputComponent,
   HookFormInputComponentProps,
 } from './InputComponent';
+export * from './types';

--- a/src/components/shared/Fields/Input/HookForm/types.ts
+++ b/src/components/shared/Fields/Input/HookForm/types.ts
@@ -1,0 +1,39 @@
+import { ReactNode } from 'react';
+import { SetValueConfig } from 'react-hook-form';
+
+import { Message, SimpleMessageValues } from '~types';
+
+export interface MaxButtonParams {
+  maxAmount: string;
+  options?: SetValueConfig;
+  customOnClickFn?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+export interface CoreInputProps {
+  /** Input field name (form variable) */
+  name: string;
+  /** Label text */
+  label?: Message;
+  /** Label text values for intl interpolation */
+  labelValues?: SimpleMessageValues;
+  /** Set the input field to a disabled state */
+  disabled?: boolean;
+  /** Should display the input with the label hidden */
+  elementOnly?: boolean;
+  /** Testing */
+  dataTest?: string;
+  /** Extra node to render on the top right in the label */
+  extra?: ReactNode;
+  /** Help text */
+  help?: Message;
+  /** Help text values for intl interpolation */
+  helpValues?: SimpleMessageValues;
+  /** Placeholder text */
+  placeholder?: Message;
+  /** Placeholder text values for intl interpolation */
+  placeholderValues?: SimpleMessageValues;
+  /** Status text */
+  status?: Message;
+  /** Status text values for intl interpolation */
+  statusValues?: SimpleMessageValues;
+}

--- a/src/components/shared/Fields/Input/index.ts
+++ b/src/components/shared/Fields/Input/index.ts
@@ -3,14 +3,4 @@ export {
   default as InputComponent,
   Props as InputComponentProps,
 } from './InputComponent';
-
-export interface InputComponentAppearance {
-  theme?: 'fat' | 'underlined' | 'minimal' | 'dotted';
-  align?: 'right';
-  helpAlign?: 'right';
-  direction?: 'horizontal';
-  colorSchema?: 'dark' | 'grey' | 'transparent' | 'info';
-  size?: 'small' | 'medium';
-  statusSchema?: 'info';
-  textSpace?: 'wrap';
-}
+export { InputComponentAppearance } from './types';

--- a/src/components/shared/Fields/Input/types.ts
+++ b/src/components/shared/Fields/Input/types.ts
@@ -1,6 +1,9 @@
 export interface InputComponentAppearance {
   theme?: 'fat' | 'underlined' | 'minimal' | 'dotted';
   align?: 'right';
-  colorSchema?: 'dark' | 'grey' | 'transparent';
-  size?: 'small';
+  direction?: 'horizontal';
+  colorSchema?: 'dark' | 'grey' | 'transparent' | 'info';
+  size?: 'small' | 'medium';
+  statusSchema?: 'info';
+  textSpace?: 'wrap';
 }

--- a/src/components/shared/Fields/InputLabel/InputLabel.css
+++ b/src/components/shared/Fields/InputLabel/InputLabel.css
@@ -56,7 +56,7 @@
   color: var(--text);
 }
 
-.helpAlignRight {
+.alignRight {
   display: flex;
   justify-content: space-between;
   align-items: baseline;

--- a/src/components/shared/Fields/InputLabel/InputLabel.css.d.ts
+++ b/src/components/shared/Fields/InputLabel/InputLabel.css.d.ts
@@ -1,12 +1,12 @@
 declare namespace InputLabelCssNamespace {
   export interface IInputLabelCss {
+    alignRight: string;
     colorSchemaDark: string;
     colorSchemaGrey: string;
     directionHorizontal: string;
     error: string;
     extra: string;
     help: string;
-    helpAlignRight: string;
     labelText: string;
     main: string;
     sizeMedium: string;

--- a/src/components/shared/Fields/InputLabel/InputLabel.tsx
+++ b/src/components/shared/Fields/InputLabel/InputLabel.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { MessageDescriptor, useIntl } from 'react-intl';
 
-import { SimpleMessageValues } from '~types';
+import { Message, SimpleMessageValues } from '~types';
 import { getMainClasses } from '~utils/css';
 
 import { InputComponentAppearance as Appearance } from '../Input';
@@ -26,7 +26,7 @@ interface Props {
   inputId?: string;
 
   /** Label text */
-  label: string | MessageDescriptor;
+  label: Message;
 
   /** Values for label text (react-intl interpolation) */
   labelValues?: SimpleMessageValues;

--- a/src/components/shared/Fields/InputStatus/index.ts
+++ b/src/components/shared/Fields/InputStatus/index.ts
@@ -1,1 +1,1 @@
-export { default, Appearance as InputStatusAppearance } from './InputStatus';
+export { default } from './InputStatus';

--- a/src/components/shared/Fields/Textarea/HookForm/Textarea.tsx
+++ b/src/components/shared/Fields/Textarea/HookForm/Textarea.tsx
@@ -1,0 +1,104 @@
+import React, { TextareaHTMLAttributes, useState } from 'react';
+import cx from 'classnames';
+import { nanoid } from 'nanoid';
+import { useFormContext } from 'react-hook-form';
+
+import { CoreInputProps } from '~shared/Fields/Input/HookForm';
+
+import { getMainClasses } from '~utils/css';
+import { formatText } from '~utils/intl';
+
+import InputLabel from '../../InputLabel';
+import InputStatus from '../../InputStatus';
+
+import { Appearance } from '../Textarea';
+import styles from '../Textarea.css';
+
+export interface Props
+  extends CoreInputProps,
+    Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'name' | 'placeholder'> {
+  /** Appearance object */
+  appearance?: Appearance;
+}
+
+const displayName = 'HookFormTextarea';
+
+const Textarea = ({
+  appearance = {},
+  elementOnly = false,
+  extra,
+  help,
+  helpValues,
+  id: idProp,
+  label,
+  labelValues,
+  maxLength = undefined,
+  name,
+  placeholder: placeholderProp,
+  placeholderValues,
+  status,
+  statusValues,
+  disabled,
+  dataTest,
+  ...textAreaProps
+}: Props) => {
+  const [id] = useState(idProp || nanoid());
+  const { register, watch, getFieldState } = useFormContext();
+  const value = watch(name);
+  const { error } = getFieldState(name);
+  const length = value?.length || 0;
+
+  const placeholder = formatText(placeholderProp, placeholderValues);
+
+  return (
+    <div className={styles.container}>
+      {!elementOnly && label && (
+        <InputLabel
+          appearance={appearance}
+          extra={extra}
+          help={help}
+          helpValues={helpValues}
+          inputId={id}
+          label={label}
+          labelValues={labelValues}
+          screenReaderOnly={elementOnly}
+        />
+      )}
+      <div className={styles.textareaWrapper}>
+        <textarea
+          {...register(name)}
+          aria-invalid={error ? true : undefined}
+          className={getMainClasses(appearance, styles)}
+          id={id}
+          maxLength={maxLength}
+          placeholder={placeholder}
+          aria-disabled={disabled}
+          disabled={disabled}
+          data-test={dataTest}
+          {...textAreaProps}
+        />
+        {maxLength && (
+          <span
+            className={cx(styles.count, {
+              [styles.limit]: length === maxLength,
+            })}
+          >
+            {length}/{maxLength}
+          </span>
+        )}
+      </div>
+      {!elementOnly && (
+        <InputStatus
+          appearance={appearance}
+          status={status}
+          statusValues={statusValues}
+          error={error?.message}
+        />
+      )}
+    </div>
+  );
+};
+
+Textarea.displayName = displayName;
+
+export default Textarea;

--- a/src/components/shared/Fields/Textarea/index.ts
+++ b/src/components/shared/Fields/Textarea/index.ts
@@ -1,3 +1,4 @@
 export { default } from './Textarea';
 export { Props as TextareaComponentProps } from './Textarea';
 export { default as TextareaAutoresize } from './TextareaAutoresize';
+export { default as HookFormTextArea } from './HookForm/Textarea';

--- a/src/components/shared/Fields/Toggle/HookForm/Toggle.tsx
+++ b/src/components/shared/Fields/Toggle/HookForm/Toggle.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import InputLabel from '~shared/Fields/InputLabel';
+import QuestionMarkTooltip from '~shared/QuestionMarkTooltip';
+
+import { getMainClasses } from '~utils/css';
+
+import styles from '../Toggle.css';
+import { HookFormCheckboxProps } from '~shared/Fields/Checkbox';
+
+const displayName = 'HookFormToggle';
+
+interface Appearance {
+  theme?: 'primary' | 'danger';
+}
+
+interface Props extends Omit<HookFormCheckboxProps, 'appearance'> {
+  appearance?: Appearance;
+}
+
+const HookFormToggle = ({
+  appearance,
+  name,
+  label,
+  labelValues,
+  disabled = false,
+  elementOnly = false,
+  onChange,
+  tooltipTextValues,
+  tooltipText,
+  tooltipPopperOptions = {
+    placement: 'right-start',
+    modifiers: [
+      {
+        name: 'offset',
+        options: {
+          offset: [-3, 10],
+        },
+      },
+    ],
+  },
+  ...toggleProps
+}: Props) => {
+  const { register, watch } = useFormContext();
+  const { onChange: hookFormOnChange, ...hookFormHelpers } = register(name);
+
+  const value = watch(name);
+
+  const mainClasses = getMainClasses(appearance, styles);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    hookFormOnChange(e);
+    onChange?.(e);
+  };
+  return (
+    <div className={styles.container}>
+      {!elementOnly && label && (
+        <InputLabel
+          label={label}
+          labelValues={labelValues}
+          appearance={{ colorSchema: 'grey' }}
+        />
+      )}
+      <div>
+        <input
+          {...hookFormHelpers}
+          type="checkbox"
+          disabled={disabled}
+          aria-checked={value}
+          aria-disabled={disabled}
+          className={styles.delegate}
+          onChange={handleChange}
+          {...toggleProps}
+        />
+        <span className={disabled ? styles.toggleDisabled : styles.toggle}>
+          <span className={value ? mainClasses : styles.toggleSwitch} />
+        </span>
+      </div>
+      {tooltipText && (
+        <QuestionMarkTooltip
+          className={styles.icon}
+          tooltipText={tooltipText}
+          tooltipPopperOptions={tooltipPopperOptions}
+          tooltipTextValues={tooltipTextValues}
+        />
+      )}
+    </div>
+  );
+};
+
+HookFormToggle.displayName = displayName;
+
+export default HookFormToggle;

--- a/src/components/shared/Fields/Toggle/index.ts
+++ b/src/components/shared/Fields/Toggle/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Toggle';
+export { default as HookFormToggle } from './HookForm/Toggle';

--- a/src/components/shared/Fields/asFieldArray.ts
+++ b/src/components/shared/Fields/asFieldArray.ts
@@ -11,9 +11,8 @@ interface Props {
 }
 
 const asFieldArray =
-  () =>
-  (Component: any) =>
-  ({ name, ...props }: Props) => {
+  <P>(Component: any) =>
+  ({ name, ...props }: P & Props) => {
     return createElement(FieldArray, {
       name,
       render: (formikProps) =>

--- a/src/components/shared/Fields/index.ts
+++ b/src/components/shared/Fields/index.ts
@@ -3,18 +3,23 @@ export { default as Checkbox, HookFormCheckbox } from './Checkbox';
 export { default as Form, ActionForm, HookForm, ActionHookForm } from './Form';
 export { default as FormStatus } from './FormStatus';
 export { default as FieldSet } from './FieldSet';
-export { default as Input } from './Input';
+export { default as Input, InputComponentAppearance } from './Input';
 export {
   Input as HookFormInput,
   InputComponent as HookFormInputComponent,
   FormattedInput as HookFormFormattedInput,
   HookFormInputProps,
+  CoreInputProps,
 } from './Input/HookForm';
 export { default as InputLabel } from './InputLabel';
 export { default as InputStatus } from './InputStatus';
 export { default as Select, Appearance, SelectOption } from './Select';
 export { default as TokenSymbolSelector } from './TokenSymbolSelector';
-export { default as Textarea, TextareaAutoresize } from './Textarea';
+export {
+  default as Textarea,
+  HookFormTextArea,
+  TextareaAutoresize,
+} from './Textarea';
 export { default as Radio, CustomRadio, CustomRadioProps } from './Radio';
 export { default as RadioGroup, CustomRadioGroup } from './RadioGroup';
 export { default as Annotations } from './Annotations';

--- a/src/components/shared/Fields/index.ts
+++ b/src/components/shared/Fields/index.ts
@@ -18,7 +18,7 @@ export { default as Textarea, TextareaAutoresize } from './Textarea';
 export { default as Radio, CustomRadio, CustomRadioProps } from './Radio';
 export { default as RadioGroup, CustomRadioGroup } from './RadioGroup';
 export { default as Annotations } from './Annotations';
-export { default as Toggle } from './Toggle';
+export { default as Toggle, HookFormToggle } from './Toggle';
 
 export { default as asFieldArray } from './asFieldArray';
 

--- a/src/components/shared/FileUpload/UploadItem.tsx
+++ b/src/components/shared/FileUpload/UploadItem.tsx
@@ -1,16 +1,18 @@
-import React, { SyntheticEvent, useEffect, useCallback, useMemo } from 'react';
+import React, { SyntheticEvent, useEffect } from 'react';
 import { defineMessages } from 'react-intl';
+import { useFieldArray, useFormContext } from 'react-hook-form';
 
-import { useField } from 'formik';
+import fileReader from '~utils/fileReader';
 
-import { UploadFile, UploadItemComponentProps } from './types';
 import Button from '../Button';
 import Icon from '../Icon';
 import { Tooltip } from '../Popover';
 import ProgressBar from '../ProgressBar';
-
-import fileReader from '~utils/fileReader';
-
+import {
+  FileUploadFormValues,
+  HookFormUploadItemComponentProps,
+  UploadFile,
+} from './types';
 import styles from './UploadItem.css';
 
 const MSG = defineMessages({
@@ -28,58 +30,53 @@ const UploadItem = ({
   idx,
   maxFileSize,
   name,
-  remove,
   upload,
-}: UploadItemComponentProps) => {
-  const [
-    ,
-    {
-      value: { file, uploaded },
-      value,
-    },
-    { setValue },
-  ] = useField<UploadFile>(name);
+}: HookFormUploadItemComponentProps) => {
+  const { setError } = useFormContext();
+  const { fields, update, remove } = useFieldArray<FileUploadFormValues>({
+    name,
+  });
+  const value = fields[idx];
+  const { file, uploaded } = value as UploadFile;
 
-  // eslint-disable-next-line no-underscore-dangle
-  const _readFiles = useMemo(
-    () =>
-      fileReader({
-        maxFilesLimit: 1,
-        maxFileSize,
-        allowedTypes: accept,
-      }),
-    [accept, maxFileSize],
-  );
+  const readFiles = fileReader({
+    maxFilesLimit: 1,
+    maxFileSize,
+    allowedTypes: accept,
+  });
 
-  const read = useCallback(async () => {
-    const [contents] = await _readFiles([file]);
+  const read = async () => {
+    const [contents] = await readFiles([file]);
     return contents;
-  }, [_readFiles, file]);
+  };
 
   const handleRemoveClick = (evt: SyntheticEvent<HTMLButtonElement>) => {
     evt.stopPropagation();
     remove(idx);
   };
 
-  const uploadFile = useCallback(async () => {
-    if (!setValue) return;
+  const uploadFile = async () => {
     let readFile;
     let fileReference;
     try {
       readFile = await read();
-      setValue({ ...value, preview: readFile.data });
+      update(idx, { ...value, preview: readFile.data });
       fileReference = await upload(readFile);
     } catch (caughtError) {
       console.error(caughtError);
-
-      /**
-       * @todo  better error handling here
-       */
-      setValue({ ...value, error: 'uploadError' });
+      setError(name, { message: caughtError });
+      update(idx, {
+        ...value,
+        errors: [{ message: caughtError, code: 'uploadError' }],
+      });
       return;
     }
-    setValue({ ...value, preview: readFile.data, uploaded: fileReference });
-  }, [read, setValue, upload, value]);
+    update(idx, {
+      ...value,
+      preview: readFile.data,
+      uploaded: fileReference,
+    });
+  };
 
   useEffect(() => {
     if (file && !error && !uploaded) {

--- a/src/components/shared/FileUpload/types.ts
+++ b/src/components/shared/FileUpload/types.ts
@@ -11,15 +11,7 @@ import {
   InputComponentAppearance as Appearance,
 } from '~shared/Fields';
 import { Message } from '~types';
-
-export interface FileReaderFile {
-  name: string;
-  type: string;
-  size: number;
-  lastModified: string;
-  uploadDate: Date;
-  data: string;
-}
+import { FileReaderFile } from '~utils/fileReader/types';
 
 export interface UploadFile {
   file: File;

--- a/src/components/shared/FileUpload/types.ts
+++ b/src/components/shared/FileUpload/types.ts
@@ -1,5 +1,10 @@
 import { FieldArrayRenderProps } from 'formik';
-import { DropzoneOptions, DropzoneState, FileRejection } from 'react-dropzone';
+import {
+  Accept,
+  DropzoneOptions,
+  DropzoneState,
+  FileRejection,
+} from 'react-dropzone';
 import { ComponentType, ReactNode, Ref } from 'react';
 import {
   CoreInputProps,
@@ -34,7 +39,19 @@ export interface UploadItemComponentProps {
   remove: FieldArrayRenderProps['remove'];
   reset: FieldArrayRenderProps['form']['resetForm'];
   upload: UploadFn;
-  validate: ValidateFileFn;
+  handleError?: (...args: any[]) => Promise<any>;
+  processingData?: boolean;
+  handleProcessingData?: (...args: any) => void;
+}
+
+export interface HookFormUploadItemComponentProps {
+  accept: Accept;
+  error?: string;
+  key: string;
+  idx: number;
+  maxFileSize: number;
+  name: string;
+  upload: UploadFn;
   handleError?: (...args: any[]) => Promise<any>;
   processingData?: boolean;
   handleProcessingData?: (...args: any) => void;
@@ -79,7 +96,7 @@ export interface FileUploadProps extends CoreInputProps {
   /** Hide the status component beneath the file uploader. Useful if you wish to display the status elsewhere, e.g. outside the component. */
   hideStatus?: boolean;
   /** The component to render each item to be uploaded */
-  itemComponent?: ComponentType<UploadItemComponentProps>;
+  itemComponent?: ComponentType<HookFormUploadItemComponentProps>;
   /** Maximum number of files to accept */
   maxFilesLimit?: number;
   /** Max file size */

--- a/src/components/shared/FileUpload/types.ts
+++ b/src/components/shared/FileUpload/types.ts
@@ -1,4 +1,11 @@
 import { FieldArrayRenderProps } from 'formik';
+import { DropzoneOptions, DropzoneState, FileRejection } from 'react-dropzone';
+import { ComponentType, ReactNode, Ref } from 'react';
+import {
+  CoreInputProps,
+  InputComponentAppearance as Appearance,
+} from '~shared/Fields';
+import { Message } from '~types';
 
 export interface FileReaderFile {
   name: string;
@@ -36,3 +43,59 @@ export interface UploadItemComponentProps {
 export type UploadFn = (fileData: FileReaderFile | File | null) => any;
 
 export type ValidateFileFn = (value: UploadFile) => string | undefined;
+
+export interface AcceptedFile {
+  file: File;
+}
+
+export interface UploadedFile extends AcceptedFile {
+  preview: string;
+  /** mutation result */
+  uploaded: any;
+}
+
+export type UserFile = AcceptedFile | FileRejection | UploadedFile;
+
+export interface FileUploadFormValues {
+  [k: string]: UserFile[];
+}
+
+export interface FileUploadProps extends CoreInputProps {
+  /** Appearance object for both label and status */
+  appearance?: Appearance;
+  /** Content to render inside the dropzone */
+  children?: ReactNode | ((props: DropzoneState) => ReactNode);
+  /** Custom classNames for different elements of the component */
+  classNames?: {
+    main?: string;
+    dropzone?: string;
+    dropzoneAccept?: string;
+    dropzoneReject?: string;
+    filesContainer?: string;
+    disabled?: string;
+  };
+  /** Options for the dropzone provider */
+  dropzoneOptions: DropzoneOptions;
+  /** Hide the status component beneath the file uploader. Useful if you wish to display the status elsewhere, e.g. outside the component. */
+  hideStatus?: boolean;
+  /** The component to render each item to be uploaded */
+  itemComponent?: ComponentType<UploadItemComponentProps>;
+  /** Maximum number of files to accept */
+  maxFilesLimit?: number;
+  /** Max file size */
+  maxSize?: number;
+  /** Placeholder element for when no files have been picked yet (renderProp) */
+  renderPlaceholder?: ReactNode | null;
+  /** Ref for programmatic opening */
+  ref?: Ref<any>;
+  /** Function to handle the actual uploading of the file */
+  upload: UploadFn;
+  /** Function to handle an upload error from the outside */
+  handleError?: (...args: any[]) => Promise<any>;
+
+  customErrorMessage?: Message;
+
+  processingData?: boolean;
+
+  handleProcessingData?: (...args: any) => void;
+}

--- a/src/components/shared/QuestionMarkTooltip/QuestionMarkTooltip.tsx
+++ b/src/components/shared/QuestionMarkTooltip/QuestionMarkTooltip.tsx
@@ -4,13 +4,13 @@ import { MessageDescriptor, FormattedMessage } from 'react-intl';
 
 import Icon from '~shared/Icon';
 import { Tooltip } from '~shared/Popover';
-import { ComplexMessageValues } from '~types';
+import { ComplexMessageValues, SimpleMessageValues } from '~types';
 
 const displayName = 'QuestionMarkTooltip';
 
 interface Props {
   tooltipText: string | MessageDescriptor;
-  tooltipTextValues?: ComplexMessageValues;
+  tooltipTextValues?: SimpleMessageValues | ComplexMessageValues;
   /** Options to pass to the underlying PopperJS element. See here for more: https://popper.js.org/docs/v2/constructors/#options. */
   tooltipPopperOptions?: PopperOptions;
   className?: string;

--- a/src/utils/cleave.ts
+++ b/src/utils/cleave.ts
@@ -1,0 +1,1 @@
+export const noSpaces = { blocks: [] };

--- a/src/utils/fileReader/types.ts
+++ b/src/utils/fileReader/types.ts
@@ -1,0 +1,14 @@
+import { Accept } from 'react-dropzone';
+
+export interface FileReaderFile
+  extends Pick<File, 'name' | 'type' | 'size' | 'lastModified'> {
+  uploadDate: number;
+  data: string;
+}
+
+export interface FileReaderOptions {
+  maxFilesLimit: number;
+  maxFileSize: number;
+  allowedTypes: Accept;
+  fileReadingFn: (reader: FileReader, file: File) => void;
+}

--- a/src/utils/hoc/index.ts
+++ b/src/utils/hoc/index.ts
@@ -1,4 +1,4 @@
-import React, { ComponentType, createElement, forwardRef, Ref } from 'react';
+import { ComponentType, createElement, forwardRef, Ref } from 'react';
 
 type HookFn<H, P, R> = (hookParams: H, props: P) => R;
 
@@ -16,17 +16,8 @@ export interface ForwardedRefProps {
 }
 
 export const withForwardingRef = <Props extends Record<string, any>>(
-  BaseComponent: React.ComponentClass<Props>,
+  BaseComponent: ComponentType<Props>,
 ) =>
   forwardRef<ForwardedRefProps, Props>((props, ref) =>
     createElement(BaseComponent, { ...props, forwardedRef: ref }),
-  );
-
-// eslint-disable-next-line @typescript-eslint/ban-types
-export const compose = (...funcs: Function[]) =>
-  funcs.reduce(
-    (a, b) =>
-      (...args) =>
-        a(b(...args)),
-    (arg) => arg,
   );


### PR DESCRIPTION
## Description

This PR migrates the components at the `edit-profile` route to use React Hook Forms instead of Formik.

It also fixes the bug in which you cannot upload an avatar after the component has errored. Now you can upload an incorrect file, and the "choose" button will let you open the OS's file explorer so you can select another.

To test, navigate to `edit-profile`, and test that the following forms work correctly:

- Profile Pic / Avatar Upload
- User main settings
- User advanced settings

**New stuff** ✨

* New HookForm specific components:
- Toggle
- Textarea

**Changes** 🏗

* Migrated the following to use React Hook Form
- UserAdvancedSettings
- UserMainSettings
- AvatarUploadItem
- AvatarUploader
- FileUpload
- UploadItem
* added types to `fileReader`
* refactored commonly used Input component props

Resolves #117
