### PR TITLE
Fix user wizard `index.ts` export order

### DIFF
--- a/src/components/common/CreateColonyWizard/StepColonyNameInputs.tsx
+++ b/src/components/common/CreateColonyWizard/StepColonyNameInputs.tsx
@@ -28,7 +28,7 @@ const MSG = defineMessages({
   },
   tooltip: {
     id: `${displayName}.tooltip`,
-    defaultMessage: `We use ENS to create a .{displayENSDomain} subdomain for your colony. You can use this to create a custom URL and invite people to join your colony.`,
+    defaultMessage: `You can use this to create a custom URL and invite people to join your colony.`,
   },
 });
 

--- a/src/components/common/CreateUserWizard/index.ts
+++ b/src/components/common/CreateUserWizard/index.ts
@@ -1,4 +1,3 @@
-export { default, ContinueWizard, UserStepTemplate } from './CreateUserWizard';
 export { default as StepUserName } from './StepUserName';
 export { default as StepUserEmail } from './StepUserEmail';
 export {
@@ -10,3 +9,4 @@ export {
   UserWizardStep2,
 } from './validation';
 export { default as ConfirmEmail } from './ConfirmEmail';
+export { default, ContinueWizard, UserStepTemplate } from './CreateUserWizard';


### PR DESCRIPTION
## Description

**Today I Learned** that the order of exports matters in `index.ts` files. This PR corrects the export order in the `UserCreationWizard` so imports are defined when the wizard loads.

**Changes** 🏗

* Move "main" export to bottom of `index.ts`
* I also update a tooltip in the ColonyCreationWizard which I meant to include in the previous commit 

