### PR TITLE
Port `useEnabledExtensions` hook

### DIFF
--- a/src/components/common/Extensions/ExtensionStatusBadge/ExtensionStatusBadge.tsx
+++ b/src/components/common/Extensions/ExtensionStatusBadge/ExtensionStatusBadge.tsx
@@ -10,10 +10,6 @@ import styles from './ExtensionStatusBadge.css';
 const displayName = 'common.Extensions.ExtensionStatusBadge';
 
 const MSG = defineMessages({
-  installed: {
-    id: `${displayName}.installed`,
-    defaultMessage: 'Installed',
-  },
   notInstalled: {
     id: `${displayName}.notInstalled`,
     defaultMessage: 'Not installed',
@@ -30,8 +26,8 @@ const MSG = defineMessages({
     id: `${displayName}.enabled`,
     defaultMessage: 'Enabled',
   },
-  notEnabled: {
-    id: `${displayName}.notEnabled`,
+  disabled: {
+    id: `${displayName}.disabled`,
     defaultMessage: 'Disabled',
   },
 });
@@ -62,7 +58,8 @@ const ExtensionStatusBadge = ({
     status = MSG.enabled;
     theme = 'primary';
   } else {
-    status = MSG.installed;
+    status = MSG.disabled;
+    theme = 'golden';
   }
 
   const isDeprecated =

--- a/src/components/common/Extensions/ExtensionStatusBadge/ExtensionStatusBadge.tsx
+++ b/src/components/common/Extensions/ExtensionStatusBadge/ExtensionStatusBadge.tsx
@@ -50,28 +50,29 @@ const ExtensionStatusBadge = ({
 
   if (!isInstalledExtensionData(extensionData)) {
     status = MSG.notInstalled;
-  } else if (!extensionData.isInitialized) {
-    status = MSG.notEnabled;
-    theme = 'golden';
+  } else if (extensionData.isDeprecated) {
+    status = MSG.deprecated;
+    theme = 'danger';
   }
   // else if (installedExtension.details?.missingPermissions.length) {
   //   status = MSG.missingPermissions;
   //   theme = 'danger';
   // }
-  else if (extensionData.isInitialized) {
+  else if (extensionData.isEnabled) {
     status = MSG.enabled;
     theme = 'primary';
   } else {
     status = MSG.installed;
   }
 
+  const isDeprecated =
+    isInstalledExtensionData(extensionData) && extensionData.isDeprecated;
+
   return (
     <div className={styles.tagContainer}>
-      {!deprecatedOnly && <Tag appearance={{ theme }} text={status} />}
-      {isInstalledExtensionData(extensionData) &&
-        extensionData.isDeprecated && (
-          <Tag appearance={{ theme: 'danger' }} text={MSG.deprecated} />
-        )}
+      {(isDeprecated || !deprecatedOnly) && (
+        <Tag appearance={{ theme }} text={status} />
+      )}
     </div>
   );
 };

--- a/src/hooks/useEnabledExtensions.tsx
+++ b/src/hooks/useEnabledExtensions.tsx
@@ -2,23 +2,23 @@ import { Extension } from '@colony/colony-js';
 
 import useExtensionsData from './useExtensionsData';
 
+type EnabledExtensionKey = `is${Extension}Enabled`;
+type EnabledExtensions = Partial<Record<EnabledExtensionKey, boolean>>;
+
 const useEnabledExtensions = () => {
   const { installedExtensionsData, loading } = useExtensionsData();
 
-  const oneTxPaymentData = installedExtensionsData.find(
-    (extensionData) => extensionData.extensionId === Extension.OneTxPayment,
+  const enabledExtensions = installedExtensionsData.reduce<EnabledExtensions>(
+    (extensions, extension) => ({
+      ...extensions,
+      [`is${extension.extensionId}Enabled`]: extension.isEnabled,
+    }),
+    {},
   );
-  const isOneTxPaymentEnabled = !!oneTxPaymentData?.isEnabled;
-
-  const votingReputationData = installedExtensionsData.find(
-    (extensionData) => extensionData.extensionId === Extension.VotingReputation,
-  );
-  const isVotingReputationEnabled = !!votingReputationData?.isEnabled;
 
   return {
     loading,
-    isOneTxPaymentEnabled,
-    isVotingReputationEnabled,
+    enabledExtensions,
   };
 };
 

--- a/src/hooks/useEnabledExtensions.tsx
+++ b/src/hooks/useEnabledExtensions.tsx
@@ -1,56 +1,25 @@
-// import { Extension } from '@colony/colony-js';
-// import { useColonyExtensionsQuery } from '~data/index';
-// import { Address } from '~types/index';
+import { Extension } from '@colony/colony-js';
 
-// interface Props {
-//   colonyAddress?: Address;
-// }
+import useExtensionsData from './useExtensionsData';
 
-/*
- * @TODO This needs to be addressed and either refactored or removed
- */
+const useEnabledExtensions = () => {
+  const { installedExtensionsData, loading } = useExtensionsData();
 
-// export const useEnabledExtensions = ({ colonyAddress }: Props) => {
-//   const { data: colonyExtensionsData, loading } = useColonyExtensionsQuery({
-//     variables: { address: colonyAddress || '' },
-//   });
-//   const installedExtensions =
-//     colonyExtensionsData?.processedColony?.installedExtensions || [];
+  const oneTxPaymentData = installedExtensionsData.find(
+    (extensionData) => extensionData.extensionId === Extension.OneTxPayment,
+  );
+  const isOneTxPaymentEnabled = !!oneTxPaymentData?.isEnabled;
 
-//   const installedVotingExtension = installedExtensions.find(
-//     ({ extensionId }) => extensionId === Extension.VotingReputation,
-//   );
-//   const installedOneTxPaymentExtension = installedExtensions.find(
-//     ({ extensionId }) => extensionId === Extension.OneTxPayment,
-//   );
+  const votingReputationData = installedExtensionsData.find(
+    (extensionData) => extensionData.extensionId === Extension.VotingReputation,
+  );
+  const isVotingReputationEnabled = !!votingReputationData?.isEnabled;
 
-//   const isVotingExtensionEnabled = !!(
-//     installedVotingExtension &&
-//     installedVotingExtension.details?.initialized &&
-//     !installedVotingExtension.details?.deprecated
-//   );
-//   const isOneTxPaymentExtensionEnabled = !!(
-//     installedOneTxPaymentExtension &&
-//     installedOneTxPaymentExtension.details?.initialized &&
-//     !installedOneTxPaymentExtension.details?.deprecated
-//   );
-
-//   const installedExtensionsAddresses = installedExtensions.map((extension) =>
-//     extension.address?.toLowerCase(),
-//   );
-
-//   return {
-//     isVotingExtensionEnabled,
-//     votingExtensionVersion: installedVotingExtension
-//       ? installedVotingExtension?.details?.version
-//       : null,
-//     isOneTxPaymentExtensionEnabled,
-//     installedExtensionsAddresses,
-//     isLoadingExtensions: loading,
-//   };
-// };
-//
-
-const useEnabledExtensions = (...args) => args;
+  return {
+    loading,
+    isOneTxPaymentEnabled,
+    isVotingReputationEnabled,
+  };
+};
 
 export default useEnabledExtensions;

--- a/src/types/extensions.ts
+++ b/src/types/extensions.ts
@@ -39,6 +39,7 @@ export interface ExtensionConfig {
 export type InstalledExtensionData = ExtensionConfig &
   ColonyExtension & {
     availableVersion: number;
+    isEnabled: boolean;
   };
 
 export type InstallableExtensionData = ExtensionConfig & {

--- a/src/utils/extensions.ts
+++ b/src/utils/extensions.ts
@@ -32,11 +32,13 @@ export const mapToInstalledExtensionData = (
   // extension is also considered initialized if it has no initialization params
   const isInitialized =
     colonyExtension?.isInitialized || !extensionConfig.initializationParams;
+  const isEnabled = isInitialized && !colonyExtension.isDeprecated;
 
   return {
     ...extensionConfig,
     ...colonyExtension,
     availableVersion: version,
     isInitialized,
+    isEnabled,
   };
 };


### PR DESCRIPTION
## Description

This small PR ports over the `useEnabledExtensions` hook. I spotted an opportunity to extract and encapsulate some logic related to checking whether an extension is enabled so I added a new field `isEnabled` to `InstalledExtensionData`. 

This also brings in a small change to `ExtensionStatusBadge` which helps us avoid weird statuses like the following:
![image](https://user-images.githubusercontent.com/112586815/209436443-0f7ff25d-4f11-485f-a6ac-24b1cfcba4ae.png)

From now, there will only be a maximum of one status shown (and deprecated will take precedence over enabled).

## Testing
It doesn't look like anything previously relying on this hook has been ported over, so you'll just have to call it anywhere in the CDapp and log out the results to verify that they're correct. For the `ExtensionStatusBadge`, try to deprecate an enabled extension, and it should show as just "Deprecated".

Resolves #128 
