### PR TITLE
Fix `/edit-profile` loading state

### DIFF
--- a/src/Entry.tsx
+++ b/src/Entry.tsx
@@ -5,8 +5,8 @@ import { IntlProvider } from 'react-intl';
 import { ApolloProvider } from '@apollo/client';
 
 import layout from '~styles/layout.css';
-import { DialogProvider } from '~shared/Dialog';
 import '~utils/yup/customMethods'; // ensures custom yup methods are available when components load
+import { DialogProvider } from '~shared/Dialog';
 // import { TokenActivationProvider } from '~users/TokenActivationProvider';
 
 import messages from './i18n/en.json';

--- a/src/components/common/ColonyHome/ColonyMembersWidget/MembersSubsection.tsx
+++ b/src/components/common/ColonyHome/ColonyMembersWidget/MembersSubsection.tsx
@@ -160,7 +160,6 @@ const MembersSubsection = ({
                 // banned={canAdministerComments && banned}
                 banned={false}
                 showInfo
-                notSet={false}
                 colony={colony}
                 user={user}
                 popperOptions={{

--- a/src/components/common/UserProfileEdit/UserAvatarUploader.tsx
+++ b/src/components/common/UserProfileEdit/UserAvatarUploader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { defineMessages } from 'react-intl';
 
 import AvatarUploader from '~shared/AvatarUploader';
@@ -6,7 +6,6 @@ import UserAvatar from '~shared/UserAvatar';
 
 import { User } from '~types';
 import { useUpdateUserProfileMutation } from '~gql';
-import { useAppContext } from '~hooks';
 import { FileReaderFile } from '~utils/fileReader/types';
 
 const displayName = 'common.UserProfileEdit.UserAvatarUploader';
@@ -27,7 +26,6 @@ const UserAvatarUploader = ({
   user,
   user: { walletAddress, profile },
 }: Props) => {
-  const { updateUser } = useAppContext();
   const [avatar, setAvatar] = useState<string | null>(profile?.avatar || null);
   const [updateAvatar, { error }] = useUpdateUserProfileMutation();
   const updatedUser = {
@@ -57,12 +55,6 @@ const UserAvatarUploader = ({
     });
     setAvatar(null);
   };
-
-  // on dismount
-  useEffect(
-    () => () => updateUser?.(user.walletAddress),
-    [updateUser, user.walletAddress],
-  );
 
   return (
     <AvatarUploader

--- a/src/components/common/UserProfileEdit/UserMainSettings.tsx
+++ b/src/components/common/UserProfileEdit/UserMainSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { defineMessages } from 'react-intl';
 import { string, object, InferType } from 'yup';
 
@@ -84,8 +84,8 @@ const UserMainSettings = ({
     location: profile?.location || '',
   };
 
-  const handleSubmit = (updatedProfile: FormValues) => {
-    editUser({
+  const handleSubmit = async (updatedProfile: FormValues) => {
+    await editUser({
       variables: {
         input: {
           id: walletAddress,
@@ -94,15 +94,10 @@ const UserMainSettings = ({
         },
       },
     });
+
+    updateUser?.(walletAddress, true);
   };
 
-  useEffect(
-    // update user on dismount
-    () => () => {
-      updateUser?.(walletAddress);
-    },
-    [walletAddress],
-  );
   return (
     <>
       <UserInfo user={user} />

--- a/src/components/common/UserProfileEdit/UserProfileEdit.tsx
+++ b/src/components/common/UserProfileEdit/UserProfileEdit.tsx
@@ -4,9 +4,8 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import { Tab, TabList, TabPanel, Tabs } from '~shared/Tabs';
 
 import ProfileTemplate from '~frame/ProfileTemplate';
-import LandingPage from '~frame/LandingPage';
 
-import { useAppContext } from '~hooks';
+import { useCanEditProfile } from '~hooks';
 
 import UserProfileSpinner from '../UserProfile/UserProfileSpinner';
 import {
@@ -29,14 +28,15 @@ const MSG = defineMessages({
 });
 
 const UserProfileEdit = () => {
-  const { user, userLoading } = useAppContext();
+  const { loadingProfile, user } = useCanEditProfile();
 
-  if (userLoading || user === undefined) {
+  if (loadingProfile) {
     return <UserProfileSpinner />;
   }
 
-  if (user === null) {
-    return <LandingPage />;
+  // By this point, if user is null or undefined, we'll be redirected to /landing by useCanEditProfile.
+  if (!user) {
+    return null;
   }
 
   return (

--- a/src/components/frame/AvatarDropdown/AvatarDropdown.tsx
+++ b/src/components/frame/AvatarDropdown/AvatarDropdown.tsx
@@ -97,8 +97,8 @@ const AvatarDropdown = ({ preventTransactions = false, spinnerMsg }: Props) => {
           <UserAvatar
             address={wallet?.address || ''}
             size="s"
-            notSet={false}
             user={user}
+            notSet={!wallet}
           />
         </button>
       )}

--- a/src/components/shared/InfoPopover/UserInfo.tsx
+++ b/src/components/shared/InfoPopover/UserInfo.tsx
@@ -23,7 +23,7 @@ const UserInfo = ({ user: { walletAddress, name, profile }, user }: Props) => {
    */
   return (
     <div className={styles.container}>
-      <UserAvatar size="s" address={walletAddress} user={user} notSet={false} />
+      <UserAvatar size="s" address={walletAddress} user={user} />
       <div className={styles.textContainer}>
         {profile?.displayName && (
           <Heading

--- a/src/components/shared/UserAvatar/UserAvatar.tsx
+++ b/src/components/shared/UserAvatar/UserAvatar.tsx
@@ -35,7 +35,6 @@ const UserAvatar = ({
   address,
   banned = false,
   colony,
-  notSet = true,
   popperOptions,
   showInfo,
   showLink,
@@ -68,7 +67,6 @@ const UserAvatar = ({
       >
         <Avatar
           avatar={imageString}
-          notSet={notSet}
           placeholderIcon="circle-person"
           seed={address && address.toLowerCase()}
           title={

--- a/src/components/shared/UserInfoPopover/UserInfo.tsx
+++ b/src/components/shared/UserInfoPopover/UserInfo.tsx
@@ -20,12 +20,7 @@ const UserInfo = ({ user }: Props) => {
 
   return (
     <div className={styles.container}>
-      <UserAvatar
-        size="s"
-        address={user.walletAddress}
-        user={user}
-        notSet={false}
-      />
+      <UserAvatar size="s" address={user.walletAddress} user={user} />
       <div className={styles.textContainer}>
         {userDisplayName && (
           <Heading

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -34,6 +34,7 @@ export { default as useTitle } from './useTitle';
 export { default as useTokenInfo, TokenInfoProvider } from './useTokenInfo';
 export { default as useUserAvatarImageFromIPFS } from './useUserAvatarImageFromIPFS';
 export { default as useUserSettings, SlotKey } from './useUserSettings';
+export { default as useCanEditProfile } from './useCanEditProfile';
 export { default as useWindowSize } from './useWindowSize';
 export { default as useAppContext } from './useAppContext';
 export { default as useUserReputation } from './useUserReputation';

--- a/src/hooks/useCanEditProfile.ts
+++ b/src/hooks/useCanEditProfile.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
+
+import { LANDING_PAGE_ROUTE } from '~routes';
+import { getLastWallet } from '~utils/autoLogin';
+import { useAppContext } from '~hooks';
+
+const useCanEditProfile = () => {
+  const { user, userLoading, walletConnecting } = useAppContext();
+
+  const navigate = useNavigate();
+  // If there's a last wallet label, it means we're logged in.
+  // If null, we're logged out and should be redirected to landing page.
+  const lastWalletLabel = getLastWallet();
+
+  useEffect(() => {
+    // cannot edit profile if we're logged out or no there's no registered user in db.
+    if (lastWalletLabel === null || user === null) {
+      navigate(LANDING_PAGE_ROUTE);
+    }
+  }, [user, lastWalletLabel]);
+
+  return {
+    loadingProfile: userLoading || walletConnecting,
+    user,
+  };
+};
+
+export default useCanEditProfile;


### PR DESCRIPTION
## Description

This PR fixes [the problem](https://github.com/JoinColony/colonyCDapp/pull/79#issuecomment-1341046043) with the loading state at `/edit-profile`.

## Testing

I have covered the following scenarios:

1. Navigate to /edit-profile with no wallet connected. --> redirects to /landing
2. Connect wallet to a wallet with a registered user, then navigate to edit-profile. --> displays Profile Edit screen
3. While on edit-profile, refresh the browser. --> shows loading spinner, then displays Profile Edit screen
4. Disconnect wallet while at edit-profile --> redirects to /landing
5. Navigate to edit-profile with a wallet that doesn't have a user associated. --> shows loading spinner, then redirects to /landing

Please double-check each and any others you can think of.

**New stuff** ✨

* `useCanEditProfile.ts` to manage loading states and redirect to landing

Resolves #134
