### PR TITLE
Port Extension Details

### DIFF
--- a/src/components/common/Extensions/ExtensionActionButton/ExtensionActionButton.tsx
+++ b/src/components/common/Extensions/ExtensionActionButton/ExtensionActionButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { defineMessages } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 
-import { useColonyContext } from '~hooks';
+import { useAppContext, useColonyContext } from '~hooks';
 import { ActionTypes } from '~redux';
 import Button, { ActionButton, IconButton } from '~shared/Button';
 import { AnyExtensionData } from '~types';
@@ -29,8 +29,9 @@ interface Props {
 const ExtensionActionButton = ({ extensionData }: Props) => {
   const navigate = useNavigate();
   const { colony } = useColonyContext();
+  const { user } = useAppContext();
 
-  if (!colony) {
+  if (!colony || !user) {
     return null;
   }
 

--- a/src/components/common/Extensions/ExtensionDetails/ExtensionDetails.css
+++ b/src/components/common/Extensions/ExtensionDetails/ExtensionDetails.css
@@ -33,3 +33,13 @@
   padding-top: 24px;
   white-space: pre-line;
 }
+
+.installedBy {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.contractAddress {
+  cursor: pointer;
+}

--- a/src/components/common/Extensions/ExtensionDetails/ExtensionDetails.css.d.ts
+++ b/src/components/common/Extensions/ExtensionDetails/ExtensionDetails.css.d.ts
@@ -3,9 +3,11 @@ declare namespace ExtensionDetailsCssNamespace {
     buttonWrapper: string;
     cellData: string;
     cellLabel: string;
+    contractAddress: string;
     extensionText: string;
     header: string;
     headerLine: string;
+    installedBy: string;
     main: string;
   }
 }

--- a/src/components/common/Extensions/ExtensionDetails/ExtensionDetails.tsx
+++ b/src/components/common/Extensions/ExtensionDetails/ExtensionDetails.tsx
@@ -114,27 +114,6 @@ const ExtensionDetails = () => {
                     h4: HeadingChunks,
                   }}
                 />
-
-                {/* @NOTE: This is some ugly displayed extension info until we have a nice table */}
-                <div>
-                  Details of <FormattedMessage {...extensionData.name} />
-                  <br />
-                  {isInstalledExtensionData(extensionData) ? (
-                    <>
-                      <div>
-                        Is Initialized:{' '}
-                        {extensionData.isInitialized ? 'yes' : 'no'}
-                      </div>
-                      <div>
-                        Is Deprecated:{' '}
-                        {extensionData.isDeprecated ? 'yes' : 'no'}
-                      </div>
-                      <div>Version: {extensionData.currentVersion}</div>
-                    </>
-                  ) : (
-                    <div>This extension is not installed</div>
-                  )}
-                </div>
               </div>
             }
           />

--- a/src/components/common/Extensions/ExtensionDetails/ExtensionDetails.tsx
+++ b/src/components/common/Extensions/ExtensionDetails/ExtensionDetails.tsx
@@ -71,19 +71,19 @@ const ExtensionDetails = () => {
     breadCrumbs.push(MSG.setup);
   }
 
+  const hasRegisteredProfile = !!user;
   // @TODO: Extend these checks to include permissions, account and network interaction
   const canExtensionBeUninstalled = !!(
+    hasRegisteredProfile &&
     isInstalledExtensionData(extensionData) &&
     extensionData.uninstallable &&
     extensionData.isDeprecated
   );
   const canExtensionBeDeprecated =
+    hasRegisteredProfile &&
     isInstalledExtensionData(extensionData) &&
     extensionData.uninstallable &&
     !extensionData.isDeprecated;
-  // @TODO: Check if the latest network extension version is greater than the current version
-  const canExtensionBeUpgraded =
-    !!user?.profile && isInstalledExtensionData(extensionData);
 
   return (
     <div className={styles.main}>
@@ -132,7 +132,6 @@ const ExtensionDetails = () => {
         extensionData={extensionData}
         canBeDeprecated={canExtensionBeDeprecated}
         canBeUninstalled={canExtensionBeUninstalled}
-        canBeUpgraded={canExtensionBeUpgraded}
       />
     </div>
   );

--- a/src/components/common/Extensions/ExtensionDetails/ExtensionDetails.tsx
+++ b/src/components/common/Extensions/ExtensionDetails/ExtensionDetails.tsx
@@ -32,6 +32,12 @@ const MSG = defineMessages({
   },
 });
 
+const HeadingChunks = (chunks: React.ReactNode[]) => (
+  <Heading tagName="h4" appearance={{ size: 'medium', margin: 'small' }}>
+    {chunks}
+  </Heading>
+);
+
 const ExtensionDetails = () => {
   const { extensionId } = useParams();
   const { colony } = useColonyContext();
@@ -102,8 +108,12 @@ const ExtensionDetails = () => {
                   text={extensionData.name}
                 />
 
-                {/* @TODO: Handle h4 chunks */}
-                <FormattedMessage {...extensionData.descriptionLong} />
+                <FormattedMessage
+                  {...extensionData.descriptionLong}
+                  values={{
+                    h4: HeadingChunks,
+                  }}
+                />
 
                 {/* @NOTE: This is some ugly displayed extension info until we have a nice table */}
                 <div>

--- a/src/components/common/Extensions/ExtensionDetails/ExtensionDetails.tsx
+++ b/src/components/common/Extensions/ExtensionDetails/ExtensionDetails.tsx
@@ -33,6 +33,7 @@ const MSG = defineMessages({
 });
 
 const HeadingChunks = (chunks: React.ReactNode[]) => (
+  // @TODO: Change to Heading4 component
   <Heading tagName="h4" appearance={{ size: 'medium', margin: 'small' }}>
     {chunks}
   </Heading>
@@ -91,7 +92,6 @@ const ExtensionDetails = () => {
         <BreadCrumb elements={breadCrumbs} />
         <hr className={styles.headerLine} />
       </div>
-
       <div>
         <Routes>
           <Route
@@ -123,7 +123,6 @@ const ExtensionDetails = () => {
               element={<ExtensionSetup extensionData={extensionData} />}
             />
           )}
-
           <Route path="*" element={<NotFoundRoute />} />
         </Routes>
       </div>

--- a/src/components/common/Extensions/ExtensionDetails/ExtensionDetailsAside.tsx
+++ b/src/components/common/Extensions/ExtensionDetails/ExtensionDetailsAside.tsx
@@ -10,9 +10,9 @@ import { useColonyContext } from '~hooks';
 
 import ExtensionActionButton from '../ExtensionActionButton';
 import ExtensionUpgradeButton from '../ExtensionUpgradeButton';
+import { getTableData } from './tableData';
 
 import styles from './ExtensionDetails.css';
-import { getTableData } from './tableData';
 
 export const displayName =
   'common.Extensions.ExtensionDetails.ExtensionDetailsAside';

--- a/src/components/common/Extensions/ExtensionDetails/ExtensionDetailsAside.tsx
+++ b/src/components/common/Extensions/ExtensionDetails/ExtensionDetailsAside.tsx
@@ -1,58 +1,23 @@
 import React from 'react';
-import { defineMessages, FormattedDate, FormattedMessage } from 'react-intl';
+import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { ActionTypes } from '~redux';
 import { DialogActionButton } from '~shared/Button';
 import { ConfirmDialog } from '~shared/Dialog';
 import { Table, TableBody, TableRow, TableCell } from '~shared/Table';
 import { AnyExtensionData, InstalledExtensionData } from '~types';
-import { isInstalledExtensionData } from '~utils/extensions';
 import { useColonyContext } from '~hooks';
-import DetailsWidgetUser from '~shared/DetailsWidgetUser';
-import InvisibleCopyableAddress from '~shared/InvisibleCopyableAddress';
-import MaskedAddress from '~shared/MaskedAddress';
 
 import ExtensionActionButton from '../ExtensionActionButton';
 import ExtensionUpgradeButton from '../ExtensionUpgradeButton';
-import ExtensionStatusBadge from '../ExtensionStatusBadge';
 
 import styles from './ExtensionDetails.css';
+import { getTableData } from './tableData';
 
-const displayName = 'common.Extensions.ExtensionDetails.ExtensionDetailsAside';
+export const displayName =
+  'common.Extensions.ExtensionDetails.ExtensionDetailsAside';
 
 const MSG = defineMessages({
-  status: {
-    id: `${displayName}.status`,
-    defaultMessage: 'Status',
-  },
-  installedBy: {
-    id: `${displayName}.ExtensionDetails.installedBy`,
-    defaultMessage: 'Installed by',
-  },
-  dateInstalled: {
-    id: `${displayName}.dateInstalled`,
-    defaultMessage: 'Date installed',
-  },
-  dateCreated: {
-    id: `${displayName}.dateCreated`,
-    defaultMessage: 'Date created',
-  },
-  latestVersion: {
-    id: `${displayName}.latestVersion`,
-    defaultMessage: 'Latest version',
-  },
-  developer: {
-    id: `${displayName}.developer`,
-    defaultMessage: 'Developer',
-  },
-  versionInstalled: {
-    id: `${displayName}.versionInstalled`,
-    defaultMessage: 'Version installed',
-  },
-  contractAddress: {
-    id: `${displayName}.contractAddress`,
-    defaultMessage: 'Contract address',
-  },
   buttonDeprecate: {
     id: `${displayName}.buttonDeprecate`,
     defaultMessage: 'Deprecate',
@@ -111,70 +76,6 @@ const ExtensionDetailsAside = ({
   const { extensionId } = extensionData;
   const { colonyAddress } = colony;
 
-  // @TODO: Display all available data
-  const tableData = isInstalledExtensionData(extensionData)
-    ? [
-        {
-          label: MSG.status,
-          value: <ExtensionStatusBadge extensionData={extensionData} />,
-        },
-        {
-          label: MSG.installedBy,
-          value: (
-            <span className={styles.installedBy}>
-              <DetailsWidgetUser
-                colony={colony}
-                walletAddress={extensionData.installedBy}
-              />
-            </span>
-          ),
-        },
-        {
-          label: MSG.dateInstalled,
-          value: <FormattedDate value={extensionData.installedAt * 1000} />,
-        },
-        {
-          label: MSG.versionInstalled,
-          value: `v${extensionData.currentVersion}`,
-        },
-        {
-          label: MSG.contractAddress,
-          value: (
-            <InvisibleCopyableAddress address={extensionData.address}>
-              <span className={styles.contractAddress}>
-                <MaskedAddress address={extensionData.address} />
-              </span>
-            </InvisibleCopyableAddress>
-          ),
-        },
-        {
-          label: MSG.developer,
-          value: 'Colony',
-        },
-      ]
-    : [
-        {
-          label: MSG.status,
-          value: <ExtensionStatusBadge extensionData={extensionData} />,
-        },
-        {
-          label: MSG.dateCreated,
-          value: <FormattedDate value={extensionData.createdAt} />,
-        },
-        {
-          label: MSG.latestVersion,
-          value: `v${extensionData.availableVersion}`,
-          // @TODO: Add extension compatibility map
-          // icon: !extensionCompatible && (
-          //   <Icon name="triangle-warning" title={MSG.warning} />
-          // ),
-        },
-        {
-          label: MSG.developer,
-          value: 'Colony',
-        },
-      ];
-
   return (
     <aside>
       <div className={styles.buttonWrapper}>
@@ -186,7 +87,7 @@ const ExtensionDetailsAside = ({
 
       <Table appearance={{ theme: 'lined' }}>
         <TableBody>
-          {tableData.map(
+          {getTableData(extensionData, colony).map(
             ({
               label,
               value,

--- a/src/components/common/Extensions/ExtensionDetails/ExtensionDetailsAside.tsx
+++ b/src/components/common/Extensions/ExtensionDetails/ExtensionDetailsAside.tsx
@@ -95,14 +95,12 @@ interface Props {
   extensionData: AnyExtensionData;
   canBeDeprecated: boolean;
   canBeUninstalled: boolean;
-  canBeUpgraded: boolean;
 }
 
 const ExtensionDetailsAside = ({
   extensionData,
   canBeDeprecated,
   canBeUninstalled,
-  canBeUpgraded,
 }: Props) => {
   const { colony } = useColonyContext();
 
@@ -181,11 +179,9 @@ const ExtensionDetailsAside = ({
     <aside>
       <div className={styles.buttonWrapper}>
         <ExtensionActionButton extensionData={extensionData} />
-        {canBeUpgraded && (
-          <ExtensionUpgradeButton
-            extensionData={extensionData as InstalledExtensionData}
-          />
-        )}
+        <ExtensionUpgradeButton
+          extensionData={extensionData as InstalledExtensionData}
+        />
       </div>
 
       <Table appearance={{ theme: 'lined' }}>

--- a/src/components/common/Extensions/ExtensionDetails/ExtensionDetailsAside.tsx
+++ b/src/components/common/Extensions/ExtensionDetails/ExtensionDetailsAside.tsx
@@ -8,6 +8,9 @@ import { Table, TableBody, TableRow, TableCell } from '~shared/Table';
 import { AnyExtensionData, InstalledExtensionData } from '~types';
 import { isInstalledExtensionData } from '~utils/extensions';
 import { useColonyContext } from '~hooks';
+import DetailsWidgetUser from '~shared/DetailsWidgetUser';
+import InvisibleCopyableAddress from '~shared/InvisibleCopyableAddress';
+import MaskedAddress from '~shared/MaskedAddress';
 
 import ExtensionActionButton from '../ExtensionActionButton';
 import ExtensionUpgradeButton from '../ExtensionUpgradeButton';
@@ -41,6 +44,14 @@ const MSG = defineMessages({
   developer: {
     id: `${displayName}.developer`,
     defaultMessage: 'Developer',
+  },
+  versionInstalled: {
+    id: `${displayName}.versionInstalled`,
+    defaultMessage: 'Version installed',
+  },
+  contractAddress: {
+    id: `${displayName}.contractAddress`,
+    defaultMessage: 'Contract address',
   },
   buttonDeprecate: {
     id: `${displayName}.buttonDeprecate`,
@@ -112,22 +123,35 @@ const ExtensionDetailsAside = ({
         {
           label: MSG.installedBy,
           value: (
-            // <span className={styles.installedBy}>
-            //   <DetailsWidgetUser
-            //     colony={colony}
-            //     walletAddress={extensionData.instaleldBy}
-            //   />
-            // </span>
-            <span>{extensionData.installedBy}</span>
+            <span className={styles.installedBy}>
+              <DetailsWidgetUser
+                colony={colony}
+                walletAddress={extensionData.installedBy}
+              />
+            </span>
           ),
         },
         {
           label: MSG.dateInstalled,
+          value: <FormattedDate value={extensionData.installedAt * 1000} />,
+        },
+        {
+          label: MSG.versionInstalled,
+          value: `v${extensionData.currentVersion}`,
+        },
+        {
+          label: MSG.contractAddress,
           value: (
-            <span>
-              {new Date(extensionData.installedAt * 1000).toISOString()}
-            </span>
+            <InvisibleCopyableAddress address={extensionData.address}>
+              <span className={styles.contractAddress}>
+                <MaskedAddress address={extensionData.address} />
+              </span>
+            </InvisibleCopyableAddress>
           ),
+        },
+        {
+          label: MSG.developer,
+          value: 'Colony',
         },
       ]
     : [

--- a/src/components/common/Extensions/ExtensionDetails/ExtensionDetailsAside.tsx
+++ b/src/components/common/Extensions/ExtensionDetails/ExtensionDetailsAside.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, FormattedDate, FormattedMessage } from 'react-intl';
 
 import { ActionTypes } from '~redux';
 import { DialogActionButton } from '~shared/Button';
@@ -29,6 +29,18 @@ const MSG = defineMessages({
   dateInstalled: {
     id: `${displayName}.dateInstalled`,
     defaultMessage: 'Date installed',
+  },
+  dateCreated: {
+    id: `${displayName}.dateCreated`,
+    defaultMessage: 'Date created',
+  },
+  latestVersion: {
+    id: `${displayName}.latestVersion`,
+    defaultMessage: 'Latest version',
+  },
+  developer: {
+    id: `${displayName}.developer`,
+    defaultMessage: 'Developer',
   },
   buttonDeprecate: {
     id: `${displayName}.buttonDeprecate`,
@@ -122,6 +134,22 @@ const ExtensionDetailsAside = ({
         {
           label: MSG.status,
           value: <ExtensionStatusBadge extensionData={extensionData} />,
+        },
+        {
+          label: MSG.dateCreated,
+          value: <FormattedDate value={extensionData.createdAt} />,
+        },
+        {
+          label: MSG.latestVersion,
+          value: `v${extensionData.availableVersion}`,
+          // @TODO: Add extension compatibility map
+          // icon: !extensionCompatible && (
+          //   <Icon name="triangle-warning" title={MSG.warning} />
+          // ),
+        },
+        {
+          label: MSG.developer,
+          value: 'Colony',
         },
       ];
 

--- a/src/components/common/Extensions/ExtensionDetails/tableData.tsx
+++ b/src/components/common/Extensions/ExtensionDetails/tableData.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { MessageDescriptor, defineMessages, FormattedDate } from 'react-intl';
 
-import { AnyExtensionData, Colony } from '~types';
+import {
+  AnyExtensionData,
+  Colony,
+  InstallableExtensionData,
+  InstalledExtensionData,
+} from '~types';
 import { isInstalledExtensionData } from '~utils/extensions';
 import DetailsWidgetUser from '~shared/DetailsWidgetUser';
 import InvisibleCopyableAddress from '~shared/InvisibleCopyableAddress';
@@ -52,57 +57,59 @@ export type TableRowData = {
   value: string | JSX.Element;
 };
 
-export const getTableData = (
-  extensionData: AnyExtensionData,
+const getInstalledExtensionTableData = (
+  extensionData: InstalledExtensionData,
   colony: Colony,
-): TableRowData[] => {
-  const statusRow = {
-    label: MSG.status,
-    value: <ExtensionStatusBadge extensionData={extensionData} />,
-  };
-  const developerRow = {
-    label: MSG.developer,
-    value: 'Colony',
-  };
-
-  if (isInstalledExtensionData(extensionData)) {
-    return [
-      statusRow,
-      {
-        label: MSG.installedBy,
-        value: (
-          <span className={styles.installedBy}>
-            <DetailsWidgetUser
-              colony={colony}
-              walletAddress={extensionData.installedBy}
-            />
-          </span>
-        ),
-      },
-      {
-        label: MSG.dateInstalled,
-        value: <FormattedDate value={extensionData.installedAt * 1000} />,
-      },
-      {
-        label: MSG.versionInstalled,
-        value: `v${extensionData.currentVersion}`,
-      },
-      {
-        label: MSG.contractAddress,
-        value: (
-          <InvisibleCopyableAddress address={extensionData.address}>
-            <span className={styles.contractAddress}>
-              <MaskedAddress address={extensionData.address} />
-            </span>
-          </InvisibleCopyableAddress>
-        ),
-      },
-      developerRow,
-    ];
-  }
-
+) => {
   return [
-    statusRow,
+    {
+      label: MSG.status,
+      value: <ExtensionStatusBadge extensionData={extensionData} />,
+    },
+    {
+      label: MSG.installedBy,
+      value: (
+        <span className={styles.installedBy}>
+          <DetailsWidgetUser
+            colony={colony}
+            walletAddress={extensionData.installedBy}
+          />
+        </span>
+      ),
+    },
+    {
+      label: MSG.dateInstalled,
+      value: <FormattedDate value={extensionData.installedAt * 1000} />,
+    },
+    {
+      label: MSG.versionInstalled,
+      value: `v${extensionData.currentVersion}`,
+    },
+    {
+      label: MSG.contractAddress,
+      value: (
+        <InvisibleCopyableAddress address={extensionData.address}>
+          <span className={styles.contractAddress}>
+            <MaskedAddress address={extensionData.address} />
+          </span>
+        </InvisibleCopyableAddress>
+      ),
+    },
+    {
+      label: MSG.developer,
+      value: 'Colony',
+    },
+  ];
+};
+
+const getInstallableExtensionData = (
+  extensionData: InstallableExtensionData,
+) => {
+  return [
+    {
+      label: MSG.status,
+      value: <ExtensionStatusBadge extensionData={extensionData} />,
+    },
     {
       label: MSG.dateCreated,
       value: <FormattedDate value={extensionData.createdAt} />,
@@ -115,6 +122,18 @@ export const getTableData = (
       //   <Icon name="triangle-warning" title={MSG.warning} />
       // ),
     },
-    developerRow,
+    {
+      label: MSG.developer,
+      value: 'Colony',
+    },
   ];
+};
+
+export const getTableData = (
+  extensionData: AnyExtensionData,
+  colony: Colony,
+): TableRowData[] => {
+  return isInstalledExtensionData(extensionData)
+    ? getInstalledExtensionTableData(extensionData, colony)
+    : getInstallableExtensionData(extensionData);
 };

--- a/src/components/common/Extensions/ExtensionDetails/tableData.tsx
+++ b/src/components/common/Extensions/ExtensionDetails/tableData.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { MessageDescriptor, defineMessages, FormattedDate } from 'react-intl';
+
+import { AnyExtensionData, Colony } from '~types';
+import { isInstalledExtensionData } from '~utils/extensions';
+import DetailsWidgetUser from '~shared/DetailsWidgetUser';
+import InvisibleCopyableAddress from '~shared/InvisibleCopyableAddress';
+import MaskedAddress from '~shared/MaskedAddress';
+
+import ExtensionStatusBadge from '../ExtensionStatusBadge';
+import { displayName } from './ExtensionDetailsAside';
+
+import styles from './ExtensionDetails.css';
+
+const MSG = defineMessages({
+  status: {
+    id: `${displayName}.status`,
+    defaultMessage: 'Status',
+  },
+  installedBy: {
+    id: `${displayName}.installedBy`,
+    defaultMessage: 'Installed by',
+  },
+  dateInstalled: {
+    id: `${displayName}.dateInstalled`,
+    defaultMessage: 'Date installed',
+  },
+  dateCreated: {
+    id: `${displayName}.dateCreated`,
+    defaultMessage: 'Date created',
+  },
+  latestVersion: {
+    id: `${displayName}.latestVersion`,
+    defaultMessage: 'Latest version',
+  },
+  developer: {
+    id: `${displayName}.developer`,
+    defaultMessage: 'Developer',
+  },
+  versionInstalled: {
+    id: `${displayName}.versionInstalled`,
+    defaultMessage: 'Version installed',
+  },
+  contractAddress: {
+    id: `${displayName}.contractAddress`,
+    defaultMessage: 'Contract address',
+  },
+});
+
+export type TableRowData = {
+  label: MessageDescriptor;
+  value: string | JSX.Element;
+};
+
+export const getTableData = (
+  extensionData: AnyExtensionData,
+  colony: Colony,
+): TableRowData[] => {
+  const statusRow = {
+    label: MSG.status,
+    value: <ExtensionStatusBadge extensionData={extensionData} />,
+  };
+  const developerRow = {
+    label: MSG.developer,
+    value: 'Colony',
+  };
+
+  if (isInstalledExtensionData(extensionData)) {
+    return [
+      statusRow,
+      {
+        label: MSG.installedBy,
+        value: (
+          <span className={styles.installedBy}>
+            <DetailsWidgetUser
+              colony={colony}
+              walletAddress={extensionData.installedBy}
+            />
+          </span>
+        ),
+      },
+      {
+        label: MSG.dateInstalled,
+        value: <FormattedDate value={extensionData.installedAt * 1000} />,
+      },
+      {
+        label: MSG.versionInstalled,
+        value: `v${extensionData.currentVersion}`,
+      },
+      {
+        label: MSG.contractAddress,
+        value: (
+          <InvisibleCopyableAddress address={extensionData.address}>
+            <span className={styles.contractAddress}>
+              <MaskedAddress address={extensionData.address} />
+            </span>
+          </InvisibleCopyableAddress>
+        ),
+      },
+      developerRow,
+    ];
+  }
+
+  return [
+    statusRow,
+    {
+      label: MSG.dateCreated,
+      value: <FormattedDate value={extensionData.createdAt} />,
+    },
+    {
+      label: MSG.latestVersion,
+      value: `v${extensionData.availableVersion}`,
+      // @TODO: Add extension compatibility map
+      // icon: !extensionCompatible && (
+      //   <Icon name="triangle-warning" title={MSG.warning} />
+      // ),
+    },
+    developerRow,
+  ];
+};

--- a/src/components/common/Extensions/ExtensionUpgradeButton/ExtensionUpgradeButton.tsx
+++ b/src/components/common/Extensions/ExtensionUpgradeButton/ExtensionUpgradeButton.tsx
@@ -22,15 +22,17 @@ const ExtensionUpgradeButton = ({ extensionData }: Props) => {
   const { colony } = useColonyContext();
   const { user } = useAppContext();
 
-  if (!isInstalledExtensionData(extensionData)) {
+  if (
+    !isInstalledExtensionData(extensionData) ||
+    extensionData.currentVersion >= extensionData.availableVersion
+  ) {
     return null;
   }
 
-  // @TODO: Check if the latest network extension version is greater than the current version
   const transform = mapPayload(() => ({
     colonyAddress: colony?.colonyAddress,
     extensionId: extensionData.extensionId,
-    version: extensionData.currentVersion + 1,
+    version: extensionData.availableVersion,
   }));
 
   if (!user?.profile || !colony) {

--- a/src/components/common/Extensions/ExtensionUpgradeButton/ExtensionUpgradeButton.tsx
+++ b/src/components/common/Extensions/ExtensionUpgradeButton/ExtensionUpgradeButton.tsx
@@ -40,6 +40,13 @@ const ExtensionUpgradeButton = ({ extensionData }: Props) => {
     colony.version as ColonyVersion,
   );
 
+  if (
+    !user?.profile ||
+    extensionData.isDeprecated ||
+    !extensionData.isInitialized
+  ) {
+    return null;
+  }
   // @TODO check user permissions for canUpgrade - hasRoot(allUserRoles)
   const canUpgrade = true;
 

--- a/src/components/common/Extensions/ExtensionUpgradeButton/ExtensionUpgradeButton.tsx
+++ b/src/components/common/Extensions/ExtensionUpgradeButton/ExtensionUpgradeButton.tsx
@@ -7,20 +7,26 @@ import {
 } from '@colony/colony-js';
 
 import { ActionButton } from '~shared/Button';
-import { InstalledExtensionData } from '~types';
+import { AnyExtensionData } from '~types';
 import { ActionTypes } from '~redux/index';
 import { mapPayload } from '~utils/actions';
 import { useAppContext, useColonyContext } from '~hooks';
 import { MIN_SUPPORTED_COLONY_VERSION } from '~constants';
+import { isInstalledExtensionData } from '~utils/extensions';
 
 interface Props {
-  extensionData: InstalledExtensionData;
+  extensionData: AnyExtensionData;
 }
 
 const ExtensionUpgradeButton = ({ extensionData }: Props) => {
   const { colony } = useColonyContext();
   const { user } = useAppContext();
 
+  if (!isInstalledExtensionData(extensionData)) {
+    return null;
+  }
+
+  // @TODO: Check if the latest network extension version is greater than the current version
   const transform = mapPayload(() => ({
     colonyAddress: colony?.colonyAddress,
     extensionId: extensionData.extensionId,
@@ -40,11 +46,7 @@ const ExtensionUpgradeButton = ({ extensionData }: Props) => {
     colony.version as ColonyVersion,
   );
 
-  if (
-    !user?.profile ||
-    extensionData.isDeprecated ||
-    !extensionData.isInitialized
-  ) {
+  if (!user || extensionData.isDeprecated || !extensionData.isInitialized) {
     return null;
   }
   // @TODO check user permissions for canUpgrade - hasRoot(allUserRoles)

--- a/src/components/shared/DetailsWidgetUser/DetailsWidgetUser.css.d.ts
+++ b/src/components/shared/DetailsWidgetUser/DetailsWidgetUser.css.d.ts
@@ -1,4 +1,15 @@
-export const main: string;
-export const textContainer: string;
-export const address: string;
-export const username: string;
+declare namespace DetailsWidgetUserCssNamespace {
+  export interface IDetailsWidgetUserCss {
+    address: string;
+    main: string;
+    textContainer: string;
+    username: string;
+  }
+}
+
+declare const DetailsWidgetUserCssModule: DetailsWidgetUserCssNamespace.IDetailsWidgetUserCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: DetailsWidgetUserCssNamespace.IDetailsWidgetUserCss;
+};
+
+export = DetailsWidgetUserCssModule;

--- a/src/components/shared/DetailsWidgetUser/DetailsWidgetUser.tsx
+++ b/src/components/shared/DetailsWidgetUser/DetailsWidgetUser.tsx
@@ -1,25 +1,29 @@
 import React from 'react';
 
-import HookedUserAvatar from '~users/HookedUserAvatar';
 import MaskedAddress from '~shared/MaskedAddress';
 import InvisibleCopyableAddress from '~shared/InvisibleCopyableAddress';
-import { useUser, Colony } from '~data/index';
-import { Address } from '~types';
+import { Address, Colony } from '~types';
+import UserAvatar from '~shared/UserAvatar';
+import { useGetCurrentUserQuery } from '~gql';
 
 import styles from './DetailsWidgetUser.css';
 
 const displayName = 'DetailsWidgetUser';
 
 interface Props {
-  colony?: Colony;
+  colony: Colony;
   walletAddress: Address;
 }
 
 const DetailsWidgetUser = ({ colony, walletAddress }: Props) => {
-  const UserAvatar = HookedUserAvatar({ fetchUser: false });
-  const userProfile = useUser(walletAddress);
-  const userDisplayName = userProfile?.profile?.displayName;
-  const username = userProfile?.profile?.username;
+  const { data } = useGetCurrentUserQuery({
+    variables: {
+      address: walletAddress,
+    },
+  });
+  const user = data?.getUserByAddress?.items?.[0];
+  const userDisplayName = user?.profile?.displayName;
+  const username = user?.name;
 
   return (
     <div className={styles.main}>
@@ -27,7 +31,7 @@ const DetailsWidgetUser = ({ colony, walletAddress }: Props) => {
         colony={colony}
         size="s"
         notSet={false}
-        user={userProfile}
+        user={user || undefined}
         address={walletAddress || ''}
         showInfo
         popperOptions={{

--- a/src/components/shared/InfoPopover/InfoPopover.tsx
+++ b/src/components/shared/InfoPopover/InfoPopover.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, useMemo } from 'react';
 import { PopperOptions } from 'react-popper-tooltip';
 
 import Popover from '~shared/Popover';
-import { AnyUser, AnyToken, Colony } from '~data/index';
+import { Colony, Token, User } from '~types';
 
 import MemberInfoPopover from './MemberInfoPopover';
 import TokenInfoPopover from './TokenInfoPopover';
@@ -10,17 +10,16 @@ import UserInfoPopover from './UserInfoPopover';
 
 interface TokenContentProps {
   isTokenNative?: boolean;
-  token?: AnyToken;
+  token?: Token;
 }
 
 interface BasicUserContentProps {
-  user?: AnyUser;
+  user?: User;
 }
 
 interface MemberContentProps {
   colony?: Colony;
-  domainId?: number | undefined;
-  user?: AnyUser;
+  user?: User;
 }
 
 type ContentProps =
@@ -55,15 +54,8 @@ const InfoPopover = ({
       'colony' in contentProps &&
       typeof contentProps.colony !== 'undefined'
     ) {
-      const { colony, domainId, user } = contentProps;
-      return (
-        <MemberInfoPopover
-          colony={colony}
-          domainId={domainId}
-          user={user}
-          banned={banned}
-        />
-      );
+      const { colony, user } = contentProps;
+      return <MemberInfoPopover colony={colony} user={user} banned={banned} />;
     }
     if ('token' in contentProps && typeof contentProps.token !== 'undefined') {
       const { isTokenNative, token } = contentProps;
@@ -81,7 +73,7 @@ const InfoPopover = ({
 
   return (
     <Popover
-      content={renderContent}
+      renderContent={renderContent}
       popperOptions={popperOptions}
       trigger={trigger}
       showArrow={showArrow}

--- a/src/components/shared/InfoPopover/MemberInfoPopover/MemberInfoPopover.tsx
+++ b/src/components/shared/InfoPopover/MemberInfoPopover/MemberInfoPopover.tsx
@@ -1,82 +1,74 @@
 import React from 'react';
-import isEmpty from 'lodash/isEmpty';
-import { BigNumber } from 'ethers';
+// import isEmpty from 'lodash/isEmpty';
+// import { BigNumber } from 'ethers';
 
 import { SpinnerLoader } from '~shared/Preloaders';
 import Tag from '~shared/Tag';
-import {
-  AnyUser,
-  useColonyNativeTokenQuery,
-  Colony,
-  useUserBalanceWithLockQuery,
-  useUserReputationForTopDomainsQuery,
-} from '~data/index';
-import { useTransformer, useAppContext } from '~hooks';
-import { getAllUserRoles } from '~modules/transformers';
-import UserInfo from '../UserInfo';
+// import {
+//   useColonyNativeTokenQuery,
+//   useUserBalanceWithLockQuery,
+//   useUserReputationForTopDomainsQuery,
+// } from '~data/index';
+import { /* useTransformer, */ useAppContext, useUserReputation } from '~hooks';
+import { Colony, User } from '~types';
+// import { getAllUserRoles } from '~modules/transformers';
 
-import UserPermissions from './UserPermissions';
-import UserTokens from './UserTokens';
+import UserInfo from '../UserInfo';
+// import UserPermissions from './UserPermissions';
+// import UserTokens from './UserTokens';
 import UserReputation from './UserReputation';
 
 import styles from './MemberInfoPopover.css';
 
 interface Props {
   colony: Colony;
-  user?: AnyUser;
+  user?: User;
   banned?: boolean;
 }
 
 const displayName = 'InfoPopover.MemberInfoPopover';
 
-const MemberInfoPopover = ({
-  colony: { colonyAddress },
-  colony,
-  user = { id: '', profile: { walletAddress: '' } },
-  banned = false,
-}: Props) => {
-  const { wallet } = useAppContext();
-  const {
-    profile: { walletAddress },
-  } = user;
+const MemberInfoPopover = ({ colony, user, banned = false }: Props) => {
+  const { user: currentUser } = useAppContext();
 
-  const { data: nativeTokenAddressData, loading: loadingNativeTokenAddress } =
-    useColonyNativeTokenQuery({
-      variables: { address: colonyAddress },
-    });
+  // const { data: nativeTokenAddressData, loading: loadingNativeTokenAddress } =
+  //   useColonyNativeTokenQuery({
+  //     variables: { address: colonyAddress },
+  //   });
 
-  const { data: userReputationData, loading: loadingUserReputation } =
-    useUserReputationForTopDomainsQuery({
-      variables: { address: walletAddress, colonyAddress },
-    });
+  const { userReputation, loading } = useUserReputation(
+    colony.colonyAddress,
+    user?.walletAddress,
+  );
 
-  const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
-  const { data: userBalanceData, loading: loadingUserBalance } =
-    useUserBalanceWithLockQuery({
-      variables: {
-        address: walletAddress,
-        tokenAddress:
-          nativeTokenAddressData?.processedColony.nativeTokenAddress || '',
-        colonyAddress,
-      },
-      /*
-      The fetchPolicy here is "no-cache" because otherwise the result would be stored
-      in the cache and then the current user's balance would change (in the other instances
-      where the current user balance is obtained using this query) to the one that it's being
-      displayed in the popover.
+  // const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
+  // const { data: userBalanceData, loading: loadingUserBalance } =
+  //   useUserBalanceWithLockQuery({
+  //     variables: {
+  //       address: walletAddress,
+  //       tokenAddress:
+  //         nativeTokenAddressData?.processedColony.nativeTokenAddress || '',
+  //       colonyAddress,
+  //     },
+  //     /*
+  //     The fetchPolicy here is "no-cache" because otherwise the result would be stored
+  //     in the cache and then the current user's balance would change (in the other instances
+  //     where the current user balance is obtained using this query) to the one that it's being
+  //     displayed in the popover.
 
-      It could also happen in reverse, the current user's balance could show up here instead
-      of the balance of a "second person" user.
+  //     It could also happen in reverse, the current user's balance could show up here instead
+  //     of the balance of a "second person" user.
 
-      Basically, all sorts of shenanigans happen when this result is stored on the cache.
-    */
-      fetchPolicy: 'no-cache',
-    });
+  //     Basically, all sorts of shenanigans happen when this result is stored on the cache.
+  //   */
+  //     fetchPolicy: 'no-cache',
+  //   });
 
   if (
-    loadingNativeTokenAddress ||
-    loadingUserReputation ||
-    loadingUserBalance
+    // loadingNativeTokenAddress ||
+    // loadingUserReputation ||
+    // loadingUserBalance
+    loading
   ) {
     return (
       <div className={`${styles.main} ${styles.loadingSpinnerContainer}`}>
@@ -90,13 +82,13 @@ const MemberInfoPopover = ({
       </div>
     );
   }
-  const nativeToken = userBalanceData?.user.userLock.nativeToken;
-  const userLock = userBalanceData?.user.userLock;
-  const inactiveBalance = BigNumber.from(userLock?.nativeToken?.balance || 0);
-  const lockedBalance = BigNumber.from(userLock?.totalObligation || 0);
-  const activeBalance = BigNumber.from(userLock?.activeTokens || 0);
+  // const nativeToken = userBalanceData?.user.userLock.nativeToken;
+  // const userLock = userBalanceData?.user.userLock;
+  // const inactiveBalance = BigNumber.from(userLock?.nativeToken?.balance || 0);
+  // const lockedBalance = BigNumber.from(userLock?.totalObligation || 0);
+  // const activeBalance = BigNumber.from(userLock?.activeTokens || 0);
 
-  const totalBalance = inactiveBalance.add(activeBalance).add(lockedBalance);
+  // const totalBalance = inactiveBalance.add(activeBalance).add(lockedBalance);
 
   return (
     <div>
@@ -106,32 +98,32 @@ const MemberInfoPopover = ({
         </div>
       )}
       <div className={styles.main}>
-        {user?.profile?.walletAddress && (
+        {user?.walletAddress && (
           <div className={styles.section}>
             <UserInfo user={user} />
           </div>
         )}
-        {userReputationData && (
+        {userReputation && (
           <div className={styles.section}>
             <UserReputation
               colony={colony}
-              userReputationForTopDomains={
-                userReputationData?.userReputationForTopDomains || []
+              userReputationForTopDomains={userReputation}
+              isCurrentUserReputation={
+                user?.walletAddress === currentUser?.walletAddress
               }
-              isCurrentUserReputation={wallet?.address === walletAddress}
             />
           </div>
         )}
-        {!totalBalance.isZero() && nativeToken && (
+        {/* {!totalBalance.isZero() && nativeToken && (
           <div className={styles.section}>
             <UserTokens totalBalance={totalBalance} nativeToken={nativeToken} />
           </div>
-        )}
-        {!isEmpty(allUserRoles) && (
+        )} */}
+        {/* {!isEmpty(allUserRoles) && (
           <div className={styles.section}>
             <UserPermissions roles={allUserRoles} />
           </div>
-        )}
+        )} */}
       </div>
     </div>
   );

--- a/src/components/shared/InfoPopover/TokenInfo.tsx
+++ b/src/components/shared/InfoPopover/TokenInfo.tsx
@@ -5,9 +5,7 @@ import { AddressZero } from '@ethersproject/constants';
 import CopyableAddress from '~shared/CopyableAddress';
 import TokenLink from '~shared/TokenLink';
 import Button from '~shared/Button';
-
-import TokenIcon from '~dashboard/HookedTokenIcon';
-import { AnyToken } from '~data/index';
+import { Token } from '~types';
 import { DEFAULT_NETWORK_INFO } from '~constants';
 
 import styles from './InfoPopover.css';
@@ -28,7 +26,7 @@ const MSG = defineMessages({
 });
 
 interface Props {
-  token: AnyToken;
+  token: Token;
   isTokenNative: boolean;
 }
 
@@ -38,7 +36,7 @@ const TokenInfo = ({ token, isTokenNative }: Props) => {
   const {
     name,
     symbol,
-    address,
+    tokenAddress,
     // decimals,
   } = token;
 
@@ -62,11 +60,11 @@ const TokenInfo = ({ token, isTokenNative }: Props) => {
       <div className={styles.section}>
         {name && (
           <div title={name} className={styles.displayName}>
-            <TokenIcon
+            {/* <TokenIcon
               token={token}
               name={token.name || undefined}
               size="xxs"
-            />
+            /> */}
             {name}
           </div>
         )}
@@ -75,8 +73,8 @@ const TokenInfo = ({ token, isTokenNative }: Props) => {
             {symbol}
           </p>
         )}
-        <div title={address} className={styles.address}>
-          <CopyableAddress full>{address}</CopyableAddress>
+        <div title={tokenAddress} className={styles.address}>
+          <CopyableAddress full>{tokenAddress}</CopyableAddress>
         </div>
         {isTokenNative && (
           <p className={styles.nativeTokenMessage}>
@@ -87,13 +85,13 @@ const TokenInfo = ({ token, isTokenNative }: Props) => {
       <div className={styles.section}>
         <TokenLink
           className={styles.etherscanLink}
-          tokenAddress={address}
+          tokenAddress={tokenAddress}
           text={MSG.viewOnEtherscan}
           textValues={{
             blockExplorerName: DEFAULT_NETWORK_INFO.blockExplorerName,
           }}
         />
-        {address !== AddressZero && (
+        {tokenAddress !== AddressZero && (
           <span className={styles.addToWallet}>
             <Button
               appearance={{ theme: 'blue' }}

--- a/src/components/shared/InfoPopover/TokenInfoPopover.tsx
+++ b/src/components/shared/InfoPopover/TokenInfoPopover.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { isEmpty } from 'lodash';
 
-import { AnyToken } from '~data/index';
+import { Token } from '~types';
 
 import TokenInfo from './TokenInfo';
 import NotAvailableMessage from './NotAvailableMessage';
@@ -9,7 +9,7 @@ import NotAvailableMessage from './NotAvailableMessage';
 import styles from './InfoPopover.css';
 
 interface Props {
-  token?: AnyToken;
+  token?: Token;
   isTokenNative: boolean;
 }
 

--- a/src/components/shared/InfoPopover/UserInfo.tsx
+++ b/src/components/shared/InfoPopover/UserInfo.tsx
@@ -4,36 +4,19 @@ import CopyableAddress from '~shared/CopyableAddress';
 import Heading from '~shared/Heading';
 import UserMention from '~shared/UserMention';
 import UserAvatar from '~shared/UserAvatar';
-
-import { AnyUser } from '~data/index';
-import useUserAvatarImageFromIPFS from '~utils/hooks/useUserAvatarImageFromIPFS';
+import { User } from '~types';
 
 import styles from './InfoPopover.css';
 
 interface Props {
-  user: AnyUser;
+  user: User;
 }
 
 const displayName = 'InfoPopover.UserInfo';
 
-const UserInfo = ({
-  user: {
-    profile: {
-      displayName: userDisplayName,
-      username,
-      walletAddress,
-      avatarHash,
-    },
-  },
-  user,
-}: Props) => {
-  /*
-   * @NOTE We have to fetch our avatar base64 data from IPFS because if we
-   * use the "normal" HookedUserAvar we cause a circular call which will
-   * exceed the call stack (obviously) and break React
-   */
-  const { image: avatarData } =
-    useUserAvatarImageFromIPFS(avatarHash || '') || {};
+const UserInfo = ({ user }: Props) => {
+  const { walletAddress, profile } = user;
+  const { displayName: userDisplayName } = profile || {};
   return (
     <div className={styles.container}>
       <UserAvatar
@@ -41,7 +24,7 @@ const UserInfo = ({
         address={walletAddress}
         user={user}
         notSet={false}
-        avatarURL={avatarData}
+        avatarURL={user.profile?.avatar ?? ''}
       />
       <div className={styles.textContainer}>
         {userDisplayName && (
@@ -50,16 +33,11 @@ const UserInfo = ({
             text={userDisplayName}
           />
         )}
-        {username && (
-          /*
-           * @NOTE Potential recurrsion loop here.
-           *
-           * Never pass `showInfo` to this instance of UserMention, otherwise you'll trigger it
-           */
-          <p className={styles.userName}>
-            <UserMention username={username} hasLink />
-          </p>
-        )}
+        {/* @NOTE Potential recurrsion loop here. * * Never pass `showInfo` to
+          this instance of UserMention, otherwise you'll trigger it */}
+        <p className={styles.userName}>
+          <UserMention username={user.name} hasLink />
+        </p>
         <div className={styles.address}>
           <CopyableAddress full>{walletAddress}</CopyableAddress>
         </div>

--- a/src/components/shared/UserAvatar/UserAvatar.tsx
+++ b/src/components/shared/UserAvatar/UserAvatar.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { PopperOptions } from 'react-popper-tooltip';
 
 import Avatar from '~shared/Avatar';
-// import InfoPopover, { Props as InfoPopoverProps } from '~shared/InfoPopover';
-// import Link from '~shared/NavLink';
-import { Address, User } from '~types';
-// import { getUsername } from '~redux/transformers';
+import InfoPopover, { Props as InfoPopoverProps } from '~shared/InfoPopover';
+import Link from '~shared/NavLink';
+import { Address, Colony, User } from '~types';
+import { getMainClasses } from '~utils/css';
 
 import styles from './UserAvatar.css';
 
@@ -43,9 +43,7 @@ interface BaseProps {
 
 /** Used for the infopopover */
 interface PropsForReputation extends BaseProps {
-  // colony?: Colony;
-  colony?: Record<string, unknown>;
-  domainId?: number;
+  colony?: Colony;
 }
 
 export type Props = BaseProps | PropsForReputation;
@@ -57,71 +55,56 @@ const UserAvatar = ({
   avatarURL,
   className,
   showInfo,
-  // showLink,
+  showLink,
   notSet,
-  // popperOptions,
+  popperOptions,
   size,
-  // banned = false,
+  banned = false,
   user,
-}: // ...rest
-Props) => {
-  // const username = getUsername(user);
-  // const username = 'tempUser';
-  // let popoverProps: InfoPopoverProps = {
-  //   popperOptions,
-  //   trigger: showInfo ? 'click' : 'disabled',
-  //   user,
-  //   showArrow: popperOptions && popperOptions.showArrow,
-  // };
-  // if ('colony' in rest) {
-  //   const { colony, domainId } = rest;
-  //   popoverProps = {
-  //     ...popoverProps,
-  //     banned,
-  //     colony,
-  //     domainId,
-  //   };
-  // }
-  // const avatar = (
-  //   <InfoPopover {...popoverProps}>
-  //     <div
-  //       // @ts-ignore
-  //       className={getMainClasses({}, styles, {
-  //         showOnClick: popoverProps.trigger === 'click',
-  //       })}
-  //     >
-  //       <Avatar
-  //         avatarURL={avatarURL}
-  //         className={className}
-  //         notSet={typeof notSet === 'undefined' ? true : notSet}
-  //         placeholderIcon="circle-person"
-  //         seed={address && address.toLowerCase()}
-  //         size={size}
-  //         title={showInfo ? '' : username || address}
-  //       />
-  //     </div>
-  //   </InfoPopover>
-  // );
-  // if (showLink && username) {
-  //   // Won't this always be lowercase?
-  //   return <Link to={`/user/${username.toLowerCase()}`}>{avatar}</Link>;
-  // }
-  // return avatar;
-  return (
-    <div className={styles.main}>
-      <Avatar
-        avatarURL={avatarURL}
-        className={className}
-        notSet={notSet ?? true}
-        placeholderIcon="circle-person"
-        seed={address && address.toLowerCase()}
-        size={size}
-        title={
-          showInfo ? '' : user?.profile?.displayName || user?.name || address
-        }
-      />
-    </div>
+  ...rest
+}: Props) => {
+  let popoverProps: InfoPopoverProps = {
+    popperOptions,
+    trigger: showInfo ? 'click' : 'disabled',
+    user,
+    showArrow: !!popperOptions?.showArrow,
+  };
+  if ('colony' in rest) {
+    const { colony } = rest;
+    popoverProps = {
+      ...popoverProps,
+      banned,
+      colony,
+    };
+  }
+  const avatar = (
+    <InfoPopover {...popoverProps}>
+      <div
+        className={getMainClasses(
+          {},
+          styles as unknown as { [k: string]: string },
+          {
+            showOnClick: popoverProps.trigger === 'click',
+          },
+        )}
+      >
+        <Avatar
+          avatarURL={avatarURL}
+          className={className}
+          notSet={notSet ?? true}
+          placeholderIcon="circle-person"
+          seed={address && address.toLowerCase()}
+          size={size}
+          title={showInfo ? '' : user?.name || address}
+        />
+      </div>
+    </InfoPopover>
   );
+  if (showLink && user?.name) {
+    // Won't this always be lowercase?
+    return <Link to={`/user/${user.name.toLowerCase()}`}>{avatar}</Link>;
+  }
+  return avatar;
 };
 
 UserAvatar.displayName = displayName;

--- a/src/components/shared/UserAvatar/UserAvatar.tsx
+++ b/src/components/shared/UserAvatar/UserAvatar.tsx
@@ -3,14 +3,11 @@ import { PopperOptions } from 'react-popper-tooltip';
 
 import Avatar from '~shared/Avatar';
 // import InfoPopover, { Props as InfoPopoverProps } from '~shared/InfoPopover';
-import Link from '~shared/NavLink';
-import { Address } from '~types';
-// import { AnyUser, Colony } from '~data/index';
+// import Link from '~shared/NavLink';
+import { Address, User } from '~types';
 // import { getUsername } from '~redux/transformers';
-import { User } from '~types';
 
 import styles from './UserAvatar.css';
-import { getMainClasses } from '~utils/css';
 
 interface BaseProps {
   /** Address of the current user for identicon fallback */
@@ -38,7 +35,6 @@ interface BaseProps {
   size?: 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl';
 
   /** The corresponding user object if available */
-  // user?: AnyUser;
   user?: User;
 
   /** Banned comment status */
@@ -61,14 +57,14 @@ const UserAvatar = ({
   avatarURL,
   className,
   showInfo,
-  showLink,
+  // showLink,
   notSet,
-  popperOptions,
+  // popperOptions,
   size,
-  banned = false,
+  // banned = false,
   user,
-  ...rest
-}: Props) => {
+}: // ...rest
+Props) => {
   // const username = getUsername(user);
   // const username = 'tempUser';
   // let popoverProps: InfoPopoverProps = {
@@ -112,17 +108,19 @@ const UserAvatar = ({
   // }
   // return avatar;
   return (
-    <Avatar
-      avatarURL={avatarURL}
-      className={className}
-      notSet={typeof notSet === 'undefined' ? true : notSet}
-      placeholderIcon="circle-person"
-      seed={address && address.toLowerCase()}
-      size={size}
-      title={
-        showInfo ? '' : user?.profile?.displayName || user?.name || address
-      }
-    />
+    <div className={styles.main}>
+      <Avatar
+        avatarURL={avatarURL}
+        className={className}
+        notSet={typeof notSet === 'undefined' ? true : notSet}
+        placeholderIcon="circle-person"
+        seed={address && address.toLowerCase()}
+        size={size}
+        title={
+          showInfo ? '' : user?.profile?.displayName || user?.name || address
+        }
+      />
+    </div>
   );
 };
 

--- a/src/components/shared/UserAvatar/UserAvatar.tsx
+++ b/src/components/shared/UserAvatar/UserAvatar.tsx
@@ -112,7 +112,7 @@ Props) => {
       <Avatar
         avatarURL={avatarURL}
         className={className}
-        notSet={typeof notSet === 'undefined' ? true : notSet}
+        notSet={notSet ?? true}
         placeholderIcon="circle-person"
         seed={address && address.toLowerCase()}
         size={size}

--- a/src/components/shared/UserMention/UserMention.tsx
+++ b/src/components/shared/UserMention/UserMention.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { PopperOptions } from 'react-popper-tooltip';
 
 import Link from '~shared/Link';
-import InfoPopover, { Props as InfoPopoverProps } from '~shared/InfoPopover';
-
-import { useUserQuery, useUserAddressQuery } from '~data/index';
+// import InfoPopover, { Props as InfoPopoverProps } from '~shared/InfoPopover';
 
 import styles from './UserMention.css';
 
@@ -33,25 +31,25 @@ const UserMention = ({
   to,
   hasLink,
   showInfo,
-  popperOptions,
+  // popperOptions,
   ...props
 }: Props) => {
   const fallbackTo = to || `/user/${username}`;
-  const popoverProps: Partial<InfoPopoverProps> = {
-    popperOptions,
-    trigger: showInfo ? 'click' : 'disabled',
-    showArrow: popperOptions && popperOptions.showArrow,
-  };
+  // const popoverProps: Partial<InfoPopoverProps> = {
+  //   popperOptions,
+  //   trigger: showInfo ? 'click' : 'disabled',
+  //   showArrow: popperOptions && popperOptions.showArrow,
+  // };
 
-  const { data: userAddressData } = useUserAddressQuery({
-    variables: {
-      name: username || '',
-    },
-  });
+  // const { data: userAddressData } = useUserAddressQuery({
+  //   variables: {
+  //     name: username || '',
+  //   },
+  // });
 
-  const { data } = useUserQuery({
-    variables: { address: userAddressData?.userAddress || '' },
-  });
+  // const { data } = useUserQuery({
+  //   variables: { address: userAddressData?.userAddress || '' },
+  // });
 
   const renderUserMention = () =>
     hasLink ? (
@@ -72,13 +70,15 @@ const UserMention = ({
     return renderUserMention();
   }
 
-  const { user } = data || {};
+  return null;
 
-  return (
-    <InfoPopover user={user} {...popoverProps}>
-      {renderUserMention()}
-    </InfoPopover>
-  );
+  // const { user } = data || {};
+
+  // return (
+  //   <InfoPopover user={user} {...popoverProps}>
+  //     {renderUserMention()}
+  //   </InfoPopover>
+  // );
 };
 
 export default UserMention;

--- a/src/constants/extensions.ts
+++ b/src/constants/extensions.ts
@@ -139,6 +139,7 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
     neededColonyPermissions: [ColonyRole.Administration, ColonyRole.Funding],
     // @NOTE: This is for testing only, should be set to false afterwards
     uninstallable: true,
+    createdAt: 1557698400000,
   },
   {
     extensionId: Extension.VotingReputation,
@@ -259,5 +260,6 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
       },
     ],
     uninstallable: true,
+    createdAt: 1603915271852,
   },
 ];

--- a/src/hooks/useUserReputation.ts
+++ b/src/hooks/useUserReputation.ts
@@ -7,6 +7,7 @@ import { useGetUserReputationQuery } from '~gql';
 interface UseUserReputationHook {
   userReputation?: string;
   totalReputation?: string;
+  loading: boolean;
 }
 
 const useUserReputation = (
@@ -15,37 +16,40 @@ const useUserReputation = (
   domainId = Id.RootDomain,
   rootHash?: string,
 ): UseUserReputationHook => {
-  const { data: userReputationData } = useGetUserReputationQuery({
-    variables: {
-      input: {
-        colonyAddress: colonyAddress ?? '',
-        walletAddress: walletAddress ?? '',
-        domainId,
-        rootHash,
+  const { data: userReputationData, loading: loadingUserReputation } =
+    useGetUserReputationQuery({
+      variables: {
+        input: {
+          colonyAddress: colonyAddress ?? '',
+          walletAddress: walletAddress ?? '',
+          domainId,
+          rootHash,
+        },
       },
-    },
-    fetchPolicy: 'cache-and-network',
-    skip: !colonyAddress || !walletAddress,
-  });
+      fetchPolicy: 'cache-and-network',
+      skip: !colonyAddress || !walletAddress,
+    });
   const userReputation = userReputationData?.getUserReputation ?? undefined;
 
-  const { data: totalReputationData } = useGetUserReputationQuery({
-    variables: {
-      input: {
-        colonyAddress: colonyAddress ?? '',
-        walletAddress: ADDRESS_ZERO,
-        domainId,
-        rootHash,
+  const { data: totalReputationData, loading: loadingTotalReputation } =
+    useGetUserReputationQuery({
+      variables: {
+        input: {
+          colonyAddress: colonyAddress ?? '',
+          walletAddress: ADDRESS_ZERO,
+          domainId,
+          rootHash,
+        },
       },
-    },
-    fetchPolicy: 'cache-and-network',
-    skip: !colonyAddress,
-  });
+      fetchPolicy: 'cache-and-network',
+      skip: !colonyAddress,
+    });
   const totalReputation = totalReputationData?.getUserReputation ?? undefined;
 
   return {
     userReputation,
     totalReputation,
+    loading: loadingUserReputation || loadingTotalReputation,
   };
 };
 

--- a/src/types/extensions.ts
+++ b/src/types/extensions.ts
@@ -34,6 +34,7 @@ export interface ExtensionConfig {
   neededColonyPermissions: ColonyRole[];
   initializationParams?: ExtensionInitParam[];
   uninstallable: boolean;
+  createdAt: number;
 }
 
 export type InstalledExtensionData = ExtensionConfig &


### PR DESCRIPTION
## Description

This PR ports over the missing parts of `ExtensionDetails`. It also fixes the React Intl warning in console as well as refactoring the checks for allowed interactions (installing, enabling, upgrading, etc.) to simplify things.

To test, look at the details page of an installed and uninstalled extension. You should see results similar to the screenshots below.

<img width="380" alt="image" src="https://user-images.githubusercontent.com/112586815/211217829-50dccfa6-99e6-4537-9e66-d0235c37e5ce.png">

<img width="925" alt="image" src="https://user-images.githubusercontent.com/112586815/211217941-443ad16c-8530-4ab6-91fc-747b996e86af.png">

Resolves #124 and #146 