### PR TITLE
Implement Custom Rpc Validation

### DIFF
--- a/src/components/common/UserProfileEdit/AdvancedSettingsRow.css
+++ b/src/components/common/UserProfileEdit/AdvancedSettingsRow.css
@@ -43,11 +43,6 @@
   color: var(--dark);
 }
 
-.validateButtonContainer {
-  display: flex;
-  justify-content: flex-end;
-}
-
 .settingsRowExtra {
   margin-top: 8px;
 }

--- a/src/components/common/UserProfileEdit/AdvancedSettingsRow.css.d.ts
+++ b/src/components/common/UserProfileEdit/AdvancedSettingsRow.css.d.ts
@@ -13,7 +13,6 @@ declare namespace AdvancedSettingsRowCssNamespace {
     toggleContainer: string;
     tooltipContainer: string;
     tooltipContent: string;
-    validateButtonContainer: string;
     version: string;
   }
 }

--- a/src/components/common/UserProfileEdit/AdvancedSettingsRow.tsx
+++ b/src/components/common/UserProfileEdit/AdvancedSettingsRow.tsx
@@ -101,7 +101,6 @@ export const getAdvancedSettingsRows = (
         label={MSG.labelRPC}
         inputName={SlotKey.CustomRPC}
         toggleName={SlotKey.DecentralizedMode}
-        handleValidation={undefined} // @TODO validation to be added later.
       />
     ),
   },

--- a/src/components/common/UserProfileEdit/CustomEndpointInput.css
+++ b/src/components/common/UserProfileEdit/CustomEndpointInput.css
@@ -1,0 +1,3 @@
+.main {
+  padding-top: 10px;
+}

--- a/src/components/common/UserProfileEdit/CustomEndpointInput.css.d.ts
+++ b/src/components/common/UserProfileEdit/CustomEndpointInput.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace CustomEndpointInputCssNamespace {
+  export interface ICustomEndpointInputCss {
+    main: string;
+  }
+}
+
+declare const CustomEndpointInputCssModule: CustomEndpointInputCssNamespace.ICustomEndpointInputCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: CustomEndpointInputCssNamespace.ICustomEndpointInputCss;
+};
+
+export = CustomEndpointInputCssModule;

--- a/src/components/common/UserProfileEdit/CustomEndpointInput.tsx
+++ b/src/components/common/UserProfileEdit/CustomEndpointInput.tsx
@@ -1,62 +1,37 @@
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
-import { defineMessages, MessageDescriptor } from 'react-intl';
+import { MessageDescriptor } from 'react-intl';
 
-import Button from '~shared/Button';
 import { HookFormInput as Input } from '~shared/Fields';
 import { noSpaces } from '~utils/cleave';
 
-import styles from './AdvancedSettingsRow.css';
-
 const displayName = 'common.UserProfileEdit.CustomEndpointInput';
 
-const MSG = defineMessages({
-  validate: {
-    id: `${displayName}.validate`,
-    defaultMessage: 'Validate',
-  },
-});
-
 interface CustomEndpointInputProps {
-  handleValidation?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   inputName: string;
   label: MessageDescriptor;
   toggleName: string;
 }
 
 const CustomEndpointInput = ({
-  handleValidation,
   inputName,
   label,
   toggleName,
 }: CustomEndpointInputProps) => {
-  const {
-    watch,
-    formState: { isValid },
-  } = useFormContext();
+  const { watch } = useFormContext();
 
   const toggleOn: boolean = watch(toggleName);
   const inputValue: string = watch(inputName);
 
   return (
-    <>
-      <Input
-        label={label}
-        appearance={{ colorSchema: 'grey' }}
-        name={inputName}
-        disabled={!toggleOn}
-        formattingOptions={noSpaces}
-        value={inputValue}
-      />
-      <div className={styles.validateButtonContainer}>
-        <Button
-          text={MSG.validate}
-          disabled={!toggleOn || !isValid}
-          onClick={handleValidation}
-          // @TODO Make button conditional on handleValidation being defined (once rpc validation added)
-        />
-      </div>
-    </>
+    <Input
+      label={label}
+      appearance={{ colorSchema: 'grey' }}
+      name={inputName}
+      disabled={!toggleOn}
+      formattingOptions={noSpaces}
+      value={inputValue}
+    />
   );
 };
 

--- a/src/components/common/UserProfileEdit/CustomEndpointInput.tsx
+++ b/src/components/common/UserProfileEdit/CustomEndpointInput.tsx
@@ -5,6 +5,8 @@ import { MessageDescriptor } from 'react-intl';
 import { HookFormInput as Input } from '~shared/Fields';
 import { noSpaces } from '~utils/cleave';
 
+import styles from './CustomEndpointInput.css';
+
 const displayName = 'common.UserProfileEdit.CustomEndpointInput';
 
 interface CustomEndpointInputProps {
@@ -24,14 +26,16 @@ const CustomEndpointInput = ({
   const inputValue: string = watch(inputName);
 
   return (
-    <Input
-      label={label}
-      appearance={{ colorSchema: 'grey' }}
-      name={inputName}
-      disabled={!toggleOn}
-      formattingOptions={noSpaces}
-      value={inputValue}
-    />
+    <div className={styles.main}>
+      <Input
+        label={label}
+        appearance={{ colorSchema: 'grey' }}
+        name={inputName}
+        disabled={!toggleOn}
+        formattingOptions={noSpaces}
+        value={inputValue}
+      />
+    </div>
   );
 };
 

--- a/src/components/common/UserProfileEdit/UserAdvancedSettings.tsx
+++ b/src/components/common/UserProfileEdit/UserAdvancedSettings.tsx
@@ -43,7 +43,7 @@ const validationSchema = object({
   [SlotKey.DecentralizedMode]: bool<boolean>(),
   [SlotKey.CustomRPC]: string()
     .defined()
-    .when(`${[SlotKey.DecentralizedMode]}`, {
+    .when(`${SlotKey.DecentralizedMode}`, {
       is: true,
       then: string()
         .required(() => MSG.invalidURLError)

--- a/src/components/common/UserProfileEdit/validation.ts
+++ b/src/components/common/UserProfileEdit/validation.ts
@@ -1,0 +1,26 @@
+import { ethers } from 'ethers';
+
+export const isValidURL = (url: string) => {
+  if (!url) {
+    return false;
+  }
+
+  try {
+    // Tidier than using a regex. URL Constructor will error if url string invalid.
+    // eslint-disable-next-line no-new
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export async function validateCustomGnosisRPC(rpcURL: string | undefined) {
+  const provider = new ethers.providers.JsonRpcProvider(rpcURL);
+  try {
+    await provider.send('eth_protocolVersion', []);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/components/shared/Fields/Input/HookForm/types.ts
+++ b/src/components/shared/Fields/Input/HookForm/types.ts
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { SetValueConfig } from 'react-hook-form';
 
-import { Message, SimpleMessageValues } from '~types';
+import { Message, SimpleMessageValues, UniversalMessageValues } from '~types';
 
 export interface MaxButtonParams {
   maxAmount: string;
@@ -15,7 +15,7 @@ export interface CoreInputProps {
   /** Label text */
   label?: Message;
   /** Label text values for intl interpolation */
-  labelValues?: SimpleMessageValues;
+  labelValues?: UniversalMessageValues;
   /** Set the input field to a disabled state */
   disabled?: boolean;
   /** Should display the input with the label hidden */
@@ -27,7 +27,7 @@ export interface CoreInputProps {
   /** Help text */
   help?: Message;
   /** Help text values for intl interpolation */
-  helpValues?: SimpleMessageValues;
+  helpValues?: UniversalMessageValues;
   /** Placeholder text */
   placeholder?: Message;
   /** Placeholder text values for intl interpolation */
@@ -35,5 +35,5 @@ export interface CoreInputProps {
   /** Status text */
   status?: Message;
   /** Status text values for intl interpolation */
-  statusValues?: SimpleMessageValues;
+  statusValues?: UniversalMessageValues;
 }

--- a/src/components/shared/Fields/InputStatus/HookForm/InputStatus.tsx
+++ b/src/components/shared/Fields/InputStatus/HookForm/InputStatus.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import { getMainClasses } from '~utils/css';
 import { formatText } from '~utils/intl';
-import { isNil } from '~utils/lodash';
 import { HookFormInputProps } from '~shared/Fields/Input/HookForm';
 import { Message } from '~types';
 
@@ -45,8 +44,7 @@ const HookFormInputStatus = ({
     <Element
       className={getMainClasses(appearance, styles, {
         error: !!error && !isLoading,
-        hidden:
-          (!text && !isLoading) || (!!error && !isNil(touched) && !touched),
+        hidden: (!text && !isLoading) || (!!error && !touched),
       })}
     >
       {isLoading ? loadingText : text}

--- a/src/utils/lodash.ts
+++ b/src/utils/lodash.ts
@@ -1,3 +1,2 @@
 export { default as once } from 'lodash/once';
 export { default as now } from 'lodash/now';
-export { default as isNil } from 'lodash/isNil';

--- a/src/utils/yup/tests/index.ts
+++ b/src/utils/yup/tests/index.ts
@@ -150,7 +150,7 @@ interface YupDebounceOptions {
  * which can improve performance.
  * @returns Debounced test function.
  */
-function yupDebounce(
+export function yupDebounce(
   fn: TestFunction,
   wait: number,
   options?: YupDebounceOptions,


### PR DESCRIPTION
## Description

This PR implements validation for a custom gnosis chain rpc in the user advanced settings. 


## Testing

Go to user advanced settings. Enter a url. Only a valid gnosis  rpc endpoint will validate (you can find some at [chainlist](https://chainlist.org/chain/100)) 

If URL is not a valid RPC: 

![unable](https://user-images.githubusercontent.com/64402732/214368263-88f8f196-b666-4dea-9370-80db2a662452.png)

If RPC is not gnosis:

![wrongid](https://user-images.githubusercontent.com/64402732/214374816-06bebe19-1cf3-4174-acd9-7b7c486f0738.png)


**New stuff** ✨

* Added gnosis chain rpc validation

**Deletions** ⚰️

* Removed the validate button since validation normally occurs automatically.

Resolves #145 
