### PR TITLE
Add `refreshEnabledExtension` util

### DIFF
--- a/src/redux/sagas/extensions/extensionEnable.ts
+++ b/src/redux/sagas/extensions/extensionEnable.ts
@@ -72,7 +72,7 @@ function* extensionEnable({
     return yield putError(ActionTypes.EXTENSION_ENABLE_ERROR, error, meta);
   }
 
-  yield call(refreshEnabledExtension, colonyAddress, extensionId);
+  refreshEnabledExtension(colonyAddress, extensionId);
 
   initChannel.close();
 

--- a/src/redux/sagas/extensions/extensionEnable.ts
+++ b/src/redux/sagas/extensions/extensionEnable.ts
@@ -6,6 +6,7 @@ import { getTxChannel } from '../transactions';
 import {
   modifyParams,
   putError,
+  refreshEnabledExtension,
   removeOldExtensionClients,
   setupEnablingGroupTransactions,
   takeFrom,
@@ -71,7 +72,7 @@ function* extensionEnable({
     return yield putError(ActionTypes.EXTENSION_ENABLE_ERROR, error, meta);
   }
 
-  // yield call(refreshExtensions);
+  yield call(refreshEnabledExtension, colonyAddress, extensionId);
 
   initChannel.close();
 

--- a/src/redux/sagas/utils/refreshExtension.ts
+++ b/src/redux/sagas/utils/refreshExtension.ts
@@ -114,3 +114,21 @@ export const refreshUninstalledExtension = (
 ) => {
   removeExtensionFromCache(colonyAddress, extensionId);
 };
+
+export const refreshEnabledExtension = (
+  colonyAddress: string,
+  extensionId: string,
+) => {
+  const existingExtension = getExistingExtension(colonyAddress, extensionId);
+
+  if (!existingExtension) {
+    return;
+  }
+
+  const modifiedExtension: ColonyExtension = {
+    ...existingExtension,
+    isInitialized: true,
+  };
+
+  saveExtensionInCache(modifiedExtension);
+};


### PR DESCRIPTION
## Description

This small PR adds a `refreshEnabledExtension` util, similarly to other functions from #147 

For testing, try to enable `VotingReputation`. You should see the status updated immediately. Please note, the status will revert back to Disabled when you refresh unless you follow the first two steps from [block-ingestor#3](https://github.com/JoinColony/block-ingestor/pull/3). Otherwise, the block ingestor simply won't pick up the enable event and won't update the db.

Resolves #152 
