### PR TITLE
Refactor wallet autologin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,4 @@ AWS_APPSYNC_GRAPHQL_URL="http://localhost:20002"
 # If the network has / or does not have support for metatranasctions
 # Ie: contracts deployed, broadcaster service active
 METATRANSACTIONS=true
+

--- a/src/components/frame/LandingPage/LandingPage.tsx
+++ b/src/components/frame/LandingPage/LandingPage.tsx
@@ -69,7 +69,7 @@ const LandingPage = () => {
   /* Ensures username is up-to-date post create user flow. */
   useEffect(() => {
     if (updateUser) {
-      updateUser(wallet?.address);
+      updateUser(wallet?.address, true);
     }
   }, [wallet, updateUser]);
 

--- a/src/components/frame/RouteLayouts/UserNavigation/Wallet/Wallet.tsx
+++ b/src/components/frame/RouteLayouts/UserNavigation/Wallet/Wallet.tsx
@@ -13,7 +13,8 @@ import {
 
 import { groupedTransactionsAndMessages } from '~redux/selectors';
 import { useAppContext, useMobile } from '~hooks';
-import { getLastWallet } from '~utils/autoLogin';
+import { getLastWallet, clearLastWallet } from '~utils/autoLogin';
+import { isBasicWallet } from '~types';
 
 import styles from './Wallet.css';
 
@@ -48,14 +49,14 @@ const Wallet = () => {
   );
 
   useLayoutEffect(() => {
-    if (!wallet && connectWallet && getLastWallet()) {
-      connectWallet();
+    if ((!wallet && getLastWallet()) || isBasicWallet(wallet)) {
+      connectWallet?.();
     }
   }, [connectWallet, wallet]);
 
   return (
     <>
-      {walletConnecting && (
+      {!wallet && walletConnecting && (
         <div className={styles.walletAutoLogin}>
           <MiniSpinnerLoader
             title={MSG.walletAutologin}
@@ -72,7 +73,10 @@ const Wallet = () => {
               : styles.connectWalletButton
           }
           text={MSG.connectWallet}
-          onClick={connectWallet}
+          onClick={() => {
+            clearLastWallet();
+            connectWallet?.();
+          }}
         />
       )}
       <span>

--- a/src/constants/externalUrls.ts
+++ b/src/constants/externalUrls.ts
@@ -1,7 +1,7 @@
 export const FEEDBACK = `https://portal.productboard.com/colony/1-colony-portal/tabs/4-bugs`;
 export const HELP = `https://colony.gitbook.io/colony`;
 export const BETA_DISCLAIMER = `https://colony.gitbook.io/colony/disclaimers/beta`;
-export const TERMS_AND_CONDITIONS = `https://colony.io/pdf/terms.pdf`;
+export const TERMS_AND_CONDITIONS = `https://colony.io/terms-of-service`;
 export const ADVANCED_SETTINGS = `https://colony.gitbook.io/colony/advanced-features/metatransactions`;
 
 /*

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,7 @@
 import { constants as ethersContants } from 'ethers';
 
+import { version } from '../../package.json';
+
 import { Network } from '~types';
 
 export * from './externalUrls';
@@ -152,3 +154,5 @@ export const ADDRESS_ZERO = ethersContants.AddressZero;
 export const GANACHE_LOCAL_RPC_URL = 'http://localhost:8545';
 
 export const isDev = process.env.NODE_ENV === 'development';
+
+export const CDAPP_VERSION = version;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -153,6 +153,6 @@ export const ADDRESS_ZERO = ethersContants.AddressZero;
 
 export const GANACHE_LOCAL_RPC_URL = 'http://localhost:8545';
 
-export const isDev = process.env.NODE_ENV === 'development';
+export const isDev = process.env.NETWORK === 'ganache';
 
 export const CDAPP_VERSION = version;

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,3 +1,4 @@
+import { utils } from 'ethers';
 import React, {
   createContext,
   useState,
@@ -5,7 +6,6 @@ import React, {
   ReactNode,
   useCallback,
 } from 'react';
-import { utils } from 'ethers';
 
 import { ActionTypes } from '~redux';
 import {
@@ -13,13 +13,13 @@ import {
   GetCurrentUserQuery,
   GetCurrentUserQueryVariables,
 } from '~gql';
-import { Wallet, User } from '~types';
+import { ColonyWallet, User } from '~types';
 import { useAsyncFunction } from '~hooks';
 
 import { getContext, ContextModule } from './index';
 
 export interface AppContextValues {
-  wallet?: Wallet;
+  wallet?: ColonyWallet | null;
   walletConnecting?: boolean;
   setWalletConnecting?: React.Dispatch<React.SetStateAction<boolean>>;
   user?: User | null;
@@ -35,7 +35,7 @@ export interface AppContextValues {
 export const AppContext = createContext<AppContextValues>({});
 
 export const AppContextProvider = ({ children }: { children: ReactNode }) => {
-  let initialWallet;
+  let initialWallet: ColonyWallet | undefined;
 
   /*
    * Wallet
@@ -47,7 +47,8 @@ export const AppContextProvider = ({ children }: { children: ReactNode }) => {
     // It means that it was not set in context yet
   }
 
-  const [wallet, setWallet] = useState(initialWallet);
+  const [wallet, setWallet] =
+    useState<AppContextValues['wallet']>(initialWallet);
   const [user, setUser] = useState<User | null | undefined>();
   const [userLoading, setUserLoading] = useState(false);
   const [walletConnecting, setWalletConnecting] = useState(false);
@@ -65,7 +66,7 @@ export const AppContextProvider = ({ children }: { children: ReactNode }) => {
             GetCurrentUserQueryVariables
           >({
             query: GetCurrentUserDocument,
-            variables: { address },
+            variables: { address: utils.getAddress(address) },
             fetchPolicy: 'network-only',
           });
           const [currentUser] = data?.getUserByAddress?.items || [];
@@ -90,8 +91,8 @@ export const AppContextProvider = ({ children }: { children: ReactNode }) => {
       updatedWallet.address = utils.getAddress(updatedWallet.address);
       setWallet(updatedWallet);
       // Update the user as soon as the wallet address changes
-      if (updatedWallet?.address !== wallet?.address) {
-        updateUser(updatedWallet?.address);
+      if (updatedWallet.address !== wallet?.address) {
+        updateUser(updatedWallet.address);
       }
     } catch (error) {
       if (wallet) {

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,6 +1,6 @@
 import { ApolloClient as ApolloClientClass } from '@apollo/client';
 
-import { Wallet as WalletType } from '~types';
+import { ColonyWallet } from '~types';
 
 import ColonyManagerClass from './ColonyManager';
 
@@ -20,13 +20,8 @@ export enum ContextModule {
   UserSettings = 'userSettings',
 }
 
-export interface IpfsWithFallbackSkeleton {
-  getString: (hash: string) => Promise<any>;
-  addString: (hash: string) => Promise<any>;
-}
-
 export interface Context {
-  [ContextModule.Wallet]?: WalletType;
+  [ContextModule.Wallet]?: ColonyWallet;
   [ContextModule.ColonyManager]?: ColonyManagerClass;
   [ContextModule.ApolloClient]?: ApolloClientClass<object>;
   [ContextModule.UserSettings]?: UserSettingsClass;
@@ -46,14 +41,11 @@ export const setContext = <K extends keyof Context>(
   context[contextKey] = contextValue;
 };
 
-export const getContext = <K extends keyof Context>(
-  contextKey: K,
-): NonNullable<Context[K]> => {
+export const getContext = <K extends keyof Context>(contextKey: K) => {
   const ctx = context[contextKey];
   if (!ctx) throw new Error(`Could not get context: ${contextKey}`);
-  // ctx is always defined from here on
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return ctx!;
+
+  return ctx;
 };
 
 export const removeContext = <K extends keyof Context>(contextKey: K) => {

--- a/src/hooks/useCanInteractWithColony.ts
+++ b/src/hooks/useCanInteractWithColony.ts
@@ -1,6 +1,7 @@
 import { Colony } from '~types';
-import { DEFAULT_NETWORK_INFO, NETWORK_AVAILABLE_CHAINS } from '~constants';
+import { DEFAULT_NETWORK_INFO } from '~constants';
 import { getWatchedColony } from '~utils/watching';
+import { isChainSupported } from '~utils/autoLogin';
 
 import useAppContext from './useAppContext';
 
@@ -18,21 +19,17 @@ export const useUserAccountRegistered = (): boolean => {
 export const useCanInteractWithNetwork = (): boolean => {
   const { wallet } = useAppContext();
   const userAccountRegistered = useUserAccountRegistered();
-
   /*
    * Short circuit early
    */
   if (!wallet) {
     return false;
   }
-  const [{ id: walletHexChainId }] = wallet.chains;
-  const userWalletChain = parseInt(walletHexChainId.slice(2), 16);
+  const [{ id: hexChainId }] = wallet.chains;
 
-  const networkContractsAvailable = Object.keys(NETWORK_AVAILABLE_CHAINS).find(
-    (networkName) =>
-      NETWORK_AVAILABLE_CHAINS[networkName].chainId === userWalletChain,
-  );
-  return userAccountRegistered && !!networkContractsAvailable;
+  const networkContractsAvailable = isChainSupported(hexChainId);
+
+  return userAccountRegistered && networkContractsAvailable;
 };
 
 /*

--- a/src/redux/sagas/colony/colonyCreate.ts
+++ b/src/redux/sagas/colony/colonyCreate.ts
@@ -2,6 +2,7 @@ import { Channel } from 'redux-saga';
 import { all, call, fork, put } from 'redux-saga/effects';
 import { getExtensionHash, Extension, ClientType, Id } from '@colony/colony-js';
 import { poll } from 'ethers/lib/utils';
+import { utils } from 'ethers';
 
 import {
   CreateColonyMetadataDocument,
@@ -73,7 +74,7 @@ function* colonyCreate({
 }: Action<ActionTypes.CREATE>) {
   const apolloClient = getContext(ContextModule.ApolloClient);
   const wallet = getContext(ContextModule.Wallet);
-  const walletAddress = wallet?.address;
+  const walletAddress = utils.getAddress(wallet.address);
   const colonyManager: ColonyManager = yield getColonyManager();
   const { networkClient } = colonyManager;
   const channelNames: string[] = [];

--- a/src/redux/sagas/setupUserContext.ts
+++ b/src/redux/sagas/setupUserContext.ts
@@ -4,22 +4,27 @@ import { all, call, fork, put } from 'redux-saga/effects';
 import actionsSagas from './actions';
 import colonySagas, { colonyCreateSaga } from './colony';
 import extensionSagas from './extensions';
+import { setContext, ContextModule, UserSettings } from '~context';
+import { ColonyWallet } from '~types';
+
+// import actionsSagas from './actions';
+// import colonySagas, {
+// } from './colony';
+// import colonyExtensionSagas from './extensions';
 // import motionSagas from './motions';
 // import whitelistSagas from './whitelist';
 // import vestingSagas from './vesting';
 import { setupUsersSagas } from './users';
-import { getWallet } from './wallet';
 
 import { ActionTypes } from '../actionTypes';
 import { AllActions } from '../types/actions';
-
-import { setContext, ContextModule, UserSettings } from '~context';
 
 // import setupResolvers from '~context/setupResolvers';
 // import AppLoadingState from '~context/appLoadingState';
 
 import { getGasPrices, putError } from './utils';
 import setupOnBeforeUnload from './setupOnBeforeUnload';
+import setupWalletContext from './setupWalletContext';
 // import { setupUserBalanceListener } from './setupUserBalanceListener';
 
 function* setupContextDependentSagas() {
@@ -51,10 +56,7 @@ export default function* setupUserContext() {
     /*
      * Get the new wallet and set it in context.
      */
-    const wallet = yield call(getWallet);
-
-    setContext(ContextModule.Wallet, wallet);
-
+    const wallet: ColonyWallet | undefined = yield call(setupWalletContext);
     yield put<AllActions>({
       type: ActionTypes.WALLET_OPEN_SUCCESS,
     });

--- a/src/redux/sagas/setupWalletContext.ts
+++ b/src/redux/sagas/setupWalletContext.ts
@@ -1,0 +1,30 @@
+import { ContextModule, getContext, setContext } from '~context';
+import { ColonyWallet } from '~types';
+import { getLastWallet } from '~utils/autoLogin';
+
+import { getBasicWallet, getWallet } from './wallet';
+
+const setupWalletContext = async () => {
+  let wallet: ColonyWallet | undefined;
+
+  try {
+    wallet = getContext(ContextModule.Wallet);
+  } catch {
+    // wallet not seen in context yet
+  }
+
+  const lastWallet = getLastWallet();
+
+  if (!wallet && lastWallet) {
+    // Perform quick "login"
+    wallet = await getBasicWallet(lastWallet);
+  } else {
+    wallet = await getWallet(lastWallet);
+  }
+
+  setContext(ContextModule.Wallet, wallet);
+
+  return wallet;
+};
+
+export default setupWalletContext;

--- a/src/redux/sagas/wallet/ganacheModule.ts
+++ b/src/redux/sagas/wallet/ganacheModule.ts
@@ -11,7 +11,7 @@ type CustomJsonRpcProvider = providers.JsonRpcProvider & {
   request: (args) => void;
 };
 
-const ganacheWalletModule = (privateKey, optionalAccountIndex = 1) => {
+const ganacheWalletModule = (privateKey: string, optionalAccountIndex = 1) => {
   const initWallet = () => {
     return {
       label: `Dev Wallet ${optionalAccountIndex}`,

--- a/src/redux/sagas/wallet/onboard.ts
+++ b/src/redux/sagas/wallet/onboard.ts
@@ -1,0 +1,89 @@
+import Onboard, { InitOptions } from '@web3-onboard/core';
+import injectedWallets from '@web3-onboard/injected-wallets';
+
+import { private_keys as ganachePrivateKeys } from '../../../../amplify/mock-data/colonyNetworkArtifacts/ganache-accounts.json';
+
+import colonyIcon from '~images/icons/colony-logo.svg';
+import {
+  isDev,
+  TERMS_AND_CONDITIONS,
+  CDAPP_VERSION,
+  TOKEN_DATA,
+  GANACHE_NETWORK,
+  GANACHE_LOCAL_RPC_URL,
+} from '~constants';
+import { intl } from '~utils/intl';
+import { getChainIdAsHex } from '~utils/autoLogin';
+import { Network } from '~types';
+
+import ganacheModule from './ganacheModule';
+
+const { formatMessage } = intl({
+  'metadata.name': 'ColonyCDapp',
+  'metadata.description': `An iteration of the Colony Dapp sporting both a fully decentralized operating mode, as well as a mode enhanced by a metadata caching layer`,
+});
+
+const getDevelopmentWallets = () => {
+  if (isDev) {
+    return (
+      Object.values(ganachePrivateKeys)
+        .map((privateKey, index) => ganacheModule(privateKey, index + 1))
+        /*
+         * Remove the wallets used by the reputation miner and the block ingestor
+         * As to not cause any "unplesantness"
+         */
+        .slice(0, -2)
+    );
+  }
+  return [];
+};
+
+const wallets = [injectedWallets(), ...getDevelopmentWallets()];
+
+// chains: [
+//   {
+//     /*
+//      * chain id for @web3-onboard needs to be expressed as a hex string
+//      */
+//     // id: `0x${GANACHE_NETWORK.chainId.toString(16)}`,
+//     id: '0x64',
+//     token: TOKEN_DATA[Network.Gnosis].symbol,
+//     label: 'Metamask Wallet',
+//     rpcUrl: 'https://rpc.gnosischain.com',
+//   },
+// ],
+
+const onboardConfig: InitOptions = {
+  wallets,
+  // Chains array only used in `ganacheModule` for use in development.
+  chains: [
+    {
+      // web3-onboard formats chain id as hex strings
+      id: getChainIdAsHex(GANACHE_NETWORK.chainId),
+      token: TOKEN_DATA[Network.Ganache].symbol,
+      label: GANACHE_NETWORK.shortName,
+      rpcUrl: GANACHE_LOCAL_RPC_URL,
+    },
+  ],
+  accountCenter: {
+    desktop: { enabled: false },
+    mobile: { enabled: false },
+  },
+  connect: {
+    showSidebar: false,
+  },
+  notify: {
+    desktop: { enabled: false, transactionHandler: () => {} },
+    mobile: { enabled: false, transactionHandler: () => {} },
+  },
+  appMetadata: {
+    name: formatMessage({ id: 'metadata.name' }),
+    icon: colonyIcon.content.replace('symbol', 'svg'),
+    description: formatMessage({ id: 'metadata.description' }),
+    agreement: { termsUrl: TERMS_AND_CONDITIONS, version: CDAPP_VERSION },
+  },
+};
+
+const onboard = Onboard(onboardConfig);
+
+export default onboard;

--- a/src/types/definitions/index.d.ts
+++ b/src/types/definitions/index.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+  ethereum: object | undefined;
+}

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -1,11 +1,21 @@
 import { WalletState } from '@web3-onboard/core';
 
-export interface Wallet extends WalletState {
+export type ColonyWallet = BasicWallet | Wallet;
+
+interface Wallet extends WalletState {
   address: string;
   balance: Record<string, string>;
   ens?: string | null;
 }
 
-export enum DevelopmentWallets {
-  Ganache = 'Ganache Wallet',
-}
+export type BasicWallet = Pick<Wallet, 'address' | 'label' | 'chains'>;
+
+export const isBasicWallet = (
+  wallet?: ColonyWallet | null,
+): wallet is BasicWallet => {
+  if (!wallet || 'balance' in wallet) {
+    return false;
+  }
+
+  return true;
+};

--- a/src/utils/autoLogin.ts
+++ b/src/utils/autoLogin.ts
@@ -24,17 +24,7 @@ export const clearLastWallet = () => localStorage.removeItem(LAST_WALLET_KEY);
 
 export const getLastWallet = () => {
   const lastWallet = localStorage.getItem(LAST_WALLET_KEY);
-  if (!lastWallet) {
-    return null;
-  }
-
-  try {
-    return JSON.parse(lastWallet) as LastWallet;
-  } catch {
-    // If parsing fails, wallet is in old format
-    clearLastWallet();
-    return null;
-  }
+  return lastWallet ? (JSON.parse(lastWallet) as LastWallet) : null;
 };
 
 export const setLastWallet = (lastWallet: LastWallet) =>


### PR DESCRIPTION
## Description

This PR implements a "quick login" functionality to the wallet connection process. If there is wallet information saved in local storage when setting up the user context (e.g. after a logged-in user refreshes the browser), instead of waiting for a full login, we store a simplified wallet in context with address and chain information. This allows queries to run and the app to be interacted with.

Then, we run the standard login via web3-onboard in the background, and once that completes store a full wallet in context.  

# Testing
- Log in and refresh the browser. Wallet connection should be instant and the app fully interactive right away.
- Log in via metamask -> same story.
- Log in via metamask to an unsupported chain. `useCanInteractWithNetwork` should return false, which should restrict what you can do (e.g. can't create a colony). 
- If you change `lastWallet` on line 22 of `setupWalletContext` to a `LastWallet` with a random `type` key, you will be able to test what happens when the wallet stored in localstorage isn't recognised (for whatever reason). You'll be prompted to select a wallet from the ui and if you don't, you'll be logged out. 


**Changes** 🏗

* Added "quick login" functionality to `setupUserContext`
* Added an effect to the `Wallet` which watches for wallet changes and initiates the full login after the quick login is complete

TODO: 
- [x] error handling
- [x] case where last wallet saved is not recognized, hence the autologin logic will fail
- [x] improve local storage for the last wallet type
- [x] Call `onboard.disconnect()` when signing out
~~- [ ] remove onboard.js:agreement key -> See comment in code at `wallet/onboard`~~
- [x] Handle case where user switches to unsupported chain #183

Resolves #35 
