### PR TITLE
Add decisions to colony navigation

### DIFF
--- a/src/components/common/ColonyHome/ColonyNavigation/ColonyNavigation.tsx
+++ b/src/components/common/ColonyHome/ColonyNavigation/ColonyNavigation.tsx
@@ -1,79 +1,17 @@
-import React, { ComponentProps, useMemo } from 'react';
-import { defineMessages } from 'react-intl';
+import React from 'react';
 
 import { useColonyContext } from '~hooks';
 
 import NavItem from './NavItem';
+import getNavigationItems, { displayName } from './colonyNavigationConfig';
 
 import styles from './ColonyNavigation.css';
-
-const displayName = 'common.ColonyHome.ColonyNavigation';
-
-const MSG = defineMessages({
-  linkTextActions: {
-    id: `${displayName}.linkTextActions`,
-    defaultMessage: 'Actions',
-  },
-  linkTextEvents: {
-    id: `${displayName}.linkTextEvents`,
-    defaultMessage: 'Events',
-  },
-  linkTextExtensions: {
-    id: `${displayName}.linkTextExtensions`,
-    defaultMessage: 'Extensions',
-  },
-  linkTextUnwrapTokens: {
-    id: `${displayName}.linkTextUnwrapTokens`,
-    defaultMessage: 'Unwrap Tokens',
-  },
-  linkTextClaimTokens: {
-    id: `${displayName}.linkTextClaimTokens`,
-    defaultMessage: 'Claim Tokens',
-  },
-  comingSoonMessage: {
-    id: `${displayName}.comingSoonMessage`,
-    defaultMessage: 'Coming Soon',
-  },
-});
 
 const ColonyNavigation = () => {
   const { colony } = useColonyContext();
   const { name } = colony || {};
 
-  /*
-   * @TODO actually determine these
-   * This can be easily inferred from the subgraph queries
-   *
-   * But for that we need to store the "current" count either in redux or
-   * in local storage... or maybe a local resolver?
-   *
-   * Problem is I couldn't get @client resolvers to work with subgrap queries :(
-   */
-  const hasNewActions = false;
-  const hasNewExtensions = false;
-
-  const items = useMemo<ComponentProps<typeof NavItem>[]>(() => {
-    if (!name) {
-      return [];
-    }
-
-    const navigationItems = [
-      {
-        linkTo: `/colony/${name}`,
-        showDot: hasNewActions,
-        text: MSG.linkTextActions,
-      },
-      {
-        linkTo: `/colony/${name}/extensions`,
-        showDot: hasNewExtensions,
-        text: MSG.linkTextExtensions,
-        dataTest: 'extensionsNavigationButton',
-      },
-    ];
-
-    return navigationItems;
-  }, [name, hasNewActions, hasNewExtensions]);
-
+  const items = getNavigationItems(name);
   return (
     <nav role="navigation" className={styles.main}>
       {items.map((itemProps) => (

--- a/src/components/common/ColonyHome/ColonyNavigation/NavItem.tsx
+++ b/src/components/common/ColonyHome/ColonyNavigation/NavItem.tsx
@@ -6,7 +6,7 @@ import { ENTER } from '~types/index';
 
 import styles from './NavItem.css';
 
-interface Props {
+export interface Props {
   disabled?: boolean;
   // exact?: boolean;
   extra?: MessageDescriptor;

--- a/src/components/common/ColonyHome/ColonyNavigation/NavItem.tsx
+++ b/src/components/common/ColonyHome/ColonyNavigation/NavItem.tsx
@@ -1,61 +1,72 @@
-import React, { KeyboardEvent, useCallback } from 'react';
-import { MessageDescriptor, useIntl } from 'react-intl';
+import React, { KeyboardEvent } from 'react';
+import { MessageDescriptor } from 'react-intl';
+import { useLocation } from 'react-router-dom';
 
 import NavLink from '~shared/NavLink';
 import { ENTER } from '~types/index';
+import { formatText } from '~utils/intl';
 
 import styles from './NavItem.css';
 
-export interface Props {
+export interface NavItemProps {
   disabled?: boolean;
   // exact?: boolean;
-  extra?: MessageDescriptor;
   linkTo: string;
   showDot?: boolean;
   text: MessageDescriptor;
   dataTest?: string;
 }
 
-const displayName = 'dashboard.ColonyHome.ColonyNavigation.NavItem';
+const displayName = 'common.ColonyHome.ColonyNavigation.NavItem';
+
+const handleLinkKeyDown = (
+  evt: KeyboardEvent<HTMLAnchorElement>,
+  disabled: boolean,
+) => {
+  if (disabled && evt.key === ENTER) {
+    evt.preventDefault();
+  }
+};
+
+const getClassNames = (
+  showDot: boolean,
+  linkTo: string,
+  currentLocation: string,
+) => {
+  const classNames = [styles.main];
+
+  if (showDot) {
+    classNames.push(styles.showDot);
+  }
+
+  if (linkTo === currentLocation) {
+    classNames.push(styles.active);
+  }
+
+  return classNames;
+};
 
 const NavItem = ({
   disabled = false,
-  // exact = true,
-  extra: extraProp,
   linkTo,
   showDot = false,
   text: textProp,
   dataTest,
-}: Props) => {
-  const { formatMessage } = useIntl();
+}: NavItemProps) => {
+  const text = formatText(textProp);
+  const { pathname } = useLocation();
+  const classNames = getClassNames(showDot, linkTo, pathname);
 
-  const handleLinkKeyDown = useCallback(
-    (evt: KeyboardEvent<HTMLAnchorElement>) => {
-      if (disabled && evt.key === ENTER) {
-        evt.preventDefault();
-      }
-    },
-    [disabled],
-  );
-
-  const text = formatMessage(textProp);
-  const extra = extraProp ? formatMessage(extraProp) : undefined;
-  const classNames = [styles.main];
-  if (showDot) {
-    classNames.push(styles.showDot);
-  }
   return (
     <NavLink
       activeClassName={styles.active}
       aria-disabled={disabled}
       className={classNames.join(' ')}
-      // exact={exact}
-      onKeyDown={handleLinkKeyDown}
+      onKeyDown={(e) => handleLinkKeyDown(e, disabled)}
       to={linkTo}
       data-test={dataTest}
     >
       <span className={styles.text}>{text}</span>
-      {extra && <span className={styles.extra}>{extra}</span>}
     </NavLink>
   );
 };

--- a/src/components/common/ColonyHome/ColonyNavigation/colonyNavigationConfig.ts
+++ b/src/components/common/ColonyHome/ColonyNavigation/colonyNavigationConfig.ts
@@ -1,6 +1,6 @@
 import { defineMessages } from 'react-intl';
 
-import { Props as NavigationItem } from './NavItem';
+import { NavItemProps as NavigationItem } from './NavItem';
 
 export const displayName = 'common.ColonyHome.ColonyNavigation';
 

--- a/src/components/common/ColonyHome/ColonyNavigation/colonyNavigationConfig.ts
+++ b/src/components/common/ColonyHome/ColonyNavigation/colonyNavigationConfig.ts
@@ -1,0 +1,72 @@
+import { defineMessages } from 'react-intl';
+
+import { Props as NavigationItem } from './NavItem';
+
+export const displayName = 'common.ColonyHome.ColonyNavigation';
+
+const MSG = defineMessages({
+  linkTextActions: {
+    id: `${displayName}.linkTextActions`,
+    defaultMessage: 'Actions',
+  },
+  linkTextExtensions: {
+    id: `${displayName}.linkTextExtensions`,
+    defaultMessage: 'Extensions',
+  },
+  linkTextDecisions: {
+    id: `${displayName}.linkTextDecisions`,
+    defaultMessage: 'Decisions',
+  },
+});
+
+const getNavigationItems = (colonyName?: string) => {
+  if (!colonyName) {
+    return [];
+  }
+
+  /*
+   * @TODO actually determine these
+   * This can be easily inferred from the subgraph queries
+   *
+   * But for that we need to store the "current" count either in redux or
+   * in local storage... or maybe a local resolver?
+   *
+   * Problem is I couldn't get @client resolvers to work with subgrap queries :(
+   */
+  const hasNewActions = false;
+  const hasNewExtensions = false;
+
+  const navigationItems: NavigationItem[] = [
+    {
+      linkTo: `/colony/${colonyName}`,
+      showDot: hasNewActions,
+      text: MSG.linkTextActions,
+    },
+    {
+      linkTo: `/colony/${colonyName}/extensions`,
+      showDot: hasNewExtensions,
+      text: MSG.linkTextExtensions,
+      dataTest: 'extensionsNavigationButton',
+    },
+  ];
+
+  // @TODO -> Requires extensions
+  /* const decisionsSupported =   
+      isVotingExtensionEnabled &&
+      votingExtensionVersion &&
+      votingExtensionVersion >= VotingReputationExtensionVersion.GreenLightweightSpaceship;
+  */
+
+  // if (decisionsSupported) {
+  navigationItems.splice(1, 0, {
+    linkTo: `/colony/${colonyName}/decisions`,
+    // showDot: hasNewDecisions,
+    text: MSG.linkTextDecisions,
+    dataTest: 'decisionsNavigationButton',
+  });
+  // }
+
+  return navigationItems;
+};
+
+export default getNavigationItems;

--- a/src/components/shared/NavLink/NavLink.tsx
+++ b/src/components/shared/NavLink/NavLink.tsx
@@ -1,8 +1,9 @@
 import React, { ReactNode } from 'react';
-import { MessageDescriptor, useIntl } from 'react-intl';
+import { MessageDescriptor } from 'react-intl';
 import { NavLink as NavLinkComponent, NavLinkProps } from 'react-router-dom';
 
 import { SimpleMessageValues } from '~types';
+import { formatText } from '~utils/intl';
 
 import styles from './NavLink.css';
 
@@ -39,15 +40,8 @@ const NavLink = ({
   to,
   ...linkProps
 }: Props) => {
-  const { formatMessage } = useIntl();
-
-  const linkText =
-    typeof text === 'string' ? text : text && formatMessage(text, textValues);
-
-  const titleText =
-    typeof title === 'string'
-      ? title
-      : title && formatMessage(title, titleValues);
+  const linkText = formatText(text, textValues);
+  const titleText = formatText(title, titleValues);
 
   return (
     <NavLinkComponent

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -232,7 +232,7 @@ const Routes = () => {
         <Route path="*" element={<NotFoundRoute />} />
       </RoutesSwitch>
     ),
-    [user],
+    [user, isMobile],
   );
 
   // if (isAppLoading) {


### PR DESCRIPTION
## Description

This PR adds the Decisions item to Colony Navigation. 

![addDecisions](https://user-images.githubusercontent.com/64402732/211755074-e1dd9622-33d8-4aea-856f-2251f7f27ac8.png)

It also tidies up the Colony Navigation view and fixes a bug where the nav item wasn't active at the correct route if you refreshed the page.

It does nothing else. I therefore suggest reviewing this in conjunction with #176, which handles the route wiring.

**Changes** 🏗

* Add Decision item to Colony Navigation

Resolves #165 
