### PR TITLE
Wire in Decision Preview Controls

### DIFF
--- a/src/components/common/ColonyDecisions/DecisionDialog/DecisionDialog.tsx
+++ b/src/components/common/ColonyDecisions/DecisionDialog/DecisionDialog.tsx
@@ -43,6 +43,7 @@ const validationSchema = object()
       .required(() => MSG.titleRequired),
     motionDomainId: number(),
     description: string().notOneOf(['<p></p>'], () => MSG.descriptionRequired),
+    walletAddress: string().address().required(),
   })
   .defined();
 
@@ -50,12 +51,14 @@ export type DecisionDialogValues = InferType<typeof validationSchema>;
 
 export interface DecisionDialogProps extends DialogProps {
   ethDomainId?: number;
+  handleSubmit?: (values: DecisionDialogValues) => void;
 }
 
 const DecisionDialog = ({
   cancel,
   close,
   ethDomainId,
+  handleSubmit,
 }: DecisionDialogProps) => {
   const { user } = useAppContext();
   const { pathname } = useLocation();
@@ -66,9 +69,12 @@ const DecisionDialog = ({
   const draftDecision = getDecisionFromLocalStorage(walletAddress);
   const content = draftDecision?.description;
 
-  const handleSubmit = (values: DecisionDialogValues) => {
+  const handleSubmitDialog = (values: DecisionDialogValues) => {
+    handleSubmit?.(values);
     setDecisionToLocalStorage(values, walletAddress);
-    navigate(`${pathname}${PREVIEW_ROUTE_SUFFIX}`);
+    if (!pathname.includes(PREVIEW_ROUTE_SUFFIX)) {
+      navigate(`${pathname}${PREVIEW_ROUTE_SUFFIX}`);
+    }
     close();
   };
 
@@ -83,8 +89,9 @@ const DecisionDialog = ({
           motionDomainId: draftDecision?.motionDomainId ?? domainId,
           title: draftDecision?.title,
           description: draftDecision?.description || '<p></p>',
+          walletAddress,
         }}
-        onSubmit={handleSubmit}
+        onSubmit={handleSubmitDialog}
         validationSchema={validationSchema}
       >
         <div className={styles.main}>

--- a/src/components/common/ColonyDecisions/DecisionDialog/DecisionDialog.tsx
+++ b/src/components/common/ColonyDecisions/DecisionDialog/DecisionDialog.tsx
@@ -21,6 +21,8 @@ import {
 
 import styles from './DecisionDialog.css';
 
+export const PREVIEW_ROUTE_SUFFIX = '/preview';
+
 const displayName = 'common.ColonyDecisions.DecisionDialog';
 
 const MSG = defineMessages({
@@ -66,7 +68,7 @@ const DecisionDialog = ({
 
   const handleSubmit = (values: DecisionDialogValues) => {
     setDecisionToLocalStorage(values, walletAddress);
-    navigate(`${pathname}/preview`);
+    navigate(`${pathname}${PREVIEW_ROUTE_SUFFIX}`);
     close();
   };
 

--- a/src/components/common/ColonyDecisions/DecisionDialog/DecisionDialog.tsx
+++ b/src/components/common/ColonyDecisions/DecisionDialog/DecisionDialog.tsx
@@ -11,6 +11,7 @@ import {
   getDecisionFromLocalStorage,
   setDecisionToLocalStorage,
 } from '~utils/decisions';
+import { DECISIONS_PREVIEW_ROUTE_SUFFIX as DECISIONS_PREVIEW } from '~routes';
 
 import {
   DecisionTitle,
@@ -20,8 +21,6 @@ import {
 } from '../DecisionDialog';
 
 import styles from './DecisionDialog.css';
-
-export const PREVIEW_ROUTE_SUFFIX = '/preview';
 
 const displayName = 'common.ColonyDecisions.DecisionDialog';
 
@@ -72,8 +71,8 @@ const DecisionDialog = ({
   const handleSubmitDialog = (values: DecisionDialogValues) => {
     handleSubmit?.(values);
     setDecisionToLocalStorage(values, walletAddress);
-    if (!pathname.includes(PREVIEW_ROUTE_SUFFIX)) {
-      navigate(`${pathname}${PREVIEW_ROUTE_SUFFIX}`);
+    if (!pathname.includes(DECISIONS_PREVIEW)) {
+      navigate(`${pathname}${DECISIONS_PREVIEW}`);
     }
     close();
   };

--- a/src/components/common/ColonyDecisions/DecisionDialog/index.ts
+++ b/src/components/common/ColonyDecisions/DecisionDialog/index.ts
@@ -1,4 +1,8 @@
-export { default, DecisionDialogValues } from './DecisionDialog';
+export {
+  default,
+  DecisionDialogValues,
+  PREVIEW_ROUTE_SUFFIX,
+} from './DecisionDialog';
 export { default as DecisionTitle } from './DecisionTitle';
 export { default as DecisionBody } from './DecisionBody';
 export { default as DecisionControls } from './DecisionControls';

--- a/src/components/common/ColonyDecisions/DecisionDialog/index.ts
+++ b/src/components/common/ColonyDecisions/DecisionDialog/index.ts
@@ -1,8 +1,4 @@
-export {
-  default,
-  DecisionDialogValues,
-  PREVIEW_ROUTE_SUFFIX,
-} from './DecisionDialog';
+export { default, DecisionDialogValues } from './DecisionDialog';
 export { default as DecisionTitle } from './DecisionTitle';
 export { default as DecisionBody } from './DecisionBody';
 export { default as DecisionControls } from './DecisionControls';

--- a/src/components/common/ColonyDecisions/DecisionPreview/DecisionData/DecisionContent.tsx
+++ b/src/components/common/ColonyDecisions/DecisionPreview/DecisionData/DecisionContent.tsx
@@ -13,8 +13,9 @@ import styles from './DecisionContent.css';
 
 const displayName = 'common.ColonyDecisions.DecisionPreview.DecisionContent';
 
+type SelectedProps = Omit<DecisionDataProps, 'setDecision'>;
 type DecisionContentProps = {
-  [k in keyof DecisionDataProps]-?: DecisionDataProps[k];
+  [k in keyof SelectedProps]-?: SelectedProps[k];
 };
 
 const DecisionContent = ({ decision, user }: DecisionContentProps) => {

--- a/src/components/common/ColonyDecisions/DecisionPreview/DecisionData/DecisionData.tsx
+++ b/src/components/common/ColonyDecisions/DecisionPreview/DecisionData/DecisionData.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Decision, User } from '~types';
 
@@ -9,14 +9,15 @@ const displayName = 'common.ColonyDecisions.DecisionPreview.DecisionData';
 export interface DecisionDataProps {
   decision?: Decision;
   user: User;
+  setDecision: ReturnType<typeof useState>[1];
 }
 
-const DecisionData = ({ decision, user }: DecisionDataProps) => {
+const DecisionData = ({ decision, user, setDecision }: DecisionDataProps) => {
   const decisionNotFound =
     !decision || decision.walletAddress !== user?.walletAddress;
 
   if (decisionNotFound) {
-    return <DecisionNotFound />;
+    return <DecisionNotFound setDecision={setDecision} />;
   }
 
   return <DecisionContent decision={decision} user={user} />;

--- a/src/components/common/ColonyDecisions/DecisionPreview/DecisionData/DecisionNotFound.tsx
+++ b/src/components/common/ColonyDecisions/DecisionPreview/DecisionData/DecisionNotFound.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
+import { Id } from '@colony/colony-js';
 
 import Button from '~shared/Button';
+import { useDialog } from '~shared/Dialog';
+import { DecisionDialog } from '~common/ColonyDecisions';
+
+import { DecisionDataProps } from './DecisionData';
 
 import styles from './DecisionNotFound.css';
 
@@ -18,21 +23,27 @@ const MSG = defineMessages({
   },
 });
 
-const DecisionNotFound = () => (
-  <div className={styles.noContent}>
-    <FormattedMessage {...MSG.noDecisionText} />
-    <Button
-      text={MSG.createDecision}
-      appearance={{ theme: 'blue' }}
-      onClick={
-        () => console.log('Implement create decision...')
-        // openDecisionDialog({
-        //   ethDomainId: Id.RootDomain,
-        // })
-      }
-    />
-  </div>
-);
+type DecisionNotFoundProps = Pick<DecisionDataProps, 'setDecision'>;
+
+const DecisionNotFound = ({ setDecision }: DecisionNotFoundProps) => {
+  const openDecisionDialog = useDialog(DecisionDialog);
+
+  return (
+    <div className={styles.noContent}>
+      <FormattedMessage {...MSG.noDecisionText} />
+      <Button
+        text={MSG.createDecision}
+        appearance={{ theme: 'blue' }}
+        onClick={() => {
+          openDecisionDialog({
+            ethDomainId: Id.RootDomain,
+            handleSubmit: setDecision,
+          });
+        }}
+      />
+    </div>
+  );
+};
 
 DecisionNotFound.displayName = displayName;
 

--- a/src/components/common/ColonyDecisions/DecisionPreview/DecisionData/index.ts
+++ b/src/components/common/ColonyDecisions/DecisionPreview/DecisionData/index.ts
@@ -1,3 +1,3 @@
-export { default } from './DecisionData';
+export { default, DecisionDataProps } from './DecisionData';
 export { default as DecisionNotFound } from './DecisionNotFound';
 export { default as DecisionContent } from './DecisionContent';

--- a/src/components/common/ColonyDecisions/DecisionPreview/DecisionPreview.tsx
+++ b/src/components/common/ColonyDecisions/DecisionPreview/DecisionPreview.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { defineMessages } from 'react-intl';
 
 import Tag from '~shared/Tag';
 import { getDecisionFromLocalStorage } from '~utils/decisions';
 import LoadingTemplate from '~frame/LoadingTemplate';
 import { useAppContext } from '~hooks';
+import { Decision } from '~types';
 
 import {
   DecisionData,
@@ -32,18 +33,12 @@ const DecisionPreview = () => {
   const { user, walletConnecting, userLoading } = useAppContext();
   const walletAddress = user?.walletAddress || '';
 
-  // Referential equality needed here to avoid infinite loop in effect.
-  const decision = useMemo(
-    () => getDecisionFromLocalStorage(walletAddress),
-    [walletAddress],
-  );
+  const [decisionPreview, setDecisionPreview] = useState<Decision>();
+  const decision = getDecisionFromLocalStorage(walletAddress);
 
-  const [decisionPreview, setDecisionPreview] = useState(decision);
-
-  useEffect(() => {
-    // Sync component state with local storage
+  if (!decisionPreview && decision) {
     setDecisionPreview(decision);
-  }, [decision]);
+  }
 
   if (walletConnecting || userLoading) {
     return (

--- a/src/components/common/ColonyDecisions/DecisionPreview/DecisionPreview.tsx
+++ b/src/components/common/ColonyDecisions/DecisionPreview/DecisionPreview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { defineMessages } from 'react-intl';
 
 import Tag from '~shared/Tag';
@@ -32,7 +32,18 @@ const DecisionPreview = () => {
   const { user, walletConnecting, userLoading } = useAppContext();
   const walletAddress = user?.walletAddress || '';
 
-  const decision = getDecisionFromLocalStorage(walletAddress);
+  // Referential equality needed here to avoid infinite loop in effect.
+  const decision = useMemo(
+    () => getDecisionFromLocalStorage(walletAddress),
+    [walletAddress],
+  );
+
+  const [decisionPreview, setDecisionPreview] = useState(decision);
+
+  useEffect(() => {
+    // Sync component state with local storage
+    setDecisionPreview(decision);
+  }, [decision]);
 
   if (walletConnecting || userLoading) {
     return (
@@ -47,10 +58,17 @@ const DecisionPreview = () => {
       <div className={styles.banner}>
         <Tag text={MSG.preview} appearance={{ theme: 'light' }} />
       </div>
-      <DecisionData decision={decision} user={user} />
+      <DecisionData
+        decision={decisionPreview}
+        setDecision={setDecisionPreview}
+        user={user}
+      />
       <div className={styles.rightContent}>
-        <DecisionPreviewControls decision={decision} />
-        {decision && <DecisionDetails decision={decision} />}
+        <DecisionPreviewControls
+          decision={decisionPreview}
+          setDecision={setDecisionPreview}
+        />
+        {decisionPreview && <DecisionDetails decision={decisionPreview} />}
       </div>
     </DecisionPreviewLayout>
   );

--- a/src/components/common/ColonyDecisions/DecisionPreview/DecisionPreviewControls/DecisionPreviewControls.tsx
+++ b/src/components/common/ColonyDecisions/DecisionPreview/DecisionPreviewControls/DecisionPreviewControls.tsx
@@ -7,7 +7,7 @@ import Button, { ActionButton } from '~shared/Button';
 import { useColonyContext } from '~hooks';
 import { ActionTypes } from '~redux';
 
-import { DecisionDataProps } from '../DecisionData/DecisionData';
+import { DecisionDataProps } from '../DecisionData';
 
 import styles from './DecisionPreviewControls.css';
 

--- a/src/components/common/ColonyDecisions/DecisionPreview/DecisionPreviewControls/DecisionPreviewControls.tsx
+++ b/src/components/common/ColonyDecisions/DecisionPreview/DecisionPreviewControls/DecisionPreviewControls.tsx
@@ -1,38 +1,30 @@
 import React from 'react';
 // import { defineMessages } from 'react-intl';
 
-import { DeleteDecisionDialog } from '~common/ColonyDecisions';
+import { DecisionDialog, DeleteDecisionDialog } from '~common/ColonyDecisions';
 import { useDialog } from '~shared/Dialog';
 import Button, { ActionButton } from '~shared/Button';
 import { useColonyContext } from '~hooks';
 import { ActionTypes } from '~redux';
-import { Decision } from '~types';
+
+import { DecisionDataProps } from '../DecisionData/DecisionData';
 
 import styles from './DecisionPreviewControls.css';
 
-interface DecisionPreviewControlsProps {
-  decision?: Decision;
-}
+type DecisionPreviewControlsProps = Omit<DecisionDataProps, 'user'>;
 
 const displayName =
   'common.ColonyDecisions.DecisionPreview.DecisionPreviewControls';
 
-// const MSG = defineMessages({
-//   decision: {
-//     id: `${displayName}.decision`,
-//     defaultMessage: 'Decision',
-//   },
-// });
-
 const DecisionPreviewControls = ({
   decision,
+  setDecision,
 }: DecisionPreviewControlsProps) => {
-  // const navigate = useNavigate();
   const { colony } = useColonyContext();
   const colonyAddress = colony?.colonyAddress;
 
   const openConfirmDeleteDialog = useDialog(DeleteDecisionDialog);
-  // const openDecisionDialog = useDialog(DecisionDialog);
+  const openDecisionDialog = useDialog(DecisionDialog);
 
   return (
     <div className={styles.buttonContainer}>
@@ -49,12 +41,11 @@ const DecisionPreviewControls = ({
           />
           <Button
             appearance={{ theme: 'blue', size: 'large' }}
-            onClick={
-              () => console.log('Implement edit button')
-              // openDecisionDialog({
-              //   colony,
-              //   ethDomainId: decisionData.motionDomainId,
-              // })
+            onClick={() =>
+              openDecisionDialog({
+                ethDomainId: decision.motionDomainId,
+                handleSubmit: setDecision,
+              })
             }
             text={{ id: 'button.edit' }}
           />

--- a/src/components/common/ColonyDecisions/DecisionPreview/DecisionPreviewControls/DecisionPreviewControls.tsx
+++ b/src/components/common/ColonyDecisions/DecisionPreview/DecisionPreviewControls/DecisionPreviewControls.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 // import { defineMessages } from 'react-intl';
 
+import { DeleteDecisionDialog } from '~common/ColonyDecisions';
+import { useDialog } from '~shared/Dialog';
+import Button, { ActionButton } from '~shared/Button';
 import { useColonyContext } from '~hooks';
 import { ActionTypes } from '~redux';
-
-import Button, { ActionButton } from '~shared/Button';
 import { Decision } from '~types';
-// import { removeDecisionFromLocalStorage } from '~utils/decisions';
 
 import styles from './DecisionPreviewControls.css';
 
@@ -31,13 +31,8 @@ const DecisionPreviewControls = ({
   const { colony } = useColonyContext();
   const colonyAddress = colony?.colonyAddress;
 
-  //const openConfirmDeleteDialog = useDialog(ConfirmDeleteDialog);
-  //  const openDecisionDialog = useDialog(DecisionDialog);
-
-  // const deleteDecision = (walletAddress: Address) => {
-  //   removeDecisionFromLocalStorage(walletAddress);
-  //   navigate(`/colony/${colonyName}/decisions`);
-  // };
+  const openConfirmDeleteDialog = useDialog(DeleteDecisionDialog);
+  // const openDecisionDialog = useDialog(DecisionDialog);
 
   return (
     <div className={styles.buttonContainer}>
@@ -45,14 +40,10 @@ const DecisionPreviewControls = ({
         <>
           <Button
             appearance={{ theme: 'blue', size: 'large' }}
-            onClick={
-              () => console.log('Implement delete decision...')
-              // openConfirmDeleteDialog({
-              //   itemName: (
-              //     <FormattedMessage {...MSG.decision} key={nanoid()} />
-              //   ),
-              //   deleteCallback: deleteDecision,
-              // })
+            onClick={() =>
+              openConfirmDeleteDialog({
+                decision,
+              })
             }
             text={{ id: 'button.delete' }}
           />

--- a/src/components/common/ColonyDecisions/DeleteDecisionDialog/DeleteDecisionDialog.css
+++ b/src/components/common/ColonyDecisions/DeleteDecisionDialog/DeleteDecisionDialog.css
@@ -1,0 +1,12 @@
+.main {
+  font-size: var(--size-normal);
+  color: var(--grey-purple);
+}
+
+.main h3, .main div {
+  margin: 15px 0 20px 0;
+}
+
+.main button {
+  min-width: 160px;
+}

--- a/src/components/common/ColonyDecisions/DeleteDecisionDialog/DeleteDecisionDialog.css.d.ts
+++ b/src/components/common/ColonyDecisions/DeleteDecisionDialog/DeleteDecisionDialog.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace DeleteDecisionDialogCssNamespace {
+  export interface IDeleteDecisionDialogCss {
+    main: string;
+  }
+}
+
+declare const DeleteDecisionDialogCssModule: DeleteDecisionDialogCssNamespace.IDeleteDecisionDialogCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: DeleteDecisionDialogCssNamespace.IDeleteDecisionDialogCss;
+};
+
+export = DeleteDecisionDialogCssModule;

--- a/src/components/common/ColonyDecisions/DeleteDecisionDialog/DeleteDecisionDialog.tsx
+++ b/src/components/common/ColonyDecisions/DeleteDecisionDialog/DeleteDecisionDialog.tsx
@@ -6,9 +6,8 @@ import Button from '~shared/Button';
 import Dialog, { DialogSection } from '~shared/Dialog';
 import { Heading3 } from '~shared/Heading';
 import { Decision } from '~types';
+import { DECISIONS_PREVIEW_ROUTE_SUFFIX as DECISIONS_PREVIEW } from '~routes';
 import { removeDecisionFromLocalStorage } from '~utils/decisions';
-
-import { PREVIEW_ROUTE_SUFFIX } from '../DecisionDialog';
 
 import styles from './DeleteDecisionDialog.css';
 
@@ -41,7 +40,7 @@ const DeleteDecisionDialog = ({
   const deleteDecision = () => {
     removeDecisionFromLocalStorage(decision.walletAddress);
     close();
-    navigate(pathname.slice(0, -PREVIEW_ROUTE_SUFFIX.length));
+    navigate(pathname.slice(0, -DECISIONS_PREVIEW.length));
   };
 
   return (

--- a/src/components/common/ColonyDecisions/DeleteDecisionDialog/DeleteDecisionDialog.tsx
+++ b/src/components/common/ColonyDecisions/DeleteDecisionDialog/DeleteDecisionDialog.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { defineMessage, FormattedMessage } from 'react-intl';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import Button from '~shared/Button';
+import Dialog, { DialogSection } from '~shared/Dialog';
+import { Heading3 } from '~shared/Heading';
+import { Decision } from '~types';
+import { removeDecisionFromLocalStorage } from '~utils/decisions';
+
+import { PREVIEW_ROUTE_SUFFIX } from '../DecisionDialog';
+
+import styles from './DeleteDecisionDialog.css';
+
+const displayName = 'common.ColonyDecisions.DeleteDecisionDialog';
+
+const MSG = defineMessage({
+  title: {
+    id: `${displayName}.title`,
+    defaultMessage: 'Delete draft Decision',
+  },
+  description: {
+    id: `${displayName}.description`,
+    defaultMessage: 'Are you sure you want to delete this draft Decision?',
+  },
+});
+
+interface DeleteDecisionDialogProps {
+  cancel: () => void;
+  close: () => void;
+  decision: Decision;
+}
+
+const DeleteDecisionDialog = ({
+  cancel,
+  close,
+  decision,
+}: DeleteDecisionDialogProps) => {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const deleteDecision = () => {
+    removeDecisionFromLocalStorage(decision.walletAddress);
+    close();
+    navigate(pathname.slice(0, -PREVIEW_ROUTE_SUFFIX.length));
+  };
+
+  return (
+    <Dialog cancel={cancel}>
+      <div className={styles.main}>
+        <DialogSection>
+          <Heading3 text={MSG.title} />
+          <div>
+            <FormattedMessage {...MSG.description} />
+          </div>
+        </DialogSection>
+        <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
+          <Button
+            text={{ id: 'button.delete' }}
+            appearance={{ theme: 'pink', size: 'large' }}
+            onClick={deleteDecision}
+          />
+        </DialogSection>
+      </div>
+    </Dialog>
+  );
+};
+
+DeleteDecisionDialog.displayName = displayName;
+
+export default DeleteDecisionDialog;

--- a/src/components/common/ColonyDecisions/DeleteDecisionDialog/index.ts
+++ b/src/components/common/ColonyDecisions/DeleteDecisionDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DeleteDecisionDialog';

--- a/src/components/common/ColonyDecisions/index.ts
+++ b/src/components/common/ColonyDecisions/index.ts
@@ -1,3 +1,4 @@
 export { default } from './ColonyDecisions';
 export { default as NewDecisionButton } from './NewDecisionButton';
 export { default as DecisionDialog } from './DecisionDialog';
+export { default as DeleteDecisionDialog } from './DeleteDecisionDialog';

--- a/src/routes/routeConstants.ts
+++ b/src/routes/routeConstants.ts
@@ -18,6 +18,8 @@ export const LANDING_PAGE_ROUTE = '/landing';
 export const COLONY_DECISIONS_ROUTE = `/decisions`;
 export const COLONY_DECISIONS_PREVIEW_ROUTE = `/colony/:colonyName/decisions/preview`;
 export const DECISIONS_PAGE_ROUTE = `/decisions/tx/:transactionHash`;
+export const DECISIONS_PREVIEW_ROUTE_SUFFIX = '/preview';
+
 // export const ACTIONS_PAGE_ROUTE = `${COLONY_HOME_ROUTE}/tx/:transactionHash`;
 // export const UNWRAP_TOKEN_ROUTE = `${COLONY_HOME_ROUTE}/unwrap-tokens`;
 // export const CLAIM_TOKEN_ROUTE = `${COLONY_HOME_ROUTE}/claim-tokens`;

--- a/src/utils/decisions.ts
+++ b/src/utils/decisions.ts
@@ -20,3 +20,7 @@ export const setDecisionToLocalStorage = (
     JSON.stringify({ ...values, walletAddress }),
   );
 };
+
+export const removeDecisionFromLocalStorage = (walletAddress: Address) => {
+  localStorage.removeItem(getLocalStorageDecisionKey(walletAddress));
+};


### PR DESCRIPTION
## Description

This PR wires in the delete and edit decision modals, and well as the "Create new decision" button at `/preview` when there is 
no stored decision. "Publish" is being handled separately.

Note: It's worth reviewing https://github.com/JoinColony/colonyCDapp/pull/201 first, since it updates the state-related logic introduced here to account for the DraftDecisionItem.

Delete decision

![deleteme](https://user-images.githubusercontent.com/64402732/213489897-a2568be3-1ad7-49a8-9201-ba4a2747fe27.png)

Create new decision

![no-decision-saved](https://user-images.githubusercontent.com/64402732/213518499-a7bf72d7-94f9-4345-bee5-6e2fd525be4c.png)

Edit existing decision

![ddetails](https://user-images.githubusercontent.com/64402732/213518697-18512c5d-a41a-4217-bfda-9749c9111d87.png)


## Testing 

Clicking delete should: 
1. Open the delete decision modal
2. Clicking "Delete" in the modal should: 
3. Navigate to `/decisions` and remove the decision from local storage.

Click edit should: 
1. Open the DecisionDialog
2. Making an update should close the modal and update the preview. 
3. If you go back to the main `/decisions` page, open the dialog, and submit it, you should still be redirected to `decisions/preview`. 

Click create new decision should:
1. Open a clean modal
2. Submitting the dialog should update decisions preview.

**New stuff** ✨

* DeleteDecisionModal
* Wire in Edit Decision
* Wire in "Create new decision"

Resolves  #169 , #193, #196 
