### PR TITLE
Add "Remove Draft Decision" modal

### DIFF
--- a/src/components/common/ColonyDecisions/DeleteDecisionDialog/DeleteDecisionDialog.tsx
+++ b/src/components/common/ColonyDecisions/DeleteDecisionDialog/DeleteDecisionDialog.tsx
@@ -37,7 +37,8 @@ const DeleteDecisionDialog = ({
 }: DeleteDecisionDialogProps) => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const deleteDecision = () => {
+
+  const handleDeleteDecision = () => {
     removeDecisionFromLocalStorage(decision.walletAddress);
     close();
     navigate(pathname.slice(0, -DECISIONS_PREVIEW.length));
@@ -56,7 +57,7 @@ const DeleteDecisionDialog = ({
           <Button
             text={{ id: 'button.delete' }}
             appearance={{ theme: 'pink', size: 'large' }}
-            onClick={deleteDecision}
+            onClick={handleDeleteDecision}
           />
         </DialogSection>
       </div>

--- a/src/components/common/ColonyDecisions/NewDecisionButton/NewDecisionButton.tsx
+++ b/src/components/common/ColonyDecisions/NewDecisionButton/NewDecisionButton.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 
 import { useDialog } from '~shared/Dialog';
-import { DecisionDialog } from '~common/ColonyDecisions';
-// import RemoveDraftCreateNewDecision from '~dashboard/Dialogs/RemoveDraftDecisionDialog';
-
 import { DialogButton } from '~shared/Button';
+import {
+  DecisionDialog,
+  RemoveExistingDecisionDialog,
+} from '~common/ColonyDecisions';
 import { useAppContext } from '~hooks';
+import { getDecisionFromLocalStorage } from '~utils/decisions';
 
 const displayName = 'common.ColonyDecisions.NewDecisionButton';
 
@@ -15,6 +17,8 @@ interface Props {
 
 const NewDecisionButton = ({ ethDomainId }: Props) => {
   const { user } = useAppContext();
+  const walletAddress = user?.walletAddress || '';
+  const decision = getDecisionFromLocalStorage(walletAddress);
 
   //   const { isVotingExtensionEnabled, isLoadingExtensions } =
   //     useEnabledExtensions({
@@ -34,12 +38,7 @@ const NewDecisionButton = ({ ethDomainId }: Props) => {
   //   });
 
   const openDecisionDialog = useDialog(DecisionDialog);
-  // const openDeleteDraftDialog = useDialog(RemoveDraftCreateNewDecision);
-
-  const openNewDecisionDialog = () => {
-    openDecisionDialog({ ethDomainId });
-    // removeDraftDecision();
-  };
+  const openDeleteDraftDialog = useDialog(RemoveExistingDecisionDialog);
 
   // @TODO: This is copied from NewActionButton, extract instead.
   // const hasRegisteredProfile = !!username && !ethereal;
@@ -47,10 +46,13 @@ const NewDecisionButton = ({ ethDomainId }: Props) => {
   // const mustUpgrade = colonyMustBeUpgraded(colony, networkVersion as string);
   // const isLoadingData = isLoadingExtensions || isLoadingUser;
 
-  const handleClick = () => openNewDecisionDialog();
-  // draftDecision?.userAddress === user?.walletAddress
-  //   ? openDeleteDraftDialog({ colony, openNewDecisionDialog })
-  //   : openNewDecisionDialog();
+  const handleClick = () => {
+    if (decision) {
+      openDeleteDraftDialog({ openDecisionDialog });
+    } else {
+      openDecisionDialog({ ethDomainId });
+    }
+  };
 
   return (
     <DialogButton

--- a/src/components/common/ColonyDecisions/RemoveExistingDecisionDialog/RemoveDecisionMessage.css
+++ b/src/components/common/ColonyDecisions/RemoveExistingDecisionDialog/RemoveDecisionMessage.css
@@ -1,0 +1,3 @@
+.redTitle {
+  color: var(--danger);
+}

--- a/src/components/common/ColonyDecisions/RemoveExistingDecisionDialog/RemoveDecisionMessage.css.d.ts
+++ b/src/components/common/ColonyDecisions/RemoveExistingDecisionDialog/RemoveDecisionMessage.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace RemoveDecisionMessageCssNamespace {
+  export interface IRemoveDecisionMessageCss {
+    redTitle: string;
+  }
+}
+
+declare const RemoveDecisionMessageCssModule: RemoveDecisionMessageCssNamespace.IRemoveDecisionMessageCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: RemoveDecisionMessageCssNamespace.IRemoveDecisionMessageCss;
+};
+
+export = RemoveDecisionMessageCssModule;

--- a/src/components/common/ColonyDecisions/RemoveExistingDecisionDialog/RemoveDecisionMessage.tsx
+++ b/src/components/common/ColonyDecisions/RemoveExistingDecisionDialog/RemoveDecisionMessage.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { nanoid } from 'nanoid';
+
+import Button from '~shared/Button';
+import { DialogSection } from '~shared/Dialog';
+import { Heading3 } from '~shared/Heading';
+
+import styles from './RemoveDecisionMessage.css';
+
+const displayName = `common.ColonyDecisions.RemoveExistingDecisionDialog.RemoveDecisionMessage`;
+
+const MSG = defineMessages({
+  title: {
+    id: `${displayName}.title`,
+    defaultMessage: '{removeDraft} and create new Decision',
+  },
+  removeDraft: {
+    id: `${displayName}.removeDraft`,
+    defaultMessage: 'Remove draft',
+  },
+  description: {
+    id: `${displayName}.description`,
+    defaultMessage: `You have an existing draft Decision, creating a new Decision will remove your existing draft. {viewDraftBtn}`,
+  },
+  viewDraft: {
+    id: `${displayName}.newDecision`,
+    defaultMessage: 'View draft',
+  },
+});
+
+interface RemoveDecisionMessageProps {
+  handleRedirect: () => void;
+}
+
+const RemoveDecisionMessage = ({
+  handleRedirect,
+}: RemoveDecisionMessageProps) => (
+  <DialogSection>
+    <Heading3
+      appearance={{ theme: 'dark' }}
+      text={MSG.title}
+      textValues={{
+        removeDraft: (
+          <span className={styles.redTitle} key={nanoid()}>
+            <FormattedMessage {...MSG.removeDraft} />
+          </span>
+        ),
+      }}
+    />
+    <FormattedMessage
+      {...MSG.description}
+      values={{
+        viewDraftBtn: (
+          <Button
+            text={MSG.viewDraft}
+            appearance={{ theme: 'blue' }}
+            onClick={handleRedirect}
+          />
+        ),
+      }}
+    />
+  </DialogSection>
+);
+
+RemoveDecisionMessage.displayName = displayName;
+
+export default RemoveDecisionMessage;

--- a/src/components/common/ColonyDecisions/RemoveExistingDecisionDialog/RemoveExistingDecisionDialog.tsx
+++ b/src/components/common/ColonyDecisions/RemoveExistingDecisionDialog/RemoveExistingDecisionDialog.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import Button from '~shared/Button';
+import Dialog, { DialogProps, DialogSection } from '~shared/Dialog';
+import { useAppContext } from '~hooks';
+import { removeDecisionFromLocalStorage } from '~utils/decisions';
+import { DECISIONS_PREVIEW_ROUTE_SUFFIX as DECISIONS_PREVIEW } from '~routes';
+
+import RemoveDecisionMessage from './RemoveDecisionMessage';
+
+const displayName = 'common.ColonyDecisions.RemoveExistingDecisionDialog';
+
+const MSG = defineMessages({
+  newDecision: {
+    id: `${displayName}.newDecision`,
+    defaultMessage: 'New Decision',
+  },
+});
+
+interface RemoveExistingDecisionDialogProps extends DialogProps {
+  openDecisionDialog: () => void;
+}
+
+const RemoveExistingDecisionDialog = ({
+  close,
+  cancel,
+  openDecisionDialog,
+}: RemoveExistingDecisionDialogProps) => {
+  const { user } = useAppContext();
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  const walletAddress = user?.walletAddress || '';
+
+  const handleRedirect = () => {
+    navigate(`${pathname}${DECISIONS_PREVIEW}`);
+    close();
+  };
+
+  const handleRemoveDecision = () => {
+    removeDecisionFromLocalStorage(walletAddress);
+    openDecisionDialog();
+    close();
+  };
+
+  return (
+    <Dialog cancel={cancel}>
+      <RemoveDecisionMessage handleRedirect={handleRedirect} />
+      <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
+        <Button
+          appearance={{ theme: 'primary', size: 'large' }}
+          text={MSG.newDecision}
+          onClick={handleRemoveDecision}
+        />
+      </DialogSection>
+    </Dialog>
+  );
+};
+
+RemoveExistingDecisionDialog.displayName = displayName;
+
+export default RemoveExistingDecisionDialog;

--- a/src/components/common/ColonyDecisions/RemoveExistingDecisionDialog/index.ts
+++ b/src/components/common/ColonyDecisions/RemoveExistingDecisionDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RemoveExistingDecisionDialog';

--- a/src/components/common/ColonyDecisions/index.ts
+++ b/src/components/common/ColonyDecisions/index.ts
@@ -2,3 +2,4 @@ export { default } from './ColonyDecisions';
 export { default as NewDecisionButton } from './NewDecisionButton';
 export { default as DecisionDialog } from './DecisionDialog';
 export { default as DeleteDecisionDialog } from './DeleteDecisionDialog';
+export { default as RemoveExistingDecisionDialog } from './RemoveExistingDecisionDialog';


### PR DESCRIPTION
## Description

This PR wires in the "Remove Draft Decision" modal. When you click "New Decision", if you have a decision stored, this modal should appear. Clicking "view draft" should take you to `/preview`; else, clicking "New Decision" should open the Editor and clear the existing decision from local storage.

Remove Saved Decision:

![rem](https://user-images.githubusercontent.com/64402732/213530424-1ab20f2e-c1c8-47af-bdab-05c2f34b5bbe.png)

**New stuff** ✨

* `RemoveExistingDecisionDialog`

Resolves #188
