### PR TITLE
Add refreshUpgradedExtension util function

### DIFF
--- a/src/redux/sagas/extensions/extensionUpgrade.ts
+++ b/src/redux/sagas/extensions/extensionUpgrade.ts
@@ -1,11 +1,9 @@
 import { takeEvery, call, fork, put } from 'redux-saga/effects';
-
 import { ClientType, getExtensionHash } from '@colony/colony-js';
 
-import { ActionTypes } from '../../actionTypes';
-import { AllActions, Action } from '../../types/actions';
-import { putError, takeFrom } from '../utils';
+import { AllActions, Action, ActionTypes } from '~redux';
 
+import { putError, refreshUpgradedExtension, takeFrom } from '../utils';
 import {
   createTransaction,
   getTxChannel,
@@ -39,7 +37,7 @@ function* extensionUpgrade({
     return yield putError(ActionTypes.EXTENSION_UPGRADE_ERROR, error, meta);
   }
 
-  // yield call(refreshExtensions);
+  refreshUpgradedExtension(colonyAddress, extensionId, version);
 
   txChannel.close();
 

--- a/src/redux/sagas/utils/refreshExtension.ts
+++ b/src/redux/sagas/utils/refreshExtension.ts
@@ -1,4 +1,5 @@
 import { getExtensionHash } from '@colony/colony-js';
+
 import { ADDRESS_ZERO } from '~constants';
 import { ContextModule, getContext } from '~context';
 import {
@@ -128,6 +129,25 @@ export const refreshEnabledExtension = (
   const modifiedExtension: ColonyExtension = {
     ...existingExtension,
     isInitialized: true,
+  };
+
+  saveExtensionInCache(modifiedExtension);
+};
+
+export const refreshUpgradedExtension = (
+  colonyAddress: string,
+  extensionId: string,
+  version: number,
+) => {
+  const existingExtension = getExistingExtension(colonyAddress, extensionId);
+
+  if (!existingExtension) {
+    return;
+  }
+
+  const modifiedExtension: ColonyExtension = {
+    ...existingExtension,
+    currentVersion: version,
   };
 
   saveExtensionInCache(modifiedExtension);


### PR DESCRIPTION
## Description

Small PR, adds a refreshUpgradedExtension function similar to all other refresh functions.

Testing is tricky, since we still haven't figured out how to install a newer version of extension in the network (I wasted some time on it yesterday with no luck), so I think we'll just have to "trust" that it works and test it comprehensively when testing the main extensions branch.

Resolves #151 
