### PR TITLE
Refactor ingestor image to depend on amplify 

### DIFF
--- a/docker/colony-cdapp-dev-env-orchestration.yaml
+++ b/docker/colony-cdapp-dev-env-orchestration.yaml
@@ -38,6 +38,8 @@ services:
     depends_on:
       network-contracts:
         condition: service_healthy
+      amplify:
+        condition: service_health
     links:
       - "network-contracts:network-contracts.docker"
       - "amplify:amplify.docker"
@@ -62,3 +64,7 @@ services:
       - "reputation-monitor:reputation-monitor.docker"
     ports:
       - '20002:20002'
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:20002"]
+      interval: 5s
+      retries: 1000

--- a/docker/colony-cdapp-dev-env-orchestration.yaml
+++ b/docker/colony-cdapp-dev-env-orchestration.yaml
@@ -39,7 +39,7 @@ services:
       network-contracts:
         condition: service_healthy
       amplify:
-        condition: service_health
+        condition: service_healthy
     links:
       - "network-contracts:network-contracts.docker"
       - "amplify:amplify.docker"

--- a/scripts/temp-create-data.js
+++ b/scripts/temp-create-data.js
@@ -4,7 +4,6 @@ const colonyJSExtras = require('@colony/colony-js/extras')
 const colonyJSIColony = require('../node_modules/@colony/colony-js/dist/cjs/contracts/IColony/9/factories/IColony__factory.js')
 const colonyJSMetaTxToken = require('../node_modules/@colony/colony-js/dist/cjs/contracts/factories/latest/MetaTxToken__factory.js')
 const { addAugmentsB } = require('../node_modules/@colony/colony-js/dist/cjs/clients/Core/augments/AddDomain.js');
-const { getExtensionHash } = require('@colony/colony-js');
 
 /*
  * @NOTE To preserve time, I just re-used a script I wrote for one of the lambda functions
@@ -57,14 +56,6 @@ const createUniqueDomain = /* GraphQL */ `
     createUniqueDomain(input: $input) { nativeId }
   }
 `;
-const setCurrentVersion = /* GraphQL */`
-  mutation SetCurrentVersion($extensionHash: String!, $version: Int!) {
-    setCurrentVersion(input: {
-      key: $extensionHash,
-      version: $version
-    })
-  }
-`
 
 /*
  * Queries
@@ -418,16 +409,6 @@ const createColony = async (colonyName, tokenAddress, singerOrWallet) => {
 };
 
 /*
- * Extensions
- */
-const setExtensionVersion = async (extensionId, version) => {
-  await graphqlRequest(setCurrentVersion, {
-    extensionHash: getExtensionHash(extensionId),
-    version
-  }, GRAPHQL_URI, API_KEY)
-}
-
-/*
  * Orchestration
  */
 const createUserAndColonyData = async () => {
@@ -458,9 +439,6 @@ const createUserAndColonyData = async () => {
   await subscribeUserToColony(secondUser.address, thirdColonyAddress);
   await subscribeUserToColony(thirdUser.address, firstColonyAddress);
   await subscribeUserToColony(thirdUser.address, secondColonyAddress);
-
-  await setExtensionVersion('OneTxPayment', 4);
-  await setExtensionVersion('VotingReputation', 8);
 };
 
 createUserAndColonyData();

--- a/src/components/shared/Alert/Alert.css.d.ts
+++ b/src/components/shared/Alert/Alert.css.d.ts
@@ -1,15 +1,26 @@
-export const newInfoBlue: string;
-export const main: string;
-export const closeButton: string;
-export const themePrimary: string;
-export const themeInfo: string;
-export const themeDanger: string;
-export const themePinky: string;
-export const sizeSmall: string;
-export const borderRadiusSmall: string;
-export const borderRadiusMedium: string;
-export const borderRadiusLarge: string;
-export const borderRadiusRound: string;
-export const borderRadiusNone: string;
-export const marginDefault: string;
-export const marginNone: string;
+declare namespace AlertCssNamespace {
+  export interface IAlertCss {
+    borderRadiusLarge: string;
+    borderRadiusMedium: string;
+    borderRadiusNone: string;
+    borderRadiusRound: string;
+    borderRadiusSmall: string;
+    closeButton: string;
+    main: string;
+    marginDefault: string;
+    marginNone: string;
+    newInfoBlue: string;
+    sizeSmall: string;
+    themeDanger: string;
+    themeInfo: string;
+    themePinky: string;
+    themePrimary: string;
+  }
+}
+
+declare const AlertCssModule: AlertCssNamespace.IAlertCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: AlertCssNamespace.IAlertCss;
+};
+
+export = AlertCssModule;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -163,5 +163,3 @@ export const ADDRESS_ZERO = ethersContants.AddressZero;
 export const GANACHE_LOCAL_RPC_URL = 'http://localhost:8545';
 
 export const isDev = process.env.NODE_ENV === 'development';
-
-export const LATEST_ONE_TX_PAYMENT_VERSION = 3; // @TODO: get progamatically instead of hard-coding

--- a/src/redux/sagas/colony/colonyCreate.ts
+++ b/src/redux/sagas/colony/colonyCreate.ts
@@ -24,10 +24,7 @@ import {
   GetTokenFromEverywhereQueryVariables,
 } from '~gql';
 import { ColonyManager, ContextModule, getContext } from '~context';
-import {
-  DEFAULT_TOKEN_DECIMALS,
-  LATEST_ONE_TX_PAYMENT_VERSION,
-} from '~constants';
+import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { ActionTypes, Action, AllActions } from '~redux/index';
 import { createAddress } from '~utils/web3';
 import { TxConfig } from '~types';
@@ -47,6 +44,7 @@ import {
   getColonyManager,
 } from '../utils';
 import { createTransaction, createTransactionChannels } from '../transactions';
+import { getOneTxPaymentVersion } from '../utils/extensionVersion';
 
 interface ChannelDefinition {
   channel: Channel<any>;
@@ -439,12 +437,10 @@ function* colonyCreate({
       /*
        * Deploy OneTx
        */
+      const oneTxHash = getExtensionHash(Extension.OneTxPayment);
+      const oneTxVersion = yield call(getOneTxPaymentVersion);
       yield put(
-        transactionAddParams(deployOneTx.id, [
-          getExtensionHash(Extension.OneTxPayment),
-          /* @TODO: get latest version of OneTxPayment extn programatically */
-          LATEST_ONE_TX_PAYMENT_VERSION || 0,
-        ]),
+        transactionAddParams(deployOneTx.id, [oneTxHash, oneTxVersion || 0]),
       );
       yield put(transactionReady(deployOneTx.id));
 

--- a/src/redux/sagas/colony/colonyCreate.ts
+++ b/src/redux/sagas/colony/colonyCreate.ts
@@ -440,7 +440,7 @@ function* colonyCreate({
       const oneTxHash = getExtensionHash(Extension.OneTxPayment);
       const oneTxVersion = yield call(getOneTxPaymentVersion);
       yield put(
-        transactionAddParams(deployOneTx.id, [oneTxHash, oneTxVersion || 0]),
+        transactionAddParams(deployOneTx.id, [oneTxHash, oneTxVersion]),
       );
       yield put(transactionReady(deployOneTx.id));
 

--- a/src/redux/sagas/utils/extensionVersion.ts
+++ b/src/redux/sagas/utils/extensionVersion.ts
@@ -1,0 +1,24 @@
+import { Extension, getExtensionHash } from '@colony/colony-js';
+
+import { ContextModule, getContext } from '~context';
+import {
+  GetCurrentExtensionVersionDocument,
+  GetCurrentExtensionVersionQuery,
+  GetCurrentExtensionVersionQueryVariables,
+} from '~gql';
+
+export const getOneTxPaymentVersion = async (): Promise<number | null> => {
+  const apolloClient = getContext(ContextModule.ApolloClient);
+
+  const { data } = await apolloClient.query<
+    GetCurrentExtensionVersionQuery,
+    GetCurrentExtensionVersionQueryVariables
+  >({
+    query: GetCurrentExtensionVersionDocument,
+    variables: {
+      extensionHash: getExtensionHash(Extension.OneTxPayment),
+    },
+  });
+
+  return data.getCurrentVersionByKey?.items[0]?.version ?? null;
+};

--- a/src/redux/sagas/utils/extensionVersion.ts
+++ b/src/redux/sagas/utils/extensionVersion.ts
@@ -7,7 +7,7 @@ import {
   GetCurrentExtensionVersionQueryVariables,
 } from '~gql';
 
-export const getOneTxPaymentVersion = async (): Promise<number | null> => {
+export const getOneTxPaymentVersion = async (): Promise<number> => {
   const apolloClient = getContext(ContextModule.ApolloClient);
 
   const { data } = await apolloClient.query<
@@ -20,5 +20,5 @@ export const getOneTxPaymentVersion = async (): Promise<number | null> => {
     },
   });
 
-  return data.getCurrentVersionByKey?.items[0]?.version ?? null;
+  return data.getCurrentVersionByKey?.items[0]?.version ?? 1;
 };


### PR DESCRIPTION
## Description

This PR adds a healthcheck for amplify image, and makes block-ingestor dependent on amplify so that it can call the necessary mutations on startup (tracking extensions for now, but I expect this will also be needed for actions and motions)

It also fixes the failing colony creation by refactoring hardcoded OneTxPayment version in `colonyCreate` saga to programatically get it from the db (something I missed while bumping the colony network version), and removes the `setCurrentVersion` mutation calls from temp-create-data script.

Resolves #137 
