### PR TITLE
Port root motion saga

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -419,7 +419,7 @@ type ColonyAction @model {
   colony: Colony! @belongsTo(fields: ["colonyId"])
   type: ColonyActionType!
   blockNumber: Int!
-  transactionHash: String!
+  isMotion: Boolean
   createdAt: AWSDateTime!
   initiatorAddress: ID
   initiator: User @hasOne(fields: ["initiatorAddress"])

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=bbad0279d810d2088c09c726fc8396f732ca1db5
+ENV BLOCK_INGESTOR_HASH=70c25ed882b5d05c3306800bfc72f44482f422a9
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/common/ColonyActions/ActionDetailsPage/ActionDetailsPage.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/ActionDetailsPage.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
 import { defineMessages } from 'react-intl';
 
-import { isTransactionFormat } from '~utils/web3';
-import { useColonyContext } from '~hooks';
+import { useColonyContext, useGetColonyAction } from '~hooks';
 import LoadingTemplate from '~frame/LoadingTemplate';
-import { useGetFullColonyByAddressQuery } from '~gql';
 
-import { mockActionData } from '../mockData';
 import {
   TransactionNotFound,
   ActionDetailsPageLayout as Layout,
@@ -28,44 +24,31 @@ const MSG = defineMessages({
   },
 });
 
-type ActionDetailsPageParams = Record<'colonyName' | 'transactionHash', string>;
+export type ActionDetailsPageParams = Record<
+  'colonyName' | 'transactionHash',
+  string
+>;
 
 const ActionDetailsPage = () => {
   const { colony } = useColonyContext();
-  const { transactionHash, colonyName } = useParams<ActionDetailsPageParams>();
+  const {
+    isInvalidTransactionHash,
+    isUnknownTransaction,
+    action,
+    loadingAction,
+  } = useGetColonyAction(colony);
 
-  const action = mockActionData.find(
-    (item) => item.transactionHash === transactionHash,
-  );
-
-  const createdAt = action?.createdAt;
   // const status = action?.transactionStatus;
-
-  const isValidTx = isTransactionFormat(transactionHash);
-  const events = ['event']; // to be taken from real data
-
-  // Todo: get colony address from the event and compare with colony in the pathname
-  // to ensure this tx was generated in this colony
-  const { data, loading: loadingColony } = useGetFullColonyByAddressQuery({
-    variables: {
-      address: action?.colonyAddress,
-    },
-  });
-
-  const txColony = data?.getColonyByAddress?.items[0];
-
   if (!colony) {
     return null;
   }
 
+  const isMotion = action?.isMotion;
+  const createdAt = action?.createdAt;
   const isInvalidTransaction =
-    !isValidTx ||
-    !events?.length ||
-    !action ||
-    !txColony ||
-    txColony.name !== colonyName;
+    isInvalidTransactionHash || isUnknownTransaction || !action;
 
-  if (loadingColony) {
+  if (loadingAction) {
     return <LoadingTemplate loadingText={MSG.loading} />;
   }
 
@@ -74,16 +57,13 @@ const ActionDetailsPage = () => {
       <Layout center>
         <TransactionNotFound
           colonyName={colony.name}
-          transactionHash={transactionHash}
           createdAt={createdAt}
           // status={status}
-          isUnknownTx={!events?.length && isValidTx}
+          isUnknownTx={isUnknownTransaction}
         />
       </Layout>
     );
   }
-
-  const isMotion = action.isMotion;
 
   if (isMotion) {
     return (

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionCountdown/EscalateButton/EscalateButton.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionCountdown/EscalateButton/EscalateButton.tsx
@@ -46,9 +46,7 @@ const EscalateButton = ({ motionId, userAddress }: EscalateButtonProps) => {
     <div className={styles.escalation}>
       <ActionButton
         appearance={{ theme: 'blue', size: 'small' }}
-        submit={ActionTypes.MOTION_ESCALATE}
-        error={ActionTypes.MOTION_ESCALATE_ERROR}
-        success={ActionTypes.MOTION_ESCALATE_SUCCESS}
+        actionType={ActionTypes.MOTION_ESCALATE}
         transform={escalateTransform}
         text={MSG.escalate}
         /*

--- a/src/components/common/ColonyActions/ActionDetailsPage/TransactionNotFound/TransactionNotFound.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/TransactionNotFound/TransactionNotFound.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
+import { useParams } from 'react-router-dom';
 
 import { Heading3 } from '~shared/Heading';
 import Button from '~shared/Button';
@@ -8,6 +9,7 @@ import NakedMoleImage from '~images/naked-mole.svg';
 import { STATUS_MAP } from '../staticMaps';
 import TransactionHash from './TransactionHash';
 import { TransactionMetaProps } from '../TransactionMeta';
+import { ActionDetailsPageParams } from '../ActionDetailsPage';
 
 import styles from './TransactionNotFound.css';
 
@@ -32,7 +34,6 @@ interface TransactionNotFoundProps {
   colonyName?: string;
   createdAt?: TransactionMetaProps['createdAt'];
   status?: number;
-  transactionHash?: string;
   isUnknownTx: boolean;
 }
 
@@ -40,36 +41,38 @@ const TransactionNotFound = ({
   colonyName,
   createdAt,
   status,
-  transactionHash,
   isUnknownTx,
-}: TransactionNotFoundProps) => (
-  <div className={styles.notFoundContainer}>
-    <NakedMoleImage />
-    <Heading3
-      text={isUnknownTx ? MSG.unknownTransaction : MSG.transactionNotFound}
-      appearance={{
-        weight: 'medium',
-        theme: 'dark',
-      }}
-    />
-    <Button
-      title={MSG.returnToColony}
-      text={MSG.returnToColony}
-      linkTo={`/colony/${colonyName}`}
-      appearance={{
-        theme: 'primary',
-        size: 'large',
-      }}
-    />
-    <div className={styles.divider} />
-    <TransactionHash
-      showMeta={isUnknownTx}
-      transactionHash={transactionHash}
-      createdAt={createdAt}
-      status={isUnknownTx ? STATUS_MAP[status ?? ''] : undefined}
-    />
-  </div>
-);
+}: TransactionNotFoundProps) => {
+  const { transactionHash } = useParams<ActionDetailsPageParams>();
+  return (
+    <div className={styles.notFoundContainer}>
+      <NakedMoleImage />
+      <Heading3
+        text={isUnknownTx ? MSG.unknownTransaction : MSG.transactionNotFound}
+        appearance={{
+          weight: 'medium',
+          theme: 'dark',
+        }}
+      />
+      <Button
+        title={MSG.returnToColony}
+        text={MSG.returnToColony}
+        linkTo={`/colony/${colonyName}`}
+        appearance={{
+          theme: 'primary',
+          size: 'large',
+        }}
+      />
+      <div className={styles.divider} />
+      <TransactionHash
+        showMeta={isUnknownTx}
+        transactionHash={transactionHash}
+        createdAt={createdAt}
+        status={isUnknownTx ? STATUS_MAP[status ?? ''] : undefined}
+      />
+    </div>
+  );
+};
 
 TransactionNotFound.displayName = displayName;
 

--- a/src/components/common/ColonyActions/ActionDetailsPage/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/index.ts
@@ -1,4 +1,4 @@
-export { default } from './ActionDetailsPage';
+export { default, ActionDetailsPageParams } from './ActionDetailsPage';
 export { default as TransactionNotFound } from './TransactionNotFound';
 export { default as ActionDetailsPageLayout } from './Layout';
 export { default as DefaultAction } from './DefaultAction';

--- a/src/components/common/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.tsx
+++ b/src/components/common/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.tsx
@@ -114,9 +114,7 @@ const ColonyUnclaimedTransfers = () => {
             <ActionButton
               text={MSG.claimButton}
               className={styles.button}
-              submit={ActionTypes.CLAIM_TOKEN}
-              error={ActionTypes.CLAIM_TOKEN_ERROR}
-              success={ActionTypes.CLAIM_TOKEN_SUCCESS}
+              actionType={ActionTypes.CLAIM_TOKEN}
               transform={transform}
               disabled={!canInteractWithColony}
             />

--- a/src/components/common/Extensions/ExtensionActionButton/ExtensionActionButton.tsx
+++ b/src/components/common/Extensions/ExtensionActionButton/ExtensionActionButton.tsx
@@ -48,9 +48,7 @@ const ExtensionActionButton = ({ extensionData }: Props) => {
     return (
       <ActionButton
         button={IconButton}
-        submit={ActionTypes.EXTENSION_INSTALL}
-        error={ActionTypes.EXTENSION_INSTALL_ERROR}
-        success={ActionTypes.EXTENSION_INSTALL_SUCCESS}
+        actionType={ActionTypes.EXTENSION_INSTALL}
         values={{
           colonyAddress: colony.colonyAddress,
           extensionData,

--- a/src/components/common/Extensions/ExtensionDetails/ExtensionDetailsAside.tsx
+++ b/src/components/common/Extensions/ExtensionDetails/ExtensionDetailsAside.tsx
@@ -113,9 +113,7 @@ const ExtensionDetailsAside = ({
             children: <FormattedMessage {...MSG.textDeprecate} />,
           }}
           appearance={{ theme: 'blue' }}
-          submit={ActionTypes.EXTENSION_DEPRECATE}
-          error={ActionTypes.EXTENSION_DEPRECATE_ERROR}
-          success={ActionTypes.EXTENSION_DEPRECATE_SUCCESS}
+          actionType={ActionTypes.EXTENSION_DEPRECATE}
           text={MSG.buttonDeprecate}
           values={{
             colonyAddress,
@@ -133,9 +131,7 @@ const ExtensionDetailsAside = ({
               children: <FormattedMessage {...MSG.textReEnable} />,
             }}
             appearance={{ theme: 'blue' }}
-            submit={ActionTypes.EXTENSION_DEPRECATE}
-            error={ActionTypes.EXTENSION_DEPRECATE_ERROR}
-            success={ActionTypes.EXTENSION_DEPRECATE_SUCCESS}
+            actionType={ActionTypes.EXTENSION_DEPRECATE}
             text={MSG.buttonReEnable}
             values={{
               colonyAddress,
@@ -150,9 +146,7 @@ const ExtensionDetailsAside = ({
               children: <FormattedMessage {...MSG.textUninstall} />,
             }}
             appearance={{ theme: 'blue' }}
-            submit={ActionTypes.EXTENSION_UNINSTALL}
-            error={ActionTypes.EXTENSION_UNINSTALL_ERROR}
-            success={ActionTypes.EXTENSION_UNINSTALL_SUCCESS}
+            actionType={ActionTypes.EXTENSION_UNINSTALL}
             values={{
               colonyAddress,
               extensionId,

--- a/src/components/common/Extensions/ExtensionUpgradeButton/ExtensionUpgradeButton.tsx
+++ b/src/components/common/Extensions/ExtensionUpgradeButton/ExtensionUpgradeButton.tsx
@@ -57,9 +57,7 @@ const ExtensionUpgradeButton = ({ extensionData }: Props) => {
   return (
     <ActionButton
       appearance={{ theme: 'primary', size: 'medium' }}
-      submit={ActionTypes.EXTENSION_UPGRADE}
-      error={ActionTypes.EXTENSION_UPGRADE_ERROR}
-      success={ActionTypes.EXTENSION_UPGRADE_SUCCESS}
+      actionType={ActionTypes.EXTENSION_UPGRADE}
       transform={transform}
       text={{ id: 'button.upgrade' }}
       disabled={

--- a/src/components/frame/LoadingTemplate/LoadingTemplate.tsx
+++ b/src/components/frame/LoadingTemplate/LoadingTemplate.tsx
@@ -35,7 +35,7 @@ const MSG = defineMessages({
 });
 
 const delayedLoadingDuration = 15 * 1000; // 15 seconds
-const failedLoadingDuration = 30 * 1000; // 30 seconds
+export const failedLoadingDuration = 30 * 1000; // 30 seconds
 
 const LoadingTemplate = ({ children, loadingText }: Props) => {
   type LoadingStateType = 'default' | 'delayed' | 'failed';

--- a/src/components/frame/LoadingTemplate/index.ts
+++ b/src/components/frame/LoadingTemplate/index.ts
@@ -1,1 +1,1 @@
-export { default } from './LoadingTemplate';
+export { default, failedLoadingDuration } from './LoadingTemplate';

--- a/src/components/shared/ActionsList/ActionsList.tsx
+++ b/src/components/shared/ActionsList/ActionsList.tsx
@@ -22,7 +22,11 @@ const ActionsList = ({
 }: Props) => (
   <ul>
     {items.map((item) => (
-      <Item key={item.id} item={item} handleOnClick={handleItemClick} />
+      <Item
+        key={item.transactionHash}
+        item={item}
+        handleOnClick={handleItemClick}
+      />
     ))}
   </ul>
 );

--- a/src/components/shared/Button/ActionButton.tsx
+++ b/src/components/shared/Button/ActionButton.tsx
@@ -4,32 +4,40 @@ import { MessageDescriptor } from 'react-intl';
 import { ActionTransformFnType } from '~utils/actions';
 import { useAsyncFunction, useMounted } from '~hooks';
 import DefaultButton from '~shared/Button';
+import { ActionTypes } from '~redux';
 import { Props as DefaultButtonProps } from './Button';
 
+const getFormAction = (
+  action: ActionTypes,
+  actionType: 'SUBMIT' | 'ERROR' | 'SUCCESS',
+) => {
+  const actionEnd = actionType === 'SUBMIT' ? '' : `_${actionType}`;
+  return `${action}${actionEnd}`;
+};
+
 interface Props extends DefaultButtonProps {
+  actionType: ActionTypes;
   button?: ElementType;
   confirmText?: any;
-  error: string;
   onConfirmToggled?: (...args: any[]) => void;
   onSuccess?: (result: any) => void;
-  submit: string;
-  success: string;
   text?: MessageDescriptor | string;
   transform?: ActionTransformFnType;
   values?: any | (() => any | Promise<any>);
 }
 
 const ActionButton = ({
+  actionType,
   button,
-  error,
-  submit,
-  success,
   onSuccess,
   // @todo Remove `values` once async transform functions are supported
   values,
   transform,
   ...props
 }: Props) => {
+  const submit = getFormAction(actionType, 'SUBMIT');
+  const error = getFormAction(actionType, 'ERROR');
+  const success = getFormAction(actionType, 'SUCCESS');
   const isMountedRef = useMounted();
   const [loading, setLoading] = useState(false);
   const asyncFunction = useAsyncFunction({ submit, error, success, transform });

--- a/src/components/shared/Button/ActionButton.tsx
+++ b/src/components/shared/Button/ActionButton.tsx
@@ -5,13 +5,14 @@ import { ActionTransformFnType } from '~utils/actions';
 import { useAsyncFunction, useMounted } from '~hooks';
 import DefaultButton from '~shared/Button';
 import { ActionTypes } from '~redux';
+
 import { Props as DefaultButtonProps } from './Button';
 
 const getFormAction = (
   action: ActionTypes,
-  actionType: 'SUBMIT' | 'ERROR' | 'SUCCESS',
+  actionType: 'ERROR' | 'SUCCESS',
 ) => {
-  const actionEnd = actionType === 'SUBMIT' ? '' : `_${actionType}`;
+  const actionEnd = `_${actionType}`;
   return `${action}${actionEnd}`;
 };
 
@@ -19,8 +20,11 @@ interface Props extends DefaultButtonProps {
   actionType: ActionTypes;
   button?: ElementType;
   confirmText?: any;
+  error?: string;
   onConfirmToggled?: (...args: any[]) => void;
   onSuccess?: (result: any) => void;
+  submit?: string;
+  success?: string;
   text?: MessageDescriptor | string;
   transform?: ActionTransformFnType;
   values?: any | (() => any | Promise<any>);
@@ -29,18 +33,26 @@ interface Props extends DefaultButtonProps {
 const ActionButton = ({
   actionType,
   button,
+  error,
+  submit,
+  success,
   onSuccess,
   // @todo Remove `values` once async transform functions are supported
   values,
   transform,
   ...props
 }: Props) => {
-  const submit = getFormAction(actionType, 'SUBMIT');
-  const error = getFormAction(actionType, 'ERROR');
-  const success = getFormAction(actionType, 'SUCCESS');
+  const submitAction = submit || actionType;
+  const errorAction = error || getFormAction(actionType, 'ERROR');
+  const successAction = success || getFormAction(actionType, 'SUCCESS');
   const isMountedRef = useMounted();
   const [loading, setLoading] = useState(false);
-  const asyncFunction = useAsyncFunction({ submit, error, success, transform });
+  const asyncFunction = useAsyncFunction({
+    submit: submitAction,
+    error: errorAction,
+    success: successAction,
+    transform,
+  });
 
   const handleClick = async () => {
     let result;

--- a/src/components/shared/Button/DialogActionButton.tsx
+++ b/src/components/shared/Button/DialogActionButton.tsx
@@ -3,28 +3,25 @@ import { MessageDescriptor } from 'react-intl';
 
 import { useDialog } from '~shared/Dialog';
 import { ActionTransformFnType } from '~utils/actions';
+import { ActionTypes } from '~redux';
 
 import { Appearance } from './Button';
 import ActionButton from './ActionButton';
 
 interface Props<D extends ComponentType<any>> {
+  actionType: ActionTypes;
   appearance?: Appearance;
   className?: string;
   dialog: D;
   dialogProps?: Omit<ComponentProps<D>, 'close' | 'cancel'>;
   disabled?: boolean;
-  submit: string;
-  success: string;
-  error: string;
   text?: MessageDescriptor | string;
   transform?: ActionTransformFnType;
   values?: any | ((dialogValues: any) => any | Promise<any>);
 }
 
 const DialogActionButton = <D extends ComponentType<any>>({
-  submit,
-  success,
-  error,
+  actionType,
   values: valuesProp = {},
   dialog,
   dialogProps,
@@ -36,15 +33,7 @@ const DialogActionButton = <D extends ComponentType<any>>({
     if (typeof valuesProp === 'function') return valuesProp(dialogValues);
     return { ...dialogValues, ...valuesProp };
   }, [dialogProps, openDialog, valuesProp]);
-  return (
-    <ActionButton
-      submit={submit}
-      success={success}
-      error={error}
-      values={values}
-      {...props}
-    />
-  );
+  return <ActionButton actionType={actionType} values={values} {...props} />;
 };
 
 export default DialogActionButton;

--- a/src/components/shared/DetailsWidget/detailsWidgetConfig.tsx
+++ b/src/components/shared/DetailsWidget/detailsWidgetConfig.tsx
@@ -231,7 +231,7 @@ const getDetailItems = (
 ): DetailItemConfig[] => {
   const detailItemsMap = getDetailItemsMap(colony, itemData);
   const detailItemKeys = getDetailItemsKeys(itemData.type);
-  const motionDetailItem = getMotionDetailItem(colony, itemData.motionDomainId);
+  const motionDetailItem = getMotionDetailItem(colony, itemData.fromDomain);
 
   const detailItems = detailItemKeys
     .map((itemKey) => detailItemsMap[itemKey])

--- a/src/components/shared/PopoverSection/MetaSection.tsx
+++ b/src/components/shared/PopoverSection/MetaSection.tsx
@@ -24,9 +24,7 @@ const MetaSection = () => {
         <ActionButton
           appearance={{ theme: 'no-style' }}
           text={MSG.signOut}
-          submit={ActionTypes.USER_LOGOUT}
-          error={ActionTypes.USER_LOGOUT_ERROR}
-          success={ActionTypes.USER_LOGOUT_SUCCESS}
+          actionType={ActionTypes.USER_LOGOUT}
           onSuccess={updateWallet}
         />
       </DropdownMenuItem>

--- a/src/graphql/fragments/actions.graphql
+++ b/src/graphql/fragments/actions.graphql
@@ -1,8 +1,7 @@
 fragment ColonyAction on ColonyAction {
-  id
+  transactionHash: id
   type
   blockNumber
-  transactionHash
   initiatorAddress
   initiator {
     ...User
@@ -17,4 +16,8 @@ fragment ColonyAction on ColonyAction {
   fromDomain
   toDomain
   createdAt
+  isMotion
+  colony {
+    colonyName: name
+  }
 }

--- a/src/graphql/fragments/actions.graphql
+++ b/src/graphql/fragments/actions.graphql
@@ -18,6 +18,6 @@ fragment ColonyAction on ColonyAction {
   createdAt
   isMotion
   colony {
-    colonyName: name
+    colonyAddress: id
   }
 }

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -125,7 +125,6 @@ export type ColonyAction = {
   toDomain?: Maybe<Scalars['String']>;
   tokenAddress?: Maybe<Scalars['String']>;
   tokenSymbol?: Maybe<Scalars['String']>;
-  transactionHash: Scalars['String'];
   type: ColonyActionType;
   updatedAt: Scalars['AWSDateTime'];
 };
@@ -295,7 +294,6 @@ export type CreateColonyActionInput = {
   toDomain?: InputMaybe<Scalars['String']>;
   tokenAddress?: InputMaybe<Scalars['String']>;
   tokenSymbol?: InputMaybe<Scalars['String']>;
-  transactionHash: Scalars['String'];
   type: ColonyActionType;
 };
 
@@ -615,7 +613,6 @@ export type ModelColonyActionConditionInput = {
   toDomain?: InputMaybe<ModelStringInput>;
   tokenAddress?: InputMaybe<ModelStringInput>;
   tokenSymbol?: InputMaybe<ModelStringInput>;
-  transactionHash?: InputMaybe<ModelStringInput>;
   type?: InputMaybe<ModelColonyActionTypeInput>;
 };
 
@@ -643,7 +640,6 @@ export type ModelColonyActionFilterInput = {
   toDomain?: InputMaybe<ModelStringInput>;
   tokenAddress?: InputMaybe<ModelStringInput>;
   tokenSymbol?: InputMaybe<ModelStringInput>;
-  transactionHash?: InputMaybe<ModelStringInput>;
   type?: InputMaybe<ModelColonyActionTypeInput>;
 };
 
@@ -1017,7 +1013,6 @@ export type ModelSubscriptionColonyActionFilterInput = {
   toDomain?: InputMaybe<ModelSubscriptionStringInput>;
   tokenAddress?: InputMaybe<ModelSubscriptionStringInput>;
   tokenSymbol?: InputMaybe<ModelSubscriptionStringInput>;
-  transactionHash?: InputMaybe<ModelSubscriptionStringInput>;
   type?: InputMaybe<ModelSubscriptionStringInput>;
 };
 
@@ -1670,7 +1665,6 @@ export type ProfileMetadataInput = {
 
 export type Query = {
   __typename?: 'Query';
-  getActionByHash?: Maybe<ModelColonyActionConnection>;
   getActionsByColony?: Maybe<ModelColonyActionConnection>;
   getColony?: Maybe<Colony>;
   getColonyAction?: Maybe<ColonyAction>;
@@ -1711,15 +1705,6 @@ export type Query = {
   listUserTokens?: Maybe<ModelUserTokensConnection>;
   listUsers?: Maybe<ModelUserConnection>;
   listWatchedColonies?: Maybe<ModelWatchedColoniesConnection>;
-};
-
-
-export type QueryGetActionByHashArgs = {
-  filter?: InputMaybe<ModelColonyActionFilterInput>;
-  limit?: InputMaybe<Scalars['Int']>;
-  nextToken?: InputMaybe<Scalars['String']>;
-  sortDirection?: InputMaybe<ModelSortDirection>;
-  transactionHash: Scalars['String'];
 };
 
 
@@ -2303,7 +2288,6 @@ export type UpdateColonyActionInput = {
   toDomain?: InputMaybe<Scalars['String']>;
   tokenAddress?: InputMaybe<Scalars['String']>;
   tokenSymbol?: InputMaybe<Scalars['String']>;
-  transactionHash?: InputMaybe<Scalars['String']>;
   type?: InputMaybe<ColonyActionType>;
 };
 
@@ -2488,7 +2472,7 @@ export type WatchedColonies = {
   userID: Scalars['ID'];
 };
 
-export type ColonyActionFragment = { __typename?: 'ColonyAction', type: ColonyActionType, blockNumber: number, initiatorAddress?: string | null, recipientAddress?: string | null, amount?: string | null, decimals?: number | null, tokenSymbol?: string | null, fromDomain?: string | null, toDomain?: string | null, createdAt: string, isMotion?: boolean | null, transactionHash: string, initiator?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, recipient?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, colony: { __typename?: 'Colony', colonyName: string } };
+export type ColonyActionFragment = { __typename?: 'ColonyAction', type: ColonyActionType, blockNumber: number, initiatorAddress?: string | null, recipientAddress?: string | null, amount?: string | null, decimals?: number | null, tokenSymbol?: string | null, fromDomain?: string | null, toDomain?: string | null, createdAt: string, isMotion?: boolean | null, transactionHash: string, initiator?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, recipient?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, colony: { __typename?: 'Colony', colonyAddress: string } };
 
 export type ColonyFragment = { __typename?: 'Colony', name: string, version: number, colonyAddress: string, nativeToken: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string }, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, status?: { __typename?: 'ColonyStatus', recovery?: boolean | null, nativeToken?: { __typename?: 'NativeTokenStatus', mintable?: boolean | null, unlockable?: boolean | null, unlocked?: boolean | null } | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null, tokens?: { __typename?: 'ModelColonyTokensConnection', items: Array<{ __typename?: 'ColonyTokens', token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> } | null, domains?: { __typename?: 'ModelDomainConnection', items: Array<{ __typename?: 'Domain', color?: DomainColor | null, description?: string | null, id: string, name?: string | null, nativeId: number, parentId?: string | null } | null> } | null, watchers?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', user: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, website?: string | null, thumbnail?: string | null } | null } } | null> } | null };
 
@@ -2563,14 +2547,14 @@ export type GetColonyActionsQueryVariables = Exact<{
 }>;
 
 
-export type GetColonyActionsQuery = { __typename?: 'Query', getActionsByColony?: { __typename?: 'ModelColonyActionConnection', nextToken?: string | null, items: Array<{ __typename?: 'ColonyAction', type: ColonyActionType, blockNumber: number, initiatorAddress?: string | null, recipientAddress?: string | null, amount?: string | null, decimals?: number | null, tokenSymbol?: string | null, fromDomain?: string | null, toDomain?: string | null, createdAt: string, isMotion?: boolean | null, transactionHash: string, initiator?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, recipient?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, colony: { __typename?: 'Colony', colonyName: string } } | null> } | null };
+export type GetColonyActionsQuery = { __typename?: 'Query', getActionsByColony?: { __typename?: 'ModelColonyActionConnection', nextToken?: string | null, items: Array<{ __typename?: 'ColonyAction', type: ColonyActionType, blockNumber: number, initiatorAddress?: string | null, recipientAddress?: string | null, amount?: string | null, decimals?: number | null, tokenSymbol?: string | null, fromDomain?: string | null, toDomain?: string | null, createdAt: string, isMotion?: boolean | null, transactionHash: string, initiator?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, recipient?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, colony: { __typename?: 'Colony', colonyAddress: string } } | null> } | null };
 
 export type GetColonyActionQueryVariables = Exact<{
   transactionHash: Scalars['ID'];
 }>;
 
 
-export type GetColonyActionQuery = { __typename?: 'Query', getColonyAction?: { __typename?: 'ColonyAction', type: ColonyActionType, blockNumber: number, initiatorAddress?: string | null, recipientAddress?: string | null, amount?: string | null, decimals?: number | null, tokenSymbol?: string | null, fromDomain?: string | null, toDomain?: string | null, createdAt: string, isMotion?: boolean | null, transactionHash: string, initiator?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, recipient?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, colony: { __typename?: 'Colony', colonyName: string } } | null };
+export type GetColonyActionQuery = { __typename?: 'Query', getColonyAction?: { __typename?: 'ColonyAction', type: ColonyActionType, blockNumber: number, initiatorAddress?: string | null, recipientAddress?: string | null, amount?: string | null, decimals?: number | null, tokenSymbol?: string | null, fromDomain?: string | null, toDomain?: string | null, createdAt: string, isMotion?: boolean | null, transactionHash: string, initiator?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, recipient?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, colony: { __typename?: 'Colony', colonyAddress: string } } | null };
 
 export type GetFullColonyByAddressQueryVariables = Exact<{
   address: Scalars['ID'];
@@ -2734,7 +2718,7 @@ export const ColonyActionFragmentDoc = gql`
   createdAt
   isMotion
   colony {
-    colonyName: name
+    colonyAddress: id
   }
 }
     ${UserFragmentDoc}`;

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -119,6 +119,7 @@ export type ColonyAction = {
   id: Scalars['ID'];
   initiator?: Maybe<User>;
   initiatorAddress?: Maybe<Scalars['ID']>;
+  isMotion?: Maybe<Scalars['Boolean']>;
   recipient?: Maybe<User>;
   recipientAddress?: Maybe<Scalars['ID']>;
   toDomain?: Maybe<Scalars['String']>;
@@ -289,6 +290,7 @@ export type CreateColonyActionInput = {
   fromDomain?: InputMaybe<Scalars['String']>;
   id?: InputMaybe<Scalars['ID']>;
   initiatorAddress?: InputMaybe<Scalars['ID']>;
+  isMotion?: InputMaybe<Scalars['Boolean']>;
   recipientAddress?: InputMaybe<Scalars['ID']>;
   toDomain?: InputMaybe<Scalars['String']>;
   tokenAddress?: InputMaybe<Scalars['String']>;
@@ -606,6 +608,7 @@ export type ModelColonyActionConditionInput = {
   decimals?: InputMaybe<ModelIntInput>;
   fromDomain?: InputMaybe<ModelStringInput>;
   initiatorAddress?: InputMaybe<ModelIdInput>;
+  isMotion?: InputMaybe<ModelBooleanInput>;
   not?: InputMaybe<ModelColonyActionConditionInput>;
   or?: InputMaybe<Array<InputMaybe<ModelColonyActionConditionInput>>>;
   recipientAddress?: InputMaybe<ModelIdInput>;
@@ -633,6 +636,7 @@ export type ModelColonyActionFilterInput = {
   fromDomain?: InputMaybe<ModelStringInput>;
   id?: InputMaybe<ModelIdInput>;
   initiatorAddress?: InputMaybe<ModelIdInput>;
+  isMotion?: InputMaybe<ModelBooleanInput>;
   not?: InputMaybe<ModelColonyActionFilterInput>;
   or?: InputMaybe<Array<InputMaybe<ModelColonyActionFilterInput>>>;
   recipientAddress?: InputMaybe<ModelIdInput>;
@@ -1007,6 +1011,7 @@ export type ModelSubscriptionColonyActionFilterInput = {
   fromDomain?: InputMaybe<ModelSubscriptionStringInput>;
   id?: InputMaybe<ModelSubscriptionIdInput>;
   initiatorAddress?: InputMaybe<ModelSubscriptionIdInput>;
+  isMotion?: InputMaybe<ModelSubscriptionBooleanInput>;
   or?: InputMaybe<Array<InputMaybe<ModelSubscriptionColonyActionFilterInput>>>;
   recipientAddress?: InputMaybe<ModelSubscriptionIdInput>;
   toDomain?: InputMaybe<ModelSubscriptionStringInput>;
@@ -1665,6 +1670,7 @@ export type ProfileMetadataInput = {
 
 export type Query = {
   __typename?: 'Query';
+  getActionByHash?: Maybe<ModelColonyActionConnection>;
   getActionsByColony?: Maybe<ModelColonyActionConnection>;
   getColony?: Maybe<Colony>;
   getColonyAction?: Maybe<ColonyAction>;
@@ -1705,6 +1711,15 @@ export type Query = {
   listUserTokens?: Maybe<ModelUserTokensConnection>;
   listUsers?: Maybe<ModelUserConnection>;
   listWatchedColonies?: Maybe<ModelWatchedColoniesConnection>;
+};
+
+
+export type QueryGetActionByHashArgs = {
+  filter?: InputMaybe<ModelColonyActionFilterInput>;
+  limit?: InputMaybe<Scalars['Int']>;
+  nextToken?: InputMaybe<Scalars['String']>;
+  sortDirection?: InputMaybe<ModelSortDirection>;
+  transactionHash: Scalars['String'];
 };
 
 
@@ -2283,6 +2298,7 @@ export type UpdateColonyActionInput = {
   fromDomain?: InputMaybe<Scalars['String']>;
   id: Scalars['ID'];
   initiatorAddress?: InputMaybe<Scalars['ID']>;
+  isMotion?: InputMaybe<Scalars['Boolean']>;
   recipientAddress?: InputMaybe<Scalars['ID']>;
   toDomain?: InputMaybe<Scalars['String']>;
   tokenAddress?: InputMaybe<Scalars['String']>;
@@ -2472,7 +2488,7 @@ export type WatchedColonies = {
   userID: Scalars['ID'];
 };
 
-export type ColonyActionFragment = { __typename?: 'ColonyAction', id: string, type: ColonyActionType, blockNumber: number, transactionHash: string, initiatorAddress?: string | null, recipientAddress?: string | null, amount?: string | null, decimals?: number | null, tokenSymbol?: string | null, fromDomain?: string | null, toDomain?: string | null, createdAt: string, initiator?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, recipient?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null };
+export type ColonyActionFragment = { __typename?: 'ColonyAction', type: ColonyActionType, blockNumber: number, initiatorAddress?: string | null, recipientAddress?: string | null, amount?: string | null, decimals?: number | null, tokenSymbol?: string | null, fromDomain?: string | null, toDomain?: string | null, createdAt: string, isMotion?: boolean | null, transactionHash: string, initiator?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, recipient?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, colony: { __typename?: 'Colony', colonyName: string } };
 
 export type ColonyFragment = { __typename?: 'Colony', name: string, version: number, colonyAddress: string, nativeToken: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string }, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, status?: { __typename?: 'ColonyStatus', recovery?: boolean | null, nativeToken?: { __typename?: 'NativeTokenStatus', mintable?: boolean | null, unlockable?: boolean | null, unlocked?: boolean | null } | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null, tokens?: { __typename?: 'ModelColonyTokensConnection', items: Array<{ __typename?: 'ColonyTokens', token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> } | null, domains?: { __typename?: 'ModelDomainConnection', items: Array<{ __typename?: 'Domain', color?: DomainColor | null, description?: string | null, id: string, name?: string | null, nativeId: number, parentId?: string | null } | null> } | null, watchers?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', user: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, website?: string | null, thumbnail?: string | null } | null } } | null> } | null };
 
@@ -2547,7 +2563,14 @@ export type GetColonyActionsQueryVariables = Exact<{
 }>;
 
 
-export type GetColonyActionsQuery = { __typename?: 'Query', getActionsByColony?: { __typename?: 'ModelColonyActionConnection', nextToken?: string | null, items: Array<{ __typename?: 'ColonyAction', id: string, type: ColonyActionType, blockNumber: number, transactionHash: string, initiatorAddress?: string | null, recipientAddress?: string | null, amount?: string | null, decimals?: number | null, tokenSymbol?: string | null, fromDomain?: string | null, toDomain?: string | null, createdAt: string, initiator?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, recipient?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null } | null> } | null };
+export type GetColonyActionsQuery = { __typename?: 'Query', getActionsByColony?: { __typename?: 'ModelColonyActionConnection', nextToken?: string | null, items: Array<{ __typename?: 'ColonyAction', type: ColonyActionType, blockNumber: number, initiatorAddress?: string | null, recipientAddress?: string | null, amount?: string | null, decimals?: number | null, tokenSymbol?: string | null, fromDomain?: string | null, toDomain?: string | null, createdAt: string, isMotion?: boolean | null, transactionHash: string, initiator?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, recipient?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, colony: { __typename?: 'Colony', colonyName: string } } | null> } | null };
+
+export type GetColonyActionQueryVariables = Exact<{
+  transactionHash: Scalars['ID'];
+}>;
+
+
+export type GetColonyActionQuery = { __typename?: 'Query', getColonyAction?: { __typename?: 'ColonyAction', type: ColonyActionType, blockNumber: number, initiatorAddress?: string | null, recipientAddress?: string | null, amount?: string | null, decimals?: number | null, tokenSymbol?: string | null, fromDomain?: string | null, toDomain?: string | null, createdAt: string, isMotion?: boolean | null, transactionHash: string, initiator?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, recipient?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null, thumbnail?: string | null } | null, meta?: { __typename?: 'Metadata', chainId?: number | null, network?: Network | null } | null } } | null> } | null } | null, colony: { __typename?: 'Colony', colonyName: string } } | null };
 
 export type GetFullColonyByAddressQueryVariables = Exact<{
   address: Scalars['ID'];
@@ -2692,10 +2715,9 @@ export const UserFragmentDoc = gql`
     ${WatchedColonyFragmentDoc}`;
 export const ColonyActionFragmentDoc = gql`
     fragment ColonyAction on ColonyAction {
-  id
+  transactionHash: id
   type
   blockNumber
-  transactionHash
   initiatorAddress
   initiator {
     ...User
@@ -2710,6 +2732,10 @@ export const ColonyActionFragmentDoc = gql`
   fromDomain
   toDomain
   createdAt
+  isMotion
+  colony {
+    colonyName: name
+  }
 }
     ${UserFragmentDoc}`;
 export const TokenFragmentDoc = gql`
@@ -3104,6 +3130,41 @@ export function useGetColonyActionsLazyQuery(baseOptions?: Apollo.LazyQueryHookO
 export type GetColonyActionsQueryHookResult = ReturnType<typeof useGetColonyActionsQuery>;
 export type GetColonyActionsLazyQueryHookResult = ReturnType<typeof useGetColonyActionsLazyQuery>;
 export type GetColonyActionsQueryResult = Apollo.QueryResult<GetColonyActionsQuery, GetColonyActionsQueryVariables>;
+export const GetColonyActionDocument = gql`
+    query GetColonyAction($transactionHash: ID!) {
+  getColonyAction(id: $transactionHash) {
+    ...ColonyAction
+  }
+}
+    ${ColonyActionFragmentDoc}`;
+
+/**
+ * __useGetColonyActionQuery__
+ *
+ * To run a query within a React component, call `useGetColonyActionQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetColonyActionQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetColonyActionQuery({
+ *   variables: {
+ *      transactionHash: // value for 'transactionHash'
+ *   },
+ * });
+ */
+export function useGetColonyActionQuery(baseOptions: Apollo.QueryHookOptions<GetColonyActionQuery, GetColonyActionQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetColonyActionQuery, GetColonyActionQueryVariables>(GetColonyActionDocument, options);
+      }
+export function useGetColonyActionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetColonyActionQuery, GetColonyActionQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetColonyActionQuery, GetColonyActionQueryVariables>(GetColonyActionDocument, options);
+        }
+export type GetColonyActionQueryHookResult = ReturnType<typeof useGetColonyActionQuery>;
+export type GetColonyActionLazyQueryHookResult = ReturnType<typeof useGetColonyActionLazyQuery>;
+export type GetColonyActionQueryResult = Apollo.QueryResult<GetColonyActionQuery, GetColonyActionQueryVariables>;
 export const GetFullColonyByAddressDocument = gql`
     query GetFullColonyByAddress($address: ID!) {
   getColonyByAddress(id: $address) {

--- a/src/graphql/queries/actions.graphql
+++ b/src/graphql/queries/actions.graphql
@@ -16,3 +16,13 @@ query GetColonyActions(
     nextToken
   }
 }
+
+query GetColonyAction(
+  $transactionHash: ID!
+) {
+  getColonyAction (
+    id: $transactionHash
+  ) {
+    ...ColonyAction
+  }
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -47,6 +47,7 @@ export { default as useUserByNameOrAddress } from './useUserByNameOrAddress';
 export { default as useExtensionData } from './useExtensionData';
 export { default as useExtensionsData } from './useExtensionsData';
 export { default as usePaginatedActions } from './usePaginatedActions';
+export { default as useGetColonyAction } from './useGetColonyAction';
 export * from './useCanInteractWithColony';
 
 /* Used in cases where we need to memoize the transformed output of any data.

--- a/src/hooks/useGetColonyAction.ts
+++ b/src/hooks/useGetColonyAction.ts
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { ActionDetailsPageParams } from '~common/ColonyActions/ActionDetailsPage/ActionDetailsPage';
+import { useGetColonyActionQuery } from '~gql';
+import { Colony } from '~types';
+import { isTransactionFormat } from '~utils/web3';
+
+const useGetColonyAction = (colony?: Colony | null) => {
+  const { transactionHash } = useParams<ActionDetailsPageParams>();
+  const isValidTx = isTransactionFormat(transactionHash);
+  const skipQuery = !colony || !isValidTx;
+  /* Unfortunately, we need to track polling state ourselves: https://github.com/apollographql/apollo-client/issues/9081#issuecomment-975722271 */
+  const [isPolling, setIsPolling] = useState(!skipQuery);
+
+  const {
+    data: actionData,
+    loading: loadingAction,
+    stopPolling: stopPollingForAction,
+  } = useGetColonyActionQuery({
+    skip: skipQuery,
+    variables: {
+      transactionHash: transactionHash ?? '',
+    },
+    pollInterval: 1000,
+  });
+
+  const action = actionData?.getColonyAction;
+
+  if (action && isPolling) {
+    stopPollingForAction();
+    setIsPolling(false);
+  }
+
+  return {
+    isInvalidTransactionHash: !isValidTx,
+    isUnknownTransaction: action?.colony?.colonyName !== colony?.name,
+    loadingAction: loadingAction || isPolling,
+    action,
+  };
+};
+
+export default useGetColonyAction;

--- a/src/hooks/useGetColonyAction.ts
+++ b/src/hooks/useGetColonyAction.ts
@@ -29,7 +29,7 @@ const useGetColonyAction = (colony?: Colony | null) => {
   useEffect(() => {
     const cancelPollingTimer = setTimeout(stopPollingForAction, pollingTimeout);
     return () => clearTimeout(cancelPollingTimer);
-  }, []);
+  }, [stopPollingForAction]);
 
   const { state: locationState } = useLocation();
   /* Don't poll if we've not been redirected from the saga */
@@ -44,7 +44,8 @@ const useGetColonyAction = (colony?: Colony | null) => {
 
   return {
     isInvalidTransactionHash: !isValidTx,
-    isUnknownTransaction: action?.colony?.colonyName !== colony?.name,
+    isUnknownTransaction:
+      isValidTx && action?.colony?.colonyAddress !== colony?.colonyAddress,
     loadingAction: loadingAction || isPolling,
     action,
   };

--- a/src/redux/sagas/motions/index.ts
+++ b/src/redux/sagas/motions/index.ts
@@ -1,35 +1,35 @@
 import { all, call } from 'redux-saga/effects';
 
-import stakeMotionSaga from './stakeMotion';
-import voteMotionSaga from './voteMotion';
-import revealVoteMotionSaga from './revealVoteMotion';
-import finalizeMotionSaga from './finalizeMotion';
-import claimMotionRewardsSaga from './claimMotionRewards';
+// import stakeMotionSaga from './stakeMotion';
+// import voteMotionSaga from './voteMotion';
+// import revealVoteMotionSaga from './revealVoteMotion';
+// import finalizeMotionSaga from './finalizeMotion';
+// import claimMotionRewardsSaga from './claimMotionRewards';
 import rootMotionSaga from './rootMotion';
-import createEditDomainMotionSaga from './createEditDomainMotion';
-import moveFundsMotionSaga from './moveFundsMotion';
-import managePermissionsMotionSaga from './managePermissionsMotion';
-import editColonyMotionSaga from './editColonyMotion';
-import updateMotionStateSaga from './updateState';
-import paymentMotionSaga from './paymentMotion';
-import escalateMotionSaga from './escalateMotion';
-import manageReputationMotionSaga from './manageReputationMotion';
+// import createEditDomainMotionSaga from './createEditDomainMotion';
+// import moveFundsMotionSaga from './moveFundsMotion';
+// import managePermissionsMotionSaga from './managePermissionsMotion';
+// import editColonyMotionSaga from './editColonyMotion';
+// import updateMotionStateSaga from './updateState';
+// import paymentMotionSaga from './paymentMotion';
+// import escalateMotionSaga from './escalateMotion';
+// import manageReputationMotionSaga from './manageReputationMotion';
 
 export default function* actionsSagas() {
   yield all([
-    call(stakeMotionSaga),
-    call(voteMotionSaga),
-    call(revealVoteMotionSaga),
-    call(finalizeMotionSaga),
-    call(claimMotionRewardsSaga),
+    // call(stakeMotionSaga),
+    // call(voteMotionSaga),
+    // call(revealVoteMotionSaga),
+    // call(finalizeMotionSaga),
+    // call(claimMotionRewardsSaga),
     call(rootMotionSaga),
-    call(createEditDomainMotionSaga),
-    call(moveFundsMotionSaga),
-    call(managePermissionsMotionSaga),
-    call(editColonyMotionSaga),
-    call(updateMotionStateSaga),
-    call(paymentMotionSaga),
-    call(escalateMotionSaga),
-    call(manageReputationMotionSaga),
+    // call(createEditDomainMotionSaga),
+    // call(moveFundsMotionSaga),
+    // call(managePermissionsMotionSaga),
+    // call(editColonyMotionSaga),
+    // call(updateMotionStateSaga),
+    // call(paymentMotionSaga),
+    // call(escalateMotionSaga),
+    // call(manageReputationMotionSaga),
   ]);
 }

--- a/src/redux/sagas/motions/rootMotion.ts
+++ b/src/redux/sagas/motions/rootMotion.ts
@@ -140,13 +140,8 @@ function* createRootMotionSaga({
 
     if (annotationMessage) {
       yield put(transactionPending(annotateRootMotion.id));
-      // TODO: confirm how we're handling passing the annotationMsg to block ingestor.
-      yield put(
-        transactionAddParams(annotateRootMotion.id, [
-          txHash,
-          annotationMessage,
-        ]),
-      );
+      // TODO: handle uploading annotation msg to db in saga
+      yield put(transactionAddParams(annotateRootMotion.id, [txHash, '']));
 
       yield put(transactionReady(annotateRootMotion.id));
 

--- a/src/redux/sagas/motions/rootMotion.ts
+++ b/src/redux/sagas/motions/rootMotion.ts
@@ -11,7 +11,11 @@ import { ColonyManager } from '~context';
 
 import { ActionTypes } from '../../actionTypes';
 import { AllActions, Action } from '../../types/actions';
-import { transactionReady, transactionPending } from '../../actionCreators';
+import {
+  transactionAddParams,
+  transactionPending,
+  transactionReady,
+} from '../../actionCreators';
 
 import { putError, takeFrom, getColonyManager } from '../utils';
 import {
@@ -136,12 +140,13 @@ function* createRootMotionSaga({
 
     if (annotationMessage) {
       yield put(transactionPending(annotateRootMotion.id));
-
-      //  const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
-
-      // yield put(
-      //   transactionAddParams(annotateRootMotion.id, [txHash, ipfsHash]),
-      // );
+      // TODO: confirm how we're handling passing the annotationMsg to block ingestor.
+      yield put(
+        transactionAddParams(annotateRootMotion.id, [
+          txHash,
+          annotationMessage,
+        ]),
+      );
 
       yield put(transactionReady(annotateRootMotion.id));
 

--- a/src/redux/sagas/motions/rootMotion.ts
+++ b/src/redux/sagas/motions/rootMotion.ts
@@ -4,24 +4,14 @@ import { AddressZero } from '@ethersproject/constants';
 
 import { ActionTypes } from '../../actionTypes';
 import { AllActions, Action } from '../../types/actions';
-import {
-  putError,
-  takeFrom,
-  routeRedirect,
-  uploadIfpsAnnotation,
-  getColonyManager,
-} from '../utils';
+import { putError, takeFrom, routeRedirect, getColonyManager } from '../utils';
 
 import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../transactions';
-import {
-  transactionReady,
-  transactionPending,
-  transactionAddParams,
-} from '../../actionCreators';
+import { transactionReady, transactionPending } from '../../actionCreators';
 
 function* createRootMotionSaga({
   payload: {
@@ -139,11 +129,11 @@ function* createRootMotionSaga({
     if (annotationMessage) {
       yield put(transactionPending(annotateRootMotion.id));
 
-      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
+      //  const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
 
-      yield put(
-        transactionAddParams(annotateRootMotion.id, [txHash, ipfsHash]),
-      );
+      // yield put(
+      //   transactionAddParams(annotateRootMotion.id, [txHash, ipfsHash]),
+      // );
 
       yield put(transactionReady(annotateRootMotion.id));
 

--- a/src/redux/sagas/motions/rootMotion.ts
+++ b/src/redux/sagas/motions/rootMotion.ts
@@ -1,17 +1,24 @@
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
-import { ClientType, Id, getChildIndex } from '@colony/colony-js';
+import {
+  ClientType,
+  Id,
+  getChildIndex,
+  AnyColonyClient,
+} from '@colony/colony-js';
 import { AddressZero } from '@ethersproject/constants';
+
+import { ColonyManager } from '~context';
 
 import { ActionTypes } from '../../actionTypes';
 import { AllActions, Action } from '../../types/actions';
-import { putError, takeFrom, routeRedirect, getColonyManager } from '../utils';
+import { transactionReady, transactionPending } from '../../actionCreators';
 
+import { putError, takeFrom, getColonyManager } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../transactions';
-import { transactionReady, transactionPending } from '../../actionCreators';
 
 function* createRootMotionSaga({
   payload: {
@@ -21,7 +28,7 @@ function* createRootMotionSaga({
     motionParams,
     annotationMessage,
   },
-  meta: { id: metaId, history },
+  meta: { id: metaId, navigate },
   meta,
 }: Action<ActionTypes.ROOT_MOTION>) {
   let txChannel;
@@ -30,8 +37,9 @@ function* createRootMotionSaga({
       throw new Error('Parameters not set for rootMotion transaction');
     }
 
-    const colonyManager = yield getColonyManager();
-    const colonyClient = yield colonyManager.getClient(
+    const colonyManager: ColonyManager = yield getColonyManager();
+
+    const colonyClient: AnyColonyClient = yield colonyManager.getClient(
       ClientType.ColonyClient,
       colonyAddress,
     );
@@ -148,7 +156,7 @@ function* createRootMotionSaga({
     });
 
     if (colonyName) {
-      yield routeRedirect(`/colony/${colonyName}/tx/${txHash}`, history);
+      navigate(`/colony/${colonyName}/tx/${txHash}`);
     }
   } catch (caughtError) {
     putError(ActionTypes.ROOT_MOTION_ERROR, caughtError, meta);

--- a/src/redux/sagas/motions/rootMotion.ts
+++ b/src/redux/sagas/motions/rootMotion.ts
@@ -156,7 +156,9 @@ function* createRootMotionSaga({
     });
 
     if (colonyName) {
-      navigate(`/colony/${colonyName}/tx/${txHash}`);
+      navigate(`/colony/${colonyName}/tx/${txHash}`, {
+        state: { isRedirect: true },
+      });
     }
   } catch (caughtError) {
     putError(ActionTypes.ROOT_MOTION_ERROR, caughtError, meta);

--- a/src/redux/sagas/setupUserContext.ts
+++ b/src/redux/sagas/setupUserContext.ts
@@ -6,7 +6,7 @@ import { colonyCreateSaga } from './colony';
 // import colonySagas, {
 // } from './colony';
 import extensionSagas from './extensions';
-// import motionSagas from './motions';
+import motionSagas from './motions';
 // import whitelistSagas from './whitelist';
 // import vestingSagas from './vesting';
 import { setupUsersSagas } from './users';
@@ -31,7 +31,7 @@ function* setupContextDependentSagas() {
     // call(colonySagas),
     call(colonyCreateSaga),
     call(extensionSagas),
-    // call(motionSagas),
+    call(motionSagas),
     // call(whitelistSagas),
     // call(vestingSagas),
     call(setupUsersSagas),

--- a/src/redux/sagas/utils/effects.ts
+++ b/src/redux/sagas/utils/effects.ts
@@ -1,4 +1,5 @@
 import { ActionPattern } from '@redux-saga/types';
+import { NavigateFunction } from 'react-router-dom';
 import { Channel } from 'redux-saga';
 import {
   all,
@@ -104,11 +105,9 @@ export const takeLatestCancellable = (
   ]);
 };
 
-export function* routeRedirect(
-  route: string,
-  historyObject, // Apparently react-router doesn't export proper types for this :(
-) {
-  if (route && historyObject) {
-    yield call(historyObject.push, route);
+export function* routeRedirect(route: string, navigate: NavigateFunction) {
+  if (route) {
+    // @ts-ignore
+    yield call<NavigateFunction>(navigate, route);
   }
 }

--- a/src/redux/sagas/utils/getNetworkClient.ts
+++ b/src/redux/sagas/utils/getNetworkClient.ts
@@ -27,7 +27,7 @@ export default function* getNetworkClient() {
   let reputationOracleUrl = new URL(`/reputation`, window.location.origin);
 
   if (DEFAULT_NETWORK === Network.Ganache) {
-    reputationOracleUrl = new URL(`/reputation`, 'http://localhost:3001');
+    reputationOracleUrl = new URL(`/reputation/local`, 'http://localhost:3001');
     const {
       etherRouterAddress: networkAddress,
       // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require, import/no-dynamic-require

--- a/src/redux/types/actions/index.ts
+++ b/src/redux/types/actions/index.ts
@@ -1,3 +1,5 @@
+import { NavigateFunction } from 'react-router-dom';
+
 import { ColonyActionTypes } from './colony';
 import { ColonyActionsActionTypes } from './colonyActions';
 import { MotionActionTypes } from './motion';
@@ -112,8 +114,13 @@ export type ActionTypeString = AllActions['type'];
 
 export type TakeFilter = (action: AllActions) => boolean;
 
+// To be replaced with MetaWithNavigate and deleted
 export type MetaWithHistory<M> = {
   history?: {
     push: <A>(route: A) => void;
   };
+} & M;
+
+export type MetaWithNavigate<M> = {
+  navigate: NavigateFunction;
 } & M;

--- a/src/redux/types/actions/motion.ts
+++ b/src/redux/types/actions/motion.ts
@@ -10,6 +10,7 @@ import {
   UniqueActionTypeWithoutPayload,
   ActionTypeWithMeta,
   MetaWithHistory,
+  MetaWithNavigate,
 } from './index';
 
 export enum RootMotionOperationNames {
@@ -183,7 +184,7 @@ export type MotionActionTypes =
         motionParams: [BigNumber] | [string];
         annotationMessage?: string;
       },
-      MetaWithHistory<object>
+      MetaWithNavigate<object>
     >
   | ErrorActionType<ActionTypes.ROOT_MOTION_ERROR, object>
   | ActionTypeWithMeta<ActionTypes.ROOT_MOTION_SUCCESS, MetaWithHistory<object>>


### PR DESCRIPTION
## Description

This PR is responsible for wiring in the root motion saga and handling the first phase of the motion lifecycle, such that we have record of the motion in the db (via block-ingestor) and can access relevant data (such as action type) for display in the ui.

It does not handle any subsequent phases of the motion lifecycle (staking, voting etc.). This will be handled subsequently.

## Testing

Switch to this branch and run a fresh build (`npm run dev`). I've updated the block ingestor hash to point to block-ingestor#16.
 
Then go to https://github.com/JoinColony/block-ingestor/pull/16 and follow the instructions to get the reputation and the voting extension installed.

Finally, once all set up, click "Test mint tokens". It should redirect you to the relevant motion page:

![Screenshot (656)](https://user-images.githubusercontent.com/64402732/218740166-c22e97ed-640c-4abd-88a6-f8c10d5d6f2b.png)

You can change the amount of tokens you mint in `ColonyActions.tsx`.

To be clear, we're just testing the UI is picking up the correct data in the mint tokens motion payload and displaying it correctly. (e.g. amount, symbol, domain id). 

We're not testing that anything else works yet in motions (voting, staking etc). The fact that some of the messages in the screenshot above aren't accurate (E.g. Steven did x) or that it goes straight to voting --> doesn't matter for the scope of this pr and will be addressed in subsequent issues.

**New stuff** ✨

* `useGetColonyAction` to handle queries at `ActionDetailsPage`

**Changes** 🏗

* Refactor action button
* Wire in root motion saga

## TODO

- [x] Wire in root motion saga
- [x] Adapt "mint token test" button to trigger it
- [x] Add necessary changes to block ingestor to pick up event (https://github.com/JoinColony/block-ingestor/pull/16)
- [x] Fire off db mutations  (https://github.com/JoinColony/block-ingestor/pull/16)
- [x] Pull data into ui and display motions page at generated tx hash

Resolves #258
