### PR TITLE
Fix infinite loop when missing package.json in lambda function directory

### DIFF
--- a/scripts/lambda-functions-dependencies.sh
+++ b/scripts/lambda-functions-dependencies.sh
@@ -6,6 +6,9 @@ for d in amplify/backend/function/*/ ; do
     [ -L "${d%/}" ] && continue
     fnName=$(echo ${d} | cut -c 26- | rev | cut -c 2- | rev)
     cd "${pwd}/${d}src"
+    # Skip if the folder doesn't contain package.json
+    # Otherwise npm will look for the root package.json and cause an infinite loop
+    !([ -f "package.json" ]) && continue
     echo "Installing dependencies for Lambda Function \"${fnName}\""
     npm i
     echo


### PR DESCRIPTION
## Description

Small fix for #244.

> I can confirm the issue, it happens whenever there's a folder in `/amplify/backend/function` that is missing `src/package.json` (it tends to happen when you switch between branches and have some leftover untracked files).
If package.json is missing, `npm i` will look in the parent directories until it finds the root package.json, which specifies the `postinstall` script, causing the infinite loop.

Resolves #244 
