### PR TITLE
Port stakeMotion saga

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/DefaultMotion.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/DefaultMotion.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import DetailsWidget from '~shared/DetailsWidget';
 
-import { useColonyContext, useEnabledExtensions } from '~hooks';
+import { useDefaultMotion } from '~hooks';
 import { ColonyAction } from '~types';
 import { motionStateMap } from '~utils/colonyMotions';
 
@@ -19,30 +19,33 @@ interface DefaultMotionProps {
   actionData: ColonyAction;
 }
 
-const DefaultMotion = ({ actionData }: DefaultMotionProps) => {
-  const { colony } = useColonyContext();
+const DefaultMotion = ({
+  actionData,
+  actionData: { motionData },
+}: DefaultMotionProps) => {
+  const { colony, showBanner, setShowBanner, showMotionHeading } =
+    useDefaultMotion(motionData);
 
-  const { isVotingReputationEnabled } = useEnabledExtensions();
-
-  const motionState = actionData.motionData?.motionState;
-
-  if (!colony || !motionState) {
+  if (!colony || !motionData) {
     return null;
   }
 
-  const showBanner = true; // !shouldDisplayMotionInActionsList(currentStake, requiredStake);
+  const { motionState } = motionData;
 
   return (
     <div className={styles.main}>
       {/* {isMobile && <ColonyHomeInfo showNavigation isMobile />} */}
       {showBanner && <StakeRequiredBanner isDecision={false} />}
-      {isVotingReputationEnabled && (
+      {showMotionHeading && (
         <MotionHeading motionState={motionStateMap[motionState]} />
       )}
       <div className={styles.container}>
         <DefaultActionContent actionData={actionData} />
         <div className={styles.widgets}>
-          <MotionPhaseWidget actionData={actionData} />
+          <MotionPhaseWidget
+            actionData={actionData}
+            setShowStakeBanner={setShowBanner}
+          />
           {/* <div className={styles.details}>
         {motionState === MotionState.Voting && (
           <VoteWidget

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MotionState } from '@colony/colony-js';
 
-import { ColonyAction } from '~types';
+import { ColonyAction, SetStateFn } from '~types';
 import StakingWidget, { StakingWidgetProvider } from './StakingWidget';
 
 const displayName =
@@ -9,10 +9,12 @@ const displayName =
 
 interface MotionPhaseWidgetProps {
   actionData: ColonyAction;
+  setShowStakeBanner: SetStateFn;
 }
 
 const MotionPhaseWidget = ({
   actionData: { motionData },
+  setShowStakeBanner,
 }: MotionPhaseWidgetProps) => {
   if (!motionData) {
     return null;
@@ -21,7 +23,10 @@ const MotionPhaseWidget = ({
   switch (motionData.motionState) {
     case MotionState.Staking: {
       return (
-        <StakingWidgetProvider motionData={motionData}>
+        <StakingWidgetProvider
+          motionData={motionData}
+          setShowStakeBanner={setShowStakeBanner}
+        >
           <StakingWidget />
         </StakingWidgetProvider>
       );

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakeButton.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakeButton.tsx
@@ -11,6 +11,7 @@ const displayName =
 interface StakeButtonProps {
   stake: Decimal;
 }
+
 const StakeButton = ({ stake }: StakeButtonProps) => {
   const { canBeStaked, isObjection, userActivatedTokens } =
     useStakingWidgetContext();

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput.tsx
@@ -20,12 +20,8 @@ const validationSchema = object({
 export type StakingWidgetValues = InferType<typeof validationSchema>;
 
 const StakingInput = () => {
-  const { transform, stakingSliderProps, limitExceeded } = useStakingInput();
-  // const handleSuccess = (_, { setFieldValue, resetForm }) => {
-  //     resetForm({});
-  //     setFieldValue('amount', 0);
-  //     scrollToRef?.current?.scrollIntoView({ behavior: 'smooth' });
-  //   },
+  const { transform, handleSuccess, stakingSliderProps, limitExceeded } =
+    useStakingInput();
 
   return (
     <ActionForm<StakingWidgetValues>
@@ -35,7 +31,7 @@ const StakingInput = () => {
       validationSchema={validationSchema}
       actionType={ActionTypes.MOTION_STAKE}
       transform={transform}
-      // onSuccess={handleSuccess}
+      onSuccess={handleSuccess}
     >
       <StakingSlider {...stakingSliderProps} />
       <StakingControls limitExceeded={limitExceeded} />

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingSlider/StakingWidgetSlider.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingSlider/StakingWidgetSlider.tsx
@@ -32,6 +32,7 @@ const StakingWidgetSlider = ({
     remainingToStake,
     userActivatedTokens,
   });
+
   return (
     <div className={styles.sliderContainer}>
       <Slider

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingWidgetProvider.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingWidgetProvider.tsx
@@ -14,6 +14,7 @@ import {
   useAppContext,
   useColonyContext,
   useMinAndRequiredStakes,
+  useUserBalance,
 } from '~hooks';
 import { MotionData, SetStateFn } from '~types';
 import {
@@ -107,23 +108,11 @@ const StakingWidgetProvider = ({
 
   const { minUserStake, requiredStake, loadingStakeData } =
     useMinAndRequiredStakes(skillRep);
-
-  // TODO
-  //   const {
-  //     data: userData,
-  //     loading: userDataLoading,
-  //   } = useUserBalanceWithLockQuery({
-  //     variables: {
-  //       address: walletAddress,
-  //       tokenAddress: nativeTokenAddress,
-  //       colonyAddress,
-  //     },
-  //   });
-  //userData?.user?.userLock?.balance || 0,
+  const userBalance = useUserBalance();
 
   const userActivatedTokens = useMemo(
-    () => new Decimal('100000000000000000000000000000000000000000'),
-    [],
+    () => new Decimal(userBalance ?? '0'),
+    [userBalance],
   );
 
   /* A user cannot stake more tokens than they have reputation. Thus, their rep is their max stake. */

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/helpers.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/helpers.ts
@@ -1,4 +1,6 @@
 import Decimal from 'decimal.js';
+import { MotionData } from '~gql';
+import { Address } from '~types';
 
 export const getStakeFromSlider = (
   sliderAmount: number,
@@ -11,11 +13,16 @@ export const getStakeFromSlider = (
     .plus(minUserStake);
 
 export const getFinalStake = (
-  amount: number,
+  sliderAmount: number,
   remainingToStake: Decimal,
   minUserStake: Decimal,
 ) => {
-  const stake = getStakeFromSlider(amount, remainingToStake, minUserStake);
+  const stake = getStakeFromSlider(
+    sliderAmount,
+    remainingToStake,
+    minUserStake,
+  );
+
   return stake.round().toString();
 };
 
@@ -24,7 +31,6 @@ export const convertStakeToPercentage = (
   requiredStake: Decimal,
 ) => {
   const divisibleRequiredStake = requiredStake.isZero() ? 1 : requiredStake;
-
   return new Decimal(stake).div(divisibleRequiredStake).mul(100).toDP(2);
 };
 
@@ -110,4 +116,12 @@ export const getUserStakeLimitPercentage = (
     remainingToStake,
     minUserStake,
   );
+};
+
+export const getUserStakes = (
+  usersStakes: MotionData['usersStakes'],
+  userAddress: Address,
+) => {
+  const userStake = usersStakes.find(({ address }) => address === userAddress);
+  return userStake?.stakes.raw ?? null;
 };

--- a/src/components/common/ColonyActions/ColonyActions.tsx
+++ b/src/components/common/ColonyActions/ColonyActions.tsx
@@ -213,7 +213,7 @@ const ColonyActions = (/* { ethDomainId }: Props */) => {
             recipientAddress: user?.walletAddress,
             domainId: colony.domains?.items[0]?.nativeId,
             singlePayment: {
-              amount: BigNumber.from(2), // this is in ethers
+              amount: BigNumber.from(10), // this is in ethers
               tokenAddress: colony.nativeToken.tokenAddress,
               decimals: 18,
             },

--- a/src/components/shared/Fields/Form/ActionHookForm.tsx
+++ b/src/components/shared/Fields/Form/ActionHookForm.tsx
@@ -9,10 +9,15 @@ import HookForm, {
   CustomSubmitHandler,
   HookFormProps,
 } from './HookForm';
+import { UseFormReturn } from 'react-hook-form';
 
 const displayName = 'Form.ActionHookForm';
 
-export type OnSuccess<V> = (result: any, values: V) => void;
+export type OnSuccess<V> = (
+  result: any,
+  values: V,
+  formHelpers: UseFormReturn,
+) => void;
 
 interface Props<V extends Record<string, any>>
   extends Omit<HookFormProps<V>, 'onError' | 'onSubmit'> {
@@ -64,7 +69,7 @@ const ActionHookForm = <V extends Record<string, any>>({
   const handleSubmit: CustomSubmitHandler<V> = async (values, formHelpers) => {
     try {
       const res = await asyncFunction(values);
-      onSuccess?.(res, values);
+      onSuccess?.(res, values, formHelpers);
     } catch (e) {
       console.error(e);
       onError?.(e, formHelpers);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -49,6 +49,7 @@ export { default as useExtensionsData } from './useExtensionsData';
 export { default as usePaginatedActions } from './usePaginatedActions';
 export { default as useGetColonyAction } from './useGetColonyAction';
 export { default as useDefaultMotion } from './useDefaultMotion';
+export { default as useUserBalance } from './useUserBalance';
 export * from './motionWidgets';
 export * from './useCanInteractWithColony';
 export { default as useColonyFundsClaims } from './useColonyFundsClaims';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -48,6 +48,7 @@ export { default as useExtensionData } from './useExtensionData';
 export { default as useExtensionsData } from './useExtensionsData';
 export { default as usePaginatedActions } from './usePaginatedActions';
 export { default as useGetColonyAction } from './useGetColonyAction';
+export { default as useDefaultMotion } from './useDefaultMotion';
 export * from './motionWidgets';
 export * from './useCanInteractWithColony';
 export { default as useColonyFundsClaims } from './useColonyFundsClaims';

--- a/src/hooks/motionWidgets/stakingWidget/helpers.ts
+++ b/src/hooks/motionWidgets/stakingWidget/helpers.ts
@@ -1,4 +1,14 @@
+import Decimal from 'decimal.js';
 import { StakingSliderProps } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingSlider/StakingSlider';
+import { Address, MotionData, RemoveTypeName } from '~types';
+
+export type UsersStakes = MotionData['usersStakes'];
+type UserStakes = RemoveTypeName<UsersStakes[0]>;
+
+enum MotionSide {
+  YAY = 'yay',
+  NAY = 'nay',
+}
 
 export const mapStakingSliderProps = ({
   isObjection,
@@ -35,3 +45,60 @@ export const mapStakingSliderProps = ({
   },
   mutableRef,
 });
+
+export const getMotionSide = (vote: number) =>
+  vote === 0 ? MotionSide.NAY : MotionSide.YAY;
+
+const getUpdatedUserStakes = (
+  userStakes: MotionData['usersStakes'][0],
+  newAmount: string,
+  vote: number,
+) => {
+  const existingStakeAmount = userStakes.stakes.raw[getMotionSide(vote)];
+  return {
+    raw: {
+      ...userStakes.stakes.raw,
+      [getMotionSide(vote)]: new Decimal(existingStakeAmount)
+        .add(newAmount)
+        .toString(),
+    },
+  };
+};
+
+export const updateUsersStakes = (
+  usersStakes: UsersStakes,
+  userAddress: Address,
+  finalStake: string,
+  vote: number,
+) => {
+  const isExistingUser = usersStakes.some(
+    ({ address }) => address === userAddress,
+  );
+
+  if (isExistingUser) {
+    return usersStakes.map((userStakes) => {
+      if (userStakes.address === userAddress) {
+        return {
+          ...userStakes,
+          stakes: getUpdatedUserStakes(userStakes, finalStake, vote),
+        };
+      }
+
+      return userStakes;
+    });
+  }
+
+  const rawStakes = {
+    [getMotionSide(vote)]: finalStake,
+    [getMotionSide(1 - vote)]: '0',
+  } as UserStakes['stakes']['raw'];
+
+  const newUserStakes: UserStakes = {
+    address: userAddress,
+    stakes: {
+      raw: rawStakes,
+    },
+  };
+
+  return [...usersStakes, newUserStakes];
+};

--- a/src/hooks/motionWidgets/stakingWidget/useMinAndRequiredStakes.ts
+++ b/src/hooks/motionWidgets/stakingWidget/useMinAndRequiredStakes.ts
@@ -2,7 +2,7 @@ import { Extension, getExtensionHash } from '@colony/colony-js';
 import Decimal from 'decimal.js';
 
 import { useGetColonyExtensionQuery } from '~gql';
-import useColonyContext from '~hooks/useColonyContext';
+import { useColonyContext } from '~hooks';
 
 const useMinAndRequiredStakes = (skillRep: string) => {
   const { colony } = useColonyContext();
@@ -30,7 +30,9 @@ const useMinAndRequiredStakes = (skillRep: string) => {
     new Decimal(10).pow(18).toString(),
   );
 
-  const requiredStake = new Decimal(skillRep).mul(totalStakeFractionPercentage);
+  const requiredStake = new Decimal(skillRep)
+    .mul(totalStakeFractionPercentage)
+    .round();
 
   /*
    * The amount of the required stake each user must stake as a minimum.

--- a/src/hooks/motionWidgets/stakingWidget/useRequiredStakeMessage.ts
+++ b/src/hooks/motionWidgets/stakingWidget/useRequiredStakeMessage.ts
@@ -1,5 +1,4 @@
 import Decimal from 'decimal.js';
-import { BigNumber } from 'ethers';
 import { useFormContext } from 'react-hook-form';
 import {
   convertStakeToPercentage,
@@ -35,14 +34,11 @@ const useRequiredStakeMessage = ({
   const isThresholdAchieved = totalPercentage >= STAKING_THRESHOLD;
   const isUnderThreshold =
     !isThresholdAchieved &&
-    stakePercentage.lt(
-      BigNumber.from(STAKING_THRESHOLD).sub(totalPercentage).toString(),
-    );
+    stakePercentage.lt(STAKING_THRESHOLD - totalPercentage);
+
   const isOverThreshold =
     isThresholdAchieved ||
-    stakePercentage.gte(
-      BigNumber.from(STAKING_THRESHOLD).sub(totalPercentage).toString(),
-    );
+    stakePercentage.gte(STAKING_THRESHOLD - totalPercentage);
 
   return {
     stake,

--- a/src/hooks/motionWidgets/stakingWidget/useStakingInput.ts
+++ b/src/hooks/motionWidgets/stakingWidget/useStakingInput.ts
@@ -1,3 +1,4 @@
+import Decimal from 'decimal.js';
 import { BigNumber } from 'ethers';
 import { useRef } from 'react';
 
@@ -5,11 +6,21 @@ import {
   getFinalStake,
   useStakingWidgetContext,
 } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
+import { StakingWidgetValues } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput';
 
 import { useAppContext, useColonyContext } from '~hooks';
+import { OnSuccess } from '~shared/Fields/Form/ActionHookForm';
+import { MotionData } from '~types';
 import { mapPayload } from '~utils/actions';
 
-import { mapStakingSliderProps } from './helpers';
+import {
+  getMotionSide,
+  mapStakingSliderProps,
+  updateUsersStakes,
+  UsersStakes,
+} from './helpers';
+
+type MotionStakes = MotionData['motionStakes'];
 
 const useStakingInput = () => {
   const { user } = useAppContext();
@@ -31,19 +42,52 @@ const useStakingInput = () => {
     totalPercentage,
     getErrorType,
     reputationLoading,
+    setMotionStakes,
+    setUsersStakes,
   } = useStakingWidgetContext();
 
+  const vote = isObjection ? 0 : 1;
+
+  const getFinalStakeFromSliderAmount = (sliderAmount: number) =>
+    getFinalStake(sliderAmount, remainingToStake, minUserStake);
+
   const transform = mapPayload(({ amount }) => {
-    const finalStake = getFinalStake(amount, remainingToStake, minUserStake);
+    const finalStake = getFinalStakeFromSliderAmount(amount);
 
     return {
       amount: finalStake,
       userAddress: user?.walletAddress,
       colonyAddress: colony?.colonyAddress,
       motionId: BigNumber.from(motionId),
-      vote: isObjection ? 0 : 1,
+      vote,
     };
   });
+
+  const handleSuccess: OnSuccess<StakingWidgetValues> = (
+    _,
+    { amount },
+    { reset },
+  ) => {
+    reset();
+    const finalStake = getFinalStakeFromSliderAmount(amount);
+    setMotionStakes((motionStakes: MotionStakes) => {
+      const side = getMotionSide(vote);
+      const updatedStake = new Decimal(motionStakes[side]).add(finalStake);
+
+      return {
+        ...motionStakes,
+        [side]: updatedStake.toString(),
+      };
+    });
+    setUsersStakes((usersStakes: UsersStakes) =>
+      updateUsersStakes(
+        usersStakes,
+        user?.walletAddress ?? '',
+        finalStake,
+        vote,
+      ),
+    );
+  };
 
   const stakingSliderProps = mapStakingSliderProps({
     isObjection,
@@ -61,7 +105,12 @@ const useStakingInput = () => {
     mutableRef,
   });
 
-  return { transform, stakingSliderProps, mutableRef, limitExceeded };
+  return {
+    transform,
+    handleSuccess,
+    stakingSliderProps,
+    limitExceeded,
+  };
 };
 
 export default useStakingInput;

--- a/src/hooks/motionWidgets/stakingWidget/useStakingSlider.ts
+++ b/src/hooks/motionWidgets/stakingWidget/useStakingSlider.ts
@@ -22,7 +22,6 @@ const useStakingSlider = ({
   const { user } = useAppContext();
   const [limitExceeded, setLimitExceeded] = useState(false);
   useImperativeHandle(mutableRef, () => ({ limitExceeded }), [limitExceeded]);
-
   const showAnnotation = !remainingToStake.isZero();
   const showValidationMessage = !!user;
   const requiredStakeMessageProps = {

--- a/src/hooks/useDefaultMotion.ts
+++ b/src/hooks/useDefaultMotion.ts
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { ColonyAction } from '~types';
+import useColonyContext from './useColonyContext';
+import useEnabledExtensions from './useEnabledExtensions';
+
+const useDefaultMotion = (motionData?: ColonyAction['motionData']) => {
+  const { colony } = useColonyContext();
+
+  const stakesUnder10Percent =
+    Number(motionData?.motionStakes.percentage.yay) +
+      Number(motionData?.motionStakes.percentage.nay) <
+    10;
+
+  const [showBanner, setShowBanner] = useState(stakesUnder10Percent);
+
+  const {
+    enabledExtensions: { isVotingReputationEnabled },
+  } = useEnabledExtensions();
+
+  return {
+    showMotionHeading: isVotingReputationEnabled,
+    showBanner,
+    setShowBanner,
+    colony,
+  };
+};
+
+export default useDefaultMotion;

--- a/src/hooks/useGetColonyAction.ts
+++ b/src/hooks/useGetColonyAction.ts
@@ -13,7 +13,6 @@ const useGetColonyAction = (colony?: Colony | null) => {
   const skipQuery = !colony || !isValidTx;
   /* Unfortunately, we need to track polling state ourselves: https://github.com/apollographql/apollo-client/issues/9081#issuecomment-975722271 */
   const [isPolling, setIsPolling] = useState(!skipQuery);
-
   const {
     data: actionData,
     loading: loadingAction,

--- a/src/hooks/useUserBalance.ts
+++ b/src/hooks/useUserBalance.ts
@@ -1,0 +1,72 @@
+import { getColonyNetworkClient, Network } from '@colony/colony-js';
+import { useEffect, useState } from 'react';
+import { providers } from 'ethers';
+
+import {
+  getReputationOracleURL,
+  networkAddress,
+} from '~redux/sagas/utils/getNetworkClient';
+import { Address, Wallet } from '~types';
+
+import useAppContext from './useAppContext';
+import useColonyContext from './useColonyContext';
+
+// TODO: Get this data from db once we have token data: https://github.com/JoinColony/colonyCDapp/issues/286
+
+const getNetworkClient = (wallet: Wallet) => {
+  const reputationOracleUrl = getReputationOracleURL();
+  const walletProvider = new providers.Web3Provider(wallet.provider);
+  const signer = walletProvider.getSigner();
+  const networkClient = getColonyNetworkClient(Network.Custom, signer, {
+    networkAddress,
+    reputationOracleEndpoint: reputationOracleUrl.href,
+  });
+
+  return networkClient;
+};
+
+const getUserLock = async (
+  tokenAddress: Address,
+  userAddress: Address,
+  wallet: Wallet,
+) => {
+  const networkClient = getNetworkClient(wallet);
+  const tokenLockingClient = await networkClient.getTokenLockingClient();
+  const userLock = await tokenLockingClient.getUserLock(
+    tokenAddress,
+    userAddress,
+  );
+
+  return userLock;
+};
+
+const useUserBalance = () => {
+  const { colony } = useColonyContext();
+  const { user, wallet } = useAppContext();
+
+  const [userBalance, setUserBalance] = useState<string>();
+  useEffect(() => {
+    const getUserBalance = async (userWallet: Wallet) => {
+      const userLock = await getUserLock(
+        colony?.nativeToken.tokenAddress ?? '',
+        user?.walletAddress ?? '',
+        userWallet,
+      );
+
+      return userLock.balance.toString();
+    };
+
+    const storeUserBalance = async (userWallet: Wallet) => {
+      const balance = await getUserBalance(userWallet);
+      setUserBalance(balance);
+    };
+
+    if (wallet && user && colony) {
+      storeUserBalance(wallet);
+    }
+  }, [wallet, colony, user]);
+
+  return userBalance;
+};
+
+export default useUserBalance;

--- a/src/redux/sagas/motions/index.ts
+++ b/src/redux/sagas/motions/index.ts
@@ -1,6 +1,6 @@
 import { all, call } from 'redux-saga/effects';
 
-// import stakeMotionSaga from './stakeMotion';
+import stakeMotionSaga from './stakeMotion';
 // import voteMotionSaga from './voteMotion';
 // import revealVoteMotionSaga from './revealVoteMotion';
 // import finalizeMotionSaga from './finalizeMotion';
@@ -17,7 +17,7 @@ import rootMotionSaga from './rootMotion';
 
 export default function* actionsSagas() {
   yield all([
-    // call(stakeMotionSaga),
+    call(stakeMotionSaga),
     // call(voteMotionSaga),
     // call(revealVoteMotionSaga),
     // call(finalizeMotionSaga),

--- a/src/redux/sagas/motions/stakeMotion.ts
+++ b/src/redux/sagas/motions/stakeMotion.ts
@@ -1,26 +1,16 @@
-import { call, fork, put, takeEvery } from 'redux-saga/effects';
+import { call, put, takeEvery } from 'redux-saga/effects';
 import { AnyVotingReputationClient, ClientType } from '@colony/colony-js';
 
 import { ActionTypes } from '../../actionTypes';
 import { AllActions, Action } from '../../types/actions';
-import {
-  putError,
-  takeFrom,
-  updateMotionValues,
-  getColonyManager,
-} from '../utils';
+import { putError, takeFrom, getColonyManager } from '../utils';
 
 import {
-  createTransaction,
+  createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../transactions';
-import {
-  transactionReady,
-  transactionPending,
-  transactionAddParams,
-} from '../../actionCreators';
-import { ipfsUpload } from '../ipfs';
+import { transactionReady } from '../../actionCreators';
 
 function* stakeMotion({
   meta,
@@ -35,54 +25,29 @@ function* stakeMotion({
 }: Action<ActionTypes.MOTION_STAKE>) {
   const txChannel = yield call(getTxChannel, meta.id);
   try {
-    const colonyManager = yield getColonyManager();
-    const colonyClient = yield colonyManager.getClient(
-      ClientType.ColonyClient,
+    const colonyManager = yield call(getColonyManager);
+
+    const votingReputationClient: AnyVotingReputationClient = yield call(
+      [colonyManager, colonyManager.getClient],
+      ClientType.VotingReputationClient,
       colonyAddress,
     );
 
-    const votingReputationClient: AnyVotingReputationClient =
-      yield colonyManager.getClient(
-        ClientType.VotingReputationClient,
-        colonyAddress,
-      );
-
-    const { domainId, rootHash } = yield votingReputationClient.getMotion(
+    const { domainId } = yield call(
+      [votingReputationClient, votingReputationClient.getMotion],
       motionId,
     );
 
-    const { skillId } = yield call(
-      [colonyClient, colonyClient.getDomain],
-      domainId,
-    );
-
-    const { key, value, branchMask, siblings } = yield call(
-      colonyClient.getReputation,
-      skillId,
-      userAddress,
-      rootHash,
-    );
-
-    const { approveStake, stakeMotionTransaction, annotateStaking } =
-      yield createTransactionChannels(meta.id, [
+    const { approveStake, stakeMotionTransaction /*annotateStaking*/ } =
+      yield call(createTransactionChannels, meta.id, [
         'approveStake',
         'stakeMotionTransaction',
-        'annotateStaking',
+        // 'annotateStaking',
       ]);
 
     const batchKey = 'stakeMotion';
 
-    const createGroupTransaction = ({ id, index }, config) =>
-      fork(createTransaction, id, {
-        ...config,
-        group: {
-          key: batchKey,
-          id: meta.id,
-          index,
-        },
-      });
-
-    yield createGroupTransaction(approveStake, {
+    yield createGroupTransaction(approveStake, batchKey, meta, {
       context: ClientType.ColonyClient,
       methodName: 'approveStake',
       identifier: colonyAddress,
@@ -90,33 +55,34 @@ function* stakeMotion({
       ready: false,
     });
 
-    yield createGroupTransaction(stakeMotionTransaction, {
+    yield createGroupTransaction(stakeMotionTransaction, batchKey, meta, {
       context: ClientType.VotingReputationClient,
       methodName: 'stakeMotionWithProofs',
       identifier: colonyAddress,
-      params: [motionId, vote, amount, key, value, branchMask, siblings],
+      params: [motionId, vote, amount],
       ready: false,
     });
 
-    if (annotationMessage) {
-      yield createGroupTransaction(annotateStaking, {
-        context: ClientType.ColonyClient,
-        methodName: 'annotateTransaction',
-        identifier: colonyAddress,
-        params: [],
-        ready: false,
-      });
-    }
+    // if (annotationMessage) {
+    //   yield createGroupTransaction(annotateStaking, {
+    //     context: ClientType.ColonyClient,
+    //     methodName: 'annotateTransaction',
+    //     identifier: colonyAddress,
+    //     params: [],
+    //     ready: false,
+    //   });
+    // }
 
     yield takeFrom(approveStake.channel, ActionTypes.TRANSACTION_CREATED);
+
     yield takeFrom(
       stakeMotionTransaction.channel,
       ActionTypes.TRANSACTION_CREATED,
     );
 
-    if (annotationMessage) {
-      yield takeFrom(annotateStaking.channel, ActionTypes.TRANSACTION_CREATED);
-    }
+    // if (annotationMessage) {
+    //   yield takeFrom(annotateStaking.channel, ActionTypes.TRANSACTION_CREATED);
+    // }
 
     yield put(transactionReady(approveStake.id));
 
@@ -136,39 +102,39 @@ function* stakeMotion({
       ActionTypes.TRANSACTION_SUCCEEDED,
     );
 
-    if (annotationMessage) {
-      yield put(transactionPending(annotateStaking.id));
+    // if (annotationMessage) {
+    //   yield put(transactionPending(annotateStaking.id));
 
-      /*
-       * Upload annotation metadata to IPFS
-       */
-      let annotationMessageIpfsHash = null;
-      annotationMessageIpfsHash = yield call(
-        ipfsUpload,
-        JSON.stringify({
-          annotationMessage,
-        }),
-      );
+    //   /*
+    //    * Upload annotation metadata to IPFS
+    //    */
+    //   let annotationMessageIpfsHash = null;
+    //   annotationMessageIpfsHash = yield call(
+    //     ipfsUpload,
+    //     JSON.stringify({
+    //       annotationMessage,
+    //     }),
+    //   );
 
-      yield put(
-        transactionAddParams(annotateStaking.id, [
-          txHash,
-          annotationMessageIpfsHash,
-        ]),
-      );
+    //   yield put(
+    //     transactionAddParams(annotateStaking.id, [
+    //       txHash,
+    //       annotationMessageIpfsHash,
+    //     ]),
+    //   );
 
-      yield put(transactionReady(annotateStaking.id));
+    //   yield put(transactionReady(annotateStaking.id));
 
-      yield takeFrom(
-        annotateStaking.channel,
-        ActionTypes.TRANSACTION_SUCCEEDED,
-      );
-    }
+    //   yield takeFrom(
+    //     annotateStaking.channel,
+    //     ActionTypes.TRANSACTION_SUCCEEDED,
+    //   );
+    // }
 
     /*
      * Update motion page values
      */
-    yield fork(updateMotionValues, colonyAddress, userAddress, motionId);
+    // yield fork(updateMotionValues, colonyAddress, userAddress, motionId);
 
     yield put<AllActions>({
       type: ActionTypes.MOTION_STAKE_SUCCESS,

--- a/src/redux/sagas/transactions/createTransaction.ts
+++ b/src/redux/sagas/transactions/createTransaction.ts
@@ -4,6 +4,7 @@ import {
   all,
   call,
   cancel,
+  fork,
   put,
   take,
   takeEvery,
@@ -131,3 +132,18 @@ export function* waitForTxResult(channel: Channel<any>) {
     throw new Error('Transaction failed');
   }
 }
+
+export const createGroupTransaction = (
+  { id, index }: { id: string; index: number },
+  key: string,
+  meta: { id: string },
+  config: any,
+) =>
+  fork(createTransaction, id, {
+    ...config,
+    group: {
+      key,
+      id: meta.id,
+      index,
+    },
+  });

--- a/src/redux/sagas/utils/getNetworkClient.ts
+++ b/src/redux/sagas/utils/getNetworkClient.ts
@@ -10,6 +10,18 @@ import { DEFAULT_NETWORK } from '~constants';
 import { ContextModule, getContext } from '~context';
 import { Network, ColonyJSNetworkMapping } from '~types';
 
+export const {
+  etherRouterAddress: networkAddress,
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require, import/no-dynamic-require
+} = require('../../../../amplify/mock-data/colonyNetworkArtifacts/etherrouter-address.json');
+
+export const getReputationOracleURL = () => {
+  if (DEFAULT_NETWORK === Network.Ganache) {
+    return new URL(`/reputation/local`, 'http://localhost:3001');
+  }
+
+  return new URL(`/reputation`, window.location.origin);
+};
 /*
  * Return an initialized ColonyNetworkClient instance.
  */
@@ -24,14 +36,9 @@ export default function* getNetworkClient() {
 
   const signer = walletProvider.getSigner();
 
-  let reputationOracleUrl = new URL(`/reputation`, window.location.origin);
+  const reputationOracleUrl = getReputationOracleURL();
 
   if (DEFAULT_NETWORK === Network.Ganache) {
-    reputationOracleUrl = new URL(`/reputation/local`, 'http://localhost:3001');
-    const {
-      etherRouterAddress: networkAddress,
-      // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require, import/no-dynamic-require
-    } = require('../../../../amplify/mock-data/colonyNetworkArtifacts/etherrouter-address.json');
     return yield call(getColonyNetworkClient, ColonyJSNetwork.Custom, signer, {
       networkAddress,
       reputationOracleEndpoint: reputationOracleUrl.href,

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -59,3 +59,8 @@ export type ColonyChainClaimWithToken = ChainFundsClaimFragment & {
 };
 
 export type ColonyClaims = ColonyERC20Claims | ColonyChainClaimWithToken;
+export type RemoveTypeName<T> = T extends object
+  ? {
+      [K in Exclude<keyof T, '__typename'>]: RemoveTypeName<T[K]>;
+    }
+  : T;


### PR DESCRIPTION
## Description

This PR ports the motion staking saga. This branch is currently a bit light on permissions and token activation, so we have to get into the truffle console to set things up correctly.

![staked](https://user-images.githubusercontent.com/64402732/223985095-78dca2a4-47f0-4cc4-9461-4c09695087ff.png)

## Test

### Setup instructions

1. Build Cdapp without block ingestor. Run webpack.
2. Checkout and run block ingestor separately on branch: https://github.com/JoinColony/block-ingestor/pull/18
3. Turn reputation monitor on: http://localhost:3001/reputation/monitor/toggle
4. Open truffle: `npm run truffle console`
5. Get your colony:  c = await IColony.at(<colony-address>)
6. Give yourself some reputation: c.emitDomainReputationReward(1, accounts[0], '1000000000000000000')
7. Then in the ui, install the voting reputation extension. Make the staking phase last a long time ((e.g. 500 hours) due to time in dev being weird)
8. Back in truffle, give voting rep extn the arbitration permission: `c.setArbitrationRole(1, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", <voting-reputation-extn-address>, 1, true)` (voting rep address is its id in the db)

For staking to work, our user needs to have activated tokens. 

To do that, in truffle:

1. Mint some tokens: c.mintTokens('number in wei'), eg '10000000000000000000' or 10 eth
2. Then get the token address: ta = await c.getToken()
4. And claim the tokens you just minted: c.claimColonyFunds(ta)

At this point, we've just simulated the "mint tokens" action, which we can't do via the ui because we're testing a mint tokens motion.

Now we need to make a payment from the colony to the user.  This can be done in the ui. 

1. In `ColonyActions.tsx`, go to `ACTION_EXPENDITURE_PAYMENT` button and set the amount to some number less than or equal to the number you just minted. Then in the ui, click the create payment button. You have just paid yourself. 

Finally, we need to activate these tokens (again, in truffle console).

1. get the network address: n = await IColonyNetwork.at('0x5CC4a96B08e8C88f2c6FC5772496FeD9666e4D1F')
2. get tokenLocking address: tlAddress = await n.getTokenLocking()
3. instantiate tokenLocking contract: l = await TokenLocking.at(tlAddress)
5. Then, with the token address from earlier, instantiate a token contract : t = await Token.at(ta)
6.  Approve tokens: t.approve(l.address, 'number you paid yourself')
7. Activate tokens! l.deposit(t.address, 'number you approved' / 10) [I've noticed the amount you approve gets an "insufficient balance error"]

Now click "Test Mint Tokens". You should be directed to the motions ui.

Stake for the motion. The UI should update immediately, and persist after a refresh. Functionality should be same as: 
https://xdai.colony.io/colony/willsworld/tx/0xa5228de05deaa0f08dcbc4f8825ac66b00f2e564643de01c4b76a98f10dfed25

After you have reviewed this, it might be an efficient use of time to review this one also: https://github.com/JoinColony/colonyCDapp/pull/310

Since they share a setup.

**Changes** 🏗

* Wire in motion staking saga and associated components

## Note

Messages in the event feed are being handled separately. https://github.com/JoinColony/colonyCDapp/issues/312
Resolves  #298
