### PR TITLE
Port objection dialog

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/ObjectButton.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/ObjectButton.tsx
@@ -1,43 +1,20 @@
 import React from 'react';
+import { useObjectButton } from '~hooks';
 
 import Button from '~shared/Button';
-import { useStakingWidgetContext } from '../../StakingWidgetProvider';
 
 const displayName =
   'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingWidget.ObjectButton';
 
 const ObjectButton = () => {
-  const { canUserStakeNay, totalNAYStaked, setIsSummary } =
-    useStakingWidgetContext();
-
-  //const openRaiseObjectionDialog = useDialog(RaiseObjectionDialog);
-
-  // const handleRaiseObjection =
-  //   (userHasPermission: boolean, stakingAmounts: StakingAmounts) =>
-  //     openRaiseObjectionDialog({
-  //       motionId,
-  //       colony,
-  //       canUserStake: userHasPermission,
-  //       scrollToRef,
-  //       isDecision,
-  //       ...stakingAmounts,
-  //     }),
-  // );
+  const { handleObjection, disabled } = useObjectButton();
 
   return (
     <Button
       appearance={{ theme: 'pink', size: 'medium' }}
       text={{ id: 'button.object' }}
-      disabled={!canUserStakeNay}
-      onClick={() =>
-        totalNAYStaked === '0'
-          ? console.log('Wire in objection modal')
-          : // ? handleRaiseObjection(canUserStake, {
-            //     ...data.motionStakes,
-            //     userActivatedTokens,
-            //   })
-            setIsSummary(true)
-      }
+      disabled={disabled}
+      onClick={handleObjection}
       dataTest="stakeWidgetObjectButton"
     />
   );

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingSlider/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingSlider/index.ts
@@ -1,1 +1,2 @@
 export { default, StakingSliderProps } from './StakingSlider';
+export * from './types';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingWidgetProvider.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingWidgetProvider.tsx
@@ -27,8 +27,9 @@ import {
 export interface StakingWidgetContextValues {
   canBeStaked: boolean;
   canUserStakeNay: boolean;
-  totalNAYStaked: string;
+  totalNAYStakes: Decimal;
   remainingToStake: Decimal;
+  remainingToFullyNayStaked: Decimal;
   minUserStake: Decimal;
   maxUserStake: Decimal;
   yayPercentage: string;
@@ -92,8 +93,8 @@ const StakingWidgetProvider = ({
   // for optimistic ui
   const [usersStakes, setUsersStakes] = useState(usersStakesFromDB);
   const [motionStakes, setMotionStakes] = useState(rawMotionStakes);
-  const { nay: totalNAYStakes } = motionStakes;
-
+  const { nay } = motionStakes;
+  const totalNAYStakes = useMemo(() => new Decimal(nay), [nay]);
   const { data: userReputation, loading: reputationLoading } =
     useGetUserReputationQuery({
       variables: {
@@ -208,6 +209,7 @@ const StakingWidgetProvider = ({
       canUserStakeNay,
       totalNAYStakes,
       remainingToStake,
+      remainingToFullyNayStaked,
       minUserStake,
       maxUserStake,
       yayPercentage: formatStakePercentage(yayPercentage),
@@ -235,6 +237,7 @@ const StakingWidgetProvider = ({
       canBeStaked,
       canUserStakeNay,
       remainingToStake,
+      remainingToFullyNayStaked,
       totalNAYStakes,
       minUserStake,
       maxUserStake,

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/index.ts
@@ -5,6 +5,12 @@ export {
   useStakingWidgetContext,
   StakingWidgetContextValues,
 } from './StakingWidgetProvider';
-export { default as StakingSlider, StakingSliderProps } from './StakingSlider';
+export {
+  default as StakingSlider,
+  StakingSliderProps,
+  SomeSliderAnnotationProps,
+  SomeStakingValidationProps,
+  SomeStakingWidgetSliderProps,
+} from './StakingSlider';
 export { SLIDER_AMOUNT_KEY } from './StakingInput';
 export * from './helpers';

--- a/src/components/common/Dialogs/index.ts
+++ b/src/components/common/Dialogs/index.ts
@@ -20,3 +20,4 @@ export {
   FormattedListToken,
 } from './TokenManagementDialog';
 // export { SmiteDialog, AwardDialog } from './AwardAndSmiteDialogs';
+export * from './motions';

--- a/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionAnnotation.tsx
+++ b/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionAnnotation.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+
+import { DialogSection } from '~shared/Dialog';
+import { Annotations } from '~shared/Fields';
+
+const displayName = 'common.Dialogs.RaiseObjectionDialog.ObjectionAnnotation';
+
+const MSG = defineMessages({
+  annotation: {
+    id: `${displayName}.annotation`,
+    defaultMessage: `Explain why you’re making this objection (optional)`,
+  },
+});
+
+interface ObjectionAnnotationProps {
+  disabled: boolean;
+}
+
+const ObjectionAnnotation = ({ disabled }: ObjectionAnnotationProps) => (
+  <DialogSection appearance={{ border: 'top' }}>
+    <Annotations
+      label={MSG.annotation}
+      name="annotation"
+      maxLength={4000}
+      disabled={disabled}
+    />
+  </DialogSection>
+);
+
+ObjectionAnnotation.displayName = displayName;
+
+export default ObjectionAnnotation;

--- a/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionControls.css
+++ b/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionControls.css
@@ -1,0 +1,3 @@
+.submitButton > button {
+  width: 160px;
+}

--- a/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionControls.css.d.ts
+++ b/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionControls.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace ObjectionControlsCssNamespace {
+  export interface IObjectionControlsCss {
+    submitButton: string;
+  }
+}
+
+declare const ObjectionControlsCssModule: ObjectionControlsCssNamespace.IObjectionControlsCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: ObjectionControlsCssNamespace.IObjectionControlsCss;
+};
+
+export = ObjectionControlsCssModule;

--- a/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionControls.tsx
+++ b/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionControls.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import Button from '~shared/Button';
+import { DialogProps, DialogSection } from '~shared/Dialog';
+
+import styles from './ObjectionControls.css';
+
+const displayName = 'common.Dialogs.RaiseObjectionDialog.ObjectionControls';
+
+interface ObjectionControlsProps {
+  cancel: DialogProps['cancel'];
+  disabled: boolean;
+}
+
+const ObjectionControls = ({ cancel, disabled }: ObjectionControlsProps) => (
+  <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
+    <Button
+      appearance={{ theme: 'secondary', size: 'large' }}
+      text={{ id: 'button.cancel' }}
+      onClick={cancel}
+    />
+    <span className={styles.submitButton}>
+      <Button
+        appearance={{ theme: 'pink', size: 'large' }}
+        text={{ id: 'button.stake' }}
+        type="submit"
+        disabled={disabled}
+        dataTest="objectDialogStakeButton"
+      />
+    </span>
+  </DialogSection>
+);
+
+ObjectionControls.displayName = displayName;
+
+export default ObjectionControls;

--- a/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionHeading.css
+++ b/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionHeading.css
@@ -1,0 +1,10 @@
+.descriptionText {
+  padding-bottom: 20px;
+}
+
+.title {
+  font-size: var(--size-medium-l);
+  font-weight: var(--weight-bold);
+  line-height: 24px;
+  color: var(--dark);
+}

--- a/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionHeading.css.d.ts
+++ b/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionHeading.css.d.ts
@@ -1,0 +1,13 @@
+declare namespace ObjectionHeadingCssNamespace {
+  export interface IObjectionHeadingCss {
+    descriptionText: string;
+    title: string;
+  }
+}
+
+declare const ObjectionHeadingCssModule: ObjectionHeadingCssNamespace.IObjectionHeadingCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: ObjectionHeadingCssNamespace.IObjectionHeadingCss;
+};
+
+export = ObjectionHeadingCssModule;

--- a/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionHeading.tsx
+++ b/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionHeading.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { DialogSection } from '~shared/Dialog';
+import ExternalLink from '~shared/ExternalLink';
+import { Heading3 } from '~shared/Heading';
+import { MD_OBJECTIONS_HELP } from '~constants';
+
+import styles from './ObjectionHeading.css';
+
+const displayName = 'common.Dialogs.RaiseObjectiongDialog.ObjectionHeading';
+
+const MSG = defineMessages({
+  title: {
+    id: `${displayName}.title`,
+    defaultMessage: 'Raise an objection',
+  },
+  objectionDescription: {
+    id: `${displayName}.objectionDescription`,
+    defaultMessage: `
+    You are about to make an objection to the motion. If fully staked,
+    it will immediately start a voting process to determine whether
+    the motion should pass. <a>Learn more</a>`,
+  },
+});
+
+const objectionDescriptionMessageValues = {
+  a: (chunks) => (
+    <ExternalLink href={MD_OBJECTIONS_HELP}>{chunks}</ExternalLink>
+  ),
+};
+
+const ObjectionDescription = () => (
+  <div className={styles.descriptionText}>
+    <FormattedMessage
+      {...MSG.objectionDescription}
+      values={objectionDescriptionMessageValues}
+    />
+  </div>
+);
+
+const ObjectionHeading = () => (
+  <>
+    <DialogSection appearance={{ theme: 'heading' }}>
+      <Heading3
+        appearance={{ margin: 'none' }}
+        text={MSG.title}
+        className={styles.title}
+      />
+    </DialogSection>
+    <DialogSection appearance={{ theme: 'sidePadding', border: 'bottom' }}>
+      <ObjectionDescription />
+    </DialogSection>
+  </>
+);
+
+ObjectionHeading.displayName = displayName;
+
+export default ObjectionHeading;

--- a/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionSlider.css
+++ b/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionSlider.css
@@ -1,0 +1,4 @@
+.main {
+  margin: 0px auto 27px;
+  width: 341px;
+}

--- a/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionSlider.css.d.ts
+++ b/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionSlider.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace ObjectionSliderCssNamespace {
+  export interface IObjectionSliderCss {
+    main: string;
+  }
+}
+
+declare const ObjectionSliderCssModule: ObjectionSliderCssNamespace.IObjectionSliderCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: ObjectionSliderCssNamespace.IObjectionSliderCss;
+};
+
+export = ObjectionSliderCssModule;

--- a/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionSlider.tsx
+++ b/src/components/common/Dialogs/motions/RaiseObjectionDialog/ObjectionSlider.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import {
+  StakingSlider,
+  StakingSliderProps,
+} from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
+import { DialogSection } from '~shared/Dialog';
+
+import styles from './ObjectionSlider.css';
+
+const displayName = 'common.Dialogs.RaiseObjectionDialog.ObjectionSlider';
+
+interface ObjectionSliderProps {
+  stakingSliderProps: StakingSliderProps;
+}
+
+const ObjectionSlider = ({ stakingSliderProps }: ObjectionSliderProps) => (
+  <DialogSection appearance={{ theme: 'sidePadding' }}>
+    <div className={styles.main}>
+      <StakingSlider {...stakingSliderProps} />
+    </div>
+  </DialogSection>
+);
+
+ObjectionSlider.displayName = displayName;
+
+export default ObjectionSlider;

--- a/src/components/common/Dialogs/motions/RaiseObjectionDialog/RaiseObjectionDialog.tsx
+++ b/src/components/common/Dialogs/motions/RaiseObjectionDialog/RaiseObjectionDialog.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { object, number, InferType, string } from 'yup';
+
+import {
+  getStakeFromSlider,
+  StakingSliderProps,
+} from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
+
+import Dialog, { DialogProps } from '~shared/Dialog';
+import { ActionHookForm as ActionForm } from '~shared/Fields';
+
+import { ActionTypes } from '~redux';
+
+import {
+  ObjectionHeading,
+  ObjectionAnnotation,
+  ObjectionControls,
+  ObjectionSlider,
+} from '.';
+
+const displayName = 'common.Dialogs.RaiseObjectionDialog';
+
+const AMOUNT_DEFAULT = 0;
+
+const validationSchema = object()
+  .shape({
+    amount: number().required().default(AMOUNT_DEFAULT),
+    annotationMessage: string(),
+  })
+  .defined();
+
+type ObjectionValues = InferType<typeof validationSchema>;
+
+interface RaiseObjectionDialogProps extends DialogProps {
+  stakingSliderProps: StakingSliderProps;
+}
+
+const RaiseObjectionDialog = ({
+  close,
+  stakingSliderProps: {
+    stakingWidgetSliderProps: {
+      remainingToStake,
+      minUserStake,
+      canBeStaked,
+      userActivatedTokens,
+    },
+  },
+  stakingSliderProps,
+}: RaiseObjectionDialogProps) => {
+  // const { transform, handleSuccess } = useRaiseObjectionDialog();
+
+  return (
+    <Dialog cancel={close}>
+      <ActionForm<ObjectionValues>
+        defaultValues={{
+          amount: AMOUNT_DEFAULT,
+          annotationMessage: undefined,
+        }}
+        actionType={ActionTypes.MOTION_STAKE}
+        validationSchema={validationSchema}
+        // onSuccess={handleSuccess}
+        // transform={transform}
+      >
+        {({ formState: { isSubmitting }, watch }) => {
+          const sliderAmount = watch('amount');
+          const stake = getStakeFromSlider(
+            sliderAmount,
+            remainingToStake,
+            minUserStake,
+          );
+          const disabled = !canBeStaked || isSubmitting;
+          return (
+            <>
+              <ObjectionHeading />
+              <ObjectionSlider stakingSliderProps={stakingSliderProps} />
+              <ObjectionAnnotation disabled={disabled} />
+              <ObjectionControls
+                cancel={close}
+                disabled={disabled || userActivatedTokens.lt(stake)}
+              />
+            </>
+          );
+        }}
+      </ActionForm>
+    </Dialog>
+  );
+};
+
+RaiseObjectionDialog.displayName = displayName;
+
+export default RaiseObjectionDialog;

--- a/src/components/common/Dialogs/motions/RaiseObjectionDialog/index.ts
+++ b/src/components/common/Dialogs/motions/RaiseObjectionDialog/index.ts
@@ -1,0 +1,5 @@
+export { default } from './RaiseObjectionDialog';
+export { default as ObjectionControls } from './ObjectionControls';
+export { default as ObjectionHeading } from './ObjectionHeading';
+export { default as ObjectionAnnotation } from './ObjectionAnnotation';
+export { default as ObjectionSlider } from './ObjectionSlider';

--- a/src/components/common/Dialogs/motions/index.ts
+++ b/src/components/common/Dialogs/motions/index.ts
@@ -1,0 +1,1 @@
+export { default as RaiseObjectionDialog } from './RaiseObjectionDialog';

--- a/src/components/shared/Dialog/DialogProvider.tsx
+++ b/src/components/shared/Dialog/DialogProvider.tsx
@@ -4,6 +4,7 @@ import React, {
   ReactNode,
   useCallback,
   useState,
+  useMemo,
 } from 'react';
 import { nanoid } from 'nanoid';
 
@@ -22,7 +23,6 @@ interface Props {
 
 const DialogProvider = ({ children }: Props) => {
   const [openDialogs, setOpenDialogs] = useState<DialogType<any>[]>([]);
-
   const closeDialog = useCallback((key: string) => {
     setOpenDialogs((prevOpenDialogs) => {
       const idx = prevOpenDialogs.findIndex((dialog) => dialog.key === key);
@@ -67,11 +67,10 @@ const DialogProvider = ({ children }: Props) => {
     [closeDialog],
   );
 
+  const value = useMemo(() => ({ openDialog: pushDialog }), [pushDialog]);
   return (
     <>
-      <DialogContext.Provider value={{ openDialog: pushDialog }}>
-        {children}
-      </DialogContext.Provider>
+      <DialogContext.Provider value={value}>{children}</DialogContext.Provider>
       {openDialogs.map(({ Dialog, props, ...dialogProps }) => (
         <Dialog {...dialogProps} {...props} />
       ))}

--- a/src/constants/externalUrls.ts
+++ b/src/constants/externalUrls.ts
@@ -18,7 +18,7 @@ export const getBlockscoutUserURL = (userAddress: string) =>
 /*
  * Motions and Disputes
  */
-export const MD_OBJECTIONS_HELP = `https://colony.io/dev/docs/colonynetwork/whitepaper-tldr-objections-and-disputes#objections`;
+export const MD_OBJECTIONS_HELP = `https://docs.colony.io/develop/dev-learning/disputes/#objections`;
 export const MD_REPUTATION_INFO = `https://colony.gitbook.io/colony/key-concepts/reputation`;
 
 /*

--- a/src/hooks/motionWidgets/stakingWidget/helpers.ts
+++ b/src/hooks/motionWidgets/stakingWidget/helpers.ts
@@ -1,5 +1,11 @@
 import Decimal from 'decimal.js';
-import { StakingSliderProps } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingSlider/StakingSlider';
+import { useRef } from 'react';
+import {
+  StakingSliderProps,
+  SomeSliderAnnotationProps,
+  SomeStakingValidationProps,
+  SomeStakingWidgetSliderProps,
+} from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
 import { Address, MotionData, RemoveTypeName } from '~types';
 
 export type UsersStakes = MotionData['usersStakes'];
@@ -9,6 +15,12 @@ enum MotionSide {
   YAY = 'yay',
   NAY = 'nay',
 }
+
+type AllStakingSliderProps = SomeSliderAnnotationProps &
+  SomeStakingValidationProps &
+  SomeStakingWidgetSliderProps & {
+    mutableRef?: ReturnType<typeof useRef>;
+  };
 
 export const mapStakingSliderProps = ({
   isObjection,
@@ -24,7 +36,7 @@ export const mapStakingSliderProps = ({
   reputationLoading,
   getErrorType,
   mutableRef,
-}): StakingSliderProps => ({
+}: AllStakingSliderProps): StakingSliderProps => ({
   stakingWidgetSliderProps: {
     isObjection,
     minUserStake,

--- a/src/hooks/motionWidgets/stakingWidget/index.ts
+++ b/src/hooks/motionWidgets/stakingWidget/index.ts
@@ -5,3 +5,5 @@ export { default as useUserStakeMessage } from './useUserStakeMessage';
 export { default as useMinAndRequiredStakes } from './useMinAndRequiredStakes';
 export { default as useStakingWidgetSlider } from './useStakingWidgetSlider';
 export { default as useStakingSlider } from './useStakingSlider';
+export { default as useObjectButton } from './useObjectButton';
+export { default as useRaiseObjectionDialog } from './useRaiseObjectionDialog';

--- a/src/hooks/motionWidgets/stakingWidget/useObjectButton.ts
+++ b/src/hooks/motionWidgets/stakingWidget/useObjectButton.ts
@@ -1,0 +1,48 @@
+import { useStakingWidgetContext } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
+import RaiseObjectionDialog from '~common/Dialogs/motions/RaiseObjectionDialog';
+import { useDialog } from '~shared/Dialog';
+import { mapStakingSliderProps } from './helpers';
+
+const useObjectButton = () => {
+  const {
+    canUserStakeNay,
+    remainingToFullyNayStaked,
+    minUserStake,
+    userActivatedTokens,
+    totalNAYStakes,
+    setIsSummary,
+    maxUserStake,
+    enoughTokens,
+    getErrorType,
+    nativeTokenDecimals,
+    nativeTokenSymbol,
+    reputationLoading,
+    totalPercentage,
+  } = useStakingWidgetContext();
+
+  const openRaiseObjectionDialog = useDialog(RaiseObjectionDialog);
+
+  const stakingSliderProps = mapStakingSliderProps({
+    canBeStaked: canUserStakeNay,
+    enoughTokens,
+    getErrorType,
+    isObjection: true,
+    maxUserStake,
+    minUserStake,
+    nativeTokenDecimals,
+    nativeTokenSymbol,
+    remainingToStake: remainingToFullyNayStaked,
+    reputationLoading,
+    totalPercentage,
+    userActivatedTokens,
+  });
+
+  const handleObjection = () =>
+    totalNAYStakes.isZero()
+      ? openRaiseObjectionDialog({ stakingSliderProps })
+      : setIsSummary(true);
+
+  return { handleObjection, disabled: !canUserStakeNay };
+};
+
+export default useObjectButton;

--- a/src/hooks/motionWidgets/stakingWidget/useRaiseObjectionDialog.ts
+++ b/src/hooks/motionWidgets/stakingWidget/useRaiseObjectionDialog.ts
@@ -1,0 +1,53 @@
+import { BigNumber } from 'ethers';
+
+import {
+  getFinalStake,
+  useStakingWidgetContext,
+} from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
+import { useAppContext, useColonyContext } from '~hooks';
+import { mapPayload } from '~utils/actions';
+
+const useRaiseObjectionDialog = () => {
+  const { user } = useAppContext();
+  const { colony } = useColonyContext();
+  const {
+    maxUserStake,
+    requiredStake,
+    totalNAYStakes,
+    minUserStake,
+    motionId,
+  } = useStakingWidgetContext();
+
+  const remainingToFullyNayStaked = requiredStake.sub(totalNAYStakes);
+
+  const transform = mapPayload(({ amount, annotationMessage }) => {
+    const finalStake = getFinalStake(
+      amount,
+      remainingToFullyNayStaked,
+      minUserStake,
+      maxUserStake,
+    );
+
+    return {
+      amount: finalStake,
+      userAddress: user?.walletAddress,
+      colonyAddress: colony?.colonyAddress,
+      motionId: BigNumber.from(motionId),
+      vote: 0,
+      annotationMessage,
+    };
+  });
+
+  const handleSuccess = () => {};
+  //     (_, { setFieldValue, resetForm }) => {
+  //       resetForm({});
+  //       setFieldValue('amount', 0);
+  //       scrollToRef?.current?.scrollIntoView({ behavior: 'smooth' });
+  //       close();
+  //     },
+  //   );
+
+  return { transform, handleSuccess };
+};
+
+export default useRaiseObjectionDialog;


### PR DESCRIPTION
## Description

I recommend testing this pr first : https://github.com/JoinColony/colonyCDapp/pull/310 since you'll implicitly be testing the ui.

This ports the objection dialog such that when you click the object button, you see: 

![objection](https://user-images.githubusercontent.com/64402732/223986942-e3d156b9-b644-463b-8223-43fba290dcc1.png)

**New stuff** ✨

* Objection dialog

Resolves #287 
