### PR TITLE
Wire in object button (motion staking)

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultAction/DefaultAction.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultAction/DefaultAction.css
@@ -15,7 +15,7 @@
   border-top: 1px solid color-mod(var(--grey-purple) alpha(15%));
   grid-template:
     "feed details" 100%
-    / minmax(51%, 460px) minmax(38%, 340px);
+    / minmax(51%, 460px) minmax(39%, 340px);
   column-gap: 11%;
 }
 

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput.tsx
@@ -12,6 +12,7 @@ const displayName =
   'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingWidget';
 
 export const SLIDER_AMOUNT_KEY = 'amount';
+export const SLIDER_AMOUNT_DEFAULT = 0;
 
 const validationSchema = object({
   [SLIDER_AMOUNT_KEY]: number().defined(),

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/index.ts
@@ -1,1 +1,6 @@
-export { default, SLIDER_AMOUNT_KEY } from './StakingInput';
+export {
+  default,
+  SLIDER_AMOUNT_KEY,
+  SLIDER_AMOUNT_DEFAULT,
+  StakingWidgetValues,
+} from './StakingInput';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingWidget.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingWidget.tsx
@@ -3,7 +3,7 @@ import { defineMessages } from 'react-intl';
 
 import { MiniSpinnerLoader } from '~shared/Preloaders';
 
-import { SingleTotalStake /*GroupedTotalStake*/ } from './TotalStakeWidget';
+import { SingleTotalStake, GroupedTotalStake } from './TotalStakeWidget';
 import StakingInput from './StakingInput';
 import { useStakingWidgetContext } from './StakingWidgetProvider';
 
@@ -19,7 +19,7 @@ const MSG = defineMessages({
   },
 });
 const StakingWidget = () => {
-  const { /*isSummary,*/ loadingStakeData } = useStakingWidgetContext();
+  const { isSummary, loadingStakeData } = useStakingWidgetContext();
 
   if (loadingStakeData) {
     return (
@@ -34,14 +34,14 @@ const StakingWidget = () => {
 
   return (
     <div className={styles.main} data-test="stakingWidget">
-      {/* {isSummary ? (
+      {isSummary ? (
         <GroupedTotalStake />
-      ) : (<> */}
-      <SingleTotalStake />
-      <StakingInput />
-      {/*
-        </>)
-        */}
+      ) : (
+        <>
+          <SingleTotalStake />
+          <StakingInput />
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingWidgetProvider.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingWidgetProvider.tsx
@@ -88,7 +88,9 @@ const StakingWidgetProvider = ({
 }: StakingWidgetProviderProps) => {
   const { user } = useAppContext();
   const { colony } = useColonyContext();
-  const [isSummary, setIsSummary] = useState(false);
+  const [isSummary, setIsSummary] = useState(
+    new Decimal(rawMotionStakes.nay).gt(0),
+  );
   const [isObjection, setIsObjection] = useState(false);
   // for optimistic ui
   const [usersStakes, setUsersStakes] = useState(usersStakesFromDB);

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/GroupedTotalStake.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/GroupedTotalStake.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { object, string, InferType } from 'yup';
+
+import { HookForm as Form } from '~shared/Fields';
+
+import { useStakingWidgetContext } from '../../StakingWidgetProvider';
+import GroupedTotalStakeHeading from './GroupedTotalStakeHeading';
+import SubmitButton from './SubmitButton';
+import TotalStakeRadios from './TotalStakeRadios';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingWidget.GroupedTotalStake';
+
+export enum StakeSide {
+  Motion = 'MOTION',
+  Objection = 'OBJECTION',
+}
+
+const validationSchema = object()
+  .shape({
+    stakeSide: string().required().defined(),
+  })
+  .defined();
+
+type GroupedTotalStakeVals = InferType<typeof validationSchema>;
+
+const GroupedTotalStake = () => {
+  const { setIsSummary, setIsObjection } = useStakingWidgetContext();
+
+  const handleSubmit = ({ stakeSide }) => {
+    setIsObjection(stakeSide === StakeSide.Objection);
+    setIsSummary(false);
+  };
+  return (
+    <Form<GroupedTotalStakeVals>
+      defaultValues={{ stakeSide: '' }}
+      validationSchema={validationSchema}
+      onSubmit={handleSubmit}
+    >
+      <GroupedTotalStakeHeading />
+      <TotalStakeRadios />
+      <SubmitButton />
+    </Form>
+  );
+};
+
+GroupedTotalStake.displayName = displayName;
+
+export default GroupedTotalStake;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/GroupedTotalStakeHeading.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/GroupedTotalStakeHeading.css
@@ -1,0 +1,17 @@
+.widgetHeading {
+  composes: widgetHeading from '../SingleTotalStake/SingleTotalStakeHeading.css';
+}
+
+.title {
+  composes: title from '../SingleTotalStake/SingleTotalStakeHeading.css';
+}
+
+.tooltip {
+  composes: tooltip from '../SingleTotalStake/SingleTotalStake.css';
+}
+
+.help {
+  margin-right: auto;
+  margin-left: 8px;
+  height: 16px;
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/GroupedTotalStakeHeading.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/GroupedTotalStakeHeading.css.d.ts
@@ -1,0 +1,15 @@
+declare namespace GroupedTotalStakeHeadingCssNamespace {
+  export interface IGroupedTotalStakeHeadingCss {
+    help: string;
+    title: string;
+    tooltip: string;
+    widgetHeading: string;
+  }
+}
+
+declare const GroupedTotalStakeHeadingCssModule: GroupedTotalStakeHeadingCssNamespace.IGroupedTotalStakeHeadingCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: GroupedTotalStakeHeadingCssNamespace.IGroupedTotalStakeHeadingCss;
+};
+
+export = GroupedTotalStakeHeadingCssModule;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/GroupedTotalStakeHeading.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/GroupedTotalStakeHeading.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+
+import { Heading5 } from '~shared/Heading';
+import QuestionMarkTooltip from '~shared/QuestionMarkTooltip';
+
+import styles from './GroupedTotalStakeHeading.css';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingWidget.GroupedTotalStakeHeading';
+
+const MSG = defineMessages({
+  crowdfundStakeTitle: {
+    id: `${displayName}.crowdfundStakeTitle`,
+    defaultMessage: 'Crowdfund stakes',
+  },
+  totalStakeTooltip: {
+    id: `${displayName}.totalStakeTooltip`,
+    defaultMessage: `The total staked amount and weight for each side of the Motion.`,
+  },
+});
+
+const GroupedTotalStakeHeading = () => (
+  <div className={styles.widgetHeading}>
+    <Heading5
+      appearance={{
+        theme: 'dark',
+        margin: 'none',
+      }}
+      text={MSG.crowdfundStakeTitle}
+      className={styles.title}
+    />
+    <QuestionMarkTooltip
+      className={styles.help}
+      tooltipClassName={styles.tooltip}
+      tooltipText={MSG.totalStakeTooltip}
+      tooltipPopperOptions={{
+        placement: 'right',
+      }}
+    />
+  </div>
+);
+
+GroupedTotalStakeHeading.displayName = displayName;
+
+export default GroupedTotalStakeHeading;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/SubmitButton.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/SubmitButton.css
@@ -1,0 +1,12 @@
+.submitButtonContainer {
+  margin-top: 10px;
+  margin-bottom: 105px;
+  margin-left: auto;
+  width: fit-content;
+}
+
+.submitButtonContainer > button {
+  padding: 2px 35px;
+  font-size: var(--size-small);
+  font-weight: var(--weight-bold);
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/SubmitButton.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/SubmitButton.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace SubmitButtonCssNamespace {
+  export interface ISubmitButtonCss {
+    submitButtonContainer: string;
+  }
+}
+
+declare const SubmitButtonCssModule: SubmitButtonCssNamespace.ISubmitButtonCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: SubmitButtonCssNamespace.ISubmitButtonCss;
+};
+
+export = SubmitButtonCssModule;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/SubmitButton.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/SubmitButton.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { useAppContext } from '~hooks';
+import Button from '~shared/Button';
+
+import styles from './SubmitButton.css';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPAge.DefaultMotion.StakingWidget.GroupedTotalStake.SubmitButton';
+
+const SubmitButton = () => {
+  const { user } = useAppContext();
+  const {
+    formState: { isValid, isDirty },
+  } = useFormContext();
+
+  return (
+    <div className={styles.submitButtonContainer}>
+      <Button
+        type="submit"
+        appearance={{ theme: 'primary', size: 'medium' }}
+        text={{ id: 'button.next' }}
+        disabled={!isValid || !user || !isDirty}
+      />
+    </div>
+  );
+};
+
+SubmitButton.displayName = displayName;
+
+export default SubmitButton;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/TotalStakeRadios.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/TotalStakeRadios.css
@@ -1,0 +1,3 @@
+.main label {
+  padding-left: 16px;
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/TotalStakeRadios.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/TotalStakeRadios.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace TotalStakeRadiosCssNamespace {
+  export interface ITotalStakeRadiosCss {
+    main: string;
+  }
+}
+
+declare const TotalStakeRadiosCssModule: TotalStakeRadiosCssNamespace.ITotalStakeRadiosCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: TotalStakeRadiosCssNamespace.ITotalStakeRadiosCss;
+};
+
+export = TotalStakeRadiosCssModule;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/TotalStakeRadios.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/TotalStakeRadios.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import { CustomRadioGroup } from '~shared/Fields';
+import { useTotalStakeRadios } from '~hooks';
+
+import styles from './TotalStakeRadios.css';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingWidget.TotalStakeRadios';
+
+const TotalStakeRadios = () => {
+  const { radioConfig, stakeSide } = useTotalStakeRadios();
+
+  return (
+    <div className={styles.main}>
+      <CustomRadioGroup
+        name="stakeSide"
+        currentlyCheckedValue={stakeSide}
+        options={radioConfig}
+        appearance={{ direction: 'vertical' }}
+      />
+    </div>
+  );
+};
+
+TotalStakeRadios.displayName = displayName;
+
+export default TotalStakeRadios;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/GroupedTotalStake/index.ts
@@ -1,0 +1,1 @@
+export { default, StakeSide } from './GroupedTotalStake';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/SingleTotalStake/SingleTotalStakeHeading.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/SingleTotalStake/SingleTotalStakeHeading.tsx
@@ -76,7 +76,7 @@ const SingleTotalStakeHeading = () => {
         <FormattedMessage
           {...MSG.stakeProgress}
           values={{
-            totalPercentage: totalPercentage,
+            totalPercentage,
             requiredStake: (
               <Numeral
                 value={requiredStake}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/TotalStakeWidget/index.ts
@@ -1,2 +1,2 @@
-// export { default as GroupedTotalStake, StakeSide } from './GroupedTotalStake';
+export { default as GroupedTotalStake, StakeSide } from './GroupedTotalStake';
 export { default as SingleTotalStake } from './SingleTotalStake';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/index.ts
@@ -1,5 +1,5 @@
 export { default } from './StakingWidget';
-// export { StakeSide } from './TotalStakeWidget';
+export { StakeSide } from './TotalStakeWidget';
 export {
   default as StakingWidgetProvider,
   useStakingWidgetContext,

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/index.ts
@@ -12,5 +12,9 @@ export {
   SomeStakingValidationProps,
   SomeStakingWidgetSliderProps,
 } from './StakingSlider';
-export { SLIDER_AMOUNT_KEY } from './StakingInput';
+export {
+  SLIDER_AMOUNT_DEFAULT,
+  SLIDER_AMOUNT_KEY,
+  StakingWidgetValues,
+} from './StakingInput';
 export * from './helpers';

--- a/src/components/shared/Fields/RadioGroup/CustomRadioGroup.tsx
+++ b/src/components/shared/Fields/RadioGroup/CustomRadioGroup.tsx
@@ -43,7 +43,7 @@ const CustomRadioGroup = ({
           value={value}
           label={label}
           key={value}
-          appearance={{ ...optionApperance, direction: appearance.direction }}
+          appearance={optionApperance}
           disabled={disabled}
           dataTest={dataTest}
           {...rest}

--- a/src/hooks/motionWidgets/stakingWidget/index.ts
+++ b/src/hooks/motionWidgets/stakingWidget/index.ts
@@ -7,3 +7,4 @@ export { default as useStakingWidgetSlider } from './useStakingWidgetSlider';
 export { default as useStakingSlider } from './useStakingSlider';
 export { default as useObjectButton } from './useObjectButton';
 export { default as useRaiseObjectionDialog } from './useRaiseObjectionDialog';
+export { default as useTotalStakeRadios } from './useTotalStakeRadios';

--- a/src/hooks/motionWidgets/stakingWidget/useObjectButton.ts
+++ b/src/hooks/motionWidgets/stakingWidget/useObjectButton.ts
@@ -1,9 +1,15 @@
-import { useStakingWidgetContext } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
+import { useFormContext } from 'react-hook-form';
+import {
+  SLIDER_AMOUNT_KEY,
+  useStakingWidgetContext,
+} from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
 import RaiseObjectionDialog from '~common/Dialogs/motions/RaiseObjectionDialog';
+import useColonyContext from '~hooks/useColonyContext';
 import { useDialog } from '~shared/Dialog';
 import { mapStakingSliderProps } from './helpers';
 
 const useObjectButton = () => {
+  const { colony } = useColonyContext();
   const {
     canUserStakeNay,
     remainingToFullyNayStaked,
@@ -18,7 +24,12 @@ const useObjectButton = () => {
     nativeTokenSymbol,
     reputationLoading,
     totalPercentage,
+    motionId,
+    setMotionStakes,
+    setUsersStakes,
   } = useStakingWidgetContext();
+  const { watch } = useFormContext();
+  const sliderAmount = watch(SLIDER_AMOUNT_KEY);
 
   const openRaiseObjectionDialog = useDialog(RaiseObjectionDialog);
 
@@ -37,9 +48,21 @@ const useObjectButton = () => {
     userActivatedTokens,
   });
 
+  const raiseObjectionDialogProps = {
+    motionId,
+    setIsSummary,
+    setMotionStakes,
+    setUsersStakes,
+    defaultSliderAmount: sliderAmount,
+    colonyAddress: colony?.colonyAddress ?? '',
+  };
+
   const handleObjection = () =>
     totalNAYStakes.isZero()
-      ? openRaiseObjectionDialog({ stakingSliderProps })
+      ? openRaiseObjectionDialog({
+          stakingSliderProps,
+          raiseObjectionDialogProps,
+        })
       : setIsSummary(true);
 
   return { handleObjection, disabled: !canUserStakeNay };

--- a/src/hooks/motionWidgets/stakingWidget/useRaiseObjectionDialog.ts
+++ b/src/hooks/motionWidgets/stakingWidget/useRaiseObjectionDialog.ts
@@ -1,51 +1,76 @@
-import { BigNumber } from 'ethers';
+import Decimal from 'decimal.js';
 
 import {
+  SLIDER_AMOUNT_DEFAULT,
+  SLIDER_AMOUNT_KEY,
+  StakingWidgetValues,
   getFinalStake,
-  useStakingWidgetContext,
 } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
-import { useAppContext, useColonyContext } from '~hooks';
-import { mapPayload } from '~utils/actions';
+import { OnSuccess } from '~shared/Fields/Form/ActionHookForm';
+import { useAppContext } from '~hooks';
+import { DialogProps } from '~shared/Dialog';
+import { Address, SetStateFn } from '~types';
+import {
+  getMotionStakingTransform,
+  MotionStakes,
+  updateMotionStakes,
+  updateUsersStakes,
+  UsersStakes,
+} from './helpers';
 
-const useRaiseObjectionDialog = () => {
-  const { user } = useAppContext();
-  const { colony } = useColonyContext();
-  const {
-    maxUserStake,
-    requiredStake,
-    totalNAYStakes,
+interface UseRaiseObjectionDialogProps {
+  remainingToFullyNayStaked: Decimal;
+  minUserStake: Decimal;
+  motionId: string;
+  setMotionStakes: SetStateFn;
+  setUsersStakes: SetStateFn;
+  setIsSummary: SetStateFn;
+  colonyAddress: Address;
+}
+
+const useRaiseObjectionDialog = (
+  close: DialogProps['close'],
+  {
+    remainingToFullyNayStaked,
     minUserStake,
     motionId,
-  } = useStakingWidgetContext();
+    setMotionStakes,
+    setUsersStakes,
+    setIsSummary,
+    colonyAddress,
+  }: UseRaiseObjectionDialogProps,
+) => {
+  const { user } = useAppContext();
+  const transform = getMotionStakingTransform({
+    colonyAddress,
+    minUserStake,
+    motionId,
+    remainingToStake: remainingToFullyNayStaked,
+    userAddress: user?.walletAddress ?? '',
+    vote: 0,
+  });
 
-  const remainingToFullyNayStaked = requiredStake.sub(totalNAYStakes);
-
-  const transform = mapPayload(({ amount, annotationMessage }) => {
+  const handleSuccess: OnSuccess<StakingWidgetValues> = (
+    _,
+    { amount },
+    { reset },
+  ) => {
     const finalStake = getFinalStake(
       amount,
       remainingToFullyNayStaked,
       minUserStake,
-      maxUserStake,
     );
 
-    return {
-      amount: finalStake,
-      userAddress: user?.walletAddress,
-      colonyAddress: colony?.colonyAddress,
-      motionId: BigNumber.from(motionId),
-      vote: 0,
-      annotationMessage,
-    };
-  });
-
-  const handleSuccess = () => {};
-  //     (_, { setFieldValue, resetForm }) => {
-  //       resetForm({});
-  //       setFieldValue('amount', 0);
-  //       scrollToRef?.current?.scrollIntoView({ behavior: 'smooth' });
-  //       close();
-  //     },
-  //   );
+    setIsSummary(true);
+    setMotionStakes((motionStakes: MotionStakes) =>
+      updateMotionStakes(motionStakes, finalStake, 0),
+    );
+    setUsersStakes((usersStakes: UsersStakes) =>
+      updateUsersStakes(usersStakes, user?.walletAddress ?? '', finalStake, 0),
+    );
+    reset({ [SLIDER_AMOUNT_KEY]: SLIDER_AMOUNT_DEFAULT });
+    close();
+  };
 
   return { transform, handleSuccess };
 };

--- a/src/hooks/motionWidgets/stakingWidget/useTotalStakeRadios.tsx
+++ b/src/hooks/motionWidgets/stakingWidget/useTotalStakeRadios.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import { defineMessages } from 'react-intl';
+
+import {
+  StakeSide,
+  useStakingWidgetContext,
+} from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
+import { useAppContext } from '~hooks';
+import { CustomRadioAppearance } from '~shared/Fields/Radio';
+import Icon from '~shared/Icon';
+import Numeral from '~shared/Numeral';
+
+const displayName = 'hooks.motionWidgets.stakingWidget.useTotalStakeRadios';
+
+const MSG = defineMessages({
+  YAYName: {
+    id: `${displayName}.YAYName`,
+    defaultMessage: 'Motion {fullyStakedEmoji}',
+  },
+  NAYName: {
+    id: `${displayName}.NAYName`,
+    defaultMessage: 'Objection {fullyStakedEmoji}',
+  },
+  stakeProgress: {
+    id: `${displayName}.stakeProgress`,
+    defaultMessage: '{totalPercentage}% of {requiredStake}',
+  },
+  fullyStaked: {
+    id: `${displayName}.fullyStaked`,
+    defaultMessage: 'Fully staked',
+  },
+});
+
+const useTotalStakeRadios = () => {
+  const {
+    yayPercentage,
+    nayPercentage,
+    nativeTokenSymbol,
+    nativeTokenDecimals,
+    requiredStake,
+  } = useStakingWidgetContext();
+  const { getValues } = useFormContext();
+  const { stakeSide } = getValues();
+  const { user } = useAppContext();
+  const isYAYSideFullyStaked = yayPercentage === '100';
+  const isNAYSideFullyStaked = nayPercentage === '100';
+
+  const radioConfig = [
+    {
+      value: StakeSide.Motion,
+      description: isYAYSideFullyStaked ? MSG.fullyStaked : MSG.stakeProgress,
+      descriptionValues: {
+        totalPercentage: yayPercentage,
+        requiredStake: (
+          <Numeral
+            value={requiredStake}
+            suffix={nativeTokenSymbol}
+            decimals={nativeTokenDecimals}
+          />
+        ),
+      },
+      label: MSG.YAYName,
+      labelValues: {
+        fullyStakedEmoji: isYAYSideFullyStaked ? (
+          <Icon name="circle-check-primary" title={MSG.fullyStaked} />
+        ) : null,
+      },
+      appearance: { theme: 'primary' } as CustomRadioAppearance,
+      disabled: isYAYSideFullyStaked || !user,
+    },
+    {
+      value: StakeSide.Objection,
+      description: isNAYSideFullyStaked ? MSG.fullyStaked : MSG.stakeProgress,
+      descriptionValues: {
+        totalPercentage: nayPercentage,
+        requiredStake: (
+          <Numeral
+            value={requiredStake}
+            suffix={nativeTokenSymbol}
+            decimals={nativeTokenDecimals}
+          />
+        ),
+      },
+      label: MSG.NAYName,
+      labelValues: {
+        fullyStakedEmoji: isNAYSideFullyStaked ? (
+          <Icon name="circle-check-primary" title={MSG.fullyStaked} />
+        ) : null,
+      },
+      appearance: { theme: 'danger' } as CustomRadioAppearance,
+      disabled: isNAYSideFullyStaked || !user,
+    },
+  ];
+
+  return { radioConfig, stakeSide };
+};
+
+export default useTotalStakeRadios;


### PR DESCRIPTION
## Description

This pr ports the `GroupedTotalStake` ui:
![crowdfund](https://user-images.githubusercontent.com/64402732/223998343-bbc99a8e-e22e-46be-8ea9-e60d9023e6e6.png)

And wires in the object button, such that you can object to a motion via the "Object" button or via the Objection stake ui: 

![object](https://user-images.githubusercontent.com/64402732/223998363-954f8710-e3db-422c-9fab-de6c58fb14fa.png)

## Testing

Follow setup instructions from: https://github.com/JoinColony/colonyCDapp/pull/299
 
Looking to emaulte this: https://xdai.colony.io/colony/willsworld/tx/0x8d216efa688de6965c53e3b498417250a36cb0a1d8d7a5c989cf007c1021658a

**New stuff** ✨

* GroupedTotalStake ui

**Changes** 🏗

* Wiring in object stake
