### PR TITLE
Expose current VotingReputation version in `useEnabledExtensions` hook

### DIFF
--- a/src/hooks/useEnabledExtensions.tsx
+++ b/src/hooks/useEnabledExtensions.tsx
@@ -2,23 +2,21 @@ import { Extension } from '@colony/colony-js';
 
 import useExtensionsData from './useExtensionsData';
 
-type EnabledExtensionKey = `is${Extension}Enabled`;
-type EnabledExtensions = Partial<Record<EnabledExtensionKey, boolean>>;
-
 const useEnabledExtensions = () => {
   const { installedExtensionsData, loading } = useExtensionsData();
 
-  const enabledExtensions = installedExtensionsData.reduce<EnabledExtensions>(
-    (extensions, extension) => ({
-      ...extensions,
-      [`is${extension.extensionId}Enabled`]: extension.isEnabled,
-    }),
-    {},
+  const oneTxPaymentExtension = installedExtensionsData.find(
+    (extension) => extension.extensionId === Extension.OneTxPayment,
+  );
+  const votingReputationExtension = installedExtensionsData.find(
+    (extension) => extension.extensionId === Extension.VotingReputation,
   );
 
   return {
     loading,
-    enabledExtensions,
+    isOneTxPaymentEnabled: !!oneTxPaymentExtension?.isEnabled,
+    isVotingReputationEnabled: !!votingReputationExtension?.isEnabled,
+    votingReputationVersion: votingReputationExtension?.currentVersion,
   };
 };
 


### PR DESCRIPTION
## Description

This small PR refactors the `useEnabledExtensions` hook back into a shape similar to the Dapp's one.

I initially did some work to add relation between `CurrentVersion` and `ColonyExtension` models but then I realised we still need separate current version queries so I ditched all that.

## Testing

Log the value returned by the hook somewhere. Install, enable, deprecate and uninstall both extensions and see if the value returned matches your actions.

Resolves #304 