### PR TITLE
Wire the Manage Funds dialog with action sagas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "redux-saga": "^1.1.3",
         "reselect": "^4.1.5",
         "scroll-into-view-if-needed": "^2.2.16",
-        "yup": "^0.29.0"
+        "yup": "^0.30.0"
       },
       "devDependencies": {
         "@aws-amplify/cli": "10.8.1",
@@ -20492,14 +20492,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/fn-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-3.0.0.tgz",
-      "integrity": "sha512-eNMNr5exLoavuAMhIUVsOKF79SWd/zG104ef6sxBTSw+cZc6BXdQXDvYcGvp0VbxVVSp1XDUNoz7mg1xMtSznA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/fnv1a": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.1.1.tgz",
@@ -31230,7 +31222,6 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -31593,7 +31584,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -56514,11 +56504,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "node_modules/synchronous-promise": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.16.tgz",
-      "integrity": "sha512-qImOD23aDfnIDNqlG1NOehdB9IYsn1V9oByPjKY1nakv2MQYCEMyX033/q+aEtYCpmYK1cv2+NTmlH+ra6GA5A=="
-    },
     "node_modules/table": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
@@ -61061,16 +61046,14 @@
       }
     },
     "node_modules/yup": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.29.3.tgz",
-      "integrity": "sha512-RNUGiZ/sQ37CkhzKFoedkeMfJM0vNQyaz+wRZJzxdKE7VfDeVKH8bb4rr7XhRLbHJz5hSjoDNwMEIaKhuMZ8gQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.30.0.tgz",
+      "integrity": "sha512-GX3vqpC9E+Ow0fmQPgqbEg7UV40XRrN1IOEgKF5v04v6T4ha2vBas/hu0thWgewk8L4wUEBLRO/EnXwYyP+p+A==",
       "dependencies": {
         "@babel/runtime": "^7.10.5",
-        "fn-name": "~3.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "lodash-es": "^4.17.11",
-        "property-expr": "^2.0.2",
-        "synchronous-promise": "^2.0.13",
+        "property-expr": "^2.0.4",
         "toposort": "^2.0.2"
       },
       "engines": {
@@ -76980,11 +76963,6 @@
           }
         }
       }
-    },
-    "fn-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-3.0.0.tgz",
-      "integrity": "sha512-eNMNr5exLoavuAMhIUVsOKF79SWd/zG104ef6sxBTSw+cZc6BXdQXDvYcGvp0VbxVVSp1XDUNoz7mg1xMtSznA=="
     },
     "fnv1a": {
       "version": "1.1.1",
@@ -105259,11 +105237,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "synchronous-promise": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.16.tgz",
-      "integrity": "sha512-qImOD23aDfnIDNqlG1NOehdB9IYsn1V9oByPjKY1nakv2MQYCEMyX033/q+aEtYCpmYK1cv2+NTmlH+ra6GA5A=="
-    },
     "table": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
@@ -108953,16 +108926,14 @@
       "dev": true
     },
     "yup": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.29.3.tgz",
-      "integrity": "sha512-RNUGiZ/sQ37CkhzKFoedkeMfJM0vNQyaz+wRZJzxdKE7VfDeVKH8bb4rr7XhRLbHJz5hSjoDNwMEIaKhuMZ8gQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.30.0.tgz",
+      "integrity": "sha512-GX3vqpC9E+Ow0fmQPgqbEg7UV40XRrN1IOEgKF5v04v6T4ha2vBas/hu0thWgewk8L4wUEBLRO/EnXwYyP+p+A==",
       "requires": {
         "@babel/runtime": "^7.10.5",
-        "fn-name": "~3.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "lodash-es": "^4.17.11",
-        "property-expr": "^2.0.2",
-        "synchronous-promise": "^2.0.13",
+        "property-expr": "^2.0.4",
         "toposort": "^2.0.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -186,6 +186,6 @@
     "redux-saga": "^1.1.3",
     "reselect": "^4.1.5",
     "scroll-into-view-if-needed": "^2.2.16",
-    "yup": "^0.29.0"
+    "yup": "^0.30.0"
   }
 }

--- a/src/components/common/Dialogs/DomainFundSelectorSection/DomainBalance.tsx
+++ b/src/components/common/Dialogs/DomainFundSelectorSection/DomainBalance.tsx
@@ -3,7 +3,11 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import { useFormContext } from 'react-hook-form';
 
 import { Token, Colony } from '~types';
-import { getTokenDecimalsWithFallback, getSelectedToken } from '~utils/tokens';
+import {
+  getTokenDecimalsWithFallback,
+  getSelectedToken,
+  getBalanceForTokenAndDomain,
+} from '~utils/tokens';
 import Numeral from '~shared/Numeral';
 
 import styles from './DomainFundSelector.css';
@@ -19,28 +23,42 @@ const MSG = defineMessages({
 
 interface Props {
   colony: Colony;
+  domainFieldName: string;
 }
 
-const getDomainFundMessageValues = (selectedToken: Token | undefined) => ({
+const getDomainFundMessageValues = (
+  colony: Colony,
+  selectedToken: Token,
+  fromDomain: number,
+) => ({
   amount: (
     <Numeral
-      value={0} // fromDomainTokenBalance || ...
+      value={getBalanceForTokenAndDomain(
+        colony.balances,
+        selectedToken.tokenAddress,
+        fromDomain,
+      )}
       decimals={getTokenDecimalsWithFallback(selectedToken?.decimals)}
     />
   ),
   symbol: selectedToken?.symbol || '???',
 });
 
-const DomainBalance = ({ colony }: Props) => {
+const DomainBalance = ({ colony, domainFieldName }: Props) => {
   const { watch } = useFormContext();
   const tokenAddress = watch('tokenAddress');
+  const domainId = watch(domainFieldName);
   const selectedToken = getSelectedToken(colony, tokenAddress);
+
+  if (!selectedToken) {
+    return null;
+  }
 
   return (
     <div className={styles.domainPotBalance}>
       <FormattedMessage
         {...MSG.domainTokenAmount}
-        values={getDomainFundMessageValues(selectedToken)}
+        values={getDomainFundMessageValues(colony, selectedToken, domainId)}
       />
     </div>
   );

--- a/src/components/common/Dialogs/DomainFundSelectorSection/DomainFundSelector.tsx
+++ b/src/components/common/Dialogs/DomainFundSelectorSection/DomainFundSelector.tsx
@@ -129,7 +129,9 @@ const DomainFundSelector = ({
         dataTest="domainIdSelector"
         itemDataTest="domainIdItem"
       />
-      {!errors[name] && <DomainBalance colony={colony} />}
+      {!errors[name] && (
+        <DomainBalance colony={colony} domainFieldName={name} />
+      )}
     </div>
   );
 };

--- a/src/components/common/Dialogs/DomainFundSelectorSection/DomainFundSelectorSection.tsx
+++ b/src/components/common/Dialogs/DomainFundSelectorSection/DomainFundSelectorSection.tsx
@@ -39,13 +39,16 @@ const DomainFundSelectorSection = ({
   disabled,
 }: Props) => {
   const { watch, setValue, trigger } = useFormContext();
-  const motionDomainId = watch('motionDomainId');
+  const toDomainId = watch('toDomainId');
 
   const handleFromDomainChange = (fromDomainId: string) => {
-    if (motionDomainId !== fromDomainId) {
-      setValue('motionDomainId', fromDomainId);
+    setValue('motionDomainId', fromDomainId);
+
+    if (transferBetweenDomains) {
+      // Touch the toDomainId field to show any error messages and trigger validation of the entire form (e.g. the amount)
+      setValue('toDomainId', toDomainId, { shouldTouch: true });
+      trigger();
     }
-    trigger();
   };
 
   return (

--- a/src/components/common/Dialogs/DomainFundSelectorSection/DomainFundSelectorSection.tsx
+++ b/src/components/common/Dialogs/DomainFundSelectorSection/DomainFundSelectorSection.tsx
@@ -41,9 +41,9 @@ const DomainFundSelectorSection = ({
   const { watch, setValue, trigger } = useFormContext();
   const { motionDomainId } = watch();
 
-  const handleFromDomainChange = (fromDomainValue) => {
-    if (motionDomainId !== fromDomainValue) {
-      setValue('motionDomainId', fromDomainValue);
+  const handleFromDomainChange = (fromDomainId: string) => {
+    if (motionDomainId !== fromDomainId) {
+      setValue('motionDomainId', fromDomainId);
     }
     trigger();
   };

--- a/src/components/common/Dialogs/DomainFundSelectorSection/DomainFundSelectorSection.tsx
+++ b/src/components/common/Dialogs/DomainFundSelectorSection/DomainFundSelectorSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { defineMessages } from 'react-intl';
 import { useFormContext } from 'react-hook-form';
 import classNames from 'classnames';
@@ -38,29 +38,14 @@ const DomainFundSelectorSection = ({
   transferBetweenDomains,
   disabled,
 }: Props) => {
-  const {
-    watch,
-    setValue,
-    formState: { errors },
-    clearErrors,
-  } = useFormContext();
-  const { motionDomainId, fromDomain, toDomain } = watch();
+  const { watch, setValue } = useFormContext();
+  const { motionDomainId } = watch();
+
   const handleFromDomainChange = (fromDomainValue) => {
     if (motionDomainId !== fromDomainValue) {
       setValue('motionDomainId', fromDomainValue);
     }
   };
-
-  useEffect(() => {
-    if (fromDomain !== toDomain) {
-      if (errors.toDomain?.type === 'same-pot') {
-        clearErrors('toDomain');
-      }
-      if (errors.fromDomain?.type === 'same-pot') {
-        clearErrors('fromDomain');
-      }
-    }
-  }, [clearErrors, errors, fromDomain, toDomain]);
 
   return (
     <div

--- a/src/components/common/Dialogs/DomainFundSelectorSection/DomainFundSelectorSection.tsx
+++ b/src/components/common/Dialogs/DomainFundSelectorSection/DomainFundSelectorSection.tsx
@@ -54,7 +54,7 @@ const DomainFundSelectorSection = ({
       })}
     >
       <DomainFundSelector
-        name="fromDomain"
+        name="fromDomainId"
         label={MSG.from}
         colony={colony}
         disabled={disabled}
@@ -69,7 +69,7 @@ const DomainFundSelectorSection = ({
             appearance={{ size: 'medium' }}
           />
           <DomainFundSelector
-            name="toDomain"
+            name="toDomainId"
             label={MSG.to}
             colony={colony}
             disabled={disabled}

--- a/src/components/common/Dialogs/DomainFundSelectorSection/DomainFundSelectorSection.tsx
+++ b/src/components/common/Dialogs/DomainFundSelectorSection/DomainFundSelectorSection.tsx
@@ -38,13 +38,14 @@ const DomainFundSelectorSection = ({
   transferBetweenDomains,
   disabled,
 }: Props) => {
-  const { watch, setValue } = useFormContext();
+  const { watch, setValue, trigger } = useFormContext();
   const { motionDomainId } = watch();
 
   const handleFromDomainChange = (fromDomainValue) => {
     if (motionDomainId !== fromDomainValue) {
       setValue('motionDomainId', fromDomainValue);
     }
+    trigger();
   };
 
   return (

--- a/src/components/common/Dialogs/DomainFundSelectorSection/DomainFundSelectorSection.tsx
+++ b/src/components/common/Dialogs/DomainFundSelectorSection/DomainFundSelectorSection.tsx
@@ -60,7 +60,7 @@ const DomainFundSelectorSection = ({
         clearErrors('fromDomain');
       }
     }
-  }, [errors, fromDomain, toDomain]);
+  }, [clearErrors, errors, fromDomain, toDomain]);
 
   return (
     <div

--- a/src/components/common/Dialogs/DomainFundSelectorSection/DomainFundSelectorSection.tsx
+++ b/src/components/common/Dialogs/DomainFundSelectorSection/DomainFundSelectorSection.tsx
@@ -39,7 +39,7 @@ const DomainFundSelectorSection = ({
   disabled,
 }: Props) => {
   const { watch, setValue, trigger } = useFormContext();
-  const { motionDomainId } = watch();
+  const motionDomainId = watch('motionDomainId');
 
   const handleFromDomainChange = (fromDomainId: string) => {
     if (motionDomainId !== fromDomainId) {

--- a/src/components/common/Dialogs/MintTokenDialog/MintTokenDialog.tsx
+++ b/src/components/common/Dialogs/MintTokenDialog/MintTokenDialog.tsx
@@ -1,15 +1,14 @@
 import React, { useState } from 'react';
 import { defineMessages } from 'react-intl';
-import { string, object, bool, InferType } from 'yup';
+import { string, object, bool, InferType, number } from 'yup';
 import { useNavigate } from 'react-router-dom';
-import Decimal from 'decimal.js';
 
 import Dialog, { DialogProps, ActionDialogProps } from '~shared/Dialog';
 import { ActionHookForm as Form } from '~shared/Fields';
-
-import { ActionTypes } from '~redux/index';
+import { ActionTypes } from '~redux';
 import { pipe, mapPayload, withMeta } from '~utils/actions';
 import { WizardDialogType } from '~hooks';
+import { toFinite } from '~utils/lodash';
 
 import MintTokenDialogForm from './MintTokenDialogForm';
 import { getMintTokenDialogPayload } from './helpers';
@@ -35,16 +34,10 @@ const validationSchema = object()
   .shape({
     forceAction: bool().defined(),
     annotation: string().max(4000).defined(),
-    mintAmount: string()
+    mintAmount: number()
       .required(() => MSG.errorAmountRequired)
-      .test(
-        'more-than-zero',
-        () => MSG.errorAmountMin,
-        (value) => {
-          const numberWithoutCommas = (value || '0').replace(/,/g, ''); // @TODO: Remove this once the fix for FormattedInputComponent value is introduced.
-          return !new Decimal(numberWithoutCommas).isZero();
-        },
-      ),
+      .transform((value) => toFinite(value))
+      .moreThan(0, () => MSG.errorAmountMin),
   })
   .defined();
 
@@ -79,7 +72,7 @@ const MintTokenDialog = ({
         defaultValues={{
           forceAction: false,
           annotation: '',
-          mintAmount: '',
+          mintAmount: 0,
           /*
            * @NOTE That since this a root motion, and we don't actually make use
            * of the motion domain selected (it's disabled), we don't need to actually

--- a/src/components/common/Dialogs/TokenAmountInput/TokenAmountInput.tsx
+++ b/src/components/common/Dialogs/TokenAmountInput/TokenAmountInput.tsx
@@ -28,6 +28,10 @@ const MSG = defineMessages({
     id: `${displayName}.address`,
     defaultMessage: 'Token',
   },
+  notEnoughBalance: {
+    id: `${displayName}.notEnoughBalance`,
+    defaultMessage: 'Insufficient balance in from team pot',
+  },
 });
 
 interface Props {
@@ -38,6 +42,7 @@ interface Props {
 const TokenAmountInput = ({ colony, disabled }: Props) => {
   const { watch } = useFormContext();
   const { amount, tokenAddress } = watch();
+
   const colonyTokens =
     colony?.tokens?.items
       .filter(notNull)
@@ -89,7 +94,7 @@ const TokenAmountInput = ({ colony, disabled }: Props) => {
           <div className={styles.tokenAmountUsd}>
             <EthUsd
               // appearance={{ theme: 'grey' }}
-              value={amount.replace(/,/g, '') || 0} // @TODO: Remove this once the fix for FormattedInputComponent value is introduced.
+              value={amount ?? 0}
             />
           </div>
         )}

--- a/src/components/common/Dialogs/TokenAmountInput/TokenAmountInput.tsx
+++ b/src/components/common/Dialogs/TokenAmountInput/TokenAmountInput.tsx
@@ -93,7 +93,7 @@ const TokenAmountInput = ({ colony, disabled }: Props) => {
           <div className={styles.tokenAmountUsd}>
             <EthUsd
               // appearance={{ theme: 'grey' }}
-              value={amount ?? 0}
+              value={amount}
             />
           </div>
         )}

--- a/src/components/common/Dialogs/TokenAmountInput/TokenAmountInput.tsx
+++ b/src/components/common/Dialogs/TokenAmountInput/TokenAmountInput.tsx
@@ -85,7 +85,7 @@ const TokenAmountInput = ({ colony, disabled }: Props) => {
             appearance={{ alignOptions: 'right', theme: 'grey' }}
             disabled={disabled}
             onChange={() => {
-              trigger();
+              trigger('amount');
             }}
           />
         </div>

--- a/src/components/common/Dialogs/TokenAmountInput/TokenAmountInput.tsx
+++ b/src/components/common/Dialogs/TokenAmountInput/TokenAmountInput.tsx
@@ -28,10 +28,6 @@ const MSG = defineMessages({
     id: `${displayName}.address`,
     defaultMessage: 'Token',
   },
-  notEnoughBalance: {
-    id: `${displayName}.notEnoughBalance`,
-    defaultMessage: 'Insufficient balance in from team pot',
-  },
 });
 
 interface Props {

--- a/src/components/common/Dialogs/TokenAmountInput/TokenAmountInput.tsx
+++ b/src/components/common/Dialogs/TokenAmountInput/TokenAmountInput.tsx
@@ -36,7 +36,7 @@ interface Props {
 }
 
 const TokenAmountInput = ({ colony, disabled }: Props) => {
-  const { watch } = useFormContext();
+  const { watch, trigger } = useFormContext();
   const { amount, tokenAddress } = watch();
 
   const colonyTokens =
@@ -84,6 +84,9 @@ const TokenAmountInput = ({ colony, disabled }: Props) => {
             elementOnly
             appearance={{ alignOptions: 'right', theme: 'grey' }}
             disabled={disabled}
+            onChange={() => {
+              trigger();
+            }}
           />
         </div>
         {tokenAddress === AddressZero && (

--- a/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialog.tsx
+++ b/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialog.tsx
@@ -86,17 +86,20 @@ const TransferFundsDialog = ({
     withMeta({ navigate }),
   );
 
+  const defaultFromDomainId = selectedDomainId || Id.RootDomain;
+  const defaultToDomainId =
+    Number(
+      domainOptions.find((option) => option.value !== defaultFromDomainId)
+        ?.value,
+    ) || Id.RootDomain;
+
   return (
     <Dialog cancel={cancel}>
       <Form<FormValues>
         defaultValues={{
           forceAction: false,
-          fromDomainId: selectedDomainId || Id.RootDomain,
-          toDomainId:
-            Number(
-              domainOptions.find((domain) => domain.value !== selectedDomainId)
-                ?.value,
-            ) || Id.RootDomain,
+          fromDomainId: defaultFromDomainId,
+          toDomainId: defaultToDomainId,
           amount: 0,
           tokenAddress: colony?.nativeToken.tokenAddress,
           annotation: '',

--- a/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialog.tsx
+++ b/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialog.tsx
@@ -42,8 +42,8 @@ type Props = Required<DialogProps> &
 const validationSchema = object()
   .shape({
     forceAction: boolean().defined(),
-    fromDomain: number().required(),
-    toDomain: number()
+    fromDomainId: number().required(),
+    toDomainId: number()
       .required()
       .when('fromDomain', (fromDomain, schema) =>
         schema.notOneOf([fromDomain], MSG.sameDomain),
@@ -91,8 +91,8 @@ const TransferFundsDialog = ({
       <Form<FormValues>
         defaultValues={{
           forceAction: false,
-          fromDomain: selectedDomainId || Id.RootDomain,
-          toDomain:
+          fromDomainId: selectedDomainId || Id.RootDomain,
+          toDomainId:
             Number(
               domainOptions.find((domain) => domain.value !== selectedDomainId)
                 ?.value,

--- a/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialog.tsx
+++ b/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialog.tsx
@@ -17,6 +17,8 @@ import { getValidationSchema } from './validation';
 
 export const displayName = 'common.TransferFundsDialog';
 
+type FormValues = InferType<ReturnType<typeof getValidationSchema>>;
+
 type Props = Required<DialogProps> &
   WizardDialogType<object> &
   ActionDialogProps & {
@@ -58,8 +60,6 @@ const TransferFundsDialog = ({
     ) || Id.RootDomain;
 
   const validationSchema = getValidationSchema(colony);
-
-  type FormValues = InferType<typeof validationSchema>;
 
   return (
     <Dialog cancel={cancel}>

--- a/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialog.tsx
+++ b/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialog.tsx
@@ -45,7 +45,7 @@ const validationSchema = object()
     fromDomainId: number().required(),
     toDomainId: number()
       .required()
-      .when('fromDomain', (fromDomain, schema) =>
+      .when('fromDomainId', (fromDomain, schema) =>
         schema.notOneOf([fromDomain], MSG.sameDomain),
       ),
     amount: number()

--- a/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialog.tsx
+++ b/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialog.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { defineMessages } from 'react-intl';
 import { Id } from '@colony/colony-js';
 import { string, object, number, boolean, InferType } from 'yup';
+import { BigNumber } from 'ethers';
+import moveDecimal from 'move-decimal-point';
 
 import { getDomainOptions } from '~utils/domains';
 import { notNull } from '~utils/arrays';
@@ -12,6 +14,7 @@ import Dialog, { ActionDialogProps, DialogProps } from '~shared/Dialog';
 import { ActionHookForm as Form } from '~shared/Fields';
 import { WizardDialogType } from '~hooks';
 import { toFinite } from '~utils/lodash';
+import { getSelectedToken, getTokenDecimalsWithFallback } from '~utils/tokens';
 
 import TransferFundsDialogForm from './TransferFundsDialogForm';
 import { getTransferFundsDialogPayload } from './helpers';
@@ -31,6 +34,10 @@ const MSG = defineMessages({
     id: `${displayName}.sameDomain`,
     defaultMessage: 'Cannot move to same team pot',
   },
+  notEnoughBalance: {
+    id: `${displayName}.notEnoughBalance`,
+    defaultMessage: 'Insufficient balance in from team pot',
+  },
 });
 
 type Props = Required<DialogProps> &
@@ -38,26 +45,6 @@ type Props = Required<DialogProps> &
   ActionDialogProps & {
     filteredDomainId?: number;
   };
-
-const validationSchema = object()
-  .shape({
-    forceAction: boolean().defined(),
-    fromDomainId: number().required(),
-    toDomainId: number()
-      .required()
-      .when('fromDomainId', (fromDomain, schema) =>
-        schema.notOneOf([fromDomain], MSG.sameDomain),
-      ),
-    amount: number()
-      .required()
-      .transform((value) => toFinite(value))
-      .moreThan(0, () => MSG.amountZero),
-    tokenAddress: string().address().required(),
-    annotation: string().max(4000).defined(),
-  })
-  .defined();
-
-type FormValues = InferType<typeof validationSchema>;
 
 const TransferFundsDialog = ({
   colony,
@@ -80,6 +67,7 @@ const TransferFundsDialog = ({
 
   const colonyDomains = colony?.domains?.items.filter(notNull) || [];
   const domainOptions = getDomainOptions(colonyDomains);
+  const colonyBalances = colony.balances?.items?.filter(notNull) || [];
 
   const transform = pipe(
     mapPayload((payload) => getTransferFundsDialogPayload(colony, payload)),
@@ -92,6 +80,57 @@ const TransferFundsDialog = ({
       domainOptions.find((option) => option.value !== defaultFromDomainId)
         ?.value,
     ) || Id.RootDomain;
+
+  const validationSchema = object()
+    .shape({
+      forceAction: boolean().defined(),
+      fromDomainId: number().required(),
+      toDomainId: number()
+        .required()
+        .when('fromDomainId', (fromDomainId, schema) =>
+          schema.notOneOf([fromDomainId], MSG.sameDomain),
+        ),
+      amount: number()
+        .required()
+        .transform((value) => toFinite(value))
+        .moreThan(0, () => MSG.amountZero)
+        .test(
+          'not-enough-balance',
+          () => MSG.notEnoughBalance,
+          (value, context) => {
+            if (!value) {
+              return true;
+            }
+
+            const { fromDomainId, tokenAddress } = context.parent;
+            const selectedDomainBalance = colonyBalances.find(
+              (balance) =>
+                balance.token.tokenAddress === tokenAddress &&
+                balance.domain.nativeId === fromDomainId,
+            );
+            const selectedToken = getSelectedToken(colony, tokenAddress);
+
+            if (!selectedDomainBalance || !selectedToken) {
+              return true;
+            }
+
+            const tokenDecimals = getTokenDecimalsWithFallback(
+              selectedToken.decimals,
+            );
+            const convertedAmount = BigNumber.from(
+              moveDecimal(value, tokenDecimals),
+            );
+
+            return convertedAmount.lte(selectedDomainBalance.balance);
+          },
+        )
+        .max(100, () => MSG.notEnoughBalance),
+      tokenAddress: string().address().required(),
+      annotation: string().max(4000).defined(),
+    })
+    .defined();
+
+  type FormValues = InferType<typeof validationSchema>;
 
   return (
     <Dialog cancel={cancel}>

--- a/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialog.tsx
+++ b/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialog.tsx
@@ -39,21 +39,15 @@ type Props = Required<DialogProps> &
     filteredDomainId?: number;
   };
 
-function checkIfSameDomain(value: number) {
-  const oppositeDomain =
-    this.parent[this.path === 'fromDomain' ? 'toDomain' : 'fromDomain'];
-  return oppositeDomain !== value;
-}
-
 const validationSchema = object()
   .shape({
     forceAction: boolean().defined(),
-    fromDomain: number()
-      .required()
-      .test('same-domain', () => MSG.sameDomain, checkIfSameDomain),
+    fromDomain: number().required(),
     toDomain: number()
       .required()
-      .test('same-domain', () => MSG.sameDomain, checkIfSameDomain),
+      .when('fromDomain', (fromDomain, schema) =>
+        schema.notOneOf([fromDomain], MSG.sameDomain),
+      ),
     amount: string()
       .required(() => MSG.requiredFieldError)
       .test(

--- a/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
+++ b/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
@@ -63,11 +63,6 @@ const TransferFundsDialogForm = ({
     hasRoleInFromDomain,
   } = useTransferFundsDialogStatus(colony, requiredRoles, enabledExtensionData);
 
-  // const cannotCreateMotion =
-  //   votingExtensionVersion ===
-  //     VotingReputationVersion.FuchsiaLightweightSpaceship &&
-  //   !values.forceAction;
-
   return (
     <>
       <DialogSection appearance={{ theme: 'sidePadding' }}>

--- a/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
+++ b/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { defineMessages } from 'react-intl';
 import { ColonyRole } from '@colony/colony-js';
 import { useFormContext } from 'react-hook-form';
@@ -30,7 +30,6 @@ import {
   getSelectedToken,
   getTokenDecimalsWithFallback,
 } from '~utils/tokens';
-import { formatText } from '~utils/intl';
 
 const displayName = 'common.TransferFundsDialog.TransferFundsDialogForm';
 
@@ -46,10 +45,6 @@ const MSG = defineMessages({
   cannotCreateMotion: {
     id: `${displayName}.cannotCreateMotion`,
     defaultMessage: `Cannot create motions using the Governance v{version} Extension. Please upgrade to a newer version (when available)`,
-  },
-  notEnoughBalance: {
-    id: `${displayName}.notEnoughBalance`,
-    defaultMessage: 'Insufficient balance in from team pot',
   },
 });
 
@@ -95,15 +90,7 @@ const TransferFundsDialogForm = ({
   const convertedAmount = BigNumber.from(
     moveDecimal(amount, getTokenDecimalsWithFallback(selectedToken?.decimals)),
   );
-  const hasEnoughBalance = convertedAmount.lte(fromDomainBalance);
-
-  useEffect(() => {
-    if (!hasEnoughBalance) {
-      setError('amount', { message: formatText(MSG.notEnoughBalance) });
-    } else {
-      clearErrors('amount');
-    }
-  }, [clearErrors, hasEnoughBalance, setError]);
+  const notEnoughBalance = convertedAmount.gt(fromDomainBalance);
 
   return (
     <>

--- a/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
+++ b/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { defineMessages } from 'react-intl';
 import { ColonyRole } from '@colony/colony-js';
 import { useFormContext } from 'react-hook-form';
-import moveDecimal from 'move-decimal-point';
-import { BigNumber } from 'ethers';
 
 import { Annotations } from '~shared/Fields';
 import {
@@ -25,11 +23,6 @@ import DomainFundSelectorSection from '../DomainFundSelectorSection';
 import { useTransferFundsDialogStatus } from './helpers';
 
 import styles from './TransferFundsDialogForm.css';
-import {
-  getBalanceForTokenAndDomain,
-  getSelectedToken,
-  getTokenDecimalsWithFallback,
-} from '~utils/tokens';
 
 const displayName = 'common.TransferFundsDialog.TransferFundsDialogForm';
 
@@ -55,15 +48,9 @@ const TransferFundsDialogForm = ({
   colony,
   enabledExtensionData,
 }: ActionDialogProps) => {
-  const { watch, setError, clearErrors } = useFormContext();
-  const {
-    fromDomain: fromDomainId,
-    toDomain: toDomainId,
-    tokenAddress,
-    amount,
-  } = watch();
+  const { watch } = useFormContext();
+  const { fromDomainId, toDomainId } = watch();
 
-  const colonyDomains = colony?.domains?.items || [];
   const fromDomain = findDomainByNativeId(fromDomainId, colony);
   const toDomain = findDomainByNativeId(toDomainId, colony);
 
@@ -80,17 +67,6 @@ const TransferFundsDialogForm = ({
   //   votingExtensionVersion ===
   //     VotingReputationVersion.FuchsiaLightweightSpaceship &&
   //   !values.forceAction;
-
-  const selectedToken = getSelectedToken(colony, tokenAddress);
-  const fromDomainBalance = getBalanceForTokenAndDomain(
-    colony.balances,
-    tokenAddress,
-    fromDomainId,
-  );
-  const convertedAmount = BigNumber.from(
-    moveDecimal(amount, getTokenDecimalsWithFallback(selectedToken?.decimals)),
-  );
-  const notEnoughBalance = convertedAmount.gt(fromDomainBalance);
 
   return (
     <>

--- a/src/components/common/Dialogs/TransferFundsDialog/helpers.ts
+++ b/src/components/common/Dialogs/TransferFundsDialog/helpers.ts
@@ -12,6 +12,7 @@ import {
 import { getUserRolesForDomain } from '~redux/transformers';
 import { Colony } from '~types';
 import { userHasRole } from '~utils/checks';
+import { findDomainByNativeId } from '~utils/domains';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
 
 export const getTransferFundsDialogPayload = (
@@ -19,8 +20,8 @@ export const getTransferFundsDialogPayload = (
   {
     tokenAddress,
     amount: transferAmount,
-    fromDomain: sourceDomain,
-    toDomain,
+    fromDomainId,
+    toDomainId,
     annotation: annotationMessage,
   },
 ) => {
@@ -33,14 +34,16 @@ export const getTransferFundsDialogPayload = (
   // Convert amount string with decimals to BigInt (eth to wei)
   const amount = BigNumber.from(moveDecimal(transferAmount, decimals));
 
+  const fromDomain = findDomainByNativeId(fromDomainId, colony);
+  const toDomain = findDomainByNativeId(toDomainId, colony);
+
   return {
-    colonyAddress: colony?.colonyAddress,
-    colonyName: colony?.name,
-    // version,
-    fromDomainId: parseInt(sourceDomain, 10),
-    toDomainId: parseInt(toDomain, 10),
-    amount,
+    colonyAddress: colony.colonyAddress,
+    colonyName: colony.name,
     tokenAddress,
+    fromDomain,
+    toDomain,
+    amount,
     annotationMessage,
   };
 };
@@ -52,7 +55,7 @@ export const useTransferFundsDialogStatus = (
 ) => {
   const { wallet } = useAppContext();
   const { watch } = useFormContext();
-  const { fromDomain: fromDomainId, toDomain: toDomainId } = watch();
+  const { fromDomainId, toDomainId } = watch();
   const fromDomainRoles = useTransformer(getUserRolesForDomain, [
     colony,
     wallet?.address,

--- a/src/components/common/Dialogs/TransferFundsDialog/validation.ts
+++ b/src/components/common/Dialogs/TransferFundsDialog/validation.ts
@@ -1,0 +1,77 @@
+import { BigNumber } from 'ethers';
+import { defineMessages } from 'react-intl';
+import { boolean, number, object, string, TestContext } from 'yup';
+import moveDecimal from 'move-decimal-point';
+
+import { Colony } from '~types';
+import { notNull } from '~utils/arrays';
+import { getSelectedToken, getTokenDecimalsWithFallback } from '~utils/tokens';
+import { toFinite } from '~utils/lodash';
+
+import { displayName } from './TransferFundsDialog';
+
+const MSG = defineMessages({
+  amountZero: {
+    id: `${displayName}.amountZero`,
+    defaultMessage: 'Amount must be greater than zero',
+  },
+  sameDomain: {
+    id: `${displayName}.sameDomain`,
+    defaultMessage: 'Cannot move to same team pot',
+  },
+  notEnoughBalance: {
+    id: `${displayName}.notEnoughBalance`,
+    defaultMessage: 'Insufficient balance in from team pot',
+  },
+});
+
+const getHasEnoughBalanceTestFn = (colony: Colony) => {
+  const colonyBalances = colony.balances?.items?.filter(notNull) || [];
+  return (value: number | undefined, context: TestContext) => {
+    if (!value) {
+      return true;
+    }
+
+    const { fromDomainId, tokenAddress } = context.parent;
+    const selectedDomainBalance = colonyBalances.find(
+      (balance) =>
+        balance.token.tokenAddress === tokenAddress &&
+        balance.domain.nativeId === fromDomainId,
+    );
+    const selectedToken = getSelectedToken(colony, tokenAddress);
+
+    if (!selectedDomainBalance || !selectedToken) {
+      return true;
+    }
+
+    const tokenDecimals = getTokenDecimalsWithFallback(selectedToken.decimals);
+    const convertedAmount = BigNumber.from(moveDecimal(value, tokenDecimals));
+
+    return convertedAmount.lte(selectedDomainBalance.balance);
+  };
+};
+
+export const getValidationSchema = (colony: Colony) => {
+  return object()
+    .shape({
+      forceAction: boolean().defined(),
+      fromDomainId: number().required(),
+      toDomainId: number()
+        .required()
+        .when('fromDomainId', (fromDomainId, schema) =>
+          schema.notOneOf([fromDomainId], MSG.sameDomain),
+        ),
+      amount: number()
+        .required()
+        .transform((value) => toFinite(value))
+        .moreThan(0, () => MSG.amountZero)
+        .test(
+          'not-enough-balance',
+          () => MSG.notEnoughBalance,
+          getHasEnoughBalanceTestFn(colony),
+        ),
+      tokenAddress: string().address().required(),
+      annotation: string().max(4000).defined(),
+    })
+    .defined();
+};

--- a/src/components/common/Dialogs/TransferFundsDialog/validation.ts
+++ b/src/components/common/Dialogs/TransferFundsDialog/validation.ts
@@ -66,7 +66,7 @@ export const getValidationSchema = (colony: Colony) => {
         .transform((value) => toFinite(value))
         .moreThan(0, () => MSG.amountZero)
         .test(
-          'not-enough-balance',
+          'has-enough-balance',
           () => MSG.notEnoughBalance,
           getHasEnoughBalanceTestFn(colony),
         ),

--- a/src/components/common/TokenCard/TokenCard.tsx
+++ b/src/components/common/TokenCard/TokenCard.tsx
@@ -14,7 +14,6 @@ import {
   getTokenDecimalsWithFallback,
 } from '~utils/tokens';
 import { useColonyContext } from '~hooks';
-import { ColonyBalances } from '~gql';
 import { ADDRESS_ZERO } from '~constants';
 
 import styles from './TokenCard.css';
@@ -43,11 +42,7 @@ const TokenCard = ({ domainId, token }: Props) => {
   const { nativeToken: nativeTokenStatus } = status || {};
 
   const currentTokenBalance =
-    getBalanceForTokenAndDomain(
-      balances as ColonyBalances,
-      token?.tokenAddress,
-      domainId,
-    ) || 0;
+    getBalanceForTokenAndDomain(balances, token?.tokenAddress, domainId) || 0;
 
   return (
     <Card key={token.tokenAddress} className={styles.main}>

--- a/src/components/shared/EthUsd/EthUsd.tsx
+++ b/src/components/shared/EthUsd/EthUsd.tsx
@@ -47,6 +47,10 @@ const EthUsd = ({
   const suffixText = formatMessage(MSG.usdAbbreviation);
 
   useEffect(() => {
+    if (!value) {
+      return () => {};
+    }
+
     let didCancel = false;
 
     setIsLoading(true);

--- a/src/components/shared/Fields/Input/HookForm/FormattedInputComponent.tsx
+++ b/src/components/shared/Fields/Input/HookForm/FormattedInputComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { defineMessages } from 'react-intl';
 import Cleave from 'cleave.js/react';
 import {
@@ -102,6 +102,14 @@ const HookFormFormattedInputComponent = ({
     setValue(name, e.target.rawValue);
     onChange?.(e);
   };
+
+  /**
+   * As the Cleave input is "detached" from hook-form, we need to set the default value,
+   * if any, when the component is mounted
+   */
+  useEffect(() => {
+    setValue(name, value);
+  }, [name, setValue, value]);
 
   return (
     <>

--- a/src/components/shared/Fields/Input/HookForm/FormattedInputComponent.tsx
+++ b/src/components/shared/Fields/Input/HookForm/FormattedInputComponent.tsx
@@ -13,11 +13,9 @@ import { HookFormInputProps as InputProps } from './Input';
 
 import styles from '../InputComponent.css';
 
-interface HookFormFormattedInputComponentProps
-  extends Omit<InputProps, 'placeholder' | 'formattingOptions'>,
-    Omit<CleaveProps, 'onChange' | 'name'> {
-  placeholder?: string;
-}
+type CleaveChangeEvent = React.ChangeEvent<
+  HTMLInputElement & { rawValue: string }
+>;
 
 const setCleaveRawValue = (
   cleave: ReactInstanceWithCleave,
@@ -56,11 +54,18 @@ export const MaxButton = ({ handleClick }: MaxButtonProps) => (
   />
 );
 
+interface HookFormFormattedInputComponentProps
+  extends Omit<InputProps, 'placeholder' | 'formattingOptions'>,
+    Omit<CleaveProps, 'onChange' | 'name'> {
+  placeholder?: string;
+}
+
 const HookFormFormattedInputComponent = ({
   options: formattingOptions,
   maxButtonParams,
   name,
   value,
+  onChange,
   ...restInputProps
 }: HookFormFormattedInputComponentProps) => {
   const { setValue } = useFormContext();
@@ -89,6 +94,15 @@ const HookFormFormattedInputComponent = ({
     }
   };
 
+  /**
+   * A custom change handler must be provided to ensure the hook-form holds the raw value of the input
+   * E.g. 123456 instead of 123,456
+   */
+  const handleCleaveChange = (e: CleaveChangeEvent) => {
+    setValue(name, e.target.rawValue);
+    onChange?.(e);
+  };
+
   return (
     <>
       {maxButtonParams && (
@@ -107,6 +121,7 @@ const HookFormFormattedInputComponent = ({
          */
         options={formattingOptions}
         onInit={(cleaveInstance) => setCleave(cleaveInstance)}
+        onChange={handleCleaveChange}
       />
     </>
   );

--- a/src/components/shared/Fields/Input/HookForm/FormattedInputComponent.tsx
+++ b/src/components/shared/Fields/Input/HookForm/FormattedInputComponent.tsx
@@ -112,7 +112,7 @@ const HookFormFormattedInputComponent = ({
       )}
       <Cleave
         {...restInputProps}
-        value={value || ''}
+        value={value}
         name={name}
         key={dynamicCleaveOptionKey}
         /*

--- a/src/components/shared/Fields/Input/HookForm/Input.tsx
+++ b/src/components/shared/Fields/Input/HookForm/Input.tsx
@@ -34,8 +34,6 @@ export interface HookFormInputProps
   maxButtonParams?: MaxButtonParams;
   /** Show ConfusableWarning based on user input */
   showConfusable?: boolean;
-  /** Custom error message to show */
-  customError?: Message;
 }
 
 const displayName = 'HookFormInput';
@@ -58,7 +56,6 @@ const HookFormInput = ({
   showConfusable = false,
   status,
   statusValues,
-  customError,
   ...restInputProps
 }: HookFormInputProps) => {
   const [id] = useState(idProp || nanoid());
@@ -111,7 +108,7 @@ const HookFormInput = ({
       {!elementOnly && (
         <InputStatus
           appearance={appearance}
-          error={error || customError}
+          error={error}
           isLoading={isLoading}
           loadingAnnotation={loadingAnnotation}
           status={status}

--- a/src/components/shared/Fields/Input/HookForm/Input.tsx
+++ b/src/components/shared/Fields/Input/HookForm/Input.tsx
@@ -34,6 +34,8 @@ export interface HookFormInputProps
   maxButtonParams?: MaxButtonParams;
   /** Show ConfusableWarning based on user input */
   showConfusable?: boolean;
+  /** Custom error message to show */
+  customError?: Message;
 }
 
 const displayName = 'HookFormInput';
@@ -56,6 +58,7 @@ const HookFormInput = ({
   showConfusable = false,
   status,
   statusValues,
+  customError,
   ...restInputProps
 }: HookFormInputProps) => {
   const [id] = useState(idProp || nanoid());
@@ -108,7 +111,7 @@ const HookFormInput = ({
       {!elementOnly && (
         <InputStatus
           appearance={appearance}
-          error={error}
+          error={error || customError}
           isLoading={isLoading}
           loadingAnnotation={loadingAnnotation}
           status={status}

--- a/src/components/shared/Fields/Input/HookForm/InputComponent.tsx
+++ b/src/components/shared/Fields/Input/HookForm/InputComponent.tsx
@@ -100,7 +100,6 @@ const HookFormInputComponent = ({
       {formattingOptions ? (
         <FormattedInput
           {...props}
-          htmlRef={ref}
           maxButtonParams={maxButtonParams}
           options={formattingOptions}
         />

--- a/src/components/shared/Fields/InputStatus/HookForm/InputStatus.tsx
+++ b/src/components/shared/Fields/InputStatus/HookForm/InputStatus.tsx
@@ -45,7 +45,7 @@ const HookFormInputStatus = ({
     <Element
       className={getMainClasses(appearance, styles, {
         error: !!error && !isLoading,
-        hidden: (!text && !isLoading) || (!!error && touched === false),
+        hidden: (!text && !isLoading) || (!!error && !touched),
       })}
     >
       {isLoading ? loadingText : text}

--- a/src/components/shared/Fields/InputStatus/HookForm/InputStatus.tsx
+++ b/src/components/shared/Fields/InputStatus/HookForm/InputStatus.tsx
@@ -40,11 +40,12 @@ const HookFormInputStatus = ({
   );
   const text = errorText || statusText;
   const Element = appearance.direction === 'horizontal' ? 'span' : 'p';
+
   return (
     <Element
       className={getMainClasses(appearance, styles, {
         error: !!error && !isLoading,
-        hidden: (!text && !isLoading) || (!!error && !touched),
+        hidden: (!text && !isLoading) || (!!error && touched === false),
       })}
     >
       {isLoading ? loadingText : text}

--- a/src/components/shared/Fields/Select/HookForm/HookFormSelect.tsx
+++ b/src/components/shared/Fields/Select/HookForm/HookFormSelect.tsx
@@ -56,6 +56,7 @@ const HookFormSelect = ({
     formState: { errors, touchedFields },
     watch,
     setValue,
+    trigger,
   } = useFormContext();
   const error = errors[name]?.message as Message | undefined;
   const touched = touchedFields[name];
@@ -116,6 +117,8 @@ const HookFormSelect = ({
       shouldTouch: true,
     });
     onChangeCallback?.(optionValue);
+    // Trigger hook-form validation with the new value
+    trigger(name);
     close();
   };
 

--- a/src/components/shared/Fields/Select/index.ts
+++ b/src/components/shared/Fields/Select/index.ts
@@ -1,3 +1,3 @@
-export { default, SelectProps } from './Select';
+export { default, Props as SelectProps } from './Select';
 export { default as SelectListBox } from './SelectListBox';
 export { Appearance, SelectOption } from './types';

--- a/src/components/shared/Fields/Select/types.ts
+++ b/src/components/shared/Fields/Select/types.ts
@@ -3,7 +3,7 @@ import { MessageDescriptor } from 'react-intl';
 
 import { SimpleMessageValues } from '~types';
 
-export { SelectProps } from './Select';
+export { Props as SelectProps } from './Select';
 
 export interface Appearance {
   alignOptions?: 'left' | 'center' | 'right';

--- a/src/components/shared/Fields/TokenSymbolSelector/TokenSymbolSelector.tsx
+++ b/src/components/shared/Fields/TokenSymbolSelector/TokenSymbolSelector.tsx
@@ -1,10 +1,8 @@
 import React, { useMemo } from 'react';
 
-import { HookFormSelect as Select } from '~shared/Fields';
+import { HookFormSelect as Select, SelectProps } from '~shared/Fields';
 import TokenIcon from '~shared/TokenIcon';
 import { Token } from '~types';
-
-import { SelectProps } from '../Select/types';
 
 import styles from './TokenSymbolSelector.css';
 

--- a/src/graphql/fragments/colony.graphql
+++ b/src/graphql/fragments/colony.graphql
@@ -29,9 +29,7 @@ fragment Colony on Colony {
     }
   }
   balances {
-    items {
-      ...ColonyBalance
-    }
+    ...ColonyBalances
   }
   fundsClaims {
     items {
@@ -76,6 +74,12 @@ fragment ColonyMetadata on ColonyMetadata {
     newDisplayName
     oldDisplayName
     hasAvatarChanged
+  }
+}
+
+fragment ColonyBalances on ColonyBalances {
+  items {
+    ...ColonyBalance
   }
 }
 

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -2755,6 +2755,8 @@ export type WatchListItemFragment = { __typename?: 'WatchedColonies', createdAt:
 
 export type ColonyMetadataFragment = { __typename?: 'ColonyMetadata', displayName: string, avatar?: string | null, thumbnail?: string | null, changelog?: Array<{ __typename?: 'ColonyMetadataChangelog', transactionHash: string, newDisplayName: string, oldDisplayName: string, hasAvatarChanged: boolean }> | null };
 
+export type ColonyBalancesFragment = { __typename?: 'ColonyBalances', items?: Array<{ __typename?: 'ColonyBalance', id: string, balance: string, domain: { __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null }, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> | null };
+
 export type ColonyBalanceFragment = { __typename?: 'ColonyBalance', id: string, balance: string, domain: { __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null }, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } };
 
 export type FundsClaimFragment = { __typename?: 'ColonyFundsClaim', id: string, createdAtBlock: number, createdAt: string, amount: string, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } };
@@ -3138,6 +3140,13 @@ export const ColonyBalanceFragmentDoc = gql`
 }
     ${DomainFragmentDoc}
 ${TokenFragmentDoc}`;
+export const ColonyBalancesFragmentDoc = gql`
+    fragment ColonyBalances on ColonyBalances {
+  items {
+    ...ColonyBalance
+  }
+}
+    ${ColonyBalanceFragmentDoc}`;
 export const FundsClaimFragmentDoc = gql`
     fragment FundsClaim on ColonyFundsClaim {
   id
@@ -3189,9 +3198,7 @@ export const ColonyFragmentDoc = gql`
     }
   }
   balances {
-    items {
-      ...ColonyBalance
-    }
+    ...ColonyBalances
   }
   fundsClaims {
     items {
@@ -3208,7 +3215,7 @@ export const ColonyFragmentDoc = gql`
 }
     ${TokenFragmentDoc}
 ${DomainFragmentDoc}
-${ColonyBalanceFragmentDoc}
+${ColonyBalancesFragmentDoc}
 ${FundsClaimFragmentDoc}
 ${ChainFundsClaimFragmentDoc}
 ${ColonyMetadataFragmentDoc}`;

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -18,6 +18,8 @@ import {
   ColonyMetadataFragment,
   UserTokenBalanceDataFragment,
   MemberUserFragment,
+  ColonyBalanceFragment,
+  ColonyBalancesFragment,
 } from '~gql';
 
 export type User = UserFragment;
@@ -68,3 +70,7 @@ export type ColonyClaims = ColonyERC20Claims | ColonyChainClaimWithToken;
 export type Member = Contributor | Watcher;
 
 export type MemberUser = MemberUserFragment;
+
+export type ColonyBalances = ColonyBalancesFragment;
+
+export type ColonyBalance = ColonyBalanceFragment;

--- a/src/utils/css/index.ts
+++ b/src/utils/css/index.ts
@@ -23,7 +23,8 @@ import { capitalizeFirstLetter } from '../strings';
  */
 export const getMainClasses = (
   { theme, ...modifiers }: any = {},
-  styleObject: { [k: string]: string } = {},
+  /** @NOTE This is temporary typing until a proper type for CSS modules imports can be figured out */
+  styleObject: any = {},
   state: { [k: string]: boolean } = {},
 ) => {
   const styles = [

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -2,8 +2,7 @@ import Decimal from 'decimal.js';
 import { BigNumber, BigNumberish } from 'ethers';
 import moveDecimal from 'move-decimal-point';
 
-import { ColonyBalances } from '~gql';
-import { Colony, Address } from '~types';
+import { Colony, Address, ColonyBalances } from '~types';
 import {
   DEFAULT_TOKEN_DECIMALS,
   COLONY_TOTAL_BALANCE_DOMAIN_ID,
@@ -12,7 +11,7 @@ import {
 import { notNull } from './arrays';
 
 export const getBalanceForTokenAndDomain = (
-  balances: ColonyBalances,
+  balances: ColonyBalances | null | undefined,
   tokenAddress: Address,
   domainId: number = COLONY_TOTAL_BALANCE_DOMAIN_ID,
 ) => {
@@ -22,7 +21,9 @@ export const getBalanceForTokenAndDomain = (
         ? domainBalance?.domain === null
         : domainBalance?.domain?.nativeId === domainId,
     )
-    .find((domainBalance) => domainBalance?.token?.id === tokenAddress);
+    .find(
+      (domainBalance) => domainBalance?.token?.tokenAddress === tokenAddress,
+    );
 
   return BigNumber.from(currentDomainBalance?.balance ?? 0);
 };


### PR DESCRIPTION
## Description

What started as a simple ticket grew quite a bit... But we now have a working Manage Funds dialog!

I struggled with setting a custom error in `react-hook-form`. Apparently `setError` doesn't influence the `isValid` property of the form state (which I find counterintuitive, but that's how it is: https://react-hook-form.com/api/useformstate/). I had to resort to conditionally passing a custom error to the input component

## Testing
Test the Transfer Funds, Mint Tokens, and Unlock Tokens dialog. Ensure the validation works as intended and the correct action is created, and then picked up by block-ingestor.

Resolves #306 
