### PR TITLE
Port motion reward claim

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -457,21 +457,22 @@ type UserStakes {
 type StakerRewards {
   address: String!
   rewards: MotionStakeValues!
+  isClaimed: Boolean!
 }
 
 type MotionData {
-  motionId: String!
+  motionId: String! # to ensure uniqueness, we format as: chainId-votingRepExtnAddress_nativeMotionId
+  nativeMotionId: String!
   usersStakes: [UserStakes!]!
   stakerRewards: [StakerRewards!]!
   motionStakes: MotionStakes!
   remainingStakes: [String!]! # tuple [nayRemaining, yayRemaining]
   userMinStake: String!
   requiredStake: String!
-  # For calculating user's max stake in client
-  rootHash: String!
-  # native domain id
-  motionDomainId: String!
+  rootHash: String! # For calculating user's max stake in client
+  motionDomainId: String! # native domain id
   isFinalized: Boolean!
+  createdBy: String! # voting rep extn address. Useful to check if we're viewing a "read-only" motion
 }
 
 # This will store the relevant events we care about for a particular colony

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=a8053043d156d5bd1beb17dd05d811d2134a27e9
+ENV BLOCK_INGESTOR_HASH=75977158916fbe6d709439bfaff625eaabc5e893
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/ClaimMotionStakes.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/ClaimMotionStakes.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import DetailItem from '~shared/DetailsWidget/DetailItem';
+import { MotionData } from '~types';
+import { useClaimWidgetConfig } from '~hooks';
+
+const displayName = `common.ColonyActions.ActionDetailsPage.DefaultMotion.ClaimMotionStakes`;
+
+interface ClaimMotionStakesProps {
+  motionData: MotionData;
+  startPollingAction: (pollInterval: number) => void;
+}
+
+const ClaimMotionStakes = ({
+  motionData,
+  startPollingAction,
+}: ClaimMotionStakesProps) => {
+  const config = useClaimWidgetConfig(motionData, startPollingAction);
+
+  return (
+    <div>
+      {config.map(({ label, item }) => (
+        <DetailItem label={label} item={item} key={label} />
+      ))}
+    </div>
+  );
+};
+
+ClaimMotionStakes.displayName = displayName;
+
+export default ClaimMotionStakes;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ClaimMotionStakes';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+
 import { StakerRewards } from '~gql';
 import { useAppContext } from '~hooks';
-
 import { ColonyAction, ColonyActionType, Address } from '~types';
 import { MotionState } from '~utils/colonyMotions';
 

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
@@ -1,13 +1,27 @@
 import React from 'react';
+import { StakerRewards } from '~gql';
+import { useAppContext } from '~hooks';
 
-import { ColonyAction, ColonyActionType } from '~types';
+import { ColonyAction, ColonyActionType, Address } from '~types';
 import { MotionState } from '~utils/colonyMotions';
 
+import ClaimMotionStakes from './ClaimMotionStakes';
 import FinalizeMotion from './FinalizeMotion';
 import StakingWidget, { StakingWidgetProvider } from './StakingWidget';
 
 const displayName =
   'common.ColonyActions.ActionDetailsPage.DefaultMotion.MotionPhaseWidget';
+
+const isMotionClaimed = (
+  stakerRewards: StakerRewards[],
+  walletAddress: Address,
+) => {
+  const userReward = stakerRewards.find(
+    ({ address }) => address === walletAddress,
+  );
+
+  return !!userReward?.isClaimed;
+};
 
 interface MotionPhaseWidgetProps {
   actionData: ColonyAction;
@@ -21,7 +35,9 @@ const MotionPhaseWidget = ({
   motionState,
   ...rest
 }: MotionPhaseWidgetProps) => {
+  const { user } = useAppContext();
   const { motionData, type, amount, fromDomain } = actionData;
+  const { stopPollingAction } = rest;
 
   if (!motionData) {
     /*
@@ -58,7 +74,16 @@ const MotionPhaseWidget = ({
         );
       }
 
-      return <div>claim!</div>;
+      const isClaimed = isMotionClaimed(
+        motionData.stakerRewards,
+        user?.walletAddress ?? '',
+      );
+
+      if (isClaimed) {
+        stopPollingAction();
+      }
+
+      return <ClaimMotionStakes motionData={motionData} {...rest} />;
     }
 
     /* Extend with other widgets as they get ported. */

--- a/src/graphql/fragments/actions.graphql
+++ b/src/graphql/fragments/actions.graphql
@@ -43,6 +43,7 @@ fragment MotionStakeValues on MotionStakeValues {
 }
 
 fragment MotionData on MotionData {
+  databaseMotionId: motionId
   motionId: nativeMotionId
   motionStakes {
     raw {

--- a/src/graphql/fragments/actions.graphql
+++ b/src/graphql/fragments/actions.graphql
@@ -43,7 +43,7 @@ fragment MotionStakeValues on MotionStakeValues {
 }
 
 fragment MotionData on MotionData {
-  motionId
+  motionId: nativeMotionId
   motionStakes {
     raw {
       ...MotionStakeValues
@@ -74,6 +74,7 @@ fragment MotionData on MotionData {
       yay
       nay
     }
+    isClaimed
   }
   isFinalized
 }

--- a/src/graphql/queries/actions.graphql
+++ b/src/graphql/queries/actions.graphql
@@ -3,12 +3,14 @@ query GetColonyActions(
   $nextToken: String
   $limit: Int
   $sortDirection: ModelSortDirection
+  $filter: ModelColonyActionFilterInput
 ) {
   getActionsByColony(
     colonyId: $colonyAddress
     nextToken: $nextToken
     limit: $limit
     sortDirection: $sortDirection
+    filter: $filter
   ) {
     items {
       ...ColonyAction

--- a/src/hooks/helpers/motionHookHelpers.ts
+++ b/src/hooks/helpers/motionHookHelpers.ts
@@ -1,8 +1,8 @@
 import { BigNumber } from 'ethers';
 import { getStakeFromSlider } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
-import { MotionStakes } from '~gql';
+import { MotionStakes, StakerRewards } from '~gql';
 import { Action, ActionTypes } from '~redux';
-import { SetStateFn } from '~types';
+import { Address, SetStateFn } from '~types';
 import { mapPayload } from '~utils/actions';
 
 type StakeMotionPayload = Action<ActionTypes.MOTION_STAKE>['payload'];
@@ -49,3 +49,14 @@ export const getHandleStakeSuccessFn =
     /* On stake success, initiate db polling so ui updates */
     startPolling(1000);
   };
+
+export const isMotionClaimed = (
+  stakerRewards: StakerRewards[],
+  walletAddress: Address,
+) => {
+  const userReward = stakerRewards.find(
+    ({ address }) => address === walletAddress,
+  );
+
+  return !!userReward?.isClaimed;
+};

--- a/src/hooks/helpers/motionHookHelpers.ts
+++ b/src/hooks/helpers/motionHookHelpers.ts
@@ -1,8 +1,8 @@
 import { BigNumber } from 'ethers';
 import { getStakeFromSlider } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
-import { MotionStakes, StakerRewards } from '~gql';
+import { MotionStakes } from '~gql';
 import { Action, ActionTypes } from '~redux';
-import { Address, SetStateFn } from '~types';
+import { SetStateFn } from '~types';
 import { mapPayload } from '~utils/actions';
 
 type StakeMotionPayload = Action<ActionTypes.MOTION_STAKE>['payload'];
@@ -49,14 +49,3 @@ export const getHandleStakeSuccessFn =
     /* On stake success, initiate db polling so ui updates */
     startPolling(1000);
   };
-
-export const isMotionClaimed = (
-  stakerRewards: StakerRewards[],
-  walletAddress: Address,
-) => {
-  const userReward = stakerRewards.find(
-    ({ address }) => address === walletAddress,
-  );
-
-  return !!userReward?.isClaimed;
-};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -63,6 +63,8 @@ export { default as useObjectButton } from './useObjectButton';
 export { default as useTotalStakeRadios } from './useTotalStakeRadios';
 export { default as useStakingInput } from './useStakingInput';
 export { default as useStakingWidgetUpdate } from './useStakingWidgetUpdate';
+export { default as useClaimWidgetConfig } from './useClaimWidgetConfig';
+
 /* Used in cases where we need to memoize the transformed output of any data.
  * Transform function has to be pure, obviously
  */

--- a/src/hooks/useClaimWidgetConfig.tsx
+++ b/src/hooks/useClaimWidgetConfig.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { BigNumber } from 'ethers';
 
 import Numeral from '~shared/Numeral';
@@ -22,6 +22,7 @@ const useClaimWidgetConfig = (
 ) => {
   const { user } = useAppContext();
   const { colony } = useColonyContext();
+  const [isClaimed, setIsClaimed] = useState(false);
 
   const userAddress = user?.walletAddress;
   const colonyAddress = colony?.colonyAddress;
@@ -53,8 +54,12 @@ const useClaimWidgetConfig = (
 
   const {
     rewards: { yay: yayReward, nay: nayReward },
-    isClaimed,
+    isClaimed: isRewardClaimed,
   } = stakerReward;
+
+  if (isRewardClaimed && !isClaimed) {
+    setIsClaimed(true);
+  }
 
   const {
     stakes: {
@@ -69,6 +74,10 @@ const useClaimWidgetConfig = (
   // Else, return full widget
   const buttonTextId = isClaimed ? 'button.claimed' : 'button.claim';
   const canClaimStakes = !userTotalStake.isZero() && !isClaimed;
+  const handleClaimSuccess = () => {
+    setIsClaimed(true);
+    startPollingAction(1000);
+  };
 
   const claimPayload = {
     userAddress,
@@ -84,7 +93,7 @@ const useClaimWidgetConfig = (
       text={{ id: buttonTextId }}
       disabled={!canClaimStakes}
       dataTest="claimStakeButton"
-      onSuccess={() => startPollingAction(1000)}
+      onSuccess={handleClaimSuccess}
     />
   );
 

--- a/src/hooks/useClaimWidgetConfig.tsx
+++ b/src/hooks/useClaimWidgetConfig.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { BigNumber } from 'ethers';
+
+import Numeral from '~shared/Numeral';
+import { intl } from '~utils/intl';
+import { MotionData } from '~types';
+import { ClaimAllMotionRewardsPayload } from '~redux/sagas/motions/claimMotionRewards';
+import Button, { ActionButton } from '~shared/Button';
+import { ActionTypes } from '~redux';
+import { useAppContext, useColonyContext } from '~hooks';
+
+const { formatMessage } = intl({
+  'label.stake': 'Stake',
+  'label.winnings': 'Winnings',
+  'label.total': 'Total',
+  'label.claim': 'Claim your tokens',
+});
+
+const useClaimWidgetConfig = (
+  { motionId, usersStakes, stakerRewards }: MotionData,
+  startPollingAction: (pollInterval: number) => void,
+) => {
+  const { user } = useAppContext();
+  const { colony } = useColonyContext();
+
+  const userAddress = user?.walletAddress;
+  const colonyAddress = colony?.colonyAddress;
+  const nativeTokenDecimals = colony?.nativeToken.decimals;
+  const nativeTokenSymbol = colony?.nativeToken.symbol;
+
+  const userStake = usersStakes.find(({ address }) => address === userAddress);
+  const stakerReward = stakerRewards.find(
+    ({ address }) => address === userAddress,
+  );
+  const claimItem = {
+    label: formatMessage({ id: 'label.claim' }),
+    item: (
+      <Button
+        appearance={{ theme: 'primary', size: 'medium' }}
+        text={{ id: 'button.claim' }}
+        disabled
+      />
+    ),
+  };
+
+  const config = [claimItem];
+
+  // Return basic view if we have insufficient data
+
+  if (!userStake || !stakerReward || !userAddress || !colonyAddress) {
+    return config;
+  }
+
+  const {
+    rewards: { yay: yayReward, nay: nayReward },
+    isClaimed,
+  } = stakerReward;
+
+  const {
+    stakes: {
+      raw: { nay: nayStakes, yay: yayStakes },
+    },
+  } = userStake;
+
+  const totals = BigNumber.from(yayReward).add(nayReward);
+  const userTotalStake = BigNumber.from(nayStakes).add(yayStakes);
+  const userWinnings = totals.sub(userTotalStake);
+
+  // Else, return full widget
+  const buttonTextId = isClaimed ? 'button.claimed' : 'button.claim';
+  const canClaimStakes = !userTotalStake.isZero() && !isClaimed;
+
+  const claimPayload = {
+    userAddress,
+    colonyAddress,
+    motionIds: [BigNumber.from(motionId)],
+  } as ClaimAllMotionRewardsPayload;
+
+  claimItem.item = (
+    <ActionButton
+      actionType={ActionTypes.MOTION_CLAIM}
+      values={claimPayload}
+      appearance={{ theme: 'primary', size: 'medium' }}
+      text={{ id: buttonTextId }}
+      disabled={!canClaimStakes}
+      dataTest="claimStakeButton"
+      onSuccess={() => startPollingAction(1000)}
+    />
+  );
+
+  const stakeItem = {
+    label: formatMessage({ id: 'label.stake' }),
+    item: (
+      <Numeral
+        value={userTotalStake}
+        decimals={nativeTokenDecimals}
+        suffix={nativeTokenSymbol}
+      />
+    ),
+  };
+
+  const winningsItem = {
+    label: formatMessage({ id: 'label.winnings' }),
+    item: (
+      <Numeral
+        value={userWinnings}
+        decimals={nativeTokenDecimals}
+        suffix={nativeTokenSymbol}
+      />
+    ),
+  };
+
+  const totalItem = {
+    label: formatMessage({ id: 'label.total' }),
+    item: (
+      <Numeral
+        value={totals}
+        decimals={nativeTokenDecimals}
+        suffix={nativeTokenSymbol}
+      />
+    ),
+  };
+
+  config.push(stakeItem, winningsItem, totalItem);
+
+  return config;
+};
+
+export default useClaimWidgetConfig;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -19,6 +19,8 @@
   "button.approve": "Approve",
   "button.cancel": "Cancel",
   "button.choose": "Choose",
+  "button.claim": "Claim",
+  "button.claimed": "Claimed",
   "button.decline": "Decline",
   "button.delete": "Delete",
   "button.dismiss": "Dismiss",

--- a/src/redux/sagas/motions/claimMotionRewards.ts
+++ b/src/redux/sagas/motions/claimMotionRewards.ts
@@ -12,6 +12,7 @@ import {
   GetColonyActionsQueryVariables,
 } from '~gql';
 import { notNull } from '~utils/arrays';
+import { getMotionDatabaseId } from '~utils/colonyMotions';
 
 import {
   ChannelDefinition,
@@ -21,7 +22,6 @@ import {
 } from '../transactions';
 
 import { getColonyManager, putError, takeFrom } from '../utils';
-import { getMotionDatabaseId } from '~utils/colonyMotions';
 
 export type ClaimAllMotionRewardsPayload =
   Action<ActionTypes.MOTION_CLAIM>['payload'];

--- a/src/redux/sagas/motions/claimMotionRewards.ts
+++ b/src/redux/sagas/motions/claimMotionRewards.ts
@@ -1,35 +1,30 @@
-import { all, call, fork, put, takeEvery } from 'redux-saga/effects';
-import { ClientType, ExtensionClient } from '@colony/colony-js';
-import { $Values } from 'utility-types';
-import { BigNumber } from 'ethers';
-import { isEmpty } from 'lodash';
+import { all, call, put, takeEvery } from 'redux-saga/effects';
+import { AnyVotingReputationClient, ClientType } from '@colony/colony-js';
+import { ApolloQueryResult } from '@apollo/client';
 
 import { ActionTypes } from '../../actionTypes';
 import { AllActions, Action } from '../../types/actions';
-import { getContext, ContextModule } from '~context';
-import { TxConfig } from '~types';
+import { getContext, ContextModule, ColonyManager } from '~context';
+import { Address, ColonyAction } from '~types';
 import {
-  ClaimableStakedMotionsDocument,
-  ClaimableStakedMotionsQuery,
-  ClaimableStakedMotionsQueryVariables,
-  UserBalanceWithLockDocument,
-  UserBalanceWithLockQuery,
-  UserBalanceWithLockQueryVariables,
-} from '~data/generated';
+  GetColonyActionsDocument,
+  GetColonyActionsQuery,
+  GetColonyActionsQueryVariables,
+} from '~gql';
+import { notNull } from '~utils/arrays';
 
 import {
   ChannelDefinition,
-  createTransaction,
+  createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../transactions';
 
-import {
-  updateMotionValues,
-  putError,
-  takeFrom,
-  getColonyManager,
-} from '../utils';
+import { getColonyManager, putError, takeFrom } from '../utils';
+import { getMotionDatabaseId } from '~utils/colonyMotions';
+
+export type ClaimAllMotionRewardsPayload =
+  Action<ActionTypes.MOTION_CLAIM>['payload'];
 
 function* claimMotionRewards({
   meta,
@@ -37,85 +32,54 @@ function* claimMotionRewards({
 }: Action<ActionTypes.MOTION_CLAIM>) {
   const txChannel = yield call(getTxChannel, meta.id);
   const apolloClient = getContext(ContextModule.ApolloClient);
-
   try {
-    const colonyManager = yield getColonyManager();
-    const votingReputationClient: ExtensionClient =
+    const colonyManager: ColonyManager = yield getColonyManager();
+    const { chainId } = yield colonyManager.provider.getNetwork();
+    const votingClient: AnyVotingReputationClient =
       yield colonyManager.getClient(
         ClientType.VotingReputationClient,
         colonyAddress,
       );
-    const colonyClient = yield colonyManager.getClient(
-      ClientType.ColonyClient,
-      colonyAddress,
+
+    const {
+      data: { getActionsByColony },
+    }: ApolloQueryResult<GetColonyActionsQuery> = yield apolloClient.query<
+      GetColonyActionsQuery,
+      GetColonyActionsQueryVariables
+    >({
+      query: GetColonyActionsDocument,
+      variables: {
+        colonyAddress,
+        filter: { isMotion: { eq: true } },
+      },
+    });
+
+    const motions = getActionsByColony?.items.filter(notNull);
+
+    if (!motions) {
+      throw new Error('Could not retrieve motions from database');
+    }
+
+    const databaseMotionIds = motionIds.map((nativeMotionId) =>
+      getMotionDatabaseId(chainId, votingClient.address, nativeMotionId),
     );
 
-    /*
-     * We need to do the claim reward transaction, potentially for both sides,
-     * Once for yay and once of nay (if the user staked both sides)
-     *
-     * To do that we try to estimate both transactions, and the one that fails,
-     * we know there are no rewards to be claimed on that side
-     */
-    const motionWithYAYClaims: BigNumber[] = [];
-    const motionWithNAYClaims: BigNumber[] = [];
-
-    yield Promise.all(
-      motionIds.map(async (motionId) => {
-        try {
-          /*
-           * @NOTE For some reason colonyJS doesn't export types for the estimate methods
-           */
-          // @ts-ignore
-          await votingReputationClient.estimateGas.claimRewardWithProofs(
-            motionId,
-            userAddress,
-            1,
-          );
-          motionWithYAYClaims.push(motionId);
-        } catch (error) {
-          /*
-           * We don't want to handle the error here as we are doing this to
-           * inferr the user's reward
-           *
-           * This is a "cheaper" alternative to looking through events, since
-           * this doesn't use so many requests
-           */
-          // silent error
-        }
-        try {
-          /*
-           * @NOTE For some reason colonyJS doesn't export types for the estimate methods
-           */
-          // @ts-ignore
-          await votingReputationClient.estimateGas.claimRewardWithProofs(
-            motionId,
-            userAddress,
-            0,
-          );
-          motionWithNAYClaims.push(motionId);
-        } catch (error) {
-          /*
-           * We don't want to handle the error here as we are doing this to
-           * inferr the user's reward
-           *
-           * This is a "cheaper" alternative to looking through events, since
-           * this doesn't use so many requests
-           */
-          // silent error
-        }
-      }),
+    const [motionsWithYayClaim, motionsWithNayClaim] = getMotionsWithClaims(
+      motions,
+      databaseMotionIds,
+      userAddress,
     );
 
-    const allMotionClaims = motionWithYAYClaims.concat(motionWithNAYClaims);
+    const allMotionClaimsCount =
+      motionsWithYayClaim.length + motionsWithNayClaim.length;
 
-    if (isEmpty(allMotionClaims)) {
+    if (!allMotionClaimsCount) {
       throw new Error('A motion with claims needs to be provided');
     }
 
     const channelNames: string[] = [];
 
-    for (let index = 0; index < allMotionClaims.length; index += 1) {
+    for (let index = 0; index < allMotionClaimsCount; index += 1) {
       channelNames.push(String(index));
     }
 
@@ -125,29 +89,16 @@ function* claimMotionRewards({
       channelNames,
     );
 
-    const createGroupTransaction = (
-      { id, index }: $Values<typeof channels>,
-      config: TxConfig,
-    ) =>
-      fork(createTransaction, id, {
-        ...config,
-        group: {
-          key: 'claimMotionRewards',
-          id: meta.id,
-          index,
-        },
-      });
-
     yield all(
       Object.keys(channels).map((id) =>
-        createGroupTransaction(channels[id], {
+        createGroupTransaction(channels[id], 'claimMotionRewards', meta, {
           context: ClientType.VotingReputationClient,
           methodName: 'claimRewardWithProofs',
           identifier: colonyAddress,
           params: [
-            allMotionClaims[id],
+            motionIds[id],
             userAddress,
-            parseInt(id, 10) > motionWithYAYClaims.length - 1 ? 0 : 1,
+            parseInt(id, 10) > motionsWithYayClaim.length - 1 ? 0 : 1,
           ],
         }),
       ),
@@ -165,38 +116,6 @@ function* claimMotionRewards({
       ),
     );
 
-    yield all(
-      [...new Set([...motionWithYAYClaims, ...motionWithNAYClaims])].map(
-        (motionId) =>
-          fork(updateMotionValues, colonyAddress, userAddress, motionId),
-      ),
-    );
-
-    yield apolloClient.query<
-      ClaimableStakedMotionsQuery,
-      ClaimableStakedMotionsQueryVariables
-    >({
-      query: ClaimableStakedMotionsDocument,
-      variables: {
-        colonyAddress: colonyAddress.toLowerCase(),
-        walletAddress: userAddress.toLowerCase(),
-      },
-      fetchPolicy: 'network-only',
-    });
-
-    yield apolloClient.query<
-      UserBalanceWithLockQuery,
-      UserBalanceWithLockQueryVariables
-    >({
-      query: UserBalanceWithLockDocument,
-      variables: {
-        colonyAddress: colonyAddress.toLowerCase(),
-        address: userAddress.toLowerCase(),
-        tokenAddress: colonyClient.tokenClient.address.toLowerCase(),
-      },
-      fetchPolicy: 'network-only',
-    });
-
     yield put<AllActions>({
       type: ActionTypes.MOTION_CLAIM_SUCCESS,
       meta,
@@ -209,6 +128,59 @@ function* claimMotionRewards({
   return null;
 }
 
-export default function* claimMotionRewardsSaga() {
+export default function* claimAllMotionRewardsSaga() {
   yield takeEvery(ActionTypes.MOTION_CLAIM, claimMotionRewards);
+}
+
+/**
+ * Client-side filtering the motions in the db for those
+ * with outstanding claims by the given user
+ */
+
+function getMotionsWithClaims(
+  motions: ColonyAction[],
+  databaseMotionIds: string[],
+  userAddress: Address,
+) {
+  const motionsWithYayClaims: string[] = [];
+  const motionsWithNayClaims: string[] = [];
+
+  motions
+    /* Filter motions by those ids provided to saga */
+    .filter(({ motionData }) =>
+      motionData
+        ? databaseMotionIds.some(
+            (databaseId) => databaseId === motionData.databaseMotionId,
+          )
+        : false,
+    )
+    .forEach(({ motionData }) => {
+      if (motionData) {
+        const { motionId } = motionData;
+        const currentUserRewards = motionData.stakerRewards.find(
+          ({ address }) => address === userAddress,
+        );
+
+        if (currentUserRewards) {
+          const {
+            rewards: { nay, yay },
+            isClaimed,
+          } = currentUserRewards;
+
+          if (isClaimed) {
+            return;
+          }
+
+          if (nay !== '0') {
+            motionsWithNayClaims.push(motionId);
+          }
+
+          if (yay !== '0') {
+            motionsWithYayClaims.push(motionId);
+          }
+        }
+      }
+    });
+
+  return [motionsWithYayClaims, motionsWithNayClaims];
 }

--- a/src/redux/sagas/motions/index.ts
+++ b/src/redux/sagas/motions/index.ts
@@ -22,7 +22,6 @@ export default function* actionsSagas() {
     // call(revealVoteMotionSaga),
     call(finalizeMotionSaga),
     call(claimMotionRewardsSaga),
-    call(claimMotionRewardsSaga),
     call(rootMotionSaga),
     // call(createEditDomainMotionSaga),
     // call(moveFundsMotionSaga),

--- a/src/redux/sagas/motions/index.ts
+++ b/src/redux/sagas/motions/index.ts
@@ -4,7 +4,7 @@ import stakeMotionSaga from './stakeMotion';
 // import voteMotionSaga from './voteMotion';
 // import revealVoteMotionSaga from './revealVoteMotion';
 import finalizeMotionSaga from './finalizeMotion';
-// import claimMotionRewardsSaga from './claimMotionRewards';
+import claimMotionRewardsSaga from './claimMotionRewards';
 import rootMotionSaga from './rootMotion';
 // import createEditDomainMotionSaga from './createEditDomainMotion';
 // import moveFundsMotionSaga from './moveFundsMotion';
@@ -21,7 +21,8 @@ export default function* actionsSagas() {
     // call(voteMotionSaga),
     // call(revealVoteMotionSaga),
     call(finalizeMotionSaga),
-    // call(claimMotionRewardsSaga),
+    call(claimMotionRewardsSaga),
+    call(claimMotionRewardsSaga),
     call(rootMotionSaga),
     // call(createEditDomainMotionSaga),
     // call(moveFundsMotionSaga),

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -31,6 +31,12 @@ export enum MotionState {
   Forced = 'Forced',
 }
 
+export const getMotionDatabaseId = (
+  chainId: number,
+  votingRepExtnAddress: string,
+  nativeMotionId: BigNumber,
+): string => `${chainId}-${votingRepExtnAddress}_${nativeMotionId}`;
+
 export const getMotionState = (
   motionState: NetworkMotionState,
   {


### PR DESCRIPTION
## Description

This PR implements the claim widget.

![claim](https://user-images.githubusercontent.com/64402732/229481074-cef5451c-6a4a-4ec9-bb7d-ffd794161e0e.png)

## Testing

Testing for both functionality (does it all work as expected) and ui (does it look right).

Follow the [set up instructions](https://github.com/JoinColony/colonyCDapp/pull/338) to be able to stake. Be sure to set the staking duration to something longer than 72 hours, as occasionally this causes the motion to fail due to how time works in development. 720 would do.

Stake in favour of the motion 100%. Do not stake against. This will break it since we haven't set up voting/reveal yet.

Fast forward time by running the following in your terminal (fast forwards by 1000 hours):

```
curl -X POST --data '{"jsonrpc":"2.0","method":"evm_increaseTime","params":[3600000],"id":1}' localhost:8545
curl -X POST --data '{"jsonrpc":"2.0","method":"evm_mine","params":[],"id":1}' localhost:8545

```

Click Finalize. You should then see it loading, before it displays the Claim Widget.
Click Claim. You should see the widget disabled, and you can verify that the rewards have been claimed by looking at the `stakerRewards` field of the motion in the database.

**Note**: It's possible that after hitting claim, your dev env will crash. It certainly has been for me ([this script specifically](https://github.com/JoinColony/colonyNetwork/blob/develop/scripts/start-blockchain-client.sh). While clearly a problem, I suggest we worry about it when we get to QA, if it's still occurring then). It doesn't fundamentally affect the testing of this branch. Just means you can't do anything after hitting claim (which is the end of the test anyway).

**New stuff** ✨

* Claim widget components
* Wired in claimReward saga

**Changes** 🏗

* Updated schema for claiming


Contributes to #322
