### PR TITLE
Port `SingleTotalStake` (staking widget component)

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStake.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStake.css
@@ -1,0 +1,4 @@
+.tooltip {
+  margin-left: 10px;
+  width: 220px;
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStake.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStake.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace SingleTotalStakeCssNamespace {
+  export interface ISingleTotalStakeCss {
+    tooltip: string;
+  }
+}
+
+declare const SingleTotalStakeCssModule: SingleTotalStakeCssNamespace.ISingleTotalStakeCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: SingleTotalStakeCssNamespace.ISingleTotalStakeCss;
+};
+
+export = SingleTotalStakeCssModule;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStake.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStake.tsx
@@ -8,6 +8,7 @@ import { Tooltip } from '~shared/Popover';
 // import SingleTotalStakeHeading from './SingleTotalStakeHeading';
 
 import styles from './SingleTotalStake.css';
+import SingleTotalStakeHeading from './SingleTotalStakeHeading';
 
 const displayName =
   'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingWidget.SingleTotalStake';
@@ -58,7 +59,7 @@ const SingleTotalStake = () => {
 
   return (
     <>
-      {/* <SingleTotalStakeHeading /> */}
+      <SingleTotalStakeHeading />
       {totalPercentage < 10 ? (
         <MinStakeTooltip>{progressBar}</MinStakeTooltip>
       ) : (

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStake.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStake.tsx
@@ -53,7 +53,7 @@ const SingleTotalStake = () => {
         backgroundTheme: 'default',
         size: 'normal',
       }}
-      // hidePercentage
+      hidePercentage
     />
   );
 

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStake.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStake.tsx
@@ -1,0 +1,74 @@
+import React, { ReactNode } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import ProgressBar from '~shared/ProgressBar';
+import { Tooltip } from '~shared/Popover';
+
+// import UserStakeMessage from './UserStakeMessage';
+// import SingleTotalStakeHeading from './SingleTotalStakeHeading';
+
+import styles from './SingleTotalStake.css';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingWidget.SingleTotalStake';
+
+const MSG = defineMessages({
+  progressTooltip: {
+    id: `${displayName}.tooltip`,
+    defaultMessage: `Stake above the minimum 10% threshold to make it visible to others within the Actions list.`,
+  },
+});
+
+interface MinStakeTooltipProps {
+  children: ReactNode;
+}
+
+const MinStakeTooltip = ({ children }: MinStakeTooltipProps) => (
+  <Tooltip
+    placement="left"
+    trigger="hover"
+    content={
+      <div className={styles.tooltip}>
+        <FormattedMessage {...MSG.progressTooltip} />
+      </div>
+    }
+  >
+    {children}
+  </Tooltip>
+);
+
+const SingleTotalStake = () => {
+  // const userHasStaked = false;
+  const isObjection = false;
+  const totalPercentage = 0;
+
+  const progressBar = (
+    <ProgressBar
+      value={totalPercentage}
+      threshold={10}
+      max={100}
+      appearance={{
+        barTheme: isObjection ? 'danger' : 'primary',
+        backgroundTheme: 'default',
+        size: 'normal',
+      }}
+      // hidePercentage
+    />
+  );
+
+  return (
+    <>
+      {/* <SingleTotalStakeHeading /> */}
+      {totalPercentage < 10 ? (
+        <MinStakeTooltip>{progressBar}</MinStakeTooltip>
+      ) : (
+        progressBar
+      )}
+      {/* {userHasStaked && <UserStakeMessage />} */}
+    </>
+  );
+};
+
+SingleTotalStake.displayName = displayName;
+
+export default SingleTotalStake;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStake.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStake.tsx
@@ -4,11 +4,10 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import ProgressBar from '~shared/ProgressBar';
 import { Tooltip } from '~shared/Popover';
 
-// import UserStakeMessage from './UserStakeMessage';
-// import SingleTotalStakeHeading from './SingleTotalStakeHeading';
+import UserStakeMessage from './UserStakeMessage';
+import SingleTotalStakeHeading from './SingleTotalStakeHeading';
 
 import styles from './SingleTotalStake.css';
-import SingleTotalStakeHeading from './SingleTotalStakeHeading';
 
 const displayName =
   'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingWidget.SingleTotalStake';
@@ -39,9 +38,9 @@ const MinStakeTooltip = ({ children }: MinStakeTooltipProps) => (
 );
 
 const SingleTotalStake = () => {
-  // const userHasStaked = false;
+  const userHasStaked = true;
   const isObjection = false;
-  const totalPercentage = 0;
+  const totalPercentage = 10;
 
   const progressBar = (
     <ProgressBar
@@ -65,7 +64,7 @@ const SingleTotalStake = () => {
       ) : (
         progressBar
       )}
-      {/* {userHasStaked && <UserStakeMessage />} */}
+      {userHasStaked && <UserStakeMessage />}
     </>
   );
 };

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStakeHeading.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStakeHeading.css
@@ -1,0 +1,35 @@
+.widgetHeading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 7px;
+}
+
+.subHeading {
+  display: flex;
+  align-items: center;
+}
+
+.tooltip {
+  composes: tooltip from './SingleTotalStake.css';
+}
+
+.stakeProgress,
+.stakeProgress span {
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  color: var(--dark);
+}
+
+.helpTooltip {
+  align-self: flex-end;
+  margin-left: 7px;
+  margin-top: 1px;
+  cursor: pointer;
+}
+
+.title {
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
+  color: var(--dark);
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStakeHeading.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStakeHeading.css.d.ts
@@ -1,0 +1,17 @@
+declare namespace SingleTotalStakeHeadingCssNamespace {
+  export interface ISingleTotalStakeHeadingCss {
+    helpTooltip: string;
+    stakeProgress: string;
+    subHeading: string;
+    title: string;
+    tooltip: string;
+    widgetHeading: string;
+  }
+}
+
+declare const SingleTotalStakeHeadingCssModule: SingleTotalStakeHeadingCssNamespace.ISingleTotalStakeHeadingCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: SingleTotalStakeHeadingCssNamespace.ISingleTotalStakeHeadingCss;
+};
+
+export = SingleTotalStakeHeadingCssModule;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStakeHeading.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStakeHeading.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { Placement } from '@popperjs/core';
+
+// import { Heading5 } from '~shared/Heading';
+import Numeral from '~shared/Numeral';
+import QuestionMarkTooltip from '~shared/QuestionMarkTooltip';
+
+import styles from './SingleTotalStakeHeading.css';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingWidget.SingleTotalStakeHeading';
+
+const MSG = defineMessages({
+  motionTitle: {
+    id: `${displayName}.motionTitle`,
+    defaultMessage: 'Stake',
+  },
+  objectionTitle: {
+    id: `${displayName}.objectionTitle`,
+    defaultMessage: 'Goal',
+  },
+  stakeToolTip: {
+    id: `${displayName}.stakeToolTip`,
+    defaultMessage: `Percentage this Motion has been staked. For it to show up in the Actions list a min 10% is required.`,
+  },
+  stakeProgress: {
+    id: `${displayName}.stakeProgress`,
+    defaultMessage: '{totalPercentage}% of {requiredStake}',
+  },
+});
+
+const tooltipOptions = {
+  placement: 'top-end' as Placement,
+  modifiers: [
+    {
+      name: 'offset',
+      options: {
+        offset: [0, 10],
+      },
+    },
+  ],
+};
+
+const SingleTotalStakeHeading = () => {
+  const totalPercentage = 0;
+  const nativeTokenSymbol = 'WILL';
+  const nativeTokenDecimals = 18;
+  const requiredStake = '1000000000000000000';
+  return (
+    <div className={styles.widgetHeading}>
+      <div className={styles.subHeading}>
+        {/* <Heading5
+          appearance={{
+            theme: 'dark',
+            margin: 'none',
+          }}
+          text={isObjection ? MSG.objectionTitle : MSG.motionTitle}
+          className={styles.title}
+        /> */}
+        <QuestionMarkTooltip
+          tooltipText={MSG.stakeToolTip}
+          className={styles.helpTooltip}
+          tooltipClassName={styles.tooltip}
+          showArrow={false}
+          tooltipPopperOptions={tooltipOptions}
+        />
+      </div>
+      <span className={styles.stakeProgress}>
+        <FormattedMessage
+          {...MSG.stakeProgress}
+          values={{
+            totalPercentage,
+            requiredStake: (
+              <Numeral
+                value={requiredStake}
+                suffix={nativeTokenSymbol}
+                decimals={nativeTokenDecimals}
+              />
+            ),
+          }}
+        />
+      </span>
+    </div>
+  );
+};
+
+SingleTotalStakeHeading.displayName = displayName;
+
+export default SingleTotalStakeHeading;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStakeHeading.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStakeHeading.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { Placement } from '@popperjs/core';
 
-// import { Heading5 } from '~shared/Heading';
+import { Heading5 } from '~shared/Heading';
 import Numeral from '~shared/Numeral';
 import QuestionMarkTooltip from '~shared/QuestionMarkTooltip';
 
@@ -47,17 +47,18 @@ const SingleTotalStakeHeading = () => {
   const nativeTokenSymbol = 'WILL';
   const nativeTokenDecimals = 18;
   const requiredStake = '1000000000000000000';
+  const isObjection = false;
   return (
     <div className={styles.widgetHeading}>
       <div className={styles.subHeading}>
-        {/* <Heading5
+        <Heading5
           appearance={{
             theme: 'dark',
             margin: 'none',
           }}
           text={isObjection ? MSG.objectionTitle : MSG.motionTitle}
           className={styles.title}
-        /> */}
+        />
         <QuestionMarkTooltip
           tooltipText={MSG.stakeToolTip}
           className={styles.helpTooltip}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/UserStakeMessage.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/UserStakeMessage.css
@@ -1,0 +1,7 @@
+.userStake,
+.userStake span {
+  margin-top: 16px;
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  color: var(--grey-purple);
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/UserStakeMessage.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/UserStakeMessage.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace UserStakeMessageCssNamespace {
+  export interface IUserStakeMessageCss {
+    userStake: string;
+  }
+}
+
+declare const UserStakeMessageCssModule: UserStakeMessageCssNamespace.IUserStakeMessageCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: UserStakeMessageCssNamespace.IUserStakeMessageCss;
+};
+
+export = UserStakeMessageCssModule;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/UserStakeMessage.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/UserStakeMessage.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import Numeral from '~shared/Numeral';
+
+import styles from './UserStakeMessage.css';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingWidget.UserStakeMessage';
+
+const MSG = defineMessages({
+  userStake: {
+    id: `${displayName}.userStake`,
+    defaultMessage: `You staked {userPercentage}% of this motion ({userStake}).`,
+  },
+});
+const UserStakeMessage = () => {
+  const nativeTokenSymbol = 'WILL';
+  const nativeTokenDecimals = 18;
+  const userStake = '100000000000000000';
+  const formattedUserStakePercentage = 10;
+
+  return (
+    <p className={styles.userStake}>
+      <FormattedMessage
+        {...MSG.userStake}
+        values={{
+          userPercentage: formattedUserStakePercentage,
+          userStake: (
+            <Numeral
+              value={userStake}
+              suffix={nativeTokenSymbol}
+              decimals={nativeTokenDecimals}
+            />
+          ),
+        }}
+      />
+    </p>
+  );
+};
+
+UserStakeMessage.displayName = displayName;
+
+export default UserStakeMessage;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SingleTotalStake';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingWidget.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingWidget.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { defineMessages } from 'react-intl';
 
 import { MiniSpinnerLoader } from '~shared/Preloaders';
+import SingleTotalStake from './SingleTotalStake';
 import StakingInput from './StakingInput';
 
 import styles from './StakingWidget.css';
@@ -34,9 +35,10 @@ const StakingWidget = () => {
       {/* {isSummary ? (
         <GroupedTotalStake />
       ) : <> */}
-      {/* <SingleTotalStake /> 
+      {/*
       </>)
         */}
+      <SingleTotalStake />
       <StakingInput />
     </div>
   );

--- a/src/components/shared/Heading/Heading5.tsx
+++ b/src/components/shared/Heading/Heading5.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import Heading, { HeadingAppearance, HeadingProps } from './Heading';
+
+const displayName = 'Heading.Heading5';
+
+export interface Heading5Props extends Omit<HeadingProps, 'appearance'> {
+  appearance?: Partial<HeadingAppearance>;
+}
+
+const Heading5 = ({ appearance, ...props }: Heading5Props) => (
+  <Heading
+    appearance={{ size: 'small', weight: 'bold', ...appearance }}
+    {...props}
+  />
+);
+
+Heading5.displayName = displayName;
+
+export default Heading5;

--- a/src/components/shared/Heading/index.ts
+++ b/src/components/shared/Heading/index.ts
@@ -1,4 +1,5 @@
 export { default, HeadingAppearance as Appearance } from './Heading';
 export { default as Heading3, Heading3Props } from './Heading3';
 export { default as Heading4 } from './Heading4';
+export { default as Heading5 } from './Heading5';
 export { default as Heading6 } from './Heading6';

--- a/src/components/shared/ProgressBar/ProgressBar.css
+++ b/src/components/shared/ProgressBar/ProgressBar.css
@@ -70,7 +70,7 @@
   flex-direction: column;
   align-items: center;
   position: absolute;
-  top: -21px;
+  top: -19px;
 }
 
 .thresholdPercentage {
@@ -82,13 +82,18 @@
 
 .thresholdSeparator {
   height: 14px;
-  width: 2px;
+  width: 3px;
   border-radius: 1px;
   background-color: var(--pink);
 }
 
+.thresholdVisibility {
+  visibility: hidden;
+}
+
 .sizeNormal .thresholdSeparator {
-  height: 22px;
+  height: 18px;
+  border-radius: 3px;
 }
 
 .borderRadiusSmall .main::-webkit-progress-bar {

--- a/src/components/shared/ProgressBar/ProgressBar.css.d.ts
+++ b/src/components/shared/ProgressBar/ProgressBar.css.d.ts
@@ -12,6 +12,7 @@ declare namespace ProgressBarCssNamespace {
     threshold: string;
     thresholdPercentage: string;
     thresholdSeparator: string;
+    thresholdVisibility: string;
     wrapper: string;
   }
 }

--- a/src/components/shared/ProgressBar/ProgressBar.tsx
+++ b/src/components/shared/ProgressBar/ProgressBar.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -24,6 +25,7 @@ interface Props {
   value?: number;
   max?: number;
   threshold?: number;
+  hidePercentage: boolean;
 }
 
 const displayName = 'ProgressBar';
@@ -39,6 +41,7 @@ const ProgressBar = ({
   value = 0,
   max = 100,
   threshold,
+  hidePercentage = false,
 }: Props) => {
   const { formatMessage } = useIntl();
   const titleText = formatMessage(MSG.titleProgress, { value, max });
@@ -51,7 +54,13 @@ const ProgressBar = ({
           }}
           className={styles.threshold}
         >
-          <span className={styles.thresholdPercentage}>{threshold}%</span>
+          <span
+            className={classNames(styles.thresholdPercentage, {
+              [styles.thresholdVisibility]: hidePercentage,
+            })}
+          >
+            {threshold}%
+          </span>
           <div className={styles.thresholdSeparator} />
         </div>
       )}


### PR DESCRIPTION
## Description

This PR ports the SingleTotalStake component, which contains the staking progress bar. 

It is the ui only. No wiring of any kind.

![staking](https://user-images.githubusercontent.com/64402732/226338709-1547b2e0-4381-4473-95c2-9501a7b8a2f5.png)

## Testing

More of a code review as not wired in. If you want to see "live", see instructions in #329 

**New stuff** ✨

* `Heading5` component
* Port Single Total Stake components (i.e. staking widget progress bar)

**Changes** 🏗

* Updates to `ProgressBar`

Contributes to #270
