### PR TITLE
Port Stake and Object buttons for staking widget input

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/ObjectButton.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/ObjectButton.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import Button from '~shared/Button';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingWidget.ObjectButton';
+
+const ObjectButton = () => {
+  //  const openRaiseObjectionDialog = useDialog(RaiseObjectionDialog);
+
+  // const handleRaiseObjection =
+  //   (userHasPermission: boolean, stakingAmounts: StakingAmounts) =>
+  //     openRaiseObjectionDialog({
+  //       motionId,
+  //       colony,
+  //       canUserStake: userHasPermission,
+  //       scrollToRef,
+  //       isDecision,
+  //       ...stakingAmounts,
+  //     }),
+  // );
+
+  return (
+    <Button
+      appearance={{ theme: 'pink', size: 'medium' }}
+      text={{ id: 'button.object' }}
+      disabled={false}
+      dataTest="stakeWidgetObjectButton"
+    />
+  );
+};
+
+ObjectButton.displayName = displayName;
+
+export default ObjectButton;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakeButton.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakeButton.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import Button from '~shared/Button';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingWidget.StakeButton';
+
+const StakeButton = () => {
+  const isObjection = false;
+  return (
+    <Button
+      appearance={{
+        theme: isObjection ? 'danger' : 'primary',
+        size: 'medium',
+      }}
+      type="submit"
+      disabled={false}
+      text={{ id: 'button.stake' }}
+      dataTest="stakeWidgetStakeButton"
+    />
+  );
+};
+
+StakeButton.displayName = displayName;
+
+export default StakeButton;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+
+import ObjectButton from './ObjectButton';
 import StakeButton from './StakeButton';
 
 import styles from './StakingControls.css';
@@ -19,8 +21,8 @@ const StakingControls = () => {
       )}
       */}
       <StakeButton />
+      <ObjectButton />
       {/*
-      {showObjectButton && <ObjectButton />}
       {showActivateButton && <ActivateButton />}
       */}
     </div>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import StakeButton from './StakeButton';
 
 import styles from './StakingControls.css';
 
@@ -16,7 +17,9 @@ const StakingControls = () => {
           onClick={() => setIsSummary(true)}
         />
       )}
-      <StakeButton stake={stake} />
+      */}
+      <StakeButton />
+      {/*
       {showObjectButton && <ObjectButton />}
       {showActivateButton && <ActivateButton />}
       */}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -36,6 +36,7 @@
   "button.continue": "Continue",
   "button.createMotion": "Create Motion",
   "button.next": "Next",
+  "button.object": "Object",
   "button.save": "Save",
   "button.stake": "Stake",
   "button.modify": "Modify",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -37,6 +37,7 @@
   "button.createMotion": "Create Motion",
   "button.next": "Next",
   "button.save": "Save",
+  "button.stake": "Stake",
   "button.modify": "Modify",
   "button.preview": "Preview",
   "button.publish": "Publish",


### PR DESCRIPTION
## Description

This PR ports the "Stake" and "Object" buttons that constitute the `StakingControls` component inside `StakingInput`. UI only, no wiring.

![Staking slider](https://user-images.githubusercontent.com/64402732/225979054-694a233d-f7d4-4ed8-bcc0-9ced5ab7090d.png)

## Testing

Really just code review, however if you want to see it "live", follow instructions in #329 

**New stuff** ✨

* Stake and object buttons

Contributes to #270
