### PR TITLE
Port staking input slider

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput.tsx
@@ -6,6 +6,7 @@ import { ActionTypes } from '~redux';
 
 import StakingControls from './StakingControls';
 import StakingSliderDescription from './StakingSliderDescription';
+import StakingWidgetSlider from './StakingWidgetSlider';
 
 const displayName =
   'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingWidget';
@@ -42,11 +43,9 @@ const StakingInput = () => {
           enoughTokens={enoughTokens}
           requiredStakeMessageProps={requiredStakeMessageProps}
         />
-      )}
-      <StakingWidgetSlider
-        {...stakingWidgetSliderProps}
-        setLimitExceeded={setLimitExceeded}
-      />
+      )} */}
+      <StakingWidgetSlider />
+      {/*
       {showValidationMessage && (
         <StakingValidationMessage
           {...stakingValidationMessageProps}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput.tsx
@@ -5,6 +5,7 @@ import { ActionHookForm as ActionForm } from '~shared/Fields';
 import { ActionTypes } from '~redux';
 
 import StakingControls from './StakingControls';
+import StakingSliderDescription from './StakingSliderDescription';
 
 const displayName =
   'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingWidget';
@@ -34,7 +35,8 @@ const StakingInput = () => {
       // transform={transform}
       // onSuccess={handleSuccess}
     >
-      {/* <SliderDescription isObjection={isObjection} />
+      <StakingSliderDescription isObjection={false} />
+      {/*
       {showAnnotation && (
         <SliderAnnotation
           enoughTokens={enoughTokens}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput.tsx
@@ -6,6 +6,7 @@ import { ActionTypes } from '~redux';
 
 import StakingControls from './StakingControls';
 import StakingSliderDescription from './StakingSliderDescription';
+import StakingSliderAnnotation from './StakingSliderAnnotation';
 import StakingWidgetSlider from './StakingWidgetSlider';
 
 const displayName =
@@ -37,13 +38,7 @@ const StakingInput = () => {
       // onSuccess={handleSuccess}
     >
       <StakingSliderDescription isObjection={false} />
-      {/*
-      {showAnnotation && (
-        <SliderAnnotation
-          enoughTokens={enoughTokens}
-          requiredStakeMessageProps={requiredStakeMessageProps}
-        />
-      )} */}
+      <StakingSliderAnnotation />
       <StakingWidgetSlider />
       {/*
       {showValidationMessage && (

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderAnnotation.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderAnnotation.css
@@ -1,0 +1,8 @@
+.minStakeAmountContainer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.tooltip {
+  width: 220px;
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderAnnotation.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderAnnotation.css.d.ts
@@ -1,0 +1,13 @@
+declare namespace StakingSliderAnnotationCssNamespace {
+  export interface IStakingSliderAnnotationCss {
+    minStakeAmountContainer: string;
+    tooltip: string;
+  }
+}
+
+declare const StakingSliderAnnotationCssModule: StakingSliderAnnotationCssNamespace.IStakingSliderAnnotationCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: StakingSliderAnnotationCssNamespace.IStakingSliderAnnotationCss;
+};
+
+export = StakingSliderAnnotationCssModule;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderAnnotation.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderAnnotation.tsx
@@ -3,6 +3,8 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { Tooltip } from '~shared/Popover';
 
+import { RequiredStakeMessage } from './StakingSliderMessages';
+
 import styles from './StakingSliderAnnotation.css';
 
 const displayName =
@@ -42,10 +44,11 @@ const StakingSliderAnnotation = () => {
         placement="top"
         popperOptions={tooltipOptions}
       >
+        <RequiredStakeMessage />
+
         {/* {showMinStakeMsg ? (
           <MinimumStakeMessage />
         ) : (
-          <RequiredStakeMessage {...requiredStakeMessageProps} />
         )} */}
       </Tooltip>
     </span>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderAnnotation.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderAnnotation.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { Tooltip } from '~shared/Popover';
+
+import styles from './StakingSliderAnnotation.css';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingSliderAnnotation';
+
+const MSG = defineMessages({
+  tooltip: {
+    id: `${displayName}.tooltip`,
+    defaultMessage: `Stake above the minimum 10% threshold to make it visible to others within the Actions list.`,
+  },
+});
+
+const tooltipOptions = {
+  modifiers: [
+    {
+      name: 'offset',
+      options: {
+        offset: [0, 0],
+      },
+    },
+  ],
+};
+
+const StakingSliderAnnotation = () => {
+  // const { user } = useAppContext();
+  // const showMinStakeMsg = !!user && !enoughTokens;
+
+  return (
+    <span className={styles.minStakeAmountContainer}>
+      <Tooltip
+        trigger="hover"
+        content={
+          <div className={styles.tooltip}>
+            <FormattedMessage {...MSG.tooltip} />
+          </div>
+        }
+        placement="top"
+        popperOptions={tooltipOptions}
+      >
+        {/* {showMinStakeMsg ? (
+          <MinimumStakeMessage />
+        ) : (
+          <RequiredStakeMessage {...requiredStakeMessageProps} />
+        )} */}
+      </Tooltip>
+    </span>
+  );
+};
+
+StakingSliderAnnotation.displayName = displayName;
+
+export default StakingSliderAnnotation;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderDescription.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderDescription.css
@@ -1,0 +1,19 @@
+.title {
+  display: flex;
+  padding: 15px 0 0;
+}
+
+.title h4 {
+  /* to align questionmark icon in the middle */
+  margin-bottom: 3px;
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
+  color: var(--dark);
+}
+
+.description {
+  margin: 1px 0 20px;
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  color: color-mod(var(--grey-purple) alpha(85%));
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderDescription.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderDescription.css.d.ts
@@ -1,0 +1,13 @@
+declare namespace StakingSliderDescriptionCssNamespace {
+  export interface IStakingSliderDescriptionCss {
+    description: string;
+    title: string;
+  }
+}
+
+declare const StakingSliderDescriptionCssModule: StakingSliderDescriptionCssNamespace.IStakingSliderDescriptionCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: StakingSliderDescriptionCssNamespace.IStakingSliderDescriptionCss;
+};
+
+export = StakingSliderDescriptionCssModule;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderDescription.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderDescription.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { Heading3 } from '~shared/Heading';
+
+import styles from './StakingSliderDescription.css';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingWidget.StakingSliderDescription';
+
+const MSG = defineMessages({
+  descriptionStake: {
+    id: `${displayName}.description`,
+    defaultMessage: `Stake is returned if the motion passes. If there is a dispute, and the motion loses, part or all of your stake will be lost.`,
+  },
+  descriptionObject: {
+    id: `${displayName}.description`,
+    defaultMessage: `Stake will be returned if the objection succeeds. If the objection fails, part or all of your stake will be lost.`,
+  },
+  titleStake: {
+    id: `${displayName}.title`,
+    defaultMessage: `Select the amount to back the motion`,
+  },
+  titleObject: {
+    id: `${displayName}.title`,
+    defaultMessage: `Select the amount to stake the objection`,
+  },
+});
+
+interface StakingSliderDescriptionProps {
+  isObjection: boolean;
+}
+
+const StakingSliderDescription = ({
+  isObjection,
+}: StakingSliderDescriptionProps) => (
+  <>
+    <div className={styles.title}>
+      <Heading3
+        text={isObjection ? MSG.titleObject : MSG.titleStake}
+        className={styles.title}
+        appearance={{ size: 'normal', theme: 'dark', margin: 'none' }}
+      />
+    </div>
+    <p className={styles.description}>
+      <FormattedMessage
+        {...(isObjection ? MSG.descriptionObject : MSG.descriptionStake)}
+      />
+    </p>
+  </>
+);
+
+StakingSliderDescription.displayName = displayName;
+
+export default StakingSliderDescription;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/RequiredStakeMessage.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/RequiredStakeMessage.css
@@ -1,0 +1,21 @@
+.amount {
+  align-self: flex-end;
+  margin-bottom: 2px;
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  color: color-mod(var(--grey-purple) alpha(85%));
+  letter-spacing: var(--spacing-medium);
+}
+
+.requiredStakeUnderThreshold {
+  color: var(--golden);
+}
+
+.requiredStakeAboveThreshold {
+  color: var(--primary);
+}
+
+.requiredStakeText {
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/RequiredStakeMessage.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/RequiredStakeMessage.css.d.ts
@@ -1,0 +1,15 @@
+declare namespace RequiredStakeMessageCssNamespace {
+  export interface IRequiredStakeMessageCss {
+    amount: string;
+    requiredStakeAboveThreshold: string;
+    requiredStakeText: string;
+    requiredStakeUnderThreshold: string;
+  }
+}
+
+declare const RequiredStakeMessageCssModule: RequiredStakeMessageCssNamespace.IRequiredStakeMessageCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: RequiredStakeMessageCssNamespace.IRequiredStakeMessageCss;
+};
+
+export = RequiredStakeMessageCssModule;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/RequiredStakeMessage.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/RequiredStakeMessage.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import classNames from 'classnames';
+import Decimal from 'decimal.js';
+
+import Numeral from '~shared/Numeral';
+import { SLIDER_AMOUNT_KEY } from '../StakingInput';
+
+import styles from './RequiredStakeMessage.css';
+
+const displayName =
+  'common.ActionDetailsPage.DefaultMotion.StakingWidget.RequiredStakeMessage';
+
+const MSG = defineMessages({
+  requiredStake: {
+    id: `${displayName}.requiredStake`,
+    defaultMessage: ` ({stakePercentage}% of required)`,
+  },
+});
+
+const RequiredStakeMessage = () => {
+  const { watch } = useFormContext();
+  const sliderAmount = watch(SLIDER_AMOUNT_KEY);
+  const isUnderThreshold = sliderAmount < 10;
+  const isOverThreshold = !isUnderThreshold;
+  const nativeTokenDecimals = 18;
+  const nativeTokenSymbol = 'WILL';
+  const stake =
+    sliderAmount === 0
+      ? 0
+      : new Decimal('1000000000000000000').div(sliderAmount);
+
+  return (
+    <div>
+      <Numeral
+        className={styles.amount}
+        value={stake}
+        decimals={nativeTokenDecimals}
+        suffix={nativeTokenSymbol}
+      />
+      <span
+        className={classNames(styles.requiredStakeText, {
+          [styles.requiredStakeUnderThreshold]: isUnderThreshold,
+          [styles.requiredStakeAboveThreshold]: isOverThreshold,
+        })}
+      >
+        <FormattedMessage
+          {...MSG.requiredStake}
+          values={{ stakePercentage: sliderAmount }}
+        />
+      </span>
+    </div>
+  );
+};
+
+RequiredStakeMessage.displayName = displayName;
+
+export default RequiredStakeMessage;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/index.ts
@@ -1,0 +1,1 @@
+export { default as RequiredStakeMessage } from './RequiredStakeMessage';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingWidgetSlider.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingWidgetSlider.css
@@ -1,0 +1,3 @@
+.sliderContainer {
+  margin-left: 6px;
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingWidgetSlider.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingWidgetSlider.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace StakingWidgetSliderCssNamespace {
+  export interface IStakingWidgetSliderCss {
+    sliderContainer: string;
+  }
+}
+
+declare const StakingWidgetSliderCssModule: StakingWidgetSliderCssNamespace.IStakingWidgetSliderCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: StakingWidgetSliderCssNamespace.IStakingWidgetSliderCss;
+};
+
+export = StakingWidgetSliderCssModule;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingWidgetSlider.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingWidgetSlider.tsx
@@ -1,0 +1,35 @@
+import Decimal from 'decimal.js';
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import Slider from '~shared/Slider';
+import { SLIDER_AMOUNT_KEY } from './StakingInput';
+
+import styles from './StakingWidgetSlider.css';
+
+const StakingWidgetSlider = () => {
+  const { watch } = useFormContext();
+  const sliderAmount = watch(SLIDER_AMOUNT_KEY);
+
+  const isObjection = false;
+  return (
+    <div className={styles.sliderContainer}>
+      <Slider
+        name="amount"
+        value={sliderAmount}
+        limit={new Decimal(1)}
+        step={1}
+        min={0}
+        max={100}
+        // disabled={!canBeStaked}
+        appearance={{
+          theme: isObjection ? 'danger' : 'primary',
+          size: 'thick',
+        }}
+        // handleLimitExceeded={setLimitExceeded}
+      />
+    </div>
+  );
+};
+
+export default StakingWidgetSlider;

--- a/src/components/shared/Numeral/Numeral.tsx
+++ b/src/components/shared/Numeral/Numeral.tsx
@@ -3,6 +3,7 @@ import { BigNumber } from 'ethers';
 import numbro from 'numbro';
 import classNames from 'classnames';
 
+import Decimal from 'decimal.js';
 import { getMainClasses } from '~utils/css';
 
 import numbroLanguage from './numbroLanguage';
@@ -20,7 +21,7 @@ numbro.setLanguage('en-GB');
 
 const displayName = 'Numeral';
 
-export type NumeralValue = string | number | BigNumber;
+export type NumeralValue = string | number | BigNumber | Decimal;
 
 export interface Appearance {
   theme?: 'dark';

--- a/src/components/shared/Slider/Slider.css.d.ts
+++ b/src/components/shared/Slider/Slider.css.d.ts
@@ -1,3 +1,14 @@
-export const main: string;
-export const primary: string;
-export const danger: string;
+declare namespace SliderCssNamespace {
+  export interface ISliderCss {
+    danger: string;
+    main: string;
+    primary: string;
+  }
+}
+
+declare const SliderCssModule: SliderCssNamespace.ISliderCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: SliderCssNamespace.ISliderCss;
+};
+
+export = SliderCssModule;

--- a/src/components/shared/Slider/Slider.tsx
+++ b/src/components/shared/Slider/Slider.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import ReactSlider from 'rc-slider';
-import { useField } from 'formik';
 import Decimal from 'decimal.js';
+import { useFormContext } from 'react-hook-form';
 
 import 'rc-slider/assets/index.css';
 
@@ -40,7 +40,7 @@ const Slider = ({
   handleLimitExceeded,
 }: Props) => {
   const [sliderValue, setSliderValue] = useState<number>(value);
-  const [, , { setValue }] = useField(name);
+  const { setValue } = useFormContext();
 
   /*
    * This is needed to trigger an outside reset of the slider
@@ -69,7 +69,7 @@ const Slider = ({
         !limitValue
       ) {
         setSliderValue(val);
-        setValue(val);
+        setValue(name, val);
         if (onChange) {
           onChange(val);
         }
@@ -82,7 +82,7 @@ const Slider = ({
         (limitValue.lt(sliderValue) || val > limitValue)
       ) {
         setSliderValue(limitValue.toNumber());
-        setValue(limitValue.toString());
+        setValue(name, limitValue.toString());
 
         if (onChange) {
           onChange(limitValue.toString());


### PR DESCRIPTION
## Description

This PR ports the slider and slider description / annotation in the staking widget input. UI only, no wiring.

![slider](https://user-images.githubusercontent.com/64402732/226338072-4ce6ac2b-eb5f-41f9-b105-8a3c2f063a33.gif)

## Testing

Mainly code review. If you want to see "live", follow instructions in #329

**New stuff** ✨

* Staking widget slider  components

**Changes**

* Updated `Slider` to use hook form
* Updated `Numeral` to accept a Decimal as a value type


Contributes to #270
