### PR TITLE
Get staked tokens balance from events

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -103,6 +103,7 @@ input GetReputationForTopDomainsInput {
 
 input GetUserTokenBalanceInput {
   walletAddress: String!
+  colonyAddress: String!
   tokenAddress: String!
 }
 

--- a/amplify/backend/function/getUserTokenBalance/src/helpers.js
+++ b/amplify/backend/function/getUserTokenBalance/src/helpers.js
@@ -1,0 +1,32 @@
+const { Extension, getLogs } = require('@colony/colony-js');
+const { utils } = require('ethers');
+
+const ContractEventSignatures = {
+  MotionStaked: 'MotionStaked(uint256,address,uint256,uint256)',
+  MotionRewardClaimed: 'MotionRewardClaimed(uint256,address,uint256,uint256)',
+};
+
+const RPC_URL = 'http://network-contracts.docker:8545'; // this needs to be extended to all supported networks
+
+exports.getStakedTokens = async (colonyAddress, networkClient) => {
+  try {
+    const colonyClient = await networkClient.getColonyClient(colonyAddress);
+    const votingReputationClient = await colonyClient.getExtensionClient(
+      Extension.VotingReputation,
+    );
+    const votingReputationAddress = votingReputationClient.address;
+
+    const motionStakedFilter = {
+      topics: [utils.id(ContractEventSignatures.MotionStaked)],
+      address: votingReputationAddress,
+    };
+    const motionStakedLogs = getLogs(
+      votingReputationClient,
+      motionStakedFilter,
+    );
+
+    return 0;
+  } catch {
+    return 0;
+  }
+};

--- a/amplify/backend/function/getUserTokenBalance/src/index.js
+++ b/amplify/backend/function/getUserTokenBalance/src/index.js
@@ -2,29 +2,17 @@ const {
   getTokenClient,
   getColonyNetworkClient,
   Network,
-  Extension,
 } = require('@colony/colony-js');
 const {
   providers,
   utils: { Logger },
   constants,
 } = require('ethers');
+const { getStakedTokens } = require('./helpers');
 
 Logger.setLogLevel(Logger.levels.ERROR);
 
 const RPC_URL = 'http://network-contracts.docker:8545'; // this needs to be extended to all supported networks
-
-const getVotingReputationClient = async (colonyAddress, networkClient) => {
-  try {
-    const colonyClient = await networkClient.getColonyClient(colonyAddress);
-    const votingReputationClient = await colonyClient.getExtensionClient(
-      Extension.VotingReputation,
-    );
-    return votingReputationClient;
-  } catch {
-    return null;
-  }
-};
 
 /**
  * @type {import('@types/aws-lambda').APIGatewayProxyHandler}
@@ -63,15 +51,12 @@ const getVotingReputationClient = async (colonyAddress, networkClient) => {
         tokenAddress,
         walletAddress,
       );
-      const votingReputationClient = await getVotingReputationClient(
-        colonyAddress,
-        networkClient,
-      );
 
       const totalObligation = await tokenLockingClient.getTotalObligation(
         walletAddress,
         tokenAddress,
       );
+      const stakedTokens = await getStakedTokens(colonyAddress, networkClient);
       const inactiveBalance = await tokenClient.balanceOf(walletAddress);
       const lockedBalance = totalObligation.add(stakedTokens);
       const activeBalance = userLock.balance.sub(totalObligation);

--- a/src/components/frame/RouteLayouts/UserNavigation/UserNavigation.tsx
+++ b/src/components/frame/RouteLayouts/UserNavigation/UserNavigation.tsx
@@ -53,10 +53,11 @@ const UserNavigation = () => {
     variables: {
       input: {
         walletAddress: wallet?.address ?? '',
+        colonyAddress: colonyAddress ?? '',
         tokenAddress: nativeToken?.tokenAddress ?? '',
       },
     },
-    skip: !wallet?.address || !nativeToken?.tokenAddress,
+    skip: !wallet?.address || !colonyAddress || !nativeToken?.tokenAddress,
   });
   const tokenBalanceData = tokenBalanceQueryData?.getUserTokenBalance;
 

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -635,6 +635,7 @@ export type GetUserReputationInput = {
 };
 
 export type GetUserTokenBalanceInput = {
+  colonyAddress: Scalars['String'];
   tokenAddress: Scalars['String'];
   walletAddress: Scalars['String'];
 };


### PR DESCRIPTION
## Description

This PR adds the functionality of getting the currently staked tokens amount to the `getUserTokenBalance` lambda, which is needed to accurately calculate locked tokens balance.

Resolves #336 
