### PR TITLE
Update staking widget ui after staking

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/ActionDetailsPage.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/ActionDetailsPage.tsx
@@ -36,6 +36,8 @@ const ActionDetailsPage = () => {
     isUnknownTransaction,
     action,
     loadingAction,
+    startPollingForAction,
+    stopPollingForAction,
   } = useGetColonyAction(colony);
 
   // const status = action?.transactionStatus;
@@ -72,7 +74,11 @@ const ActionDetailsPage = () => {
   if (isMotion) {
     return (
       <Layout isMotion>
-        <DefaultMotion actionData={action} />
+        <DefaultMotion
+          actionData={action}
+          startPollingAction={startPollingForAction}
+          stopPollingAction={stopPollingForAction}
+        />
       </Layout>
     );
   }

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/DefaultMotion.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/DefaultMotion.tsx
@@ -6,6 +6,7 @@ import DetailsWidget from '~shared/DetailsWidget';
 import { useColonyContext, useEnabledExtensions } from '~hooks';
 import { ColonyAction } from '~types';
 import { motionStateMap } from '~utils/colonyMotions';
+import { STAKING_THRESHOLD } from '~constants';
 
 import { DefaultActionContent } from '../DefaultAction';
 import MotionHeading from './MotionHeading';
@@ -32,17 +33,17 @@ const DefaultMotion = ({ actionData }: DefaultMotionProps) => {
   const motionState = MotionState.Staking;
   const {
     motionData: {
-      motionStakes: {
-        percentage: { nay, yay },
-      },
+      motionStakes: { percentage: percentageStaked },
     },
   } = actionData;
-  const stakeLessThan10Percent = Number(nay) + Number(yay) < 10;
+  const isUnderThreshold =
+    Number(percentageStaked.nay) + Number(percentageStaked.yay) <
+    STAKING_THRESHOLD;
 
   return (
     <div className={styles.main}>
       {/* {isMobile && <ColonyHomeInfo showNavigation isMobile />} */}
-      {stakeLessThan10Percent && <StakeRequiredBanner isDecision={false} />}
+      {isUnderThreshold && <StakeRequiredBanner isDecision={false} />}
       {isVotingReputationEnabled && (
         <MotionHeading motionState={motionStateMap[motionState]} />
       )}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/DefaultMotion.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/DefaultMotion.tsx
@@ -19,9 +19,11 @@ const displayName = 'common.ColonyActions.ActionDetailsPage.DefaultMotion';
 
 interface DefaultMotionProps {
   actionData: ColonyAction;
+  startPollingAction: (pollingInterval: number) => void;
+  stopPollingAction: () => void;
 }
 
-const DefaultMotion = ({ actionData }: DefaultMotionProps) => {
+const DefaultMotion = ({ actionData, ...rest }: DefaultMotionProps) => {
   const { colony } = useColonyContext();
 
   const { isVotingReputationEnabled } = useEnabledExtensions();
@@ -53,6 +55,7 @@ const DefaultMotion = ({ actionData }: DefaultMotionProps) => {
           <MotionPhaseWidget
             actionData={actionData}
             motionState={motionState}
+            {...rest}
           />
           {/* <div className={styles.details}>
         {motionState === MotionState.Voting && (

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
@@ -10,11 +10,14 @@ const displayName =
 interface MotionPhaseWidgetProps {
   actionData: ColonyAction;
   motionState: MotionState;
+  startPollingAction: (pollingInterval: number) => void;
+  stopPollingAction: () => void;
 }
 
 const MotionPhaseWidget = ({
   actionData,
   motionState,
+  ...rest
 }: MotionPhaseWidgetProps) => {
   const { motionData } = actionData;
 
@@ -30,7 +33,7 @@ const MotionPhaseWidget = ({
   switch (motionState) {
     case MotionState.Staking: {
       return (
-        <StakingWidgetProvider motionData={motionData}>
+        <StakingWidgetProvider motionData={motionData} {...rest}>
           <StakingWidget />
         </StakingWidgetProvider>
       );

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStake.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStake.tsx
@@ -3,6 +3,7 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 
 import ProgressBar from '~shared/ProgressBar';
 import { Tooltip } from '~shared/Popover';
+import { STAKING_THRESHOLD } from '~constants';
 
 import UserStakeMessage from './UserStakeMessage';
 import SingleTotalStakeHeading from './SingleTotalStakeHeading';
@@ -49,6 +50,8 @@ const SingleTotalStake = () => {
     isObjection ? percentageStaked.nay : percentageStaked.yay,
   );
 
+  const isUnderThreshold = totalPercentage < STAKING_THRESHOLD;
+
   const progressBar = (
     <ProgressBar
       value={totalPercentage}
@@ -69,7 +72,7 @@ const SingleTotalStake = () => {
         totalPercentage={totalPercentage}
         requiredStake={requiredStake}
       />
-      {totalPercentage < 10 ? (
+      {isUnderThreshold ? (
         <MinStakeTooltip>{progressBar}</MinStakeTooltip>
       ) : (
         progressBar

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput.tsx
@@ -4,11 +4,12 @@ import { BigNumber } from 'ethers';
 
 import { ActionHookForm as ActionForm } from '~shared/Fields';
 import { Action, ActionTypes } from '~redux';
+import { useStakingInput } from '~hooks';
 import { mapPayload } from '~utils/actions';
 import { MotionVote } from '~utils/colonyMotions';
 import { useAppContext, useColonyContext } from '~hooks';
 
-import { useStakingWidgetContext, getStakeFromSlider } from '..';
+import { getStakeFromSlider } from '..';
 import { StakingControls, StakingSlider } from '.';
 
 const displayName =
@@ -48,31 +49,8 @@ export const getStakingTransformFn = (
   });
 
 const StakingInput = () => {
-  // const handleSuccess = (_, { setFieldValue, resetForm }) => {
-  //     resetForm({});
-  //     setFieldValue('amount', 0);
-  //     scrollToRef?.current?.scrollIntoView({ behavior: 'smooth' });
-  //   },
-
-  const { user } = useAppContext();
-  const { colony } = useColonyContext();
-  const {
-    motionId,
-    remainingStakes: [nayRemaining, yayRemaining],
-    userMinStake,
-    canBeStaked,
-    isObjection,
-  } = useStakingWidgetContext();
-  const remainingToStake = isObjection ? nayRemaining : yayRemaining;
-  const vote = isObjection ? MotionVote.Nay : MotionVote.Yay;
-  const transform = getStakingTransformFn(
-    remainingToStake,
-    userMinStake,
-    user?.walletAddress ?? '',
-    colony?.colonyAddress ?? '',
-    motionId,
-    vote,
-  );
+  const { transform, handleSuccess, canBeStaked, isObjection } =
+    useStakingInput();
   return (
     <ActionForm<StakingWidgetValues>
       defaultValues={{

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput.tsx
@@ -1,15 +1,10 @@
 import React from 'react';
 import { InferType, number, object } from 'yup';
-import { BigNumber } from 'ethers';
 
 import { ActionHookForm as ActionForm } from '~shared/Fields';
-import { Action, ActionTypes } from '~redux';
+import { ActionTypes } from '~redux';
 import { useStakingInput } from '~hooks';
-import { mapPayload } from '~utils/actions';
-import { MotionVote } from '~utils/colonyMotions';
-import { useAppContext, useColonyContext } from '~hooks';
 
-import { getStakeFromSlider } from '..';
 import { StakingControls, StakingSlider } from '.';
 
 const displayName =
@@ -22,31 +17,6 @@ const validationSchema = object({
 }).defined();
 
 export type StakingWidgetValues = InferType<typeof validationSchema>;
-type StakeMotionPayload = Action<ActionTypes.MOTION_STAKE>['payload'];
-
-export const getStakingTransformFn = (
-  remainingToStake: string,
-  userMinStake: string,
-  userAddress: string,
-  colonyAddress: string,
-  motionId: string,
-  vote: number,
-) =>
-  mapPayload(({ amount: sliderAmount }) => {
-    const finalStake = getStakeFromSlider(
-      sliderAmount,
-      remainingToStake,
-      userMinStake,
-    );
-
-    return {
-      amount: finalStake,
-      userAddress,
-      colonyAddress,
-      motionId: BigNumber.from(motionId),
-      vote,
-    } as StakeMotionPayload;
-  });
 
 const StakingInput = () => {
   const { transform, handleSuccess, canBeStaked, isObjection } =
@@ -59,7 +29,7 @@ const StakingInput = () => {
       validationSchema={validationSchema}
       actionType={ActionTypes.MOTION_STAKE}
       transform={transform}
-      // onSuccess={handleSuccess}
+      onSuccess={handleSuccess}
     >
       <StakingSlider canBeStaked={canBeStaked} isObjection={isObjection} />
       {/*

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/RequiredStakeMessage.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/RequiredStakeMessage.tsx
@@ -4,7 +4,9 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 
 import Numeral from '~shared/Numeral';
+import { STAKING_THRESHOLD } from '~constants';
 import { getStakeFromSlider, getRemainingStakePercentage } from '../../helpers';
+
 import { SLIDER_AMOUNT_KEY } from '..';
 
 import styles from './RequiredStakeMessage.css';
@@ -36,7 +38,8 @@ const RequiredStakeMessage = ({
 }: RequiredStakeMessageProps) => {
   const { watch } = useFormContext();
   const sliderAmount = watch(SLIDER_AMOUNT_KEY);
-  const isUnderThreshold = sliderAmount < 10 - totalPercentageStaked;
+  const isUnderThreshold =
+    sliderAmount < STAKING_THRESHOLD - totalPercentageStaked;
   const stake = getStakeFromSlider(
     sliderAmount,
     remainingToStake,

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/RequiredStakeMessage.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/RequiredStakeMessage.tsx
@@ -4,7 +4,7 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 
 import Numeral from '~shared/Numeral';
-import { getStakeFromSlider, getStakePercentage } from '../../helpers';
+import { getStakeFromSlider, getRemainingStakePercentage } from '../../helpers';
 import { SLIDER_AMOUNT_KEY } from '..';
 
 import styles from './RequiredStakeMessage.css';
@@ -42,7 +42,7 @@ const RequiredStakeMessage = ({
     remainingToStake,
     userMinStake,
   );
-  const stakePercentage = getStakePercentage(stake, remainingToStake);
+  const stakePercentage = getRemainingStakePercentage(stake, remainingToStake);
 
   return (
     <div>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/index.ts
@@ -1,7 +1,6 @@
 export {
   default,
   SLIDER_AMOUNT_KEY,
-  getStakingTransformFn,
   StakingWidgetValues,
 } from './StakingInput';
 export { default as StakingControls } from './StakingControls';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/index.ts
@@ -2,6 +2,7 @@ export {
   default,
   SLIDER_AMOUNT_KEY,
   getStakingTransformFn,
+  StakingWidgetValues,
 } from './StakingInput';
 export { default as StakingControls } from './StakingControls';
 export { default as StakingSliderLabel } from './StakingSliderLabel';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingWidget.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingWidget.tsx
@@ -23,10 +23,9 @@ const MSG = defineMessages({
 });
 
 const StakingWidget = () => {
-  const loadingStakeData = false;
-  const { isSummary } = useStakingWidgetContext();
+  const { isSummary, isRefetching } = useStakingWidgetContext();
 
-  if (loadingStakeData) {
+  if (isRefetching) {
     return (
       <div className={styles.main}>
         <MiniSpinnerLoader

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingWidgetProvider.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingWidgetProvider.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react';
 
-import { useAppContext } from '~hooks';
+import { useAppContext, useStakingWidgetUpdate } from '~hooks';
 import { MotionData, SetStateFn } from '~types';
 
 export interface StakingWidgetContextValues extends MotionData {
@@ -15,6 +15,7 @@ export interface StakingWidgetContextValues extends MotionData {
   setIsObjection: SetStateFn;
   isSummary: boolean;
   setIsSummary: SetStateFn;
+  startPollingAction: (pollingInterval: number) => void;
 }
 
 const StakingWidgetContext = createContext<
@@ -34,6 +35,8 @@ export const useStakingWidgetContext = () => {
 interface StakingWidgetProviderProps {
   children: ReactNode;
   motionData: MotionData;
+  startPollingAction: (pollingInterval: number) => void;
+  stopPollingAction: () => void;
 }
 
 export const StakingWidgetProvider = ({
@@ -45,6 +48,8 @@ export const StakingWidgetProvider = ({
     remainingStakes: [nayRemaining, yayRemaining],
   },
   motionData,
+  startPollingAction,
+  stopPollingAction,
 }: StakingWidgetProviderProps) => {
   const { user } = useAppContext();
   const [isObjection, setIsObjection] = useState<boolean>(false);
@@ -59,6 +64,7 @@ export const StakingWidgetProvider = ({
     () => ({
       ...motionData,
       canBeStaked,
+      startPollingAction,
       isObjection,
       setIsObjection,
       isSummary,
@@ -67,6 +73,7 @@ export const StakingWidgetProvider = ({
     [
       motionData,
       canBeStaked,
+      startPollingAction,
       isObjection,
       setIsObjection,
       isSummary,

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingWidgetProvider.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingWidgetProvider.tsx
@@ -15,6 +15,8 @@ export interface StakingWidgetContextValues extends MotionData {
   setIsObjection: SetStateFn;
   isSummary: boolean;
   setIsSummary: SetStateFn;
+  isRefetching: boolean;
+  setIsRefetching: SetStateFn;
   startPollingAction: (pollingInterval: number) => void;
 }
 
@@ -45,6 +47,7 @@ export const StakingWidgetProvider = ({
     motionStakes: {
       raw: { nay: nayStakes },
     },
+    motionStakes,
     remainingStakes: [nayRemaining, yayRemaining],
   },
   motionData,
@@ -56,6 +59,10 @@ export const StakingWidgetProvider = ({
   const showSummary = Number(nayStakes) > 0;
   const [isSummary, setIsSummary] = useState<boolean>(showSummary);
   const remainingToStake = isObjection ? nayRemaining : yayRemaining;
+  const [isRefetching, setIsRefetching] = useStakingWidgetUpdate(
+    motionStakes,
+    stopPollingAction,
+  );
 
   // Todo: extend this definition
   const canBeStaked = !!(user && remainingToStake !== '0');
@@ -69,6 +76,8 @@ export const StakingWidgetProvider = ({
       setIsObjection,
       isSummary,
       setIsSummary,
+      isRefetching,
+      setIsRefetching,
     }),
     [
       motionData,
@@ -78,6 +87,8 @@ export const StakingWidgetProvider = ({
       setIsObjection,
       isSummary,
       setIsSummary,
+      isRefetching,
+      setIsRefetching,
     ],
   );
 

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/helpers.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/helpers.ts
@@ -11,7 +11,7 @@ export const getStakeFromSlider = (
     .add(userMinStake);
 
 /* BigNumbers round down, therefore if it's been rounded down to zero, display '1' */
-export const getStakePercentage = (
+export const getRemainingStakePercentage = (
   stake: BigNumber,
   remainingToStake: string,
 ) =>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/index.ts
@@ -4,6 +4,7 @@ export {
   default as StakingInput,
   StakingSlider,
   getStakingTransformFn,
+  StakingWidgetValues,
 } from './StakingInput';
 export { default as GroupedTotalStake } from './GroupedTotalStake';
 export * from './StakingWidgetProvider';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/index.ts
@@ -3,8 +3,8 @@ export { default as SingleTotalStake } from './SingleTotalStake';
 export {
   default as StakingInput,
   StakingSlider,
-  getStakingTransformFn,
   StakingWidgetValues,
+  SLIDER_AMOUNT_KEY,
 } from './StakingInput';
 export { default as GroupedTotalStake } from './GroupedTotalStake';
 export * from './StakingWidgetProvider';

--- a/src/components/common/Dialogs/RaiseObjectionDialog/RaiseObjectionDialog.tsx
+++ b/src/components/common/Dialogs/RaiseObjectionDialog/RaiseObjectionDialog.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { object, number, InferType, string } from 'yup';
 
 import Dialog, { DialogProps } from '~shared/Dialog';
-import { ActionHookForm as ActionForm } from '~shared/Fields';
+import { ActionHookForm as ActionForm, OnSuccess } from '~shared/Fields';
 import { ActionTypes } from '~redux';
 import { mapPayload } from '~utils/actions';
 
@@ -29,6 +29,7 @@ type ObjectionValues = InferType<typeof validationSchema>;
 
 interface RaiseObjectionDialogProps extends DialogProps {
   canBeStaked: boolean;
+  handleStakeSuccess: OnSuccess<ObjectionValues>;
   transform: ReturnType<typeof mapPayload>;
   setIsSummary: SetStateFn;
   amount: number;
@@ -37,14 +38,17 @@ interface RaiseObjectionDialogProps extends DialogProps {
 const RaiseObjectionDialog = ({
   close,
   canBeStaked,
+  handleStakeSuccess,
   transform,
   setIsSummary,
   amount,
 }: RaiseObjectionDialogProps) => {
-  const handleSuccess = () => {
+  const handleSuccess: OnSuccess<ObjectionValues> = (...args) => {
+    handleStakeSuccess(...args);
     setIsSummary(true);
     close();
   };
+
   return (
     <Dialog cancel={close}>
       <ActionForm<ObjectionValues>

--- a/src/components/shared/Fields/Form/ActionHookForm.tsx
+++ b/src/components/shared/Fields/Form/ActionHookForm.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FieldValues, UseFormReturn } from 'react-hook-form';
 
 import { ActionTypes } from '~redux';
 import { ActionTransformFnType, getFormAction } from '~utils/actions';
@@ -12,7 +13,11 @@ import HookForm, {
 
 const displayName = 'Form.ActionHookForm';
 
-export type OnSuccess<V> = (result: any, values: V) => void;
+export type OnSuccess<V extends FieldValues> = (
+  values: V,
+  formHelpers: UseFormReturn<V, any>,
+  result: any,
+) => void;
 
 interface Props<V extends Record<string, any>>
   extends Omit<HookFormProps<V>, 'onError' | 'onSubmit'> {
@@ -64,7 +69,7 @@ const ActionHookForm = <V extends Record<string, any>>({
   const handleSubmit: CustomSubmitHandler<V> = async (values, formHelpers) => {
     try {
       const res = await asyncFunction(values);
-      onSuccess?.(res, values);
+      onSuccess?.(values, formHelpers, res);
     } catch (e) {
       console.error(e);
       onError?.(e, formHelpers);

--- a/src/components/shared/Fields/Form/index.ts
+++ b/src/components/shared/Fields/Form/index.ts
@@ -1,4 +1,4 @@
 export { default } from './Form';
 export { default as HookForm } from './HookForm';
 export { default as ActionForm } from './ActionForm';
-export { default as ActionHookForm } from './ActionHookForm';
+export { default as ActionHookForm, OnSuccess } from './ActionHookForm';

--- a/src/components/shared/Fields/index.ts
+++ b/src/components/shared/Fields/index.ts
@@ -1,6 +1,12 @@
 export { default as AmountTokens } from './AmountTokens';
 export { default as Checkbox, HookFormCheckbox } from './Checkbox';
-export { default as Form, ActionForm, HookForm, ActionHookForm } from './Form';
+export {
+  default as Form,
+  ActionForm,
+  HookForm,
+  ActionHookForm,
+  OnSuccess,
+} from './Form';
 export { default as FormStatus } from './FormStatus';
 export { default as FieldSet } from './FieldSet';
 export { default as Input, InputComponentAppearance } from './Input';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -154,3 +154,5 @@ export const ADDRESS_ZERO = ethersContants.AddressZero;
 export const GANACHE_LOCAL_RPC_URL = 'http://localhost:8545';
 
 export const isDev = process.env.NODE_ENV === 'development';
+
+export const STAKING_THRESHOLD = 10;

--- a/src/hooks/helpers/index.ts
+++ b/src/hooks/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './motionHookHelpers';

--- a/src/hooks/helpers/motionHookHelpers.ts
+++ b/src/hooks/helpers/motionHookHelpers.ts
@@ -1,0 +1,30 @@
+import { BigNumber } from 'ethers';
+import { getStakeFromSlider } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
+import { Action, ActionTypes } from '~redux';
+import { mapPayload } from '~utils/actions';
+
+type StakeMotionPayload = Action<ActionTypes.MOTION_STAKE>['payload'];
+
+export const getStakingTransformFn = (
+  remainingToStake: string,
+  userMinStake: string,
+  userAddress: string,
+  colonyAddress: string,
+  motionId: string,
+  vote: number,
+) =>
+  mapPayload(({ amount: sliderAmount }) => {
+    const finalStake = getStakeFromSlider(
+      sliderAmount,
+      remainingToStake,
+      userMinStake,
+    );
+
+    return {
+      amount: finalStake,
+      userAddress,
+      colonyAddress,
+      motionId: BigNumber.from(motionId),
+      vote,
+    } as StakeMotionPayload;
+  });

--- a/src/hooks/helpers/motionHookHelpers.ts
+++ b/src/hooks/helpers/motionHookHelpers.ts
@@ -1,6 +1,8 @@
 import { BigNumber } from 'ethers';
 import { getStakeFromSlider } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
+import { MotionStakes } from '~gql';
 import { Action, ActionTypes } from '~redux';
+import { SetStateFn } from '~types';
 import { mapPayload } from '~utils/actions';
 
 type StakeMotionPayload = Action<ActionTypes.MOTION_STAKE>['payload'];
@@ -28,3 +30,22 @@ export const getStakingTransformFn = (
       vote,
     } as StakeMotionPayload;
   });
+
+export const compareMotionStakes = (
+  oldMotionStakes: MotionStakes,
+  newMotionStates: MotionStakes | undefined,
+) =>
+  oldMotionStakes.raw.yay !== newMotionStates?.raw.yay ||
+  oldMotionStakes.raw.nay !== newMotionStates?.raw.nay;
+
+export const getHandleStakeSuccessFn =
+  (
+    setIsRefetching: SetStateFn,
+    startPolling: (pollingInterval: number) => void,
+  ) =>
+  (_, { reset }) => {
+    reset();
+    setIsRefetching(true);
+    /* On stake success, initiate db polling so ui updates */
+    startPolling(1000);
+  };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -55,6 +55,7 @@ export { default as useTokenTotalBalance } from './useTokenTotalBalance';
 export { default as useStakingSlider } from './useStakingSlider';
 export { default as useObjectButton } from './useObjectButton';
 export { default as useTotalStakeRadios } from './useTotalStakeRadios';
+export { default as useStakingInput } from './useStakingInput';
 /* Used in cases where we need to memoize the transformed output of any data.
  * Transform function has to be pure, obviously
  */

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -56,6 +56,7 @@ export { default as useStakingSlider } from './useStakingSlider';
 export { default as useObjectButton } from './useObjectButton';
 export { default as useTotalStakeRadios } from './useTotalStakeRadios';
 export { default as useStakingInput } from './useStakingInput';
+export { default as useStakingWidgetUpdate } from './useStakingWidgetUpdate';
 /* Used in cases where we need to memoize the transformed output of any data.
  * Transform function has to be pure, obviously
  */

--- a/src/hooks/useGetColonyAction.ts
+++ b/src/hooks/useGetColonyAction.ts
@@ -17,6 +17,7 @@ const useGetColonyAction = (colony?: Colony | null) => {
   const {
     data: actionData,
     loading: loadingAction,
+    startPolling: startPollingForAction,
     stopPolling: stopPollingForAction,
   } = useGetColonyActionQuery({
     skip: skipQuery,
@@ -48,6 +49,8 @@ const useGetColonyAction = (colony?: Colony | null) => {
       isValidTx && action?.colony?.colonyAddress !== colony?.colonyAddress,
     loadingAction: loadingAction || isPolling,
     action,
+    startPollingForAction,
+    stopPollingForAction,
   };
 };
 

--- a/src/hooks/useObjectButton.ts
+++ b/src/hooks/useObjectButton.ts
@@ -3,16 +3,13 @@ import { useFormContext } from 'react-hook-form';
 import {
   useStakingWidgetContext,
   SLIDER_AMOUNT_KEY,
-  StakingWidgetValues,
 } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
 import { RaiseObjectionDialog } from '~common/Dialogs';
 import { useDialog } from '~shared/Dialog';
-import { OnSuccess } from '~shared/Fields';
 import { MotionVote } from '~utils/colonyMotions';
 
-import { getStakingTransformFn } from './helpers';
-import useAppContext from './useAppContext';
-import useColonyContext from './useColonyContext';
+import { getHandleStakeSuccessFn, getStakingTransformFn } from './helpers';
+import { useAppContext, useColonyContext } from '.';
 
 const useObjectButton = () => {
   const { user } = useAppContext();
@@ -24,6 +21,8 @@ const useObjectButton = () => {
     userMinStake,
     motionId,
     setIsSummary,
+    setIsRefetching,
+    startPollingAction,
   } = useStakingWidgetContext();
 
   const transform = getStakingTransformFn(
@@ -37,9 +36,11 @@ const useObjectButton = () => {
 
   const canUserStakedNay = !!(user && nayRemaining !== '0');
 
-  const handleStakeSuccess: OnSuccess<StakingWidgetValues> = (_, { reset }) => {
-    reset();
-  };
+  const handleStakeSuccess = getHandleStakeSuccessFn(
+    setIsRefetching,
+    startPollingAction,
+  );
+
   const handleObjection = () =>
     openRaiseObjectionDialog({
       canBeStaked: canUserStakedNay,

--- a/src/hooks/useObjectButton.ts
+++ b/src/hooks/useObjectButton.ts
@@ -1,14 +1,16 @@
 import { useFormContext } from 'react-hook-form';
 
 import {
-  getStakingTransformFn,
   useStakingWidgetContext,
+  SLIDER_AMOUNT_KEY,
+  StakingWidgetValues,
 } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
-import { SLIDER_AMOUNT_KEY } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput';
 import { RaiseObjectionDialog } from '~common/Dialogs';
 import { useDialog } from '~shared/Dialog';
+import { OnSuccess } from '~shared/Fields';
 import { MotionVote } from '~utils/colonyMotions';
 
+import { getStakingTransformFn } from './helpers';
 import useAppContext from './useAppContext';
 import useColonyContext from './useColonyContext';
 
@@ -35,10 +37,14 @@ const useObjectButton = () => {
 
   const canUserStakedNay = !!(user && nayRemaining !== '0');
 
+  const handleStakeSuccess: OnSuccess<StakingWidgetValues> = (_, { reset }) => {
+    reset();
+  };
   const handleObjection = () =>
     openRaiseObjectionDialog({
       canBeStaked: canUserStakedNay,
       transform,
+      handleStakeSuccess,
       setIsSummary,
       amount: getValues(SLIDER_AMOUNT_KEY),
     });

--- a/src/hooks/useStakingInput.ts
+++ b/src/hooks/useStakingInput.ts
@@ -1,10 +1,11 @@
 import {
   useStakingWidgetContext,
-  getStakingTransformFn,
   StakingWidgetValues,
 } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
 import { OnSuccess } from '~shared/Fields';
+
 import { MotionVote } from '~utils/colonyMotions';
+import { getStakingTransformFn } from './helpers';
 
 import useAppContext from './useAppContext';
 import useColonyContext from './useColonyContext';

--- a/src/hooks/useStakingInput.ts
+++ b/src/hooks/useStakingInput.ts
@@ -1,0 +1,43 @@
+import {
+  useStakingWidgetContext,
+  getStakingTransformFn,
+  StakingWidgetValues,
+} from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
+import { OnSuccess } from '~shared/Fields';
+import { MotionVote } from '~utils/colonyMotions';
+
+import useAppContext from './useAppContext';
+import useColonyContext from './useColonyContext';
+
+const useStakingInput = () => {
+  const { user } = useAppContext();
+  const { colony } = useColonyContext();
+
+  const {
+    canBeStaked,
+    isObjection,
+    motionId,
+    remainingStakes: [nayRemaining, yayRemaining],
+    userMinStake,
+  } = useStakingWidgetContext();
+
+  const vote = isObjection ? MotionVote.Nay : MotionVote.Yay;
+  const remainingToStake = isObjection ? nayRemaining : yayRemaining;
+
+  const transform = getStakingTransformFn(
+    remainingToStake,
+    userMinStake,
+    user?.walletAddress ?? '',
+    colony?.colonyAddress ?? '',
+    motionId,
+    vote,
+  );
+
+  const handleSuccess: OnSuccess<StakingWidgetValues> = (_, { reset }) => {
+    reset();
+  };
+
+  return { transform, handleSuccess, canBeStaked, isObjection };
+};
+
+export default useStakingInput;

--- a/src/hooks/useStakingInput.ts
+++ b/src/hooks/useStakingInput.ts
@@ -1,25 +1,21 @@
-import {
-  useStakingWidgetContext,
-  StakingWidgetValues,
-} from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
-import { OnSuccess } from '~shared/Fields';
+import { useStakingWidgetContext } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
 
 import { MotionVote } from '~utils/colonyMotions';
-import { getStakingTransformFn } from './helpers';
+import { getHandleStakeSuccessFn, getStakingTransformFn } from './helpers';
 
-import useAppContext from './useAppContext';
-import useColonyContext from './useColonyContext';
+import { useAppContext, useColonyContext } from '.';
 
 const useStakingInput = () => {
   const { user } = useAppContext();
   const { colony } = useColonyContext();
-
   const {
     canBeStaked,
     isObjection,
     motionId,
     remainingStakes: [nayRemaining, yayRemaining],
     userMinStake,
+    setIsRefetching,
+    startPollingAction,
   } = useStakingWidgetContext();
 
   const vote = isObjection ? MotionVote.Nay : MotionVote.Yay;
@@ -34,9 +30,10 @@ const useStakingInput = () => {
     vote,
   );
 
-  const handleSuccess: OnSuccess<StakingWidgetValues> = (_, { reset }) => {
-    reset();
-  };
+  const handleSuccess = getHandleStakeSuccessFn(
+    setIsRefetching,
+    startPollingAction,
+  );
 
   return { transform, handleSuccess, canBeStaked, isObjection };
 };

--- a/src/hooks/useStakingWidgetUpdate.ts
+++ b/src/hooks/useStakingWidgetUpdate.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+
+import { MotionStakes } from '~gql';
+import { SetStateFn } from '~types';
+
+import { compareMotionStakes } from './helpers';
+
+const useStakingWidgetUpdate = (
+  motionStakes: MotionStakes,
+  stopPollingAction: () => void,
+): [boolean, SetStateFn] => {
+  const [isRefetching, setIsRefetching] = useState(false);
+  const [prevStakes, setPrevMotionStakes] = useState(motionStakes);
+
+  useEffect(() => {
+    const haveChanged = compareMotionStakes(prevStakes, motionStakes);
+    if (haveChanged) {
+      setIsRefetching(false);
+      setPrevMotionStakes(motionStakes);
+      stopPollingAction();
+    }
+  }, [motionStakes, prevStakes, setIsRefetching, stopPollingAction]);
+
+  return [isRefetching, setIsRefetching];
+};
+
+export default useStakingWidgetUpdate;


### PR DESCRIPTION
## Description

I initially intended this PR to "optimistically" update the ui, however, it transpires that it's much simpler just to poll the db and show a loading spinner while we wait. So the tradeoff is increased simplicity at the expense of waiting for the block ingestor to process the staking event before we show the user the updated values (where optimistic ui would be instant, but require every component to keep track of its own state, in addition to it already being held in the db). 

Therefore, this PR adds ensures the staking widget updates correctly after staking or objecting.


## Testing

Set up your env via [these instructions](https://github.com/JoinColony/colonyCDapp/pull/338)

Then stake both for and against the motion. You should see a loading state while we poll the db, and then updated values in the widget once the db updates (and, of course, the polling should stop).

Also, if you're testing this before testing #344 , #345, and #346, confirm that the objection dialog modal works, as does the grouped total stake view (and report comments in their respective prs).

![updates](https://user-images.githubusercontent.com/64402732/228464830-9e23bb83-aa2c-48a3-b134-b0e3b3bd0c6c.gif)

**New stuff** ✨

* `useStakingWidgetUpdate` to handle polling cancellation and loading state

**Changes** 🏗

* Add polling to stake widget
* Add loading state to stake widget
* Wire in handle success in both staking input and objection modal

Contributes to #270
