### PR TITLE
Connect Edit Colony Details dialog with saga

### DIFF
--- a/src/components/common/ColonyActions/ColonyActions.tsx
+++ b/src/components/common/ColonyActions/ColonyActions.tsx
@@ -236,19 +236,6 @@ const ColonyActions = (/* { ethDomainId }: Props */) => {
         )}
         text="Test Move Funds"
       />
-      <ActionButton
-        submit={ActionTypes.ACTION_EDIT_COLONY}
-        error={ActionTypes.ACTION_EDIT_COLONY_ERROR}
-        success={ActionTypes.ACTION_EDIT_COLONY_SUCCESS}
-        transform={pipe(
-          mergePayload({
-            colony,
-            colonyDisplayName: 'New Colony Name',
-          }),
-          withMeta({ navigate }),
-        )}
-        text="Test Edit Colony"
-      />
       {actions.length ? (
         <>
           <ActionsListHeading

--- a/src/components/common/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialogForm.tsx
+++ b/src/components/common/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialogForm.tsx
@@ -146,6 +146,7 @@ const EditColonyDetailsDialogForm = ({
                   colony={colony}
                   colonyAddress={colonyAddress}
                   size="xl"
+                  preferThumbnail={false}
                 />
               )}
             </>

--- a/src/components/common/Dialogs/EditColonyDetailsDialog/helpers.ts
+++ b/src/components/common/Dialogs/EditColonyDetailsDialog/helpers.ts
@@ -2,33 +2,16 @@ import { Colony } from '~types';
 
 export const getEditColonyDetailsDialogPayload = (
   colony: Colony,
-  {
-    colonyAvatarImage,
-    colonyDisplayName: payloadDisplayName,
-    annotationMessage,
-  },
-) => {
-  const colonyTokens = colony.tokens?.items || [];
-
-  return {
-    colonyAddress: colony.colonyAddress,
-    colonyName: colony.name,
-    colonyDisplayName: payloadDisplayName,
-    colonyAvatarImage:
-      typeof colonyAvatarImage === 'string' || colonyAvatarImage === null
-        ? colonyAvatarImage
-        : colony.metadata?.thumbnail,
-    colonyAvatarHash: colony.metadata?.avatar,
-    hasAvatarChanged: !!(
-      typeof colonyAvatarImage === 'string' || colonyAvatarImage === null
-    ),
-    colonyTokens: colonyTokens.filter(
-      (colonyToken) =>
-        colonyToken?.token.tokenAddress !== colony.nativeToken.tokenAddress,
-    ),
-    // verifiedAddresses: colonyData?.processedColony?.whitelistedAddresses,
-    annotationMessage,
-    // isWhitelistActivated:
-    //   colonyData?.processedColony?.isWhitelistActivated,
-  };
-};
+  { colonyAvatarImage, colonyDisplayName, annotationMessage },
+) => ({
+  colony,
+  colonyDisplayName,
+  colonyAvatarImage:
+    typeof colonyAvatarImage === 'string' || colonyAvatarImage === null
+      ? colonyAvatarImage
+      : colony.metadata?.thumbnail,
+  // verifiedAddresses: colonyData?.processedColony?.whitelistedAddresses,
+  annotationMessage,
+  // isWhitelistActivated:
+  //   colonyData?.processedColony?.isWhitelistActivated,
+});

--- a/src/components/frame/SubscribedColoniesList/SubscribedColoniesList.tsx
+++ b/src/components/frame/SubscribedColoniesList/SubscribedColoniesList.tsx
@@ -84,6 +84,7 @@ const SubscribedColoniesList = () => {
                       colony={item?.colony}
                       colonyAddress={colonyAddress}
                       size="s"
+                      preferThumbnail={false}
                     />
                   </div>
                 </NavLink>

--- a/src/redux/sagas/actions/editColony.ts
+++ b/src/redux/sagas/actions/editColony.ts
@@ -34,7 +34,6 @@ function* editColonyAction({
     colony: { colonyAddress, name: colonyName },
     colonyDisplayName,
     colonyAvatarImage,
-    // hasAvatarChanged,
   },
   meta: { id: metaId, navigate },
   meta,
@@ -100,39 +99,6 @@ function* editColonyAction({
 
     yield put(transactionPending(editColony.id));
 
-    // /*
-    //  * Upload colony metadata to IPFS
-    //  *
-    //  * @NOTE Only (re)upload the avatar if it has changed, otherwise just use
-    //  * the old hash.
-    //  * This cuts down on some transaction signing wait time, since IPFS uplaods
-    //  * tend to be on the slower side :(
-    //  */
-    // let colonyAvatarIpfsHash = null;
-    // if (colonyAvatarImage && hasAvatarChanged) {
-    //   colonyAvatarIpfsHash = yield call(
-    //     ipfsUpload,
-    //     JSON.stringify({
-    //       image: colonyAvatarImage,
-    //     }),
-    //   );
-    // }
-
-    // /*
-    //  * Upload colony metadata to IPFS
-    //  */
-    // let colonyMetadataIpfsHash = null;
-    // colonyMetadataIpfsHash = yield call(
-    //   ipfsUpload,
-    //   JSON.stringify({
-    //     colonyDisplayName,
-    //     colonyAvatarHash: hasAvatarChanged
-    //       ? colonyAvatarIpfsHash
-    //       : colonyAvatarHash,
-    //     colonyTokens,
-    //   }),
-    // );
-
     /**
      * @NOTE: In order for the ColonyMetadata event (which is the only event associated with Colony Edit action) to be emitted,
      * the second parameter must be non-empty.
@@ -167,6 +133,7 @@ function* editColonyAction({
               txHash,
               colony.metadata,
               colonyDisplayName,
+              colonyAvatarImage,
             ),
           },
         },

--- a/src/redux/sagas/actions/editColony.ts
+++ b/src/redux/sagas/actions/editColony.ts
@@ -34,6 +34,7 @@ function* editColonyAction({
     colony: { colonyAddress, name: colonyName },
     colonyDisplayName,
     colonyAvatarImage,
+    // hasAvatarChanged,
   },
   meta: { id: metaId, navigate },
   meta,
@@ -98,6 +99,39 @@ function* editColonyAction({
     // }
 
     yield put(transactionPending(editColony.id));
+
+    // /*
+    //  * Upload colony metadata to IPFS
+    //  *
+    //  * @NOTE Only (re)upload the avatar if it has changed, otherwise just use
+    //  * the old hash.
+    //  * This cuts down on some transaction signing wait time, since IPFS uplaods
+    //  * tend to be on the slower side :(
+    //  */
+    // let colonyAvatarIpfsHash = null;
+    // if (colonyAvatarImage && hasAvatarChanged) {
+    //   colonyAvatarIpfsHash = yield call(
+    //     ipfsUpload,
+    //     JSON.stringify({
+    //       image: colonyAvatarImage,
+    //     }),
+    //   );
+    // }
+
+    // /*
+    //  * Upload colony metadata to IPFS
+    //  */
+    // let colonyMetadataIpfsHash = null;
+    // colonyMetadataIpfsHash = yield call(
+    //   ipfsUpload,
+    //   JSON.stringify({
+    //     colonyDisplayName,
+    //     colonyAvatarHash: hasAvatarChanged
+    //       ? colonyAvatarIpfsHash
+    //       : colonyAvatarHash,
+    //     colonyTokens,
+    //   }),
+    // );
 
     /**
      * @NOTE: In order for the ColonyMetadata event (which is the only event associated with Colony Edit action) to be emitted,

--- a/src/redux/sagas/utils/metadataChangelog.ts
+++ b/src/redux/sagas/utils/metadataChangelog.ts
@@ -37,6 +37,7 @@ export const getUpdatedColonyMetadataChangelog = (
   transactionHash: string,
   metadata: ColonyMetadata,
   newDisplayName?: string,
+  newAvatarImage?: string | null,
 ): ColonyMetadataChangelogInput[] => {
   const existingChangelog = getExistingChangelog(metadata.changelog);
 
@@ -46,8 +47,10 @@ export const getUpdatedColonyMetadataChangelog = (
       transactionHash,
       newDisplayName: newDisplayName ?? metadata.displayName,
       oldDisplayName: metadata.displayName,
-      // @TODO: Actually check whether the avatar has changed
-      hasAvatarChanged: false,
+      hasAvatarChanged:
+        newAvatarImage === undefined
+          ? false
+          : newAvatarImage !== metadata.avatar,
     },
   ];
 };


### PR DESCRIPTION
Connected EditColonyDetails with the related saga. Also updated sidebar and dialog `ColonyAvatar` to prefer avatar over the thumbnail so that the actual uploaded image is shown.

### Dialog and sidebar after uploading an avatar and reloading:
![FireShot Capture 824 - Colony CDapp - localhost](https://user-images.githubusercontent.com/18473896/228082155-2c9b0a09-d8b6-4b2f-aefc-160a7289799f.png)

Contributes to #309 
