### PR TITLE
Wire up ColonyUpgrade component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@apollo/client": "^3.6.9",
-        "@colony/colony-js": "^6.1.0",
+        "@colony/colony-js": "^6.3.6",
         "@colony/redux-promise-listener": "^1.2.0",
         "@colony/unicode-confusables-noascii": "^0.1.2",
         "@formatjs/intl-pluralrules": "^5.0.2",
@@ -2526,9 +2526,9 @@
       }
     },
     "node_modules/@colony/colony-js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-6.1.0.tgz",
-      "integrity": "sha512-t4x3IOjyT+fxz6EIoQ4073N7cumPwb0GYwoaYUvJZlJtMzOm5tk8oFvE6puYaQjlsmHMU/VJvvWVZlJ1GIPzoQ==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-6.3.6.tgz",
+      "integrity": "sha512-vfmby0kKiwKjmBt1O/YD5iv8SGVebHg5DucTYYleW6gc7I5VtMonlgFCwGEwWtgPZWEgvJskDUcya/bZYrTBTg==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       },
@@ -31230,7 +31230,6 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -31593,7 +31592,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -62772,9 +62770,9 @@
       }
     },
     "@colony/colony-js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-6.1.0.tgz",
-      "integrity": "sha512-t4x3IOjyT+fxz6EIoQ4073N7cumPwb0GYwoaYUvJZlJtMzOm5tk8oFvE6puYaQjlsmHMU/VJvvWVZlJ1GIPzoQ==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-6.3.6.tgz",
+      "integrity": "sha512-vfmby0kKiwKjmBt1O/YD5iv8SGVebHg5DucTYYleW6gc7I5VtMonlgFCwGEwWtgPZWEgvJskDUcya/bZYrTBTg==",
       "requires": {
         "cross-fetch": "^3.1.5"
       }

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.6.9",
-    "@colony/colony-js": "^6.1.0",
+    "@colony/colony-js": "^6.3.6",
     "@colony/redux-promise-listener": "^1.2.0",
     "@colony/unicode-confusables-noascii": "^0.1.2",
     "@formatjs/intl-pluralrules": "^5.0.2",

--- a/src/components/common/ColonyHome/ColonyHomeLayout.tsx
+++ b/src/components/common/ColonyHome/ColonyHomeLayout.tsx
@@ -11,7 +11,7 @@ import ColonyUnclaimedTransfers from './ColonyUnclaimedTransfers';
 import ColonyMembersWidget from './ColonyMembersWidget';
 import ColonyExtensions from './ColonyExtensionsWidget';
 import ColonyDomainDescription from './ColonyDomainDescription';
-// import ColonyUpgrade from './ColonyUpgrade';
+import ColonyUpgrade from './ColonyUpgrade';
 import OneTxPaymentUpgrade from './OneTxPaymentUpgrade';
 // import ExtensionUpgrade from './ExtensionUpgrade';
 import ColonyHomeInfo from './ColonyHomeInfo';
@@ -82,6 +82,7 @@ const ColonyHomeLayout = ({
           </aside>
         )}
       </div>
+      <ColonyUpgrade />
       <OneTxPaymentUpgrade />
     </div>
   );

--- a/src/components/common/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
+++ b/src/components/common/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
@@ -1,20 +1,25 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { useDialog } from '~shared/Dialog';
-import NetworkContractUpgradeDialog from '~dialogs/NetworkContractUpgradeDialog';
+import { NetworkContractUpgradeDialog } from '~common/Dialogs';
 import Alert from '~shared/Alert';
 import Button from '~shared/Button';
 import ExternalLink from '~shared/ExternalLink';
-import { useNetworkContracts } from '~data/index';
-import { useTransformer, useAppContext, useColonyContext } from '~hooks';
-import { getNetworkRelaseLink } from '~utils/external';
 import {
-  colonyMustBeUpgraded,
-  colonyShouldBeUpgraded,
-} from '~modules/dashboard/checks';
-import { hasRoot } from '~modules/users/checks';
-import { getAllUserRoles } from '~modules/transformers';
+  useTransformer,
+  useAppContext,
+  useColonyContext,
+  useColonyContractVersion,
+  useEnabledExtensions,
+} from '~hooks';
+import { getNetworkReleaseLink } from '~utils/external';
+import {
+  hasRoot,
+  mustColonyBeUpgraded,
+  canColonyBeUpgraded,
+} from '~utils/checks';
+import { getAllUserRoles } from '~redux/transformers';
 
 import styles from './ColonyUpgrade.css';
 
@@ -34,18 +39,16 @@ const MSG = defineMessages({
 
 const ColonyUpgrade = () => {
   const { colony } = useColonyContext();
-
-  const openUpgradeVersionDialog = useDialog(NetworkContractUpgradeDialog);
-  const { version: networkVersion } = useNetworkContracts();
+  const { colonyContractVersion } = useColonyContractVersion();
+  const openUpgradeColonyDialog = useDialog(NetworkContractUpgradeDialog);
   const { user, wallet } = useAppContext();
-
-  const handleUpgradeColony = useCallback(
-    () =>
-      openUpgradeVersionDialog({
-        colony,
-      }),
-    [colony, openUpgradeVersionDialog],
-  );
+  const enabledExtensionData = useEnabledExtensions();
+  const handleUpgradeColony = () =>
+    colony &&
+    openUpgradeColonyDialog({
+      colony,
+      enabledExtensionData,
+    });
 
   const allUserRoles = useTransformer(getAllUserRoles, [
     colony,
@@ -54,11 +57,8 @@ const ColonyUpgrade = () => {
 
   const canUpgradeColony = user?.name && hasRoot(allUserRoles);
 
-  const mustUpgrade = colonyMustBeUpgraded(colony, networkVersion as string);
-  const shouldUpdgrade = colonyShouldBeUpgraded(
-    colony,
-    networkVersion as string,
-  );
+  const mustUpgrade = mustColonyBeUpgraded(colony, colonyContractVersion);
+  const canUpgrade = canColonyBeUpgraded(colony, colonyContractVersion);
 
   if (mustUpgrade) {
     return (
@@ -86,7 +86,7 @@ const ColonyUpgrade = () => {
     );
   }
 
-  if (shouldUpdgrade) {
+  if (canUpgrade) {
     return (
       <div className={styles.upgradeBannerContainer}>
         <Alert
@@ -105,10 +105,7 @@ const ColonyUpgrade = () => {
                     linkToRelease: (
                       <ExternalLink
                         text={{ id: 'text.learnMore' }}
-                        href={getNetworkRelaseLink(
-                          // parseInt(colony.version, 10) + 1,
-                          10,
-                        )}
+                        href={getNetworkReleaseLink()}
                       />
                     ),
                   }}

--- a/src/utils/checks/canColonyBeUpgraded.ts
+++ b/src/utils/checks/canColonyBeUpgraded.ts
@@ -1,4 +1,16 @@
 import { Colony } from '~types';
 
-export const canColonyBeUpgraded = (colony: Colony, contractVersion: number) =>
-  contractVersion > colony.version;
+const minimumRequiredColonyVersion = 4;
+
+export const canColonyBeUpgraded = (
+  colony: Colony | undefined,
+  contractVersion: number,
+) => colony && contractVersion > colony.version;
+
+export const mustColonyBeUpgraded = (
+  colony: Colony | undefined,
+  networkVersion: number,
+) =>
+  colony &&
+  canColonyBeUpgraded(colony, networkVersion) &&
+  colony.version < minimumRequiredColonyVersion;

--- a/src/utils/external/index.ts
+++ b/src/utils/external/index.ts
@@ -1,6 +1,6 @@
 import { formatUnits } from 'ethers/lib.esm/utils';
 import { BigNumber } from 'ethers';
-import { ColonyVersion, releaseMap } from '@colony/colony-js';
+import { LATEST_TAG } from '@colony/colony-js/extras';
 
 import { DEFAULT_NETWORK } from '~constants';
 import {
@@ -115,5 +115,4 @@ export const getBlockExplorerLink = ({
   return `https://${networkSubdomain}etherscan.${tld}/${linkType}/${addressOrHash}`;
 };
 
-export const getNetworkRelaseLink = (version: ColonyVersion) =>
-  `${NETWORK_RELEASES}/${releaseMap[version]}`;
+export const getNetworkReleaseLink = () => `${NETWORK_RELEASES}/${LATEST_TAG}`;


### PR DESCRIPTION
`colony-js` had to be updated to import the latest network release tag from it as the previous import was no longer available.

**When the user can update to a newer version:**
![FireShot Capture 829 - Colony CDapp - localhost](https://user-images.githubusercontent.com/18473896/228884810-15cb08bd-cc17-41da-86c9-5a6eaedd39cd.png)

In order to test, the process should be the same as the one for https://github.com/JoinColony/colonyCDapp/pull/313 but now a warning should appear in the colony's home.

**When the colony version is below v4:**
![FireShot Capture 828 - Colony CDapp - localhost](https://user-images.githubusercontent.com/18473896/228884872-8b14f28e-59da-49df-a0b3-013191ee3a01.png)

In order to test, I just changed `colonyContractVersion` in line 60 of `ColonyUpgrade` to `3`.

Resolves #59 
