### PR TITLE
Port activate button (II)

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/ActivateButton.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/ActivateButton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { useTokenActivationContext } from '~hooks';
+import Button from '~shared/Button';
+
+const displayName =
+  'common.ColonyActions.DefaultMotion.StakingWidget.StakingControls.ActivateButton';
+
+const ActivateButton = () => {
+  const { setIsOpen } = useTokenActivationContext();
+  return (
+    <Button
+      appearance={{
+        theme: 'primary',
+        size: 'medium',
+      }}
+      text={{ id: 'button.activate' }}
+      onClick={() => setIsOpen(true)}
+    />
+  );
+};
+
+ActivateButton.displayName = displayName;
+
+export default ActivateButton;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakeButton.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakeButton.tsx
@@ -9,15 +9,13 @@ const displayName =
 interface StakeButtonProps {
   isLoadingData: boolean;
   enoughTokensToStakeMinimum: boolean;
-  remainingToStake: string;
 }
 
 const StakeButton = ({
   isLoadingData,
   enoughTokensToStakeMinimum,
-  remainingToStake,
 }: StakeButtonProps) => {
-  const { isObjection } = useStakingWidgetContext();
+  const { isObjection, remainingToStake } = useStakingWidgetContext();
   return (
     <Button
       appearance={{

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.css
@@ -1,7 +1,6 @@
 .buttonGroup {
   display: flex;
   margin-top: 30px;
-  column-gap: 10px;
 }
 
 .buttonGroup button {

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BackButton, ObjectButton, StakeButton } from '.';
+import { BackButton, ObjectButton, StakeButton, ActivateButton } from '.';
 import useStakingControls from './useStakingControls';
 
 import styles from './StakingControls.css';
@@ -13,8 +13,12 @@ interface StakingControlsProps {
 }
 
 const StakingControls = ({ limitExceeded }: StakingControlsProps) => {
-  const { showBackButton, enoughTokensToStakeMinimum, isLoadingData } =
-    useStakingControls(limitExceeded);
+  const {
+    showBackButton,
+    showActivateButton,
+    enoughTokensToStakeMinimum,
+    isLoadingData,
+  } = useStakingControls(limitExceeded);
 
   return (
     <div className={styles.buttonGroup}>
@@ -29,9 +33,7 @@ const StakingControls = ({ limitExceeded }: StakingControlsProps) => {
           enoughTokensToStakeMinimum={enoughTokensToStakeMinimum}
         />
       )}
-      {/*
       {showActivateButton && <ActivateButton />}
-      */}
     </div>
   );
 };

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 
-import { BackButton, ObjectButton, StakeButton, ActivateButton } from '.';
-import useStakingControls from './useStakingControls';
+import {
+  BackButton,
+  ObjectButton,
+  StakeButton,
+  ActivateButton,
+  useStakingControls,
+} from '.';
 
 import styles from './StakingControls.css';
 

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.tsx
@@ -1,43 +1,27 @@
 import React from 'react';
 
-import { useAppContext, useColonyContext } from '~hooks';
-
-import { useStakingWidgetContext } from '../../StakingWidgetProvider';
-import { useEnoughTokensForStaking } from '../useEnoughTokensForStaking';
 import { BackButton, ObjectButton, StakeButton } from '.';
+import useStakingControls from './useStakingControls';
 
 import styles from './StakingControls.css';
 
 const displayName =
   'common.ColonyActions.ActionDetailsPage.DefaultMotion.StakingWidget.StakingWidgetControls';
 
-const StakingControls = () => {
-  const { user, userLoading, walletConnecting } = useAppContext();
-  const { colony, loading: loadingColony } = useColonyContext();
-  const {
-    motionStakes: {
-      raw: { nay: nayStakes },
-    },
-    remainingToStake,
-    userMinStake,
-  } = useStakingWidgetContext();
-  const { tokenAddress } = colony?.nativeToken || {};
-  const showBackButton = nayStakes !== '0';
-  const { loadingUserTokenBalance, enoughTokensToStakeMinimum } =
-    useEnoughTokensForStaking(
-      tokenAddress ?? '',
-      user?.walletAddress ?? '',
-      userMinStake,
-    );
-  const isLoadingData =
-    loadingUserTokenBalance || userLoading || walletConnecting || loadingColony;
+interface StakingControlsProps {
+  limitExceeded: boolean;
+}
+
+const StakingControls = ({ limitExceeded }: StakingControlsProps) => {
+  const { showBackButton, enoughTokensToStakeMinimum, isLoadingData } =
+    useStakingControls(limitExceeded);
+
   return (
     <div className={styles.buttonGroup}>
       {showBackButton && <BackButton />}
       <StakeButton
         isLoadingData={isLoadingData}
         enoughTokensToStakeMinimum={enoughTokensToStakeMinimum}
-        remainingToStake={remainingToStake}
       />
       {!showBackButton && (
         <ObjectButton

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/index.ts
@@ -2,3 +2,4 @@ export { default } from './StakingControls';
 export { default as BackButton } from './BackButton';
 export { default as ObjectButton } from './ObjectButton';
 export { default as StakeButton } from './StakeButton';
+export { default as ActivateButton } from './ActivateButton';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/index.ts
@@ -3,3 +3,4 @@ export { default as BackButton } from './BackButton';
 export { default as ObjectButton } from './ObjectButton';
 export { default as StakeButton } from './StakeButton';
 export { default as ActivateButton } from './ActivateButton';
+export { default as useStakingControls } from './useStakingControls';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/useStakingControls.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/useStakingControls.tsx
@@ -1,0 +1,73 @@
+import { BigNumber } from 'ethers';
+
+import { useGetUserReputationQuery } from '~gql';
+import { useAppContext, useColonyContext } from '~hooks';
+
+import { useStakingWidgetContext } from '../../StakingWidgetProvider';
+import { useEnoughTokensForStaking } from '../useEnoughTokensForStaking';
+
+const useStakingControls = (limitExceeded: boolean) => {
+  const { colony, loading: loadingColony } = useColonyContext();
+  const { user, userLoading, walletConnecting } = useAppContext();
+  const {
+    motionStakes: {
+      raw: { nay: nayStakes },
+    },
+    userMinStake,
+    motionDomainId,
+    rootHash,
+    remainingToStake,
+  } = useStakingWidgetContext();
+
+  const {
+    userActivatedTokens,
+    enoughTokensToStakeMinimum,
+    loadingUserTokenBalance,
+  } = useEnoughTokensForStaking(
+    colony?.nativeToken.tokenAddress ?? '',
+    user?.walletAddress ?? '',
+    userMinStake,
+  );
+
+  const { data, loading: loadingReputation } = useGetUserReputationQuery({
+    variables: {
+      input: {
+        colonyAddress: colony?.colonyAddress ?? '',
+        walletAddress: user?.walletAddress ?? '',
+        domainId: Number(motionDomainId),
+        rootHash,
+      },
+    },
+  });
+
+  const userReputation = data?.getUserReputation;
+  /* User cannot stake more than their reputation in tokens. */
+  const userMaxStake = BigNumber.from(userReputation ?? '0');
+  const enoughReputationToStakeMinimum =
+    userMaxStake.gt(0) && userMaxStake.gte(userMinStake);
+
+  const showBackButton = nayStakes !== '0';
+
+  const showActivateButton =
+    !!user &&
+    remainingToStake !== '0' &&
+    enoughReputationToStakeMinimum &&
+    enoughTokensToStakeMinimum &&
+    limitExceeded;
+
+  return {
+    showBackButton,
+    showActivateButton,
+    userActivatedTokens,
+    enoughTokensToStakeMinimum,
+    enoughReputationToStakeMinimum,
+    isLoadingData:
+      loadingColony ||
+      userLoading ||
+      walletConnecting ||
+      loadingUserTokenBalance ||
+      loadingReputation,
+  };
+};
+
+export default useStakingControls;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { InferType, number, object } from 'yup';
 
 import { ActionHookForm as ActionForm } from '~shared/Fields';
@@ -20,6 +20,7 @@ export type StakingWidgetValues = InferType<typeof validationSchema>;
 
 const StakingInput = () => {
   const { transform, handleSuccess, isObjection } = useStakingInput();
+  const [limitExceeded, setLimitExceeded] = useState(false);
 
   return (
     <ActionForm<StakingWidgetValues>
@@ -31,8 +32,12 @@ const StakingInput = () => {
       transform={transform}
       onSuccess={handleSuccess}
     >
-      <StakingSlider isObjection={isObjection} />
-      <StakingControls />
+      <StakingSlider
+        isObjection={isObjection}
+        limitExceeded={limitExceeded}
+        setLimitExceeded={setLimitExceeded}
+      />
+      <StakingControls limitExceeded={limitExceeded} />
     </ActionForm>
   );
 };

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSlider.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSlider.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useAppContext, useStakingSlider } from '~hooks';
+import { SetStateFn } from '~types';
 
 import {
   StakingSliderDescription,
@@ -13,9 +14,15 @@ const displayName =
 
 interface StakingSliderProps {
   isObjection: boolean;
+  limitExceeded: boolean;
+  setLimitExceeded: SetStateFn;
 }
 
-const StakingSlider = ({ isObjection }: StakingSliderProps) => {
+const StakingSlider = ({
+  isObjection,
+  limitExceeded,
+  setLimitExceeded,
+}: StakingSliderProps) => {
   const { user } = useAppContext();
   const {
     remainingToStake,
@@ -26,6 +33,7 @@ const StakingSlider = ({ isObjection }: StakingSliderProps) => {
     enoughTokensToStakeMinimum,
     isLoadingData,
     userActivatedTokens,
+    userStakeLimitDecimal,
   } = useStakingSlider(isObjection);
 
   const displayLabel = !!user && !isLoadingData && remainingToStake !== '0';
@@ -50,12 +58,15 @@ const StakingSlider = ({ isObjection }: StakingSliderProps) => {
         isLoading={isLoadingData}
         remainingToStake={remainingToStake}
         enoughTokensToStakeMinimum={enoughTokensToStakeMinimum}
+        limit={userStakeLimitDecimal}
+        handleLimitExceeded={setLimitExceeded}
       />
       {displayLabel && (
         <StakingValidationMessage
           enoughTokensToStakeMinimum={enoughTokensToStakeMinimum}
           userActivatedTokens={userActivatedTokens}
           userMinStake={userMinStake}
+          limitExceeded={limitExceeded}
         />
       )}
     </>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/StakingValidationMessage.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/StakingValidationMessage.tsx
@@ -1,27 +1,47 @@
 import { BigNumber } from 'ethers';
 import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
 
 import TokenErrorMessage from './TokenErrorMessage';
+import styles from './StakingValidationMessage.css';
 
 const displayName =
   'common.ColonyActions.DefaultMotion.StakingWidget.StakingValidationMessage';
+
+const MSG = defineMessages({
+  limitExceeded: {
+    id: `${displayName}.limitExceeded`,
+    defaultMessage: `Oops! You don't have enough active tokens. To stake more than this, please activate more tokens.`,
+  },
+});
 
 interface StakingValidationMessageProps {
   enoughTokensToStakeMinimum: boolean;
   userActivatedTokens: BigNumber;
   userMinStake: string;
+  limitExceeded: boolean;
 }
 
 const StakingValidationMessage = ({
   enoughTokensToStakeMinimum,
   userActivatedTokens,
   userMinStake,
+  limitExceeded,
 }: StakingValidationMessageProps) => {
   const tokensLeftToActivate = BigNumber.from(userMinStake)
     .sub(userActivatedTokens)
     .toString();
+
   if (!enoughTokensToStakeMinimum) {
     return <TokenErrorMessage tokensLeftToActivate={tokensLeftToActivate} />;
+  }
+
+  if (limitExceeded) {
+    return (
+      <div className={styles.validationError}>
+        <FormattedMessage {...MSG.limitExceeded} />
+      </div>
+    );
   }
 
   return null;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingWidgetSlider.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingWidgetSlider.tsx
@@ -1,10 +1,10 @@
 import Decimal from 'decimal.js';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
-
 import { useAppContext } from '~hooks';
 
 import Slider from '~shared/Slider';
+import { SetStateFn } from '~types';
 import { SLIDER_AMOUNT_KEY } from './StakingInput';
 
 import styles from './StakingWidgetSlider.css';
@@ -17,6 +17,8 @@ interface StakingWidgetSliderProps {
   remainingToStake: string;
   enoughTokensToStakeMinimum: boolean;
   isObjection: boolean;
+  limit: Decimal;
+  handleLimitExceeded: SetStateFn;
 }
 
 const StakingWidgetSlider = ({
@@ -24,6 +26,8 @@ const StakingWidgetSlider = ({
   remainingToStake,
   enoughTokensToStakeMinimum,
   isObjection,
+  limit,
+  handleLimitExceeded,
 }: StakingWidgetSliderProps) => {
   const { user } = useAppContext();
   const { watch } = useFormContext();
@@ -34,7 +38,7 @@ const StakingWidgetSlider = ({
       <Slider
         name="amount"
         value={sliderAmount}
-        limit={new Decimal(1)}
+        limit={limit}
         step={1}
         min={0}
         max={100}
@@ -48,7 +52,7 @@ const StakingWidgetSlider = ({
           theme: isObjection ? 'danger' : 'primary',
           size: 'thick',
         }}
-        // handleLimitExceeded={setLimitExceeded}
+        handleLimitExceeded={handleLimitExceeded}
       />
     </div>
   );

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/helpers.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/helpers.ts
@@ -1,14 +1,20 @@
+import Decimal from 'decimal.js';
 import { BigNumber } from 'ethers';
 
 export const getStakeFromSlider = (
   sliderAmount: number,
   remainingToStake: string,
   userMinStake: string,
-) =>
-  BigNumber.from(sliderAmount)
-    .mul(BigNumber.from(remainingToStake).sub(userMinStake))
+) => {
+  const exactStake = new Decimal(sliderAmount)
+    .mul(BigNumber.from(remainingToStake).sub(userMinStake).toString())
     .div(100)
-    .add(userMinStake);
+    .add(userMinStake)
+    .floor()
+    .toString();
+
+  return BigNumber.from(exactStake);
+};
 
 /* BigNumbers round down, therefore if it's been rounded down to zero, display '1' */
 export const getRemainingStakePercentage = (

--- a/src/components/common/Dialogs/RaiseObjectionDialog/ObjectionSlider.tsx
+++ b/src/components/common/Dialogs/RaiseObjectionDialog/ObjectionSlider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { StakingSlider } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget';
 import { DialogSection } from '~shared/Dialog';
@@ -7,13 +7,21 @@ import styles from './ObjectionSlider.css';
 
 const displayName = 'common.Dialogs.RaiseObjectionDialog.ObjectionSlider';
 
-const ObjectionSlider = () => (
-  <DialogSection appearance={{ theme: 'sidePadding' }}>
-    <div className={styles.main}>
-      <StakingSlider isObjection />
-    </div>
-  </DialogSection>
-);
+const ObjectionSlider = () => {
+  // Note: this doesn't live in StakingSlider because it's also needed by StakingControls
+  const [limitExceeded, setLimitExceeded] = useState(false);
+  return (
+    <DialogSection appearance={{ theme: 'sidePadding' }}>
+      <div className={styles.main}>
+        <StakingSlider
+          isObjection
+          limitExceeded={limitExceeded}
+          setLimitExceeded={setLimitExceeded}
+        />
+      </div>
+    </DialogSection>
+  );
+};
 
 ObjectionSlider.displayName = displayName;
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -16,6 +16,7 @@
   "role.6": "Administration",
   "role.unknown": "Unknown",
   "button.accept": "Accept",
+  "button.activate": "Activate",
   "button.approve": "Approve",
   "button.cancel": "Cancel",
   "button.choose": "Choose",


### PR DESCRIPTION
## Description

This PR ports the activate tokens button as well as the corresponding error message when a user hits a staking limit caused by insufficient active tokens.

![limit](https://user-images.githubusercontent.com/64402732/230018217-832eaf27-a1da-4942-bf3c-fc7403df0ab5.png)

## Testing

Following on from #364, you can activate tokens in the UI via TokenActivationPopover. Activate fewer than the required stake, and then refresh the browser. 

You should see a limit on the staking slider and the activate button/error msg appear if you hit that limit.

**New stuff** ✨

* Activate Button
* Limit exceeded message

**Changes** 🏗

* `getStakeFromSlider` to use Decimal for increased precision

Contributes to #270
