### PR TITLE
Port staking error messages (III)

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/ObjectButton.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/ObjectButton.tsx
@@ -9,11 +9,13 @@ const displayName =
 interface ObjectButtonProps {
   isLoadingData: boolean;
   enoughTokensToStakeMinimum: boolean;
+  enoughReputationToStakeMinimum: boolean;
 }
 
 const ObjectButton = ({
   isLoadingData,
   enoughTokensToStakeMinimum,
+  enoughReputationToStakeMinimum,
 }: ObjectButtonProps) => {
   const { user } = useAppContext();
   const { handleObjection } = useObjectButton();
@@ -22,7 +24,12 @@ const ObjectButton = ({
     <Button
       appearance={{ theme: 'pink', size: 'medium' }}
       text={{ id: 'button.object' }}
-      disabled={!user || isLoadingData || !enoughTokensToStakeMinimum}
+      disabled={
+        !user ||
+        isLoadingData ||
+        !enoughTokensToStakeMinimum ||
+        !enoughReputationToStakeMinimum
+      }
       dataTest="stakeWidgetObjectButton"
       onClick={handleObjection}
     />

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakeButton.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakeButton.tsx
@@ -14,7 +14,7 @@ interface StakeButtonProps {
   isLoadingData: boolean;
   enoughTokensToStakeMinimum: boolean;
   enoughReputationToStakeMinimum: boolean;
-  cantStakeMore: boolean;
+  canStakeMore: boolean;
   userMaxStake: BigNumber;
   userActivatedTokens: BigNumber;
   userNeedsMoreReputation: boolean;
@@ -27,7 +27,7 @@ const StakeButton = ({
   userNeedsMoreReputation,
   userMaxStake,
   userActivatedTokens,
-  cantStakeMore,
+  canStakeMore,
 }: StakeButtonProps) => {
   const { user } = useAppContext();
   const { isObjection, remainingToStake, usersStakes, userMinStake } =
@@ -60,7 +60,7 @@ const StakeButton = ({
       disabled={
         isLoadingData ||
         userHasReachedReputationLimit ||
-        cantStakeMore ||
+        !canStakeMore ||
         !enoughTokensToStakeMinimum ||
         !enoughReputationToStakeMinimum ||
         remainingToStake === '0'

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakeButton.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakeButton.tsx
@@ -9,13 +9,16 @@ const displayName =
 interface StakeButtonProps {
   isLoadingData: boolean;
   enoughTokensToStakeMinimum: boolean;
+  cantStakeMore: boolean;
 }
 
 const StakeButton = ({
   isLoadingData,
   enoughTokensToStakeMinimum,
+  cantStakeMore,
 }: StakeButtonProps) => {
   const { isObjection, remainingToStake } = useStakingWidgetContext();
+
   return (
     <Button
       appearance={{
@@ -24,7 +27,10 @@ const StakeButton = ({
       }}
       type="submit"
       disabled={
-        isLoadingData || !enoughTokensToStakeMinimum || remainingToStake === '0'
+        isLoadingData ||
+        cantStakeMore ||
+        !enoughTokensToStakeMinimum ||
+        remainingToStake === '0'
       }
       /* userActivatedTokens.lt(
         getDecimalStake(values.amount).round(),

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.tsx
@@ -23,6 +23,7 @@ const StakingControls = ({ limitExceeded }: StakingControlsProps) => {
     showActivateButton,
     enoughTokensToStakeMinimum,
     isLoadingData,
+    cantStakeMore,
   } = useStakingControls(limitExceeded);
 
   return (
@@ -31,6 +32,7 @@ const StakingControls = ({ limitExceeded }: StakingControlsProps) => {
       <StakeButton
         isLoadingData={isLoadingData}
         enoughTokensToStakeMinimum={enoughTokensToStakeMinimum}
+        cantStakeMore={cantStakeMore}
       />
       {!showBackButton && (
         <ObjectButton

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.tsx
@@ -24,7 +24,7 @@ const StakingControls = ({ limitExceeded }: StakingControlsProps) => {
     enoughTokensToStakeMinimum,
     enoughReputationToStakeMinimum,
     isLoadingData,
-    cantStakeMore,
+    canStakeMore,
     userNeedsMoreReputation,
     userMaxStake,
     userActivatedTokens,
@@ -37,7 +37,7 @@ const StakingControls = ({ limitExceeded }: StakingControlsProps) => {
         isLoadingData={isLoadingData}
         enoughTokensToStakeMinimum={enoughTokensToStakeMinimum}
         enoughReputationToStakeMinimum={enoughReputationToStakeMinimum}
-        cantStakeMore={cantStakeMore}
+        canStakeMore={canStakeMore}
         userNeedsMoreReputation={userNeedsMoreReputation}
         userMaxStake={userMaxStake}
         userActivatedTokens={userActivatedTokens}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/StakingControls.tsx
@@ -22,8 +22,12 @@ const StakingControls = ({ limitExceeded }: StakingControlsProps) => {
     showBackButton,
     showActivateButton,
     enoughTokensToStakeMinimum,
+    enoughReputationToStakeMinimum,
     isLoadingData,
     cantStakeMore,
+    userNeedsMoreReputation,
+    userMaxStake,
+    userActivatedTokens,
   } = useStakingControls(limitExceeded);
 
   return (
@@ -32,12 +36,17 @@ const StakingControls = ({ limitExceeded }: StakingControlsProps) => {
       <StakeButton
         isLoadingData={isLoadingData}
         enoughTokensToStakeMinimum={enoughTokensToStakeMinimum}
+        enoughReputationToStakeMinimum={enoughReputationToStakeMinimum}
         cantStakeMore={cantStakeMore}
+        userNeedsMoreReputation={userNeedsMoreReputation}
+        userMaxStake={userMaxStake}
+        userActivatedTokens={userActivatedTokens}
       />
       {!showBackButton && (
         <ObjectButton
           isLoadingData={isLoadingData}
           enoughTokensToStakeMinimum={enoughTokensToStakeMinimum}
+          enoughReputationToStakeMinimum={enoughReputationToStakeMinimum}
         />
       )}
       {showActivateButton && <ActivateButton />}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/useStakingControls.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/useStakingControls.tsx
@@ -4,6 +4,10 @@ import { useGetUserReputationQuery } from '~gql';
 import { useAppContext, useColonyContext } from '~hooks';
 
 import { useStakingWidgetContext } from '../../StakingWidgetProvider';
+import {
+  userCantStakeMore,
+  userHasInsufficientReputation,
+} from '../StakingSliderMessages/helpers';
 import { useEnoughTokensForStaking } from '../useEnoughTokensForStaking';
 
 const useStakingControls = (limitExceeded: boolean) => {
@@ -48,13 +52,18 @@ const useStakingControls = (limitExceeded: boolean) => {
 
   const showBackButton = nayStakes !== '0';
 
-  const cantStakeMore =
-    BigNumber.from(remainingToStake).lte(userMinStake) &&
-    remainingToStake !== '0';
+  const cantStakeMore = userCantStakeMore(userMinStake, remainingToStake);
+
+  const userNeedsMoreReputation = userHasInsufficientReputation(
+    userActivatedTokens,
+    userMaxStake,
+    remainingToStake,
+  );
 
   const showActivateButton =
     !!user &&
     !cantStakeMore &&
+    !userNeedsMoreReputation &&
     remainingToStake !== '0' &&
     enoughReputationToStakeMinimum &&
     enoughTokensToStakeMinimum &&
@@ -63,9 +72,11 @@ const useStakingControls = (limitExceeded: boolean) => {
   return {
     showBackButton,
     showActivateButton,
-    userActivatedTokens,
     enoughTokensToStakeMinimum,
     enoughReputationToStakeMinimum,
+    userNeedsMoreReputation,
+    userMaxStake,
+    userActivatedTokens,
     cantStakeMore,
     isLoadingData:
       loadingColony ||

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/useStakingControls.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/useStakingControls.tsx
@@ -48,8 +48,13 @@ const useStakingControls = (limitExceeded: boolean) => {
 
   const showBackButton = nayStakes !== '0';
 
+  const cantStakeMore =
+    BigNumber.from(remainingToStake).lte(userMinStake) &&
+    remainingToStake !== '0';
+
   const showActivateButton =
     !!user &&
+    !cantStakeMore &&
     remainingToStake !== '0' &&
     enoughReputationToStakeMinimum &&
     enoughTokensToStakeMinimum &&
@@ -61,6 +66,7 @@ const useStakingControls = (limitExceeded: boolean) => {
     userActivatedTokens,
     enoughTokensToStakeMinimum,
     enoughReputationToStakeMinimum,
+    cantStakeMore,
     isLoadingData:
       loadingColony ||
       userLoading ||

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/useStakingControls.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/useStakingControls.tsx
@@ -5,7 +5,7 @@ import { useAppContext, useColonyContext } from '~hooks';
 
 import { useStakingWidgetContext } from '../../StakingWidgetProvider';
 import {
-  userCantStakeMore,
+  userCanStakeMore,
   userHasInsufficientReputation,
 } from '../StakingSliderMessages/helpers';
 import { useEnoughTokensForStaking } from '../useEnoughTokensForStaking';
@@ -52,7 +52,7 @@ const useStakingControls = (limitExceeded: boolean) => {
 
   const showBackButton = nayStakes !== '0';
 
-  const cantStakeMore = userCantStakeMore(userMinStake, remainingToStake);
+  const canStakeMore = userCanStakeMore(userMinStake, remainingToStake);
 
   const userNeedsMoreReputation = userHasInsufficientReputation(
     userActivatedTokens,
@@ -62,7 +62,7 @@ const useStakingControls = (limitExceeded: boolean) => {
 
   const showActivateButton =
     !!user &&
-    !cantStakeMore &&
+    canStakeMore &&
     !userNeedsMoreReputation &&
     remainingToStake !== '0' &&
     enoughReputationToStakeMinimum &&
@@ -77,7 +77,7 @@ const useStakingControls = (limitExceeded: boolean) => {
     userNeedsMoreReputation,
     userMaxStake,
     userActivatedTokens,
-    cantStakeMore,
+    canStakeMore,
     isLoadingData:
       loadingColony ||
       userLoading ||

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSlider.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSlider.tsx
@@ -34,9 +34,12 @@ const StakingSlider = ({
     isLoadingData,
     userActivatedTokens,
     userStakeLimitDecimal,
+    enoughReputationToStakeMinimum,
+    userMaxStake,
   } = useStakingSlider(isObjection);
 
-  const displayLabel = !!user && !isLoadingData && remainingToStake !== '0';
+  const displayErrMsg = !!user && !isLoadingData && remainingToStake !== '0';
+  const displayLabel = displayErrMsg && enoughReputationToStakeMinimum;
 
   return (
     <>
@@ -58,14 +61,19 @@ const StakingSlider = ({
         isLoading={isLoadingData}
         remainingToStake={remainingToStake}
         enoughTokensToStakeMinimum={enoughTokensToStakeMinimum}
+        enoughReputationToStakeMinimum={enoughReputationToStakeMinimum}
         limit={userStakeLimitDecimal}
         handleLimitExceeded={setLimitExceeded}
       />
-      {displayLabel && (
+      {displayErrMsg && (
         <StakingValidationMessage
+          enoughReputationToStakeMinimum={enoughReputationToStakeMinimum}
           enoughTokensToStakeMinimum={enoughTokensToStakeMinimum}
-          userActivatedTokens={userActivatedTokens}
           userMinStake={userMinStake}
+          userActivatedTokens={userActivatedTokens}
+          userMaxStake={userMaxStake}
+          remainingToStake={remainingToStake}
+          nativeTokenDecimals={nativeTokenDecimals}
           limitExceeded={limitExceeded}
         />
       )}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/NotEnoughReputationMessage.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/NotEnoughReputationMessage.tsx
@@ -1,0 +1,53 @@
+import { BigNumber } from 'ethers';
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import Numeral from '~shared/Numeral';
+
+import styles from './StakingValidationMessage.css';
+
+const displayName =
+  'common.ColonyActions.StakingWidget.StakingSliderMessages.NotEnoughReputationMessage.tsx';
+
+const MSG = defineMessages({
+  notEnoughReputation: {
+    id: `${displayName}.notEnoughReputation`,
+    defaultMessage: `The minimum reputation required to stake in this team is {minimumReputation} points. When this motion was created you only had {userReputation} points, so you can't stake on this motion. If you now have more than {minimumReputation} Reputation points, you will be able to stake on future motions.`,
+  },
+});
+
+interface NotEnoughReptationMessageProps {
+  userMinStake: string;
+  userMaxStake: BigNumber;
+  nativeTokenDecimals: number;
+}
+
+const NotEnoughReputationMessage = ({
+  userMinStake,
+  userMaxStake,
+  nativeTokenDecimals,
+}: NotEnoughReptationMessageProps) => (
+  <div className={styles.validationError}>
+    <FormattedMessage
+      {...MSG.notEnoughReputation}
+      values={{
+        minimumReputation: (
+          <Numeral
+            className={styles.validationError}
+            value={userMinStake}
+            decimals={nativeTokenDecimals}
+          />
+        ),
+        userReputation: (
+          <Numeral
+            className={styles.validationError}
+            value={userMaxStake}
+            decimals={nativeTokenDecimals}
+          />
+        ),
+      }}
+    />
+  </div>
+);
+
+export default NotEnoughReputationMessage;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/StakingValidationMessage.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/StakingValidationMessage.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import TokenErrorMessage from './TokenErrorMessage';
+import NotEnoughReputationMessage from './NotEnoughReputationMessage';
+
 import styles from './StakingValidationMessage.css';
 
 const displayName =
@@ -20,38 +22,95 @@ const MSG = defineMessages({
     id: `${displayName}.limitExceeded`,
     defaultMessage: `Oops! You don't have enough active tokens. To stake more than this, please activate more tokens.`,
   },
+  moreRepNeeded: {
+    id: `${displayName}.moreRepNeeded`,
+    defaultMessage: `Oops! Your ability to stake is limited by the amount of Reputation you have. To be able to stake more on future motions, you'll need to earn more Reputation.`,
+  },
+  cantStakeMore: {
+    id: `${displayName}.cantStakeMore`,
+    defaultMessage: `The amount left to stake is less than the minimum stake. A motion can't be staked more than 100%.`,
+  },
 });
+
+enum StakingValidationErrors {
+  CANT_STAKE_MORE = 'cantStakeMore',
+  MORE_REP_NEEDED = 'moreRepNeeded',
+  LIMIT_EXCEEDED = 'limitExceeded',
+}
 
 interface StakingValidationMessageProps {
   enoughTokensToStakeMinimum: boolean;
   userActivatedTokens: BigNumber;
-  userMinStake: string;
   limitExceeded: boolean;
+  nativeTokenDecimals: number;
+  userMinStake: string;
+  userMaxStake: BigNumber;
+  enoughReputation: boolean;
+  remainingToStake: string;
 }
 
 const StakingValidationMessage = ({
   enoughTokensToStakeMinimum,
   userActivatedTokens,
-  userMinStake,
   limitExceeded,
+  enoughReputation,
+  nativeTokenDecimals,
+  userMinStake,
+  userMaxStake,
+  remainingToStake,
 }: StakingValidationMessageProps) => {
   const tokensLeftToActivate = BigNumber.from(userMinStake)
     .sub(userActivatedTokens)
     .toString();
 
+  if (!enoughReputation) {
+    return (
+      <NotEnoughReputationMessage
+        userMaxStake={userMaxStake}
+        userMinStake={userMinStake}
+        nativeTokenDecimals={nativeTokenDecimals}
+      />
+    );
+  }
+
   if (!enoughTokensToStakeMinimum) {
     return <TokenErrorMessage tokensLeftToActivate={tokensLeftToActivate} />;
   }
 
-  if (limitExceeded) {
-    return (
-      <div className={styles.validationError}>
-        <FormattedMessage {...MSG.limitExceeded} />
-      </div>
-    );
+  let errorType: StakingValidationErrors | undefined;
+
+  /*
+   * User's reputation in the domain is less than the amount still needed to stake, i.e. their
+   * staking ability is limited, not by their number of tokens activated, but by their (lack of) reputation.
+   */
+  const userNeedsMoreReputation =
+    userActivatedTokens.gt(userMaxStake) && userMaxStake.lt(remainingToStake);
+
+  /*
+   * Occurs when the remaining amount to be staked is less than the user's minimum stake. (i.e. can't
+   * stake more than 100% of a motion)
+   */
+  const cantStakeMore =
+    BigNumber.from(remainingToStake).lte(userMinStake) &&
+    remainingToStake !== '0';
+
+  if (cantStakeMore) {
+    errorType = StakingValidationErrors.CANT_STAKE_MORE;
+  } else if (userNeedsMoreReputation) {
+    errorType = StakingValidationErrors.MORE_REP_NEEDED;
+  } else if (limitExceeded) {
+    errorType = StakingValidationErrors.LIMIT_EXCEEDED;
   }
 
-  return null;
+  if (!errorType) {
+    return null;
+  }
+
+  return (
+    <div className={styles.validationError}>
+      <FormattedMessage {...MSG[errorType]} />
+    </div>
+  );
 };
 
 StakingValidationMessage.displayName = displayName;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/StakingValidationMessage.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/StakingValidationMessage.tsx
@@ -6,17 +6,10 @@ import TokenErrorMessage from './TokenErrorMessage';
 import NotEnoughReputationMessage from './NotEnoughReputationMessage';
 
 import styles from './StakingValidationMessage.css';
-import { userCantStakeMore, userHasInsufficientReputation } from './helpers';
+import { userCanStakeMore, userHasInsufficientReputation } from './helpers';
 
 const displayName =
   'common.ColonyActions.DefaultMotion.StakingWidget.StakingValidationMessage';
-
-const MSG = defineMessages({
-  limitExceeded: {
-    id: `${displayName}.limitExceeded`,
-    defaultMessage: `Oops! You don't have enough active tokens. To stake more than this, please activate more tokens.`,
-  },
-});
 
 const MSG = defineMessages({
   limitExceeded: {
@@ -86,9 +79,9 @@ const StakingValidationMessage = ({
     remainingToStake,
   );
 
-  const cantStakeMore = userCantStakeMore(userMinStake, remainingToStake);
+  const canStakeMore = userCanStakeMore(userMinStake, remainingToStake);
 
-  if (cantStakeMore) {
+  if (!canStakeMore) {
     errorType = StakingValidationErrors.CANT_STAKE_MORE;
   } else if (userNeedsMoreReputation) {
     errorType = StakingValidationErrors.MORE_REP_NEEDED;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/StakingValidationMessage.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/StakingValidationMessage.tsx
@@ -15,6 +15,13 @@ const MSG = defineMessages({
   },
 });
 
+const MSG = defineMessages({
+  limitExceeded: {
+    id: `${displayName}.limitExceeded`,
+    defaultMessage: `Oops! You don't have enough active tokens. To stake more than this, please activate more tokens.`,
+  },
+});
+
 interface StakingValidationMessageProps {
   enoughTokensToStakeMinimum: boolean;
   userActivatedTokens: BigNumber;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/helpers.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/helpers.ts
@@ -16,8 +16,7 @@ export const userHasInsufficientReputation = (
  * stake more than 100% of a motion)
  */
 
-export const userCantStakeMore = (
+export const userCanStakeMore = (
   userMinStake: string,
   remainingToStake: string,
-) =>
-  BigNumber.from(remainingToStake).lt(userMinStake) && remainingToStake !== '0';
+) => BigNumber.from(remainingToStake).gte(userMinStake);

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/helpers.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/helpers.ts
@@ -1,0 +1,23 @@
+import { BigNumber } from 'ethers';
+
+/**
+ * Utility to determine if user's reputation in the domain is less than the amount still needed to stake, i.e. their
+ * staking ability is limited, not by their number of tokens activated, but by their (lack of) reputation.
+ */
+export const userHasInsufficientReputation = (
+  userActivatedTokens: BigNumber,
+  userMaxStake: BigNumber,
+  remainingToStake: string,
+) => userActivatedTokens.gt(userMaxStake) && userMaxStake.lt(remainingToStake);
+
+/**
+ *
+ * Utility to determine whether the remaining amount to be staked is less than the user's minimum stake. (i.e. can't
+ * stake more than 100% of a motion)
+ */
+
+export const userCantStakeMore = (
+  userMinStake: string,
+  remainingToStake: string,
+) =>
+  BigNumber.from(remainingToStake).lt(userMinStake) && remainingToStake !== '0';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/index.ts
@@ -4,3 +4,4 @@ export {
 } from './RequiredStakeMessage';
 export { default as StakingValidationMessage } from './StakingValidationMessage';
 export { default as MinimumStakeMessage } from './MinimumStakeMessage';
+export * from './helpers';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingWidgetSlider.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingWidgetSlider.tsx
@@ -1,8 +1,8 @@
 import Decimal from 'decimal.js';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
-import { useAppContext } from '~hooks';
 
+import { useAppContext } from '~hooks';
 import Slider from '~shared/Slider';
 import { SetStateFn } from '~types';
 import { SLIDER_AMOUNT_KEY } from './StakingInput';
@@ -17,6 +17,7 @@ interface StakingWidgetSliderProps {
   remainingToStake: string;
   enoughTokensToStakeMinimum: boolean;
   isObjection: boolean;
+  enoughReputationToStakeMinimum: boolean;
   limit: Decimal;
   handleLimitExceeded: SetStateFn;
 }
@@ -26,6 +27,7 @@ const StakingWidgetSlider = ({
   remainingToStake,
   enoughTokensToStakeMinimum,
   isObjection,
+  enoughReputationToStakeMinimum,
   limit,
   handleLimitExceeded,
 }: StakingWidgetSliderProps) => {
@@ -46,7 +48,8 @@ const StakingWidgetSlider = ({
           isLoading ||
           !user ||
           remainingToStake === '0' ||
-          !enoughTokensToStakeMinimum
+          !enoughTokensToStakeMinimum ||
+          !enoughReputationToStakeMinimum
         }
         appearance={{
           theme: isObjection ? 'danger' : 'primary',

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/index.ts
@@ -5,6 +5,7 @@ export {
   StakingSlider,
   StakingWidgetValues,
   SLIDER_AMOUNT_KEY,
+  userHasInsufficientReputation,
 } from './StakingInput';
 export { default as GroupedTotalStake } from './GroupedTotalStake';
 export * from './StakingWidgetProvider';

--- a/src/hooks/helpers/motionHookHelpers.ts
+++ b/src/hooks/helpers/motionHookHelpers.ts
@@ -62,6 +62,7 @@ export const calculateStakeLimitDecimal = (
   userTotalStake: string,
   userActivatedTokens: BigNumber,
 ) => {
+  // corresponds to cantStakeMore error
   if (BigNumber.from(remainingToStake).lt(userMinStake)) {
     return new Decimal(0);
   }
@@ -71,6 +72,11 @@ export const calculateStakeLimitDecimal = (
 
   let adjustedStakingLimit = stakingLimit.sub(userMinStake);
 
+  /*
+   * Corresponds to moreRepNeeded error. If a user's ability to stake is limited
+   * by their reputation, then every time they stake, the limit should decrease to reflect
+   * the fact their total stake is getting closer to their max stake.
+   */
   if (
     userHasInsufficientReputation(
       userActivatedTokens,

--- a/src/hooks/useStakingSlider.ts
+++ b/src/hooks/useStakingSlider.ts
@@ -72,6 +72,7 @@ const useStakingSlider = (isObjection: boolean) => {
   /* User cannot stake more than their reputation in tokens. */
   const userMaxStake = BigNumber.from(userReputation ?? '0');
   const remainingToStake = isObjection ? nayRemaining : yayRemaining;
+  const enoughReputation = userMaxStake.gt(0) && userMaxStake.gte(userMinStake);
 
   const userStakeLimitDecimal = calculateStakeLimitDecimal(
     remainingToStake,
@@ -97,7 +98,10 @@ const useStakingSlider = (isObjection: boolean) => {
       userLoading ||
       walletConnecting ||
       loadingReputation ||
+      loadingReputation ||
       loadingActionData,
+    enoughReputation,
+    userMaxStake,
   };
 };
 

--- a/src/hooks/useStakingSlider.ts
+++ b/src/hooks/useStakingSlider.ts
@@ -43,7 +43,12 @@ const useStakingSlider = (isObjection: boolean) => {
     },
     rootHash,
     motionDomainId,
+    usersStakes,
   } = motionData;
+
+  const userStakes = usersStakes.find(
+    ({ address }) => address === user?.walletAddress,
+  );
 
   const { nativeTokenDecimals, nativeTokenSymbol, tokenAddress } = nativeToken;
 
@@ -72,12 +77,18 @@ const useStakingSlider = (isObjection: boolean) => {
   /* User cannot stake more than their reputation in tokens. */
   const userMaxStake = BigNumber.from(userReputation ?? '0');
   const remainingToStake = isObjection ? nayRemaining : yayRemaining;
-  const enoughReputation = userMaxStake.gt(0) && userMaxStake.gte(userMinStake);
+  const userTotalStake = isObjection
+    ? userStakes?.stakes.raw.nay
+    : userStakes?.stakes.raw.yay;
+
+  const enoughReputationToStakeMinimum =
+    userMaxStake.gt(0) && userMaxStake.gte(userMinStake);
 
   const userStakeLimitDecimal = calculateStakeLimitDecimal(
     remainingToStake,
     userMinStake,
     userMaxStake,
+    userTotalStake ?? '0',
     userActivatedTokens,
   );
 
@@ -91,6 +102,7 @@ const useStakingSlider = (isObjection: boolean) => {
     nativeTokenDecimals,
     nativeTokenSymbol,
     enoughTokensToStakeMinimum,
+    enoughReputationToStakeMinimum,
     userActivatedTokens,
     userStakeLimitDecimal,
     isLoadingData:
@@ -100,7 +112,6 @@ const useStakingSlider = (isObjection: boolean) => {
       loadingReputation ||
       loadingReputation ||
       loadingActionData,
-    enoughReputation,
     userMaxStake,
   };
 };


### PR DESCRIPTION
## Description

This PR ports the following staking validation error messages:

### Amount left to stake is less than min user stake 
![Screenshot (724)](https://user-images.githubusercontent.com/64402732/230068118-85f4417a-7ce1-4c83-a160-8b825c1e438d.png)

### User does not have enough reputation to stake 100% of the motion
![staking-limit](https://user-images.githubusercontent.com/64402732/230060943-6a59ecb9-fa24-4f95-b51e-705daaa58da4.gif)

### User does not have enough reputation to stake the min user stake
![min-rep](https://user-images.githubusercontent.com/64402732/230053913-f8660ef3-816d-494b-9f03-6081fb2bcd7d.png)


### Testing

1. Amount left to stake is less than min user stake 

Stake a motion 99%. You should find yourself in that awkward position where the amount left to stake is less than the min user stake. I have copied the logic over exactly from the dapp, but updated the copy as the previous message said: 
"The motion can't be staked more than the minimum stake", which is obviously false.

2.  User does not have enough reputation to stake 100% of the motion

For this it'll be easiest to manually hardcode the `userMaxStake` values in `useStakingSlider` and `useStakingControls`. It needs to be more than the min user stake, but less than the required stake. `10000000000000000` worked for me.

(Note that we have userMaxStake in two places due to the StakingSlider handling its own data. Because I can't access colony context or staking widget provider context inside the objection dialog, sharing logic between these two is very awkward).

As you stake, you should see the limit decrease since you're get closer and closer to your max stake.

3. User does not have enough reputation to stake the min user stake

Reset the max user stake to what it should be. Create a motion with a user with reputation, like normal. Then switch to a wallet without rep and you should see the error message.

**New stuff**  ✨

* The staking error messages seen above

Contributes to #270
