### PR TITLE
Port Voting widget UI

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/DefaultMotion.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/DefaultMotion.tsx
@@ -4,7 +4,7 @@ import { MotionState as NetworkMotionState } from '@colony/colony-js';
 import DetailsWidget from '~shared/DetailsWidget';
 import { useColonyContext, useEnabledExtensions } from '~hooks';
 import { ColonyAction } from '~types';
-import { getMotionState } from '~utils/colonyMotions';
+import { getMotionState, MotionState } from '~utils/colonyMotions';
 import { STAKING_THRESHOLD } from '~constants';
 
 import { DefaultActionContent } from '../DefaultAction';
@@ -36,7 +36,7 @@ const DefaultMotion = ({
     return null;
   }
 
-  const motionState = getMotionState(networkMotionState, actionData.motionData);
+  const motionState = MotionState.Voting; //getMotionState(networkMotionState, actionData.motionData);
 
   const {
     motionData: {

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
@@ -8,6 +8,7 @@ import { MotionState } from '~utils/colonyMotions';
 import ClaimMotionStakes from './ClaimMotionStakes';
 import FinalizeMotion from './FinalizeMotion';
 import StakingWidget, { StakingWidgetProvider } from './StakingWidget';
+import { VotingWidget } from './VotingWidget';
 
 const displayName =
   'common.ColonyActions.ActionDetailsPage.DefaultMotion.MotionPhaseWidget';
@@ -84,6 +85,16 @@ const MotionPhaseWidget = ({
       }
 
       return <ClaimMotionStakes motionData={motionData} {...rest} />;
+    }
+
+    case MotionState.Voting: {
+      return (
+        <VotingWidget
+          actionType={type}
+          motionData={motionData}
+          motionState={motionState}
+        />
+      );
     }
 
     /* Extend with other widgets as they get ported. */

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteButton.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteButton.css
@@ -1,0 +1,4 @@
+.main button {
+  width: 100px;
+  font-size: var(--size-small);
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteButton.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteButton.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace VoteButtonCssNamespace {
+  export interface IVoteButtonCss {
+    main: string;
+  }
+}
+
+declare const VoteButtonCssModule: VoteButtonCssNamespace.IVoteButtonCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: VoteButtonCssNamespace.IVoteButtonCss;
+};
+
+export = VoteButtonCssModule;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteButton.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteButton.tsx
@@ -7,6 +7,8 @@ import { formatText } from '~utils/intl';
 
 import { VOTE_FORM_KEY } from './VotingWidget';
 
+import styles from './VoteButton.css';
+
 const displayName =
   'common.ColonyActions.ActionDetailsPage.DefaultMotion.VotingWidget.VoteButton';
 
@@ -23,22 +25,24 @@ const VoteButton = () => {
   const vote = getValues(VOTE_FORM_KEY);
 
   return (
-    <Button
-      appearance={{ theme: 'primary', size: 'medium' }}
-      text={formatText({
-        id: hasUserVoted ? 'button.changeVote' : 'button.vote',
-      })}
-      disabled={
-        !isValid ||
-        !user ||
-        vote === undefined ||
-        !hasReputationToVote ||
-        isSubmitting
-      }
-      type="submit"
-      loading={isSubmitting}
-      dataTest="voteButton"
-    />
+    <div className={styles.main}>
+      <Button
+        appearance={{ theme: 'primary', size: 'medium' }}
+        text={formatText({
+          id: hasUserVoted ? 'button.changeVote' : 'button.vote',
+        })}
+        disabled={
+          !isValid ||
+          !user ||
+          vote === undefined ||
+          !hasReputationToVote ||
+          isSubmitting
+        }
+        type="submit"
+        loading={isSubmitting}
+        dataTest="voteButton"
+      />
+    </div>
   );
 };
 

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteButton.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteButton.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { useAppContext } from '~hooks';
+import Button from '~shared/Button';
+import { formatText } from '~utils/intl';
+
+import { VOTE_FORM_KEY } from './VotingWidget';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPage.DefaultMotion.VotingWidget.VoteButton';
+
+const VoteButton = () => {
+  const { user } = useAppContext();
+  const {
+    formState: { isValid, isSubmitting },
+    getValues,
+  } = useFormContext();
+
+  // TODO
+  const hasUserVoted = false;
+  const hasReputationToVote = true;
+  const vote = getValues(VOTE_FORM_KEY);
+
+  return (
+    <Button
+      appearance={{ theme: 'primary', size: 'medium' }}
+      text={formatText({
+        id: hasUserVoted ? 'button.changeVote' : 'button.vote',
+      })}
+      disabled={
+        !isValid ||
+        !user ||
+        vote === undefined ||
+        !hasReputationToVote ||
+        isSubmitting
+      }
+      type="submit"
+      loading={isSubmitting}
+      dataTest="voteButton"
+    />
+  );
+};
+
+VoteButton.displayName = displayName;
+
+export default VoteButton;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteDetails.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteDetails.css
@@ -1,0 +1,3 @@
+.main > div:last-of-type {
+  border-bottom-color: transparent;
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteDetails.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteDetails.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace VoteDetailsCssNamespace {
+  export interface IVoteDetailsCss {
+    main: string;
+  }
+}
+
+declare const VoteDetailsCssModule: VoteDetailsCssNamespace.IVoteDetailsCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: VoteDetailsCssNamespace.IVoteDetailsCss;
+};
+
+export = VoteDetailsCssModule;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteDetails.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteDetails.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import DetailItem from '~shared/DetailsWidget/DetailItem';
+import { MotionState } from '~utils/colonyMotions';
+
+import { useVoteDetailsConfig } from './useVoteDetailsConfig';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPage.DefaultMotion.VotingWidget.VoteDetails';
+
+interface VoteDetailsProps {
+  motionState: MotionState;
+  button: JSX.Element;
+}
+
+const VoteDetails = ({ motionState, button }: VoteDetailsProps) => {
+  const voteDetailsConfig = useVoteDetailsConfig(motionState, button);
+  return voteDetailsConfig.map((config) => (
+    <DetailItem {...config} key={config.label.id} />
+  ));
+};
+
+VoteDetails.displayName = displayName;
+
+export default VoteDetails;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteDetails.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteDetails.tsx
@@ -8,7 +8,7 @@ import { useVoteDetailsConfig } from './useVoteDetailsConfig';
 const displayName =
   'common.ColonyActions.ActionDetailsPage.DefaultMotion.VotingWidget.VoteDetails';
 
-interface VoteDetailsProps {
+export interface VoteDetailsProps {
   motionState: MotionState;
   button: JSX.Element;
 }

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteDetails.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteDetails.tsx
@@ -4,6 +4,7 @@ import DetailItem from '~shared/DetailsWidget/DetailItem';
 import { MotionState } from '~utils/colonyMotions';
 
 import { useVoteDetailsConfig } from './useVoteDetailsConfig';
+import styles from './VoteDetails.css';
 
 const displayName =
   'common.ColonyActions.ActionDetailsPage.DefaultMotion.VotingWidget.VoteDetails';
@@ -18,11 +19,11 @@ export interface VoteDetailsProps {
 const VoteDetails = (props: VoteDetailsProps) => {
   const voteDetailsConfig = useVoteDetailsConfig(props);
   return (
-    <>
+    <div className={styles.main}>
       {voteDetailsConfig.map((config) => (
         <DetailItem {...config} key={config.label} />
       ))}
-    </>
+    </div>
   );
 };
 

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteDetails.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteDetails.tsx
@@ -10,14 +10,20 @@ const displayName =
 
 export interface VoteDetailsProps {
   motionState: MotionState;
-  button: JSX.Element;
+  motionId: string;
+  motionDomainId: string;
+  hasUserVoted: boolean;
 }
 
-const VoteDetails = ({ motionState, button }: VoteDetailsProps) => {
-  const voteDetailsConfig = useVoteDetailsConfig(motionState, button);
-  return voteDetailsConfig.map((config) => (
-    <DetailItem {...config} key={config.label.id} />
-  ));
+const VoteDetails = (props: VoteDetailsProps) => {
+  const voteDetailsConfig = useVoteDetailsConfig(props);
+  return (
+    <>
+      {voteDetailsConfig.map((config) => (
+        <DetailItem {...config} key={config.label} />
+      ))}
+    </>
+  );
 };
 
 VoteDetails.displayName = displayName;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteRewardItem.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteRewardItem.css
@@ -1,0 +1,33 @@
+.tokenIcon {
+  margin-right: 6px;
+}
+
+.range {
+  display: inline-block;
+  margin: -2px 5px 0;
+  height: 1px;
+  width: 30px;
+  position: relative;
+  vertical-align: middle;
+  background: linear-gradient(90deg, var(--pink) 4.65%, var(--primary) 101.16%);
+}
+
+.range::before,
+.range::after {
+  display: block;
+  height: 5px;
+  width: 5px;
+  position: absolute;
+  top: -2px;
+  border-radius: 50%;
+}
+
+.range::before {
+  left: 0;
+  background-color: var(--pink);
+}
+
+.range::after {
+  right: 0;
+  background-color: var(--primary);
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteRewardItem.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteRewardItem.css.d.ts
@@ -1,0 +1,13 @@
+declare namespace VoteRewardItemCssNamespace {
+  export interface IVoteRewardItemCss {
+    range: string;
+    tokenIcon: string;
+  }
+}
+
+declare const VoteRewardItemCssModule: VoteRewardItemCssNamespace.IVoteRewardItemCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: VoteRewardItemCssNamespace.IVoteRewardItemCss;
+};
+
+export = VoteRewardItemCssModule;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteRewardItem.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteRewardItem.tsx
@@ -8,7 +8,7 @@ import styles from './VoteRewardItem.css';
 const displayName =
   'common.ColonyActions.ActionDetailsPage.DefaultMotion.VotingWidget.VoteReward';
 
-const VoteReward = () => {
+const VoteRewardItem = () => {
   const { colony } = useColonyContext();
   const { nativeToken } = colony || {};
   const minReward = '1000000000000000000';
@@ -66,6 +66,6 @@ const VoteReward = () => {
     )} */
 };
 
-VoteReward.displayName = displayName;
+VoteRewardItem.displayName = displayName;
 
-export default VoteReward;
+export default VoteRewardItem;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteRewardItem.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteRewardItem.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { useColonyContext } from '~hooks';
+import Numeral from '~shared/Numeral';
+import TokenIcon from '~shared/TokenIcon';
+
+import styles from './VoteRewardItem.css';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPage.DefaultMotion.VotingWidget.VoteReward';
+
+const VoteReward = () => {
+  const { colony } = useColonyContext();
+  const { nativeToken } = colony || {};
+  const minReward = '1000000000000000000';
+  const maxReward = '10000000000000000000';
+  const showRewardRange = minReward !== maxReward;
+  // if (motionState === MotionState.Voting) {
+  return (
+    <>
+      {nativeToken && (
+        <TokenIcon
+          className={styles.tokenIcon}
+          token={nativeToken}
+          size="xxs"
+        />
+      )}
+      {minReward && (
+        <Numeral
+          value={minReward}
+          decimals={nativeToken?.decimals}
+          appearance={{ theme: 'dark', size: 'small' }}
+          suffix={showRewardRange ? undefined : nativeToken?.symbol}
+        />
+      )}
+      {showRewardRange && maxReward && (
+        <>
+          <div className={styles.range} />
+          <Numeral
+            value={maxReward}
+            decimals={nativeToken?.decimals}
+            appearance={{ theme: 'dark', size: 'small' }}
+            suffix={nativeToken?.symbol}
+          />
+        </>
+      )}
+    </>
+  );
+  // }
+  /* {motionState === MotionState.Reveal && (
+      <>
+        <TokenIcon
+          className={styles.tokenIcon}
+          token={nativeToken}
+          name={nativeToken.name || nativeToken.address}
+          size="xxs"
+        />
+        <Numeral
+          value={getFormattedTokenValue(
+            voterReward.motionVoterReward.reward,
+            nativeToken?.decimals,
+          )}
+          suffix={nativeToken?.symbol}
+          appearance={{ theme: 'dark', size: 'small' }}
+        />
+      </>
+    )} */
+};
+
+VoteReward.displayName = displayName;
+
+export default VoteReward;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingPanel.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingPanel.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { useAppContext } from '~hooks';
+import { CustomRadioGroup } from '~shared/Fields';
+
+import { getVotingPanelConfig } from './getVotingPanelConfig';
+import { VOTE_FORM_KEY } from './VotingWidget';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPage.DefaultMotion.VotingWidget.VotingPanel';
+
+const VotingPanel = () => {
+  const { user } = useAppContext();
+  const {
+    formState: { isSubmitting },
+    getValues,
+  } = useFormContext();
+
+  // Wire in...
+  const hasReputationToVote = true;
+  const vote = getValues(VOTE_FORM_KEY);
+  const disabled = !user || !hasReputationToVote || isSubmitting;
+  const config = getVotingPanelConfig(vote, disabled);
+
+  return (
+    <CustomRadioGroup
+      appearance={{ direction: 'vertical' }}
+      options={config}
+      currentlyCheckedValue={vote}
+      name="vote"
+      disabled={disabled}
+    />
+  );
+};
+
+VotingPanel.displayName = displayName;
+
+export default VotingPanel;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingWidget.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingWidget.css
@@ -1,0 +1,16 @@
+.main {
+  display: block;
+  margin: 0px 0 100px 0;
+}
+
+.voteHiddenContainer {
+  margin-top: 20px;
+  padding: 13px 10px;
+  width: 340px;
+  background: var(--colony-light-blue);
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
+  text-align: center;
+  white-space: pre-line;
+  color: var(--grey-purple);
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingWidget.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingWidget.css.d.ts
@@ -1,0 +1,13 @@
+declare namespace VotingWidgetCssNamespace {
+  export interface IVotingWidgetCss {
+    main: string;
+    voteHiddenContainer: string;
+  }
+}
+
+declare const VotingWidgetCssModule: VotingWidgetCssNamespace.IVotingWidgetCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: VotingWidgetCssNamespace.IVotingWidgetCss;
+};
+
+export = VotingWidgetCssModule;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingWidget.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingWidget.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { object, number, InferType } from 'yup';
+
+import { ActionHookForm as ActionForm } from '~shared/Fields';
+import { ActionTypes } from '~redux';
+
+import styles from './VotingWidget.css';
+import VotingWidgetHeading from './VotingWidgetHeading';
+import { ColonyActionType } from '~gql';
+import VoteButton from './VoteButton';
+import { MotionData } from '~types';
+import { MotionState } from '~utils/colonyMotions';
+import VoteDetails from './VoteDetails';
+import VotingPanel from './VotingPanel';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPage.DefaultMotion.VotingWidget';
+
+const MSG = defineMessages({
+  voteHidden: {
+    id: `${displayName}.voteHidden`,
+    defaultMessage: `Your vote is hidden from others.\nYou can change your vote.`,
+  },
+});
+
+const validationSchema = object()
+  .shape({
+    vote: number().required(),
+  })
+  .defined();
+
+type VotingFormValues = InferType<typeof validationSchema>;
+
+interface VotingWidgetProps {
+  actionType: ColonyActionType;
+  motionData: MotionData;
+  motionState: MotionState;
+}
+
+export const VOTE_FORM_KEY = 'vote';
+
+const VotingWidget = ({
+  actionType,
+  // motionData: { motionId },
+  motionState,
+}: VotingWidgetProps) => {
+  const hasUserVoted = false;
+  return (
+    <>
+      {hasUserVoted && (
+        <p className={styles.voteHiddenContainer}>
+          <FormattedMessage {...MSG.voteHidden} />
+        </p>
+      )}
+      <ActionForm<VotingFormValues>
+        defaultValues={{
+          [VOTE_FORM_KEY]: undefined,
+        }}
+        validationSchema={validationSchema}
+        actionType={ActionTypes.MOTION_VOTE}
+        // transform={transform}
+        // onSuccess={handleSuccess}
+      >
+        <div className={styles.main}>
+          <VotingWidgetHeading actionType={actionType} />
+          <VotingPanel />
+          <VoteDetails
+            // motionId={motionId}
+            motionState={motionState}
+            // showReward={hasReputationToVote}
+            button={<VoteButton />}
+          />
+        </div>
+      </ActionForm>
+    </>
+  );
+};
+
+VotingWidget.displayName = displayName;
+
+export default VotingWidget;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingWidget.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingWidget.tsx
@@ -5,14 +5,12 @@ import { object, number, InferType } from 'yup';
 import { ActionHookForm as ActionForm } from '~shared/Fields';
 import { ActionTypes } from '~redux';
 
-import styles from './VotingWidget.css';
-import VotingWidgetHeading from './VotingWidgetHeading';
 import { ColonyActionType } from '~gql';
-import VoteButton from './VoteButton';
 import { MotionData } from '~types';
 import { MotionState } from '~utils/colonyMotions';
-import VoteDetails from './VoteDetails';
-import VotingPanel from './VotingPanel';
+import { VoteDetails, VotingPanel, VotingWidgetHeading } from '.';
+
+import styles from './VotingWidget.css';
 
 const displayName =
   'common.ColonyActions.ActionDetailsPage.DefaultMotion.VotingWidget';
@@ -42,7 +40,7 @@ export const VOTE_FORM_KEY = 'vote';
 
 const VotingWidget = ({
   actionType,
-  // motionData: { motionId },
+  motionData: { motionId, motionDomainId },
   motionState,
 }: VotingWidgetProps) => {
   const hasUserVoted = false;
@@ -66,10 +64,10 @@ const VotingWidget = ({
           <VotingWidgetHeading actionType={actionType} />
           <VotingPanel />
           <VoteDetails
-            // motionId={motionId}
+            motionId={motionId}
             motionState={motionState}
-            // showReward={hasReputationToVote}
-            button={<VoteButton />}
+            motionDomainId={motionDomainId}
+            hasUserVoted={false}
           />
         </div>
       </ActionForm>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingWidgetHeading.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingWidgetHeading.css
@@ -1,0 +1,3 @@
+.main h4 {
+  padding: 20px 0;
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingWidgetHeading.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingWidgetHeading.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace VotingWidgetHeadingCssNamespace {
+  export interface IVotingWidgetHeadingCss {
+    main: string;
+  }
+}
+
+declare const VotingWidgetHeadingCssModule: VotingWidgetHeadingCssNamespace.IVotingWidgetHeadingCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: VotingWidgetHeadingCssNamespace.IVotingWidgetHeadingCss;
+};
+
+export = VotingWidgetHeadingCssModule;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingWidgetHeading.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingWidgetHeading.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+
+import { ColonyActionType } from '~gql';
+import { Heading4 } from '~shared/Heading';
+import { formatText } from '~utils/intl';
+
+import styles from './VotingWidgetHeading.css';
+
+const displayName =
+  'common.ColonyActions.ActionDetailsPage.DefaultMotion.VotingWidgetHeading';
+
+const MSG = defineMessages({
+  title: {
+    id: `${displayName}.title`,
+    defaultMessage: `Should "{actionType}" be approved?`,
+  },
+});
+
+interface VotingWidgetHeadingProps {
+  actionType: ColonyActionType;
+}
+
+const VotingWidgetHeading = ({ actionType }: VotingWidgetHeadingProps) => {
+  const formattedActionType = formatText({ id: 'action.type' }, { actionType });
+  return (
+    <div className={styles.main}>
+      <Heading4
+        text={MSG.title}
+        textValues={{
+          actionType: formattedActionType,
+        }}
+        appearance={{ weight: 'bold', theme: 'dark', margin: 'none' }}
+      />
+    </div>
+  );
+};
+
+VotingWidgetHeading.displayName = displayName;
+
+export default VotingWidgetHeading;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/getVotingPanelConfig.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/getVotingPanelConfig.ts
@@ -22,26 +22,22 @@ const getIcon = (
 export const getVotingPanelConfig = (
   checkedValue: MotionVote,
   inputDisabled: boolean,
-): CustomRadioProps[] => [
+): Omit<CustomRadioProps, 'checked' | 'name'>[] => [
   {
     value: MotionVote.Yay,
     label: { id: 'button.yes' },
-    name: 'vote',
     appearance: {
       theme: 'primary',
     },
-    checked: false,
     icon: getIcon(inputDisabled, MotionVote.Yay, checkedValue),
     dataTest: 'yesVoteButton',
   },
   {
     value: MotionVote.Nay,
     label: { id: 'button.no' },
-    name: 'vote',
     appearance: {
       theme: 'danger',
     },
-    checked: false,
     icon: getIcon(inputDisabled, MotionVote.Nay, checkedValue),
   },
 ];

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/getVotingPanelConfig.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/getVotingPanelConfig.ts
@@ -1,0 +1,47 @@
+import { CustomRadioProps } from '~shared/Fields';
+import { MotionVote } from '~utils/colonyMotions';
+
+const getIcon = (
+  inputDisabled: boolean,
+  vote: MotionVote,
+  checkedValue?: MotionVote,
+) => {
+  const direction = vote === MotionVote.Nay ? 'down' : 'up';
+  const icon = `circle-thumbs-${direction}`;
+  if (inputDisabled) {
+    return `${icon}-grey`;
+  }
+
+  if (checkedValue === vote) {
+    return icon;
+  }
+
+  return `${icon}-outlined`;
+};
+
+export const getVotingPanelConfig = (
+  checkedValue: MotionVote,
+  inputDisabled: boolean,
+): CustomRadioProps[] => [
+  {
+    value: MotionVote.Yay,
+    label: { id: 'button.yes' },
+    name: 'vote',
+    appearance: {
+      theme: 'primary',
+    },
+    checked: false,
+    icon: getIcon(inputDisabled, MotionVote.Yay, checkedValue),
+    dataTest: 'yesVoteButton',
+  },
+  {
+    value: MotionVote.Nay,
+    label: { id: 'button.no' },
+    name: 'vote',
+    appearance: {
+      theme: 'danger',
+    },
+    checked: false,
+    icon: getIcon(inputDisabled, MotionVote.Nay, checkedValue),
+  },
+];

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/index.ts
@@ -1,0 +1,1 @@
+export { default as VotingWidget } from './VotingWidget';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/index.ts
@@ -1,2 +1,7 @@
 export { default as VotingWidget } from './VotingWidget';
+export { default as VoteButton } from './VoteButton';
+export { VoteDetailsProps } from './VoteDetails';
 export { default as VoteRewardItem } from './VoteRewardItem';
+export { default as VotingPanel } from './VotingPanel';
+export { default as VoteDetails } from './VoteDetails';
+export { default as VotingWidgetHeading } from './VotingWidgetHeading';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/index.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/index.ts
@@ -1,1 +1,2 @@
 export { default as VotingWidget } from './VotingWidget';
+export { default as VoteRewardItem } from './VoteRewardItem';

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/useVoteDetailsConfig.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/useVoteDetailsConfig.tsx
@@ -6,7 +6,7 @@ import { DetailItemProps } from '~shared/DetailsWidget';
 import MemberReputation from '~shared/MemberReputation';
 import { intl } from '~utils/intl';
 
-import { VoteDetailsProps, VoteButton, VoteReward } from '.';
+import { VoteDetailsProps, VoteButton, VoteRewardItem } from '.';
 
 const { formatMessage } = intl({
   'label.votingMethod': 'Voting method',
@@ -29,7 +29,7 @@ interface VoteDetailsConfig extends DetailItemProps {
 
 export const useVoteDetailsConfig = ({
   //  motionState,
-  motionId,
+  // motionId,
   motionDomainId,
 }: // hasUserVoted,
 VoteDetailsProps): VoteDetailsConfig[] => {
@@ -72,13 +72,7 @@ VoteDetailsProps): VoteDetailsConfig[] => {
       {
         label: formatMessage({ id: 'label.reward' }),
         tooltipText: formatMessage({ id: 'tooltip.reward' }),
-        item: (
-          <VoteReward
-            //  motionState={motionState}
-            motionId={motionId}
-            motionDomainId={motionDomainId}
-          />
-        ),
+        item: <VoteRewardItem />,
       },
     );
   }

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/useVoteDetailsConfig.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/useVoteDetailsConfig.tsx
@@ -1,89 +1,87 @@
+import { BigNumber } from 'ethers';
 import React from 'react';
-import { defineMessages, MessageDescriptor } from 'react-intl';
+
 import { useAppContext, useColonyContext, useUserReputation } from '~hooks';
 import { DetailItemProps } from '~shared/DetailsWidget';
 import MemberReputation from '~shared/MemberReputation';
-import { MotionState } from '~utils/colonyMotions';
-import { formatText } from '~utils/intl';
-import VoteReward from './VoteReward';
+import { intl } from '~utils/intl';
 
-const MSG = defineMessages({
-  votingMethodLabel: {
-    id: 'dashboard.ActionsPage.VoteWidget.votingMethodLabel',
-    defaultMessage: `Voting method`,
-  },
-  votingMethodValue: {
-    id: 'dashboard.ActionsPage.VoteWidget.votingMethodValue',
-    defaultMessage: `Reputation-weighted`,
-  },
-  votingMethodTooltip: {
-    id: 'dashboard.ActionsPage.VoteWidget.votingMethodTooltip',
-    defaultMessage: `Votes are weighted by reputation in the team in which the vote is happening.`,
-  },
-  reputationTeamLabel: {
-    id: 'dashboard.ActionsPage.VoteWidget.reputationTeamLabel',
-    defaultMessage: `Reputation in team`,
-  },
-  reputationTeamTooltip: {
-    id: 'dashboard.ActionsPage.VoteWidget.reputationTeamTooltip',
-    defaultMessage: `This is the % of the reputation you have in this team.`,
-  },
-  rewardLabel: {
-    id: 'dashboard.ActionsPage.VoteWidget.rewardLabel',
-    defaultMessage: `Reward`,
-  },
-  rewardTooltip: {
-    id: 'dashboard.ActionsPage.VoteWidget.rewardTooltip',
-    defaultMessage: `This is the range of values between which your reward for voting will be, subject to the number of people that participate in the vote.`,
-  },
-  rulesLabel: {
-    id: 'dashboard.ActionsPage.VoteWidget.rulesLabel',
-    defaultMessage: `Rules`,
-  },
-  rulesTooltip: {
-    id: 'dashboard.ActionsPage.VoteWidget.rulesTooltip',
-    defaultMessage: `Votes are secret and must be revealed at the end of the voting period to count.`,
-  },
+import { VoteDetailsProps, VoteButton, VoteReward } from '.';
+
+const { formatMessage } = intl({
+  'label.votingMethod': 'Voting method',
+  'value.votingMethod': 'Reputation-weighted',
+  'tooltip.votingMethod':
+    'Votes are weighted by reputation in the team in which the vote is happening.',
+  'label.reputationTeam': 'Reputation in team',
+  'tooltip.reputationTeam':
+    'This is the % of the reputation you have in this team.',
+  'label.reward': 'Reward',
+  'tooltip.reward': `This is the range of values between which your reward for voting will be, subject to the number of people that participate in the vote.`,
+  'label.rules': 'Rules',
+  'tooltip.rules':
+    'Votes are secret and must be revealed at the end of the voting period to count.',
 });
 
 interface VoteDetailsConfig extends DetailItemProps {
-  label: MessageDescriptor;
+  label: string;
 }
-export const useVoteDetailsConfig = (
-  motionState: MotionState,
-  button: JSX.Element,
-): VoteDetailsConfig[] => {
+
+export const useVoteDetailsConfig = ({
+  //  motionState,
+  motionId,
+  motionDomainId,
+}: // hasUserVoted,
+VoteDetailsProps): VoteDetailsConfig[] => {
   const { user } = useAppContext();
   const { colony } = useColonyContext();
   const { userReputation, totalReputation } = useUserReputation(
     colony?.colonyAddress ?? '',
     user?.walletAddress ?? '',
+    Number(motionDomainId),
   );
-  return [
+  const hasReputationToVote = BigNumber.from(userReputation ?? 0).gt(0);
+
+  const config = [
     {
-      label: MSG.votingMethodLabel,
-      tooltipText: MSG.votingMethodTooltip,
-      item: formatText(MSG.votingMethodValue),
+      label: formatMessage({ id: 'label.votingMethod' }),
+      tooltipText: formatMessage({ id: 'tooltip.votingMethod' }),
+      item: formatMessage({ id: 'value.votingMethod' }),
     },
     {
-      label: MSG.reputationTeamLabel,
-      tooltipText: MSG.reputationTeamTooltip,
-      item: (
-        <MemberReputation
-          userReputation={userReputation}
-          totalReputation={totalReputation}
-        />
-      ),
-    },
-    {
-      label: MSG.rewardLabel,
-      tooltipText: MSG.rewardTooltip,
-      item: <VoteReward motionState={motionState} />,
-    },
-    {
-      label: MSG.rulesLabel,
-      tooltipText: MSG.rulesTooltip,
-      item: button,
+      label: formatMessage({ id: 'label.rules' }),
+      tooltipText: formatMessage({ id: 'tooltip.rules' }),
+      item: <VoteButton />,
     },
   ];
+
+  if (hasReputationToVote) {
+    config.splice(
+      1,
+      0,
+      {
+        label: formatMessage({ id: 'label.reputationTeam' }),
+        tooltipText: formatMessage({ id: 'tooltip.reputationTeam' }),
+        item: (
+          <MemberReputation
+            userReputation={userReputation}
+            totalReputation={totalReputation}
+          />
+        ),
+      },
+      {
+        label: formatMessage({ id: 'label.reward' }),
+        tooltipText: formatMessage({ id: 'tooltip.reward' }),
+        item: (
+          <VoteReward
+            //  motionState={motionState}
+            motionId={motionId}
+            motionDomainId={motionDomainId}
+          />
+        ),
+      },
+    );
+  }
+
+  return config;
 };

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/useVoteDetailsConfig.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/useVoteDetailsConfig.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { defineMessages, MessageDescriptor } from 'react-intl';
+import { useAppContext, useColonyContext, useUserReputation } from '~hooks';
+import { DetailItemProps } from '~shared/DetailsWidget';
+import MemberReputation from '~shared/MemberReputation';
+import { MotionState } from '~utils/colonyMotions';
+import { formatText } from '~utils/intl';
+import VoteReward from './VoteReward';
+
+const MSG = defineMessages({
+  votingMethodLabel: {
+    id: 'dashboard.ActionsPage.VoteWidget.votingMethodLabel',
+    defaultMessage: `Voting method`,
+  },
+  votingMethodValue: {
+    id: 'dashboard.ActionsPage.VoteWidget.votingMethodValue',
+    defaultMessage: `Reputation-weighted`,
+  },
+  votingMethodTooltip: {
+    id: 'dashboard.ActionsPage.VoteWidget.votingMethodTooltip',
+    defaultMessage: `Votes are weighted by reputation in the team in which the vote is happening.`,
+  },
+  reputationTeamLabel: {
+    id: 'dashboard.ActionsPage.VoteWidget.reputationTeamLabel',
+    defaultMessage: `Reputation in team`,
+  },
+  reputationTeamTooltip: {
+    id: 'dashboard.ActionsPage.VoteWidget.reputationTeamTooltip',
+    defaultMessage: `This is the % of the reputation you have in this team.`,
+  },
+  rewardLabel: {
+    id: 'dashboard.ActionsPage.VoteWidget.rewardLabel',
+    defaultMessage: `Reward`,
+  },
+  rewardTooltip: {
+    id: 'dashboard.ActionsPage.VoteWidget.rewardTooltip',
+    defaultMessage: `This is the range of values between which your reward for voting will be, subject to the number of people that participate in the vote.`,
+  },
+  rulesLabel: {
+    id: 'dashboard.ActionsPage.VoteWidget.rulesLabel',
+    defaultMessage: `Rules`,
+  },
+  rulesTooltip: {
+    id: 'dashboard.ActionsPage.VoteWidget.rulesTooltip',
+    defaultMessage: `Votes are secret and must be revealed at the end of the voting period to count.`,
+  },
+});
+
+interface VoteDetailsConfig extends DetailItemProps {
+  label: MessageDescriptor;
+}
+export const useVoteDetailsConfig = (
+  motionState: MotionState,
+  button: JSX.Element,
+): VoteDetailsConfig[] => {
+  const { user } = useAppContext();
+  const { colony } = useColonyContext();
+  const { userReputation, totalReputation } = useUserReputation(
+    colony?.colonyAddress ?? '',
+    user?.walletAddress ?? '',
+  );
+  return [
+    {
+      label: MSG.votingMethodLabel,
+      tooltipText: MSG.votingMethodTooltip,
+      item: formatText(MSG.votingMethodValue),
+    },
+    {
+      label: MSG.reputationTeamLabel,
+      tooltipText: MSG.reputationTeamTooltip,
+      item: (
+        <MemberReputation
+          userReputation={userReputation}
+          totalReputation={totalReputation}
+        />
+      ),
+    },
+    {
+      label: MSG.rewardLabel,
+      tooltipText: MSG.rewardTooltip,
+      item: <VoteReward motionState={motionState} />,
+    },
+    {
+      label: MSG.rulesLabel,
+      tooltipText: MSG.rulesTooltip,
+      item: button,
+    },
+  ];
+};

--- a/src/components/shared/DetailsWidget/DetailItem.tsx
+++ b/src/components/shared/DetailsWidget/DetailItem.tsx
@@ -9,7 +9,7 @@ import styles from './DetailItem.css';
 
 const displayName = 'DetailsWidget.DetailItem';
 
-interface DetailItemProps {
+export interface DetailItemProps {
   label: Message;
   labelValues?: UniversalMessageValues;
   item: ReactNode;

--- a/src/components/shared/DetailsWidget/index.ts
+++ b/src/components/shared/DetailsWidget/index.ts
@@ -1,4 +1,5 @@
 export { default } from './DetailsWidget';
+export { default as DetailItem, DetailItemProps } from './DetailItem';
 export { default as ActionTypeDetail } from './ActionTypeDetail';
 export { default as AmountDetail } from './AmountDetail';
 export { default as DomainDescriptionDetail } from './DomainDescriptionDetail';

--- a/src/components/shared/Fields/RadioGroup/CustomRadioGroup.tsx
+++ b/src/components/shared/Fields/RadioGroup/CustomRadioGroup.tsx
@@ -15,7 +15,7 @@ interface Props {
   appearance?: Appearance;
   options: Omit<CustomRadioProps, 'name' | 'checked'>[];
   /** Currently selected value */
-  currentlyCheckedValue: string;
+  currentlyCheckedValue?: string | number;
   /** HTML field name */
   name: string;
   /** Disable the input */
@@ -33,25 +33,22 @@ const CustomRadioGroup = ({
   appearance = { direction: 'horizontal' },
   disabled,
   dataTest,
-}: Props) => {
-  return (
-    <div className={getMainClasses(appearance, styles)}>
-      {options.map(({ value, label, appearance: optionApperance, ...rest }) => (
-        <CustomRadio
-          checked={currentlyCheckedValue === value}
-          name={name}
-          value={value}
-          label={label}
-          key={value}
-          appearance={{ ...optionApperance }}
-          disabled={disabled}
-          dataTest={dataTest}
-          {...rest}
-        />
-      ))}
-    </div>
-  );
-};
+}: Props) => (
+  <div className={getMainClasses(appearance, styles)}>
+    {options.map(({ value, appearance: optionApperance, ...rest }) => (
+      <CustomRadio
+        checked={currentlyCheckedValue === value}
+        name={name}
+        value={value}
+        key={value}
+        appearance={{ ...optionApperance }}
+        disabled={disabled}
+        dataTest={dataTest}
+        {...rest}
+      />
+    ))}
+  </div>
+);
 
 CustomRadioGroup.displayName = displayName;
 

--- a/src/components/shared/Numeral/Numeral.css
+++ b/src/components/shared/Numeral/Numeral.css
@@ -5,3 +5,7 @@
 .themeDark {
   color: var(--dark);
 }
+
+.sizeSmall {
+  font-size: var(--size-small);
+}

--- a/src/components/shared/Numeral/Numeral.css.d.ts
+++ b/src/components/shared/Numeral/Numeral.css.d.ts
@@ -1,6 +1,7 @@
 declare namespace NumeralCssNamespace {
   export interface INumeralCss {
     main: string;
+    sizeSmall: string;
     themeDark: string;
   }
 }

--- a/src/components/shared/Numeral/Numeral.tsx
+++ b/src/components/shared/Numeral/Numeral.tsx
@@ -25,6 +25,7 @@ export type NumeralValue = string | number | BigNumber | Decimal;
 
 export interface Appearance {
   theme?: 'dark';
+  size?: 'small';
 }
 
 export interface Props extends HTMLAttributes<HTMLSpanElement> {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -48,6 +48,8 @@
   "button.publish": "Publish",
   "button.update": "Update",
   "button.upgrade": "Upgrade",
+  "button.changeVote": "Change Vote",
+  "button.vote": "Vote",
   "input.resetText": "Cancel",
   "label.amount": "Amount",
   "label.name": "Name",


### PR DESCRIPTION
## Description

This PR ports the voting widget ui (only, no wiring).

![voting widg](https://user-images.githubusercontent.com/64402732/230361161-c1197ff8-43de-4beb-8fca-6348c77f89fa.png)


## Testing

Just follow the basic set up to "Test mint token", as I've hardcoded it to show the voting widget for convenience in this pr.

I.e:

Install voting rep, then in truffle console:

```
c = await IColony.at('<colony-address>')
c.emitDomainReputationReward(1, accounts[0], '1000000000000000000')
c.setArbitrationRole(1, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", '<voting-rep-extn-address>', 1, true)
```

After clicking "Test mint token", you should see the voting widget. It does nothing so just testing for ui.

**New stuff** ✨

* Voting widget components

Contributes to #326
