### PR TITLE
Add GraphQL schema annotations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,7 @@ indent_size = 2
 [*.css]
 indent_style = space
 indent_size = 2
+
+[*.graphql]
+indent_style = space
+indent_size = 2

--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -1562,11 +1562,11 @@ type ColonyHistoricRole @model {
 
   """Unique identifier of the domain"""
   domainId: ID!
-  """Expaneded `Domain` model, based on the `domainId` given"""
+  """Expanded `Domain` model, based on the `domainId` given"""
   domain: Domain! @hasOne(fields: ["domainId"])
   """Unique identifier of the Colony"""
   colonyId: ID!
-  """Expaneded `Colony` model, based on the `colonyId` given"""
+  """Expanded `Colony` model, based on the `colonyId` given"""
   colony: Colony! @hasOne(fields: ["colonyId"])
 
   # Amplify will automatically populate one of the following fields with related model if it finds one

--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -9,116 +9,116 @@ input AMPLIFY {
 # but I never could get it to work
 
 """
-Input data for fetching a token's information from DB or chain.
+Input data for fetching a token's information from DB or chain
 """
 input TokenFromEverywhereArguments {
-  """Address of the token on the blockchain."""
+  """Address of the token on the blockchain"""
   tokenAddress: String!
 }
 
 """
-Input data for fetching the list of members for a specific Colony.
+Input data for fetching the list of members for a specific Colony
 """
 input MembersForColonyInput {
-  """Address of the Colony."""
+  """Address of the Colony"""
   colonyAddress: String!
-  """Root hash for the reputation state."""
+  """Root hash for the reputation state"""
   rootHash: String
-  """ID of the domain within the Colony."""
+  """ID of the domain within the Colony"""
   domainId: Int
-  """Sorting method to apply to the member list."""
+  """Sorting method to apply to the member list"""
   sortingMethod: SortingMethod
 }
 
 """
-Input data for creating a unique user within the Colony Network. Use this instead of the automatically generated `CreateUserInput` input type.
+Input data for creating a unique user within the Colony Network Use this instead of the automatically generated `CreateUserInput` input type
 """
 input CreateUniqueUserInput {
-  """Unique identifier for the user. This is the user's wallet address."""
+  """Unique identifier for the user. This is the user's wallet address"""
   id: ID!
-  """The username."""
+  """The username"""
   name: String!
-  """Profile data for the user."""
+  """Profile data for the user"""
   profile: ProfileInput
 }
 
 """
-**Deprecated** Extra permissions for a user, stored during the registration process.
+**Deprecated** Extra permissions for a user, stored during the registration process
 """
 enum EmailPermissions {
-  """Permission to send notifications to the user."""
+  """Permission to send notifications to the user"""
   sendNotifications
-  """Person is registered and solved the captcha, they can use gasless transactions."""
+  """Person is registered and solved the captcha, they can use gasless transactions"""
   isHuman
 }
 
 """
-Input data for a user's profile metadata.
+Input data for a user's profile metadata
 """
 input ProfileMetadataInput {
-  """List of email permissions for the user."""
+  """List of email permissions for the user"""
   emailPermissions: [String!]!
 }
 
 """
-Input data for relevant chain metadata of a Colony (if applicable).
+Input data for relevant chain metadata of a Colony (if applicable)
 """
 input ChainMetadataInput {
-  """The network the Colony is deployed on."""
+  """The network the Colony is deployed on"""
   network: Network
-  """The chain ID of the network."""
+  """The chain ID of the network"""
   chainId: Int!
-  """The transaction hash of the creation transaction."""
+  """The transaction hash of the creation transaction"""
   transactionHash: String
-  """The log index of the creation transaction."""
+  """The log index of the creation transaction"""
   logIndex: Int
-  """The block number of the creation transaction."""
+  """The block number of the creation transaction"""
   blockNumber: Int
 }
 
 """
-Input data for the status of a Colony's native token.
+Input data for the status of a Colony's native token
 
-Colonies can have different types of native tokens in various modes. Here we define some important properties that the dApp uses to enable or disable certain features or views. This is set when a Colony is created and can be changed later.
+Colonies can have different types of native tokens in various modes. Here we define some important properties that the dApp uses to enable or disable certain features or views. This is set when a Colony is created and can be changed later
 """
 input NativeTokenStatusInput {
-  """Whether the native token is unlocked."""
+  """Whether the native token is unlocked"""
   unlocked: Boolean
-  """Whether the native token is mintable."""
+  """Whether the native token is mintable"""
   mintable: Boolean
-  """Whether the native token can be unlocked."""
+  """Whether the native token can be unlocked"""
   unlockable: Boolean
 }
 
 """
-Input data for a Colony's status information.
+Input data for a Colony's status information
 
-This is set when a Colony is created and can be changed later.
+This is set when a Colony is created and can be changed later
 """
 input ColonyStatusInput {
-  """Status information for the Colony's native token."""
+  """Status information for the Colony's native token"""
   nativeToken: NativeTokenStatusInput
-  """Whether the Colony is in recovery mode."""
+  """Whether the Colony is in recovery mode"""
   recovery: Boolean
 }
 
 """
-Input data for creating a unique Colony within the Colony Network. Use this instead of the automatically generated `CreateColonyInput` input type.
+Input data for creating a unique Colony within the Colony Network. Use this instead of the automatically generated `CreateColonyInput` input type
 """
 input CreateUniqueColonyInput {
-  """Unique identifier for the Colony. This is the Colony's contract address."""
+  """Unique identifier for the Colony. This is the Colony's contract address"""
   id: ID!
-  """Display name of the Colony."""
+  """Display name of the Colony"""
   name: String!
-  """Unique identifier for the Colony's native token (this is its address)."""
+  """Unique identifier for the Colony's native token (this is its address)"""
   colonyNativeTokenId: ID!
-  """Type of the Colony (regular or MetaColony)."""
+  """Type of the Colony (regular or MetaColony)"""
   type: ColonyType
-  """Status information for the Colony."""
+  """Status information for the Colony"""
   status: ColonyStatusInput
-  """Metadata related to the Colony's creation on the blockchain."""
+  """Metadata related to the Colony's creation on the blockchain"""
   chainMetadata: ChainMetadataInput!
-  """Version of the currently deployed Colony contract."""
+  """Version of the currently deployed Colony contract"""
   version: Int!
 }
 
@@ -126,61 +126,61 @@ input CreateUniqueColonyInput {
 Input data to use when creating or changing a user profile
 """
 input ProfileInput {
-  """The unique identifier for the user profile."""
+  """The unique identifier for the user profile"""
   id: ID
-  """The URL of the user's avatar image."""
+  """The URL of the user's avatar image"""
   avatar: String
-  """The URL of the user's thumbnail image."""
+  """The URL of the user's thumbnail image"""
   thumbnail: String
-  """The display name of the user."""
+  """The display name of the user"""
   displayName: String
   """A short description or biography of the user."""
   bio: String
-  """The user's location (e.g., city or country)."""
+  """The user's location (e.g., city or country)"""
   location: String
-  """The user's personal or professional website."""
+  """The user's personal or professional website"""
   website: AWSURL
-  """The user's email address."""
+  """The user's email address"""
   email: AWSEmail
-  """Any additional metadata or settings related to the user profile."""
+  """Any additional metadata or settings related to the user profile"""
   meta: ProfileMetadataInput
 }
 
 """
-Input data for a user's reputation within a Domain in a Colony. If no `domainId` is passed, the Root Domain is used.
-A `rootHash` can be provided, to get reputation at a certain point in the past.
+Input data for a user's reputation within a Domain in a Colony. If no `domainId` is passed, the Root Domain is used
+A `rootHash` can be provided, to get reputation at a certain point in the past
 """
 input GetUserReputationInput {
-  """The Ethereum wallet address of the user."""
+  """The Ethereum wallet address of the user"""
   walletAddress: String!
-  """The Ethereum address of the Colony."""
+  """The Ethereum address of the Colony"""
   colonyAddress: String!
-  """The ID of the Domain within the Colony. If not provided, defaults to the Root Domain."""
+  """The ID of the Domain within the Colony. If not provided, defaults to the Root Domain"""
   domainId: Int
-  """The root hash of the reputation tree at a specific point in time."""
+  """The root hash of the reputation tree at a specific point in time"""
   rootHash: String
 }
 
 """
-Input data for updating an extension's information within a Colony, based on the Colony ID and extension hash.
+Input data for updating an extension's information within a Colony, based on the Colony ID and extension hash
 The hash is generated like so: `keccak256(toUtf8Bytes(extensionName))`, where `extensionName` is the name of the extension contract file in the Colony Network
 """
 input UpdateExtensionByColonyAndHashInput {
-  """The unique identifier for the Colony."""
+  """The unique identifier for the Colony"""
   colonyId: ID!
-  """The hash of the extension to be updated."""
+  """The hash of the extension to be updated"""
   hash: String!
-  """A flag to indicate whether the extension is deprecated."""
+  """A flag to indicate whether the extension is deprecated"""
   isDeprecated: Boolean
-  """A flag to indicate whether the extension is deleted."""
+  """A flag to indicate whether the extension is deleted"""
   isDeleted: Boolean
-  """A flag to indicate whether the extension is initialized."""
+  """A flag to indicate whether the extension is initialized"""
   isInitialized: Boolean
-  """The version of the extension."""
+  """The version of the extension"""
   version: Int
-  """The Ethereum address of the user who installed the extension."""
+  """The Ethereum address of the user who installed the extension"""
   installedBy: String
-  """The timestamp when the extension was installed."""
+  """The timestamp when the extension was installed"""
   installedAt: AWSTimestamp
 }
 
@@ -197,7 +197,7 @@ input SetCurrentVersionInput {
 }
 
 """
-Return type for tokens gotten from DB or from chain.
+Return type for tokens gotten from DB or from chain
 """
 type TokenFromEverywhereReturn {
   """List of tokens found"""
@@ -205,103 +205,130 @@ type TokenFromEverywhereReturn {
 }
 
 """
-Input data for retrieving a user's reputation within the top domains of a Colony.
+Input data for retrieving a user's reputation within the top domains of a Colony
 """
 input GetReputationForTopDomainsInput {
-  """The wallet address of the user."""
+  """The wallet address of the user"""
   walletAddress: String!
-  """The address of the Colony."""
+  """The address of the Colony"""
   colonyAddress: String!
-  """The root hash of the reputation tree at a specific point in time."""
+  """The root hash of the reputation tree at a specific point in time"""
   rootHash: String
 }
 
 """
-Input data for retrieving a user's token balance for a specific token.
+Input data for retrieving a user's token balance for a specific token
 """
 input GetUserTokenBalanceInput {
-  """The wallet address of the user."""
+  """The wallet address of the user"""
   walletAddress: String!
   """The Colony address"""
   colonyAddress: String!
-  """The address of the token."""
+  """The address of the token"""
   tokenAddress: String!
 }
 
+"""
+Input data for retrieving the state of a motion (i.e. the current period)
+"""
 input GetMotionStateInput {
+  """The Ethereum address of the Colony"""
   colonyAddress: String!
+  """The internal id of the motion in the database"""
   databaseMotionId: String!
+  """The hash of the associated transaction"""
   transactionHash: String!
 }
 
+"""
+Input data for retrieving the voting rewards for a user within a finished motion
+"""
 input GetVoterRewardsInput {
+  """The Ethereum address of the user who voted"""
   voterAddress: String!
+  """The Ethereum address of the Colony"""
   colonyAddress: String!
+  """The on chain id of the domain in which the motion was created"""
   nativeMotionDomainId: String!
+  """The on chain id of the motion"""
   motionId: String!
+  """The root hash of the reputation tree at the time the motion was created"""
   rootHash: String!
 }
 
+"""
+Input data for retrieving the timeout of the current period the motion is in
+"""
 input GetMotionTimeoutPeriodsInput {
+  """The on chain id of the motion"""
   motionId: String!
+  """The Ethereum address of the user who voted"""
   colonyAddress: String!
 }
 
 """
-A type representing a user's reputation within a domain.
+A type representing a user's reputation within a domain
 """
 type UserDomainReputation {
-  """The integer ID of the Domain within the Colony."""
+  """The integer ID of the Domain within the Colony"""
   domainId: Int!
-  """The user's reputation within the domain, represented as a percentage."""
+  """The user's reputation within the domain, represented as a percentage"""
   reputationPercentage: String!
 }
 
 """
-A return type that contains an array of UserDomainReputation items.
+A return type that contains an array of UserDomainReputation items
 """
 type GetReputationForTopDomainsReturn {
-  """An array of UserDomainReputation items."""
+  """An array of UserDomainReputation items"""
   items: [UserDomainReputation!]
 }
 
 """
-A return type representing the breakdown of a user's token balance.
+A return type representing the breakdown of a user's token balance
 """
 type GetUserTokenBalanceReturn {
-  """The total token balance, including inactive, locked, and active balances."""
+  """The total token balance, including inactive, locked, and active balances"""
   balance: String
   """
-  The inactive portion of the user's token balance.
-  This is the balance of a token that is in a users wallet but can't be used by the Colony Network (e.g. for governance).
+  The inactive portion of the user's token balance
+  This is the balance of a token that is in a users wallet but can't be used by the Colony Network (e.g. for governance)
   """
   inactiveBalance: String
   """
-  The locked portion of the user's token balance.
-  This is the balance of a token that is staked (e.g. in motions).
+  The locked portion of the user's token balance
+  This is the balance of a token that is staked (e.g. in motions)
   """
   lockedBalance: String
   """
-  The active portion of the user's token balance.
-  This is the balance that is approved for the Colony Network to use (e.g. for governance).
+  The active portion of the user's token balance
+  This is the balance that is approved for the Colony Network to use (e.g. for governance)
   """
   activeBalance: String
   """
-  The pending portion of the user's token balance.
-  These are tokens that have been sent to the wallet, but are inaccessible until all locks are cleared and then these tokens are claimed.
+  The pending portion of the user's token balance
+  These are tokens that have been sent to the wallet, but are inaccessible until all locks are cleared and then these tokens are claimed
   """
   pendingBalance: String
 }
 
+"""
+A return type that contains the timeout periods the motion can be in
+Represented via a string-integer in milliseconds. Will report 0 for periods that are elapsed and will show the accumulated time for later periods
+"""
 type GetMotionTimeoutPeriodsReturn {
+  """Time left in staking period"""
   timeLeftToStake: String!
+  """Time left in voting period"""
   timeLeftToVote: String!
+  """Time left in reveal period"""
   timeLeftToReveal: String!
+  """Time left in escalation period"""
   timeLeftToEscalate: String!
 }
 
 """
-A return type representing the members of a Colony.
+A return type representing the members of a Colony
 
 Definitions:
 * Member = User watching a Colony, with or without reputation
@@ -315,15 +342,28 @@ type MembersForColonyReturn {
   watchers: [Watcher!]
 }
 
+"""
+A return type that contains the voting reward for a user and a motion
+`min` and `max` specify the potential reward range when the actual reward is unknown (before the _reveal_ phase)
+"""
 type VoterRewardsReturn {
+  """
+  The minimum possible reward amount
+  Only useful before the _reveal_ phase, when the actual amount is known
+  """
   min: String!
+  """
+  The maximum possible reward amount
+  Only useful before the _reveal_ phase, when the actual amount is known
+  """
   max: String!
+  """The actual reward amount"""
   reward: String!
 }
 
 """
-Variants of different token types a Colony can use.
-As Colonies can use multiple tokens and even own tokens (BYOT), we need to differentiate.
+Variants of different token types a Colony can use
+As Colonies can use multiple tokens and even own tokens (BYOT), we need to differentiate
 """
 enum TokenType {
   """A (ERC20-compatible) token that was deployed with Colony. It has a few more features, like minting through the Colony itself"""
@@ -336,156 +376,171 @@ enum TokenType {
 
 
 """
-Variants of supported Ethereum networks.
+Variants of supported Ethereum networks
 """
 enum Network {
-  """Local development network using Ganache."""
+  """Local development network using Ganache"""
   GANACHE
-  """Ethereum Mainnet."""
+  """Ethereum Mainnet"""
   MAINNET
-  """Ethereum Goerli test network."""
+  """Ethereum Goerli test network"""
   GOERLI
-  """Gnosis Chain network."""
+  """Gnosis Chain network"""
   GNOSIS
-  """Fork of Gnosis Chain for QA purposes."""
+  """Fork of Gnosis Chain for QA purposes"""
   GNOSISFORK
 }
 
 """
-Variants of available domain colors as used in the dApp.
+Variants of available domain colors as used in the dApp
 """
 enum DomainColor {
-  """A light pink color."""
+  """A light pink color"""
   LIGHT_PINK
-  """A pink color."""
+  """A pink color"""
   PINK
-  """A black color."""
+  """A black color"""
   BLACK
-  """An emerald green color."""
+  """An emerald green color"""
   EMERALD_GREEN
-  """A blue color."""
+  """A blue color"""
   BLUE
-  """A yellow color."""
+  """A yellow color"""
   YELLOW
-  """A red color."""
+  """A red color"""
   RED
-  """A green color."""
+  """A green color"""
   GREEN
-  """A pale indigo color."""
+  """A pale indigo color"""
   PERIWINKLE
-  """A gold color."""
+  """A gold color"""
   GOLD
-  """An aqua color."""
+  """An aqua color"""
   AQUA
-  """A blue-grey(ish) color."""
+  """A blue-grey(ish) color"""
   BLUE_GREY
-  """A purple color."""
+  """A purple color"""
   PURPLE
-  """An orange color."""
+  """An orange color"""
   ORANGE
-  """A magenta color."""
+  """A magenta color"""
   MAGENTA
-  """A purple-grey(ish) color."""
+  """A purple-grey(ish) color"""
   PURPLE_GREY
 }
 
 """
-Variants of Colony types.
+Variants of Colony types
 """
 enum ColonyType {
-  """A regular Colony."""
+  """A regular Colony"""
   COLONY
-  """The MetaColony, which governs the entire Colony Network."""
+  """The MetaColony, which governs the entire Colony Network"""
   METACOLONY
 }
 
 """
-Variants of Colony Network blockchain events.
+Variants of Colony Network blockchain events
 
-These can all happen in a Colony and will be interpreted by the dApp according to their types.
+These can all happen in a Colony and will be interpreted by the dApp according to their types
 """
 enum ColonyActionType {
-  """A generic or unspecified Colony action."""
+  """A generic or unspecified Colony action"""
   GENERIC
+  """An motion action placeholder that should not be used"""
   NULL_MOTION
-  """An action unrelated to the currently viewed Colony. """
+  """An action unrelated to the currently viewed Colony """
   WRONG_COLONY
-  """An action related to a payment within a Colony."""
+  """An action related to a payment within a Colony"""
   PAYMENT
+  """An action related to a payment that was created via a motion within a Colony"""
   PAYMENT_MOTION
-  """An action related to the recovery functionality of a Colony."""
+  """An action related to the recovery functionality of a Colony"""
   RECOVERY
-  """An action related to moving funds between domains."""
+  """An action related to moving funds between domains"""
   MOVE_FUNDS
+  """An action related to moving funds between domains via a motion"""
   MOVE_FUNDS_MOTION
-  """An action related to unlocking a token within a Colony."""
+  """An action related to unlocking a token within a Colony"""
   UNLOCK_TOKEN
+  """An action related to unlocking a token within a Colony via a motion"""
   UNLOCK_TOKEN_MOTION
-  """An action related to minting tokens within a Colony."""
+  """An action related to minting tokens within a Colony"""
   MINT_TOKENS
+  """An action related to minting tokens within a Colony via a motion"""
   MINT_TOKENS_MOTION
-  """An action related to creating a domain within a Colony."""
+  """An action related to creating a domain within a Colony"""
   CREATE_DOMAIN
+  """An action related to creating a domain within a Colony via a motion"""
   CREATE_DOMAIN_MOTION
-  """An action related to upgrading a Colony's version."""
+  """An action related to upgrading a Colony's version"""
   VERSION_UPGRADE
+  """An action related to upgrading a Colony's version via a motion"""
   VERSION_UPGRADE_MOTION
-  """An action related to editing a Colony's details."""
+  """An action related to editing a Colony's details"""
   COLONY_EDIT
+  """An action related to editing a Colony's details via a motion"""
   COLONY_EDIT_MOTION
-  """An action related to editing a domain's details."""
+  """An action related to editing a domain's details"""
   EDIT_DOMAIN
+  """An action related to editing a domain's details via a motion"""
   EDIT_DOMAIN_MOTION
-  """An action related to setting user roles within a Colony."""
+  """An action related to setting user roles within a Colony"""
   SET_USER_ROLES
+  """An action related to setting user roles within a Colony via a motion"""
   SET_USER_ROLES_MOTION
-  """An action related to a domain reputation penalty within a Colony (smite)."""
+  """An action related to a domain reputation penalty within a Colony (smite)"""
   EMIT_DOMAIN_REPUTATION_PENALTY
+  """An action related to a domain reputation penalty within a Colony (smite) via a motion"""
   EMIT_DOMAIN_REPUTATION_PENALTY_MOTION
-  """An action related to a domain reputation reward within a Colony."""
+  """An action related to a domain reputation reward within a Colony"""
   EMIT_DOMAIN_REPUTATION_REWARD
+  """An action related to a domain reputation reward within a Colony via a motion"""
   EMIT_DOMAIN_REPUTATION_REWARD_MOTION
 }
 
 """
-Variants of sorting methods for a member list.
+Variants of sorting methods for a member list
 """
 enum SortingMethod {
-  """Sort members by highest reputation."""
+  """Sort members by highest reputation"""
   BY_HIGHEST_REP
-  """Sort members by lowest reputation."""
+  """Sort members by lowest reputation"""
   BY_LOWEST_REP
-  """Sort members by having more permissions."""
+  """Sort members by having more permissions"""
   BY_MORE_PERMISSIONS
-  """Sort members by having fewer permissions."""
+  """Sort members by having fewer permissions"""
   BY_LESS_PERMISSIONS
 }
 
-"""Root query type."""
+"""Root query type"""
 type Query {
   """Fetch a token's information. Tries to get the data from the DB first, if that fails, resolves to get data from chain"""
   getTokenFromEverywhere(
     input: TokenFromEverywhereArguments
   ): TokenFromEverywhereReturn @function(name: "fetchTokenFromChain-${env}")
-  """Retrieve a user's reputation within the top domains of a Colony."""
+  """Retrieve a user's reputation within the top domains of a Colony"""
   getReputationForTopDomains(
     input: GetReputationForTopDomainsInput
   ): GetReputationForTopDomainsReturn
     @function(name: "getReputationForTopDomains-${env}")
-  """Retrieve a user's reputation within a specific domain in a Colony."""
+  """Retrieve a user's reputation within a specific domain in a Colony"""
   getUserReputation(input: GetUserReputationInput): String
     @function(name: "getUserReputation-${env}")
-  """Retrieve a user's token balance for a specific token."""
+  """Retrieve a user's token balance for a specific token"""
   getUserTokenBalance(
     input: GetUserTokenBalanceInput
   ): GetUserTokenBalanceReturn @function(name: "getUserTokenBalance-${env}")
-  """Fetch the list of members for a specific Colony."""
+  """Fetch the list of members for a specific Colony"""
   getMembersForColony(input: MembersForColonyInput): MembersForColonyReturn
     @function(name: "getMembersForColony-${env}")
+  """Get the state of a motion (i.e. the current period)"""
   getMotionState(input: GetMotionStateInput): Int!
     @function(name: "fetchMotionState-${env}")
+  """Get the voting reward for a user and a motion"""
   getVoterRewards(input: GetVoterRewardsInput): VoterRewardsReturn
     @function(name: "fetchVoterRewards-${env}")
+  """Get the timeout for the current period of a motion"""
   getMotionTimeoutPeriods(
     input: GetMotionTimeoutPeriodsInput
   ): GetMotionTimeoutPeriodsReturn
@@ -493,21 +548,20 @@ type Query {
 }
 
 """
-Root mutation type.
+Root mutation type
 """
 type Mutation {
   """Create a unique user within the Colony Network. Use this instead of the automatically generated `createUser` mutation"""
   createUniqueUser(input: CreateUniqueUserInput): User
     @function(name: "createUniqueUser-${env}")
-  """Create a unique Colony within the Colony Network. Use this instead of the automatically generate `createColony` mutation"""
+  """Create a unique Colony within the Colony Network. Use this instead of the automatically generated `createColony` mutation"""
   createUniqueColony(input: CreateUniqueColonyInput): Colony
     @function(name: "createUniqueColony-${env}")
   """Updates the latest available version of a Colony or an extension"""
   setCurrentVersion(input: SetCurrentVersionInput): Boolean
     @function(name: "setCurrentVersion-${env}")
   """
-  Update an extension's details for a specific Colony.
-
+  Update an extension's details for a specific Colony
   The extension hash is generated like so: `keccak256(toUtf8Bytes(extensionName))`, where `extensionName` is the name of the extension contract file in the Colony Network (e.g. `VotingReputation`)
   """
   updateExtensionByColonyAndHash(
@@ -516,184 +570,182 @@ type Mutation {
 }
 
 """
-Represents a user's profile within the Colony Network.
+Represents a user's profile within the Colony Network
 """
 type Profile @model {
-  """Unique identifier for the user's profile."""
+  """Unique identifier for the user's profile"""
   id: ID!
-  """URL of the user's avatar image."""
+  """URL of the user's avatar image"""
   avatar: String
-  """URL of the user's thumbnail image."""
+  """URL of the user's thumbnail image"""
   thumbnail: String
-  """Display name of the user."""
+  """Display name of the user"""
   displayName: String
-  """User's bio information."""
+  """User's bio information"""
   bio: String
-  """User's location information."""
+  """User's location information"""
   location: String
-  """URL of the user's website."""
+  """URL of the user's website"""
   website: AWSURL
-  """User's email address."""
+  """User's email address"""
   email: AWSEmail @index(name: "byEmail", queryField: "getProfileByEmail")
-  """Metadata associated with the user's profile."""
+  """Metadata associated with the user's profile"""
   meta: ProfileMetadata
 }
 
 """
-Represents the status of a Colony's native token.
-
-Colonies can have different types of native tokens in various modes. Here we define some important properties that the dApp uses to enable or disable certain features or views. This is set when a Colony is created and can be changed later.
+Represents the status of a Colony's native token
+Colonies can have different types of native tokens in various modes. Here we define some important properties that the dApp uses to enable or disable certain features or views. This is set when a Colony is created and can be changed later
 """
 type NativeTokenStatus {
-  """Whether the native token is unlocked."""
+  """Whether the native token is unlocked"""
   unlocked: Boolean
-  """Whether the user has permissions to mint new tokens."""
+  """Whether the user has permissions to mint new tokens"""
   mintable: Boolean
-  """Whether the native token can be unlocked."""
+  """Whether the native token can be unlocked"""
   unlockable: Boolean
 }
 
 """
-Represents the status of a Colony.
+Represents the status of a Colony
 
 This contains important meta information about the Colony's token and other fundamental settings
 """
 type ColonyStatus {
-  """Status information for the Colony's native token."""
+  """Status information for the Colony's native token"""
   nativeToken: NativeTokenStatus
-  """Whether the Colony is in recovery mode."""
+  """Whether the Colony is in recovery mode"""
   recovery: Boolean
 }
 
 """
-Represents metadata related to a blockchain event.
-
+Represents metadata related to a blockchain event
 Applies to Colonies, Tokens and Events, but not all fields are revlant to all
 It does not apply to user accounts as they can live on all networks
 """
 type ChainMetadata {
-  """The network the event occurred on."""
+  """The network the event occurred on"""
   network: Network
-  """The chain ID of the event."""
+  """The chain ID of the event"""
   chainId: Int!
-  """The transaction hash of the event."""
+  """The transaction hash of the event"""
   transactionHash: String
-  """The log index of the event."""
+  """The log index of the event"""
   logIndex: Int
-  """The block number of the event."""
+  """The block number of the event"""
   blockNumber: Int
 }
 
 """
-Represents metadata for a user's profile. Mostly user specific settings.
+Represents metadata for a user's profile. Mostly user specific settings
 """
 type ProfileMetadata {
-  """List of email permissions for the user."""
+  """List of email permissions for the user"""
   emailPermissions: [String!]!
 }
 
 """
-Represents a contributor within the Colony Network.
+Represents a contributor within the Colony Network
 
-A contributor is a Colony member who has reputation.
+A contributor is a Colony member who has reputation
 """
 type Contributor {
-  """Wallet address of the contributor."""
+  """Wallet address of the contributor"""
   address: String!
-  """User data associated with the contributor."""
+  """User data associated with the contributor"""
   user: User
-  """Reputation percentage of the contributor (of all reputation within the Colony)."""
+  """Reputation percentage of the contributor (of all reputation within the Colony)"""
   reputationPercentage: String
-  """Reputation amount of the contributor (as an absolute number)."""
+  """Reputation amount of the contributor (as an absolute number)"""
   reputationAmount: String
 }
 
 """
-Represents a watcher within the Colony Network.
+Represents a watcher within the Colony Network
 
-A watcher is a Colony member who doesn't have reputation.
+A watcher is a Colony member who doesn't have reputation
 """
 type Watcher {
-  """Wallet address of the watcher."""
+  """Wallet address of the watcher"""
   address: String!
-  """User data associated with the watcher."""
+  """User data associated with the watcher"""
   user: User
 }
 
-"""Represents an ERC20-compatible token that is used by Colonies and users."""
+"""Represents an ERC20-compatible token that is used by Colonies and users"""
 type Token @model {
-  """Unique identifier for the token (contract address)."""
+  """Unique identifier for the token (contract address)"""
   id: ID!
     @index(name: "byAddress", queryField: "getTokenByAddress")
     @index(sortKeyFields: ["createdAt"]) # contract address
-  """Name of the token."""
+  """Name of the token"""
   name: String!
-  """Symbol of the token."""
+  """Symbol of the token"""
   symbol: String!
-  """Decimal precision of the token."""
+  """Decimal precision of the token"""
   decimals: Int!
   """Type of the token. See `TokenType` for more information"""
   type: TokenType @index(name: "byType", queryField: "getTokensByType")
-  """List of colonies using the token."""
+  """List of colonies using the token"""
   colonies: [Colony] @manyToMany(relationName: "ColonyTokens")
-  """List of users using the token."""
+  """List of users using the token"""
   users: [User] @manyToMany(relationName: "UserTokens")
-  """URL of the token's avatar image (logo)."""
+  """URL of the token's avatar image (logo)"""
   avatar: String
-  """URL of the token's thumbnail image (Small logo)."""
+  """URL of the token's thumbnail image (Small logo)"""
   thumbnail: String
-  """Metadata related to the chain of the token."""
+  """Metadata related to the chain of the token"""
   chainMetadata: ChainMetadata!
-  """Timestamp of the token model's creation in the database."""
+  """Timestamp of the token model's creation in the database"""
   createdAt: AWSDateTime!
 }
 
 """
-Represents a Colony within the Colony Network.
+Represents a Colony within the Colony Network
 """
 type Colony @model {
-  """Unique identifier for the Colony (contract address)."""
+  """Unique identifier for the Colony (contract address)"""
   id: ID! @index(name: "byAddress", queryField: "getColonyByAddress")
-  """(Short) name of the Colony."""
+  """(Short) name of the Colony"""
   name: String! @index(name: "byName", queryField: "getColonyByName")
-  """The unique address of the native token of the Colony."""
+  """The unique address of the native token of the Colony"""
   nativeTokenId: ID!
     @index(name: "byNativeTokenId", queryField: "getColoniesByNativeTokenId")
-  """The native token of the Colony."""
+  """The native token of the Colony"""
   nativeToken: Token! @hasOne(fields: ["nativeTokenId"])
-  """List of tokens that are used within the Colony."""
+  """List of tokens that are used within the Colony"""
   tokens: [Token] @manyToMany(relationName: "ColonyTokens")
-  """Status information for the Colony."""
+  """Status information for the Colony"""
   status: ColonyStatus
-  """List of domains of the Colony."""
+  """List of domains of the Colony"""
   domains: [Domain] @hasMany(indexName: "byColony", fields: ["id"])
-  """List of users watching the Colony."""
+  """List of users watching the Colony"""
   watchers: [User] @manyToMany(relationName: "WatchedColonies")
-  """List of Colony funds claims for all ERC20 tokens."""
+  """List of Colony funds claims for all ERC20 tokens"""
   # NOTE: Could not merge these two fields properly
   # Ideally we would merge data from these two into one field, but I couldn't do that
   # meaning we'll have to merge this data in-app (or not at all, works either way)
   # If you have a better idea, on how to merged them, I'll all ears..
   fundsClaims: [ColonyFundsClaim] @hasMany
-  """List of native chain token claims (e.g., Token 0x0000...0000: ETH, xDAI, etc.)."""
+  """List of native chain token claims (e.g., Token 0x0000...0000: ETH, xDAI, etc.)"""
   # This is not an array since only a single token type can be returned
   chainFundsClaim: ColonyChainFundsClaim
     @function(name: "fetchColonyNativeFundsClaim-${env}")
-  """Type of the Colony (Regular or Metacolony)."""
+  """Type of the Colony (Regular or Metacolony)"""
   type: ColonyType @index(name: "byType", queryField: "getColonyByType")
-  """Returns a list token balances for each domain and each token that the colony has."""
+  """Returns a list token balances for each domain and each token that the colony has"""
   balances: ColonyBalances @function(name: "fetchColonyBalances-${env}")
-  """Metadata related to the chain of the Colony."""
+  """Metadata related to the chain of the Colony"""
   chainMetadata: ChainMetadata!
-  """List of extensions installed in the Colony."""
+  """List of extensions installed in the Colony"""
   extensions: [ColonyExtension!] @hasMany(indexName: "byColony", fields: ["id"])
-  """Version of the Colony."""
+  """Version of the Colony"""
   version: Int!
-  """List of actions that happened within the Colony."""
+  """List of actions that happened within the Colony"""
   actions: [ColonyAction] @hasMany
-  """List of motions within the Colony that have unclaimed stakes."""
+  """List of motions within the Colony that have unclaimed stakes"""
   motionsWithUnclaimedStakes: [ColonyUnclaimedStake!]
-  """Metadata of the Colony."""
+  """Metadata of the Colony"""
   metadata: ColonyMetadata @hasOne(fields: ["id"])
   """List of all roles within the Colony"""
   # @TODO This should not be fetched upfront
@@ -702,163 +754,183 @@ type Colony @model {
   roles: [ColonyRole] @hasMany
 }
 
+"""
+Unclaimed staking rewards for a motion
+"""
 type ColonyUnclaimedStake {
-  motionId: String! # database id
+  """The on chain id of the motion"""
+  motionId: String!
+  """List of unclaimed staking rewards for that motion"""
   unclaimedRewards: [StakerRewards!]!
 }
 
+"""Colony token modifications that are stored temporarily and commited to the database once the corresponding motion passes"""
 type PendingModifiedTokenAddresses {
+  """List of tokens that were added to the Colony's token list"""
   added: [String!]
+  """List of tokens that were removed from the Colony's token list"""
   removed: [String!]
 }
 
 """
-Represents metadata for a Colony.
+Represents metadata for a Colony
 """
 type ColonyMetadata @model {
-  """Unique identifier for the Colony (contract address)."""
+  """Unique identifier for the Colony (contract address)"""
   id: ID!
-  """Display name of the Colony."""
+  """Display name of the Colony"""
   displayName: String!
-  """URL of the Colony's avatar image."""
+  """URL of the Colony's avatar image"""
   avatar: String
-  """URL of the Colony's thumbnail image."""
+  """URL of the Colony's thumbnail image"""
   thumbnail: String
-  """List of Colony metadata changelog entries."""
+  """List of Colony metadata changelog entries"""
   changelog: [ColonyMetadataChangelog!]
+  """The address book feature (aka Whitelist is active for this Colony)"""
   isWhitelistActivated: Boolean
+  """List of addresses that are in the address book"""
   whitelistedAddresses: [String!]
-  modifiedTokenAddresses: PendingModifiedTokenAddresses # only present on pendingColonyMetadata for consumption in block ingestor
+  """
+  Token addresses that were modified in a previous action (motion)
+  Only present on pendingColonyMetadata for consumption in block ingestor
+  """
+  modifiedTokenAddresses: PendingModifiedTokenAddresses #
 }
 
 """
-Represents a changelog entry for Colony metadata.
-
-This is used to traverse through the history of metadata values and consolidate them into a final state.
+Represents a changelog entry for Colony metadata
+This is used to traverse through the history of metadata values and consolidate them into a final state
 """
 type ColonyMetadataChangelog {
-  """Transaction hash associated with the changelog entry."""
+  """Transaction hash associated with the changelog entry"""
   transactionHash: String!
-  """Display name of the Colony before the change."""
+  """Display name of the Colony before the change"""
   oldDisplayName: String!
-  """Display name of the Colony after the change."""
+  """Display name of the Colony after the change"""
   newDisplayName: String!
-  """Indicates whether the avatar has changed."""
+  """Indicates whether the avatar has changed"""
   hasAvatarChanged: Boolean!
+  """Whether entries in the address book (whitelist) have changed"""
   hasWhitelistChanged: Boolean!
+  """Whether tokens have been added or removed from the Colony's token list"""
   haveTokensChanged: Boolean!
 }
 
 """
-Represents a User within the Colony Network.
+Represents a User within the Colony Network
 """
 type User @model {
-  """Unique identifier for the user (wallet address)."""
+  """Unique identifier for the user (wallet address)"""
   id: ID! @index(name: "byAddress", queryField: "getUserByAddress")
-  """(Short) name of the user."""
+  """(Short) name of the user"""
   name: String! @index(name: "byName", queryField: "getUserByName")
-  """List of tokens the user is using."""
+  """List of tokens the user is using"""
   tokens: [Token] @manyToMany(relationName: "UserTokens")
-  """Profile ID associated with the user."""
+  """Profile ID associated with the user"""
   profileId: ID
-  """Profile information of the user."""
+  """Profile information of the user"""
   profile: Profile @hasOne(fields: ["profileId"])
-  """List of Colonies the user is watching."""
+  """List of Colonies the user is watching"""
   watchlist: [Colony] @manyToMany(relationName: "WatchedColonies") # colony subscriptions
   """List of stakes the User made"""
   stakes: [ColonyStake!]! @hasMany(indexName: "byUserAddress", fields: ["id"])
 }
 
-# Keeps track of the current amount a user has staked in a colony
-# When a user stakes, totalAmount increases. When a user reclaims their stake, totalAmount decreases.
+"""
+Keeps track of the current amount a user has staked in a colony
+When a user stakes, totalAmount increases. When a user reclaims their stake, totalAmount decreases.
+"""
 type ColonyStake @model {
-  id: ID! # <userId>_<colonyId>
+  """
+  Unique identifier for the stake
+  Format: `<userId>_<colonyId>`
+  """
+  id: ID! #
+  """Unique identifier for the user"""
   userId: ID!
     @index(
       name: "byUserAddress"
       queryField: "getColonyStakeByUserAddress"
       sortKeyFields: ["colonyId"]
     )
+  """Unique identifier for the Colony"""
   colonyId: ID!
+  """Total staked amount"""
   totalAmount: String!
 }
 
 """
-Represents a Domain within the Colony Network.
+Represents a Domain within the Colony Network
 """
 type Domain @model {
   """
-  Unique identifier for the Domain.
-
+  Unique identifier for the Domain
   This should be in the following format: `colonyAddress_nativeId`
   The native id is the auto-incrementing integer that is assigned to a domain from the contract on creation
   """
   # Has to be self-managed
   id: ID!
-  """Colony ID associated with the Domain."""
+  """Colony ID associated with the Domain"""
   colonyId: ID! @index(name: "byColony")
-  """Colony associated with the Domain."""
+  """Colony associated with the Domain"""
   colony: Colony! @belongsTo(fields: ["colonyId"])
   """
-  Native ID of the Domain.
-
+  Native ID of the Domain
   The native id is the auto-incrementing integer that is assigned to a domain from the contract on creation
   """
   nativeId: Int!
   """
-  Native funding pot ID of the Domain.
-
+  Native funding pot ID of the Domain
   The native funding pot ID is assigned to a domain from the contract on creation
   """
   nativeFundingPotId: Int!
   """
-  Native skill ID of the Domain.
-
+  Native skill ID of the Domain
   The native skill ID is assigned to a domain from the contract on creation
   """
   nativeSkillId: Int!
   """Indicates whether the Domain is the root domain (ID 1)"""
   isRoot: Boolean!
-  """Metadata of the Domain."""
+  """Metadata of the Domain"""
   metadata: DomainMetadata @hasOne(fields: ["id"])
 }
 
 """
-Represents metadata for a Domain.
+Represents metadata for a Domain
 """
 type DomainMetadata @model {
   """
-  Unique identifier for the Domain metadata.
+  Unique identifier for the Domain metadata
   This field is referenced by Domain id, so has to be in the same format: colonyAddress_nativeId
   """
   id: ID!
-  """Name of the Domain."""
+  """Name of the Domain"""
   name: String!
-  """Description of the Domain."""
+  """Description of the Domain"""
   description: String!
-  """Color associated with the Domain."""
+  """Color associated with the Domain"""
   color: DomainColor!
-  """List of Domain metadata changelog entries."""
+  """List of Domain metadata changelog entries"""
   changelog: [DomainMetadataChangelog!]
 }
 
 """
-Represents a changelog entry for Domain metadata.
+Represents a changelog entry for Domain metadata
 """
 type DomainMetadataChangelog {
-  """Transaction hash associated with the changelog entry."""
+  """Transaction hash associated with the changelog entry"""
   transactionHash: String!
-  """Name of the Domain before the change."""
+  """Name of the Domain before the change"""
   oldName: String!
-  """Name of the Domain after the change."""
+  """Name of the Domain after the change"""
   newName: String!
-  """Color of the Domain before the change."""
+  """Color of the Domain before the change"""
   oldColor: DomainColor!
-  """Color of the Domain after the change."""
+  """Color of the Domain after the change"""
   newColor: DomainColor!
-  """Description of the Domain before the change."""
+  """Description of the Domain before the change"""
   oldDescription: String!
-  """Description of the Domain after the change."""
+  """Description of the Domain after the change"""
   newDescription: String!
 }
 
@@ -866,38 +938,41 @@ type DomainMetadataChangelog {
 Represents a Colony Funds Claim for all ERC20 tokens (except native chain tokens)
 """
 type ColonyFundsClaim @model {
-  """Unique identifier for the Colony Funds Claim."""
+  """Unique identifier for the Colony Funds Claim"""
   id: ID! @index(sortKeyFields: ["createdAt"])
-  """Token associated with the Colony Funds Claim."""
+  """Token associated with the Colony Funds Claim"""
   token: Token! @hasOne
-  """Block number when the Funds Claim was created."""
+  """Block number when the Funds Claim was created"""
   createdAtBlock: Int!
-  """Timestamp when the Funds Claim was created."""
+  """Timestamp when the Funds Claim was created"""
   createdAt: AWSDateTime!
-  """Amount claimed in the Colony Funds Claim."""
+  """Amount claimed in the Colony Funds Claim"""
   amount: String!
 }
 
 """
 Represents a native Colony Chain Funds Claim
-
-E.g., Token 0x0000...0000: ETH, xDAI, etc.
+E.g., Token 0x0000...0000: ETH, xDAI, etc
 """
+# This is really not elegant, but there's no other proper solution, as you can't
+# return the Token @hadOne relationship from the lambda function
+# Note that we don't need token details for the values that we're fetching (since
+# it's implied), but it would have been nice not to have to basically repeat the type
 type ColonyChainFundsClaim {
-  """Unique identifier for the Colony Chain Funds Claim."""
+  """Unique identifier for the Colony Chain Funds Claim"""
   id: ID!
-  """Block number when the Chain Funds Claim was created."""
+  """Block number when the Chain Funds Claim was created"""
   createdAtBlock: Int!
-  """Timestamp when the Chain Funds Claim was created."""
+  """Timestamp when the Chain Funds Claim was created"""
   createdAt: AWSDateTime!
-  """Timestamp when the Chain Funds Claim was last updated."""
+  """Timestamp when the Chain Funds Claim was last updated"""
   updatedAt: AWSDateTime!
-  """Amount claimed in the Colony Chain Funds Claim."""
+  """Amount claimed in the Colony Chain Funds Claim"""
   amount: String!
 }
 
 """
-Represents a Colony balance for a specific domain and token.
+Represents a Colony balance for a specific domain and token
 """
 # This is not a @model since it will only be returned by a lambda function
 # so don't need to create tables for them
@@ -906,157 +981,264 @@ Represents a Colony balance for a specific domain and token.
 # you'd never actually be able to read that data since the return is overwritten
 # by the lambda function
 type ColonyBalance {
-  """Unique identifier for the Colony Balance."""
+  """Unique identifier for the Colony Balance"""
   id: ID!
-  """Balance of the specific token in the domain."""
+  """Balance of the specific token in the domain"""
   balance: String!
-  """Domain associated with the Colony Balance."""
+  """Domain associated with the Colony Balance"""
   domain: Domain
   """
-  Token associated with the Colony Balance.
-  Note that for the chain native token, name and symbol are empty.
+  Token associated with the Colony Balance
+  Note that for the chain native token, name and symbol are empty
   """
   token: Token!
 }
 
-"""Represents a collection of Colony balances."""
+"""Represents a collection of Colony balances"""
 type ColonyBalances {
-  """List of Colony balances."""
+  """List of Colony balances"""
   items: [ColonyBalance]
 }
 
-"""Input type for specifying a Domain."""
+"""Input type for specifying a Domain"""
 input DomainInput {
-  """Unique identifier for the Domain."""
+  """Unique identifier for the Domain"""
   id: ID!
 }
 
-"""Input type for specifying a Token."""
+"""Input type for specifying a Token"""
 input TokenInput {
-  """Unique identifier for the Token."""
+  """Unique identifier for the Token"""
   id: ID!
 }
 
+"""Input type for modifying the staked side of a motion"""
 input MotionStakeValuesInput {
+  """Number of votes for this motion"""
   yay: String!
+  """Number of votes against this motion"""
   nay: String!
 }
 
+"""Staked sides of a motion"""
 type MotionStakeValues {
+  """Number of votes for this motion"""
   yay: String!
+  """Number of votes against this motion"""
   nay: String!
 }
 
+"""Input used to modify the staked sides of a motion"""
 input MotionStakesInput {
+  """Absolute values denominated in the native token"""
   raw: MotionStakeValuesInput!
+  """Values in percentage of the total stakes"""
   percentage: MotionStakeValuesInput!
 }
 
+"""Staked sides of a motion"""
 type MotionStakes {
+  """Absolute values denominated in the native token"""
   raw: MotionStakeValues!
+  """Values in percentage of the total stakes"""
   percentage: MotionStakeValues!
 }
 
+"""Input used to modify the stakes of a user for a motion"""
 input UserStakesInput {
+  """The user's wallet address"""
   address: String!
+  """Stake values"""
   stakes: MotionStakesInput!
 }
 
+"""Stakes that a user has made for a motion"""
 type UserStakes {
+  """The user's wallet address"""
   address: String!
+  """Stake values"""
   stakes: MotionStakes!
 }
 
+"""Input used to modify the staker rewards of a user for a motion"""
 input StakerRewardsInput {
+  """The user's wallet address"""
   address: String!
+  """Rewards associated with the staked sides of a motion"""
   rewards: MotionStakeValuesInput!
+  """Whether the voter reward is already claimed or not"""
   isClaimed: Boolean!
 }
 
+"""Staker rewards of a user for a motion"""
 type StakerRewards {
+  """The user's wallet address"""
   address: String!
+  """Rewards associated with the staked sides of a motion"""
   rewards: MotionStakeValues!
+  """Whether the voter reward is already claimed or not"""
   isClaimed: Boolean!
 }
 
+"""Input used to modify a voter record of a user for a motion"""
 input VoterRecordInput {
+  """The user's wallet address"""
   address: String!
+  """The voting weight denominated by the user's reputation"""
   voteCount: String!
-  vote: Int # nullable since we don't know the vote until it's revealed
+  """
+  The actual vote (yay or nay)
+  nullable since we don't know the vote until it's revealed
+  """
+  vote: Int
 }
 
+"""A voter record of a user for a motion"""
 type VoterRecord {
+  """The user's wallet address"""
   address: String!
+  """The voting weight denominated by the user's reputation"""
   voteCount: String!
-  vote: Int # nullable since we don't know the vote until it's revealed
+  """
+  The actual vote (yay or nay)
+  nullable since we don't know the vote until it's revealed
+  """
+  vote: Int
 }
 
+"""Input used to create a motion status update message"""
 input MotionMessageInput {
+  """
+  Wallet address of the initiator of the status update
+  The zero address is used for messages that don't have an initiator (system messages)
+  """
   initiatorAddress: String!
+  """Internal name of the status update event (e.g. `MotionCreated`, `MotionStaked`, etc.)"""
   name: String!
+  """Unique id for the message"""
   messageKey: String!
+  """Cast vote attached to the status update (if applicable)"""
   vote: String
+  """Token amount relevant to the status update (if applicable)"""
   amount: String
 }
 
+"""A status update message for a motion (will appear in the motion's timeline)"""
 type MotionMessage @model {
+  """
+  Wallet address of the initiator of the status update
+  The zero address is used for messages that don't have an initiator (system messages)
+  """
   initiatorAddress: ID!
+  """Internal name of the status update event (e.g. `MotionCreated`, `MotionStaked`, etc.)"""
   name: String!
+  """Unique id for the message"""
   messageKey: String!
+  """The internal database id of the motion"""
   motionId: ID!
     @index(
       name: "byMotionId"
       queryField: "getMotionMessageByMotionId"
       sortKeyFields: ["createdAt"]
     )
+  """Extended user object for given initiatorAddress"""
   initiatorUser: User @hasOne(fields: ["initiatorAddress"])
+  """Cast vote attached to the status update (if applicable)"""
   vote: String
+  """Token amount relevant to the status update (if applicable)"""
   amount: String
+  """Timestamp of when the status update was created in the database"""
   createdAt: AWSDateTime!
 }
 
+"""Input used to change the current state of a motion"""
 input MotionStateHistoryInput {
+  """Voting period is elapsed"""
   hasVoted: Boolean!
+  """Whether the motion has passed"""
   hasPassed: Boolean!
+  """Whether the motion has failed"""
   hasFailed: Boolean!
+  """Whether the motion has failed and cannot be finalized (e.g. if it doesn't get staked)"""
   hasFailedNotFinalizable: Boolean!
+  """Motion is in reveal phase (votes are being revealed)"""
   inRevealPhase: Boolean!
 }
 
+"""Quick access flages to check the current state of a motion in its lifecycle"""
 type MotionStateHistory {
+  """Voting period is elapsed"""
   hasVoted: Boolean!
+  """Whether the motion has passed"""
   hasPassed: Boolean!
+  """Whether the motion has failed"""
   hasFailed: Boolean!
+  """Whether the motion has failed and cannot be finalized (e.g. if it doesn't get staked)"""
   hasFailedNotFinalizable: Boolean!
+  """Motion is in reveal phase (votes are being revealed)"""
   inRevealPhase: Boolean!
 }
 
+"""Represents a Motion within a Colony"""
 type ColonyMotion @model {
-  id: ID! # to ensure uniqueness, we format as: chainId-votingRepExtnAddress_nativeMotionId
+  """
+  The internal database id of the motion
+  To ensure uniqueness, we format as: `chainId-votingRepExtnAddress_nativeMotionId`
+  """
+  id: ID!
+  """The on chain id of the motion"""
   nativeMotionId: String!
+  """List of stakes that users have made for a motion"""
   usersStakes: [UserStakes!]!
+  """List of staker rewards users will be receiving for a motion"""
   stakerRewards: [StakerRewards!]!
+  """Staked sides of a motion"""
   motionStakes: MotionStakes!
-  remainingStakes: [String!]! # tuple [nayRemaining, yayRemaining]
+  """
+  Stakes remaining to activate either side of the motion
+  It's a tuple: `[nayRemaining, yayRemaining]`
+  """
+  remainingStakes: [String!]!
+  """The minimum stake that a user has to provide for it to be accepted"""
   userMinStake: String!
+  """The total required stake for one side to be activated"""
   requiredStake: String!
-  rootHash: String! # For calculating user's max stake in client
-  motionDomainId: ID! # domain db id
+  """Unique identifier of the motions domain in the database"""
+  motionDomainId: ID!
+  """Expanded domain in which the motion was created"""
   motionDomain: Domain! @hasOne(fields: ["motionDomainId"])
+  """
+  The reputation root hash at the time of the creation of the motion
+  Used for calculating a user's max stake in client
+  """
+  rootHash: String!
+  """The on chain id of the domain associated with the motion"""
   nativeMotionDomainId: String! # native domain id
+  """Whether the motion was finalized or not"""
   isFinalized: Boolean!
-  createdBy: String! # voting rep extn address. Useful to check if we're viewing a "read-only" motion
+  """
+  Address of the VotingReputation extension
+  Useful to check if we're viewing a "read-only" motion
+  """
+  createdBy: String!
+  """A list of all of the votes cast within in the motion"""
   voterRecord: [VoterRecord!]!
+  """Total voting outcome for the motion (accumulated votes)"""
   revealedVotes: MotionStakes! ## I.e. MotionVotes (same type)
+  """The amount of reputation that has submitted a vote"""
   repSubmitted: String!
+  """The total amount of reputation (among all users) that can vote for this motion"""
   skillRep: String!
+  """Simple flag indicating whether both sides of staking have been activated"""
   hasObjection: Boolean!
+  """Quick access flages to check the current state of a motion in its lifecycle"""
   motionStateHistory: MotionStateHistory!
+  """List of motion status update messages"""
   messages: [MotionMessage!]! @hasMany(indexName: "byMotionId", fields: ["id"])
 }
 
 """
-Represents an event triggered by a smart contract within the Colony Network.
+Represents an event triggered by a smart contract within the Colony Network
 """
 # This will store the relevant events we care about for a particular colony
 # Altough it might also hold events emmited by other clients (eg: network or token)
@@ -1065,54 +1247,69 @@ Represents an event triggered by a smart contract within the Colony Network.
 # data from an event, also save that even for future use
 type ContractEvent @model {
   """
-  Unique identifier for the Contract Event, in the format chainID_transactionHash_logIndex.
+  Unique identifier for the Contract Event, in the format chainID_transactionHash_logIndex
   """
   id: ID!
-  """Name of the event."""
+  """Name of the event"""
   # i'm debating if this should be a enum or not, but this was you don't have to
   # update this schema every time you want to start tracking a new event
   name: String!
-  """The unique signature of the event."""
+  """The unique signature of the event"""
   signature: String!
-  """Metadata associated with the event's chain."""
+  """Metadata associated with the event's chain"""
   chainMetadata: ChainMetadata!
-  """Optional association with a Colony."""
+  """Optional association with a Colony"""
   colony: Colony @hasOne
-  """Optional association with a Token."""
+  """Optional association with a Token"""
   token: Token @hasOne
-  """Optional association with a Domain."""
+  """Optional association with a Domain"""
   domain: Domain @hasOne
-  """Optional association with a User."""
+  """Optional association with a User"""
   user: User @hasOne
-  """Address of the agent who initiated the event."""
+  """Address of the agent who initiated the event"""
   agent: String!
-  """Address of the target contract on the receiving end of the event."""
+  """Address of the target contract on the receiving end of the event"""
   target: String!
-  """Optional encoded arguments as a JSON string."""
+  """Optional encoded arguments as a JSON string"""
   encodedArguments: String
 }
 
+"""
+Parameters that were set when installing the VotingReputation extension
+For more info see [here](https://docs.colony.io/colonysdk/api/classes/VotingReputation#extension-parameters)
+"""
 type VotingReputationParams {
+  """Percentage of the team's reputation that needs to be staked ot activate either side of the motion"""
   totalStakeFraction: String!
+  """Percentage of the losing side's stake that is awarded to the voters"""
   voterRewardFraction: String!
+  """Minimum percentage of the total stake that each user has to provide"""
   userMinStakeFraction: String!
+  """Percentage of the total reputation that voted should end the voting period"""
   maxVoteFraction: String!
+  """Time that the staking period will last (in seconds)"""
   stakePeriod: String!
+  """Time that the voting period will last (in seconds)"""
   submitPeriod: String!
+  """Time that the reveal period will last (in seconds)"""
   revealPeriod: String!
+  """Time that the escalation period will last (in seconds)"""
   escalationPeriod: String!
 }
 
-# Parameters an extension is initialised with, e.g VotingRepExtn
+"""
+Map of parameters that extensions are initialised with
+"""
 type ExtensionParams {
+  """Initialization parameters for the `VotingReputation` extension"""
   votingReputation: VotingReputationParams
 }
 
 """
-Represents a single extension installed on a Colony.
+Represents a single extension installed on a Colony
 """
 type ColonyExtension @model {
-  """Unique identifier for the ColonyExtension."""
+  """Unique identifier for the ColonyExtension"""
   id: ID!
   """The identifier of the Colony that the extension belongs to (the Colony's address)"""
   colonyId: ID!
@@ -1121,116 +1318,138 @@ type ColonyExtension @model {
       sortKeyFields: ["hash"]
       queryField: "getExtensionByColonyAndHash"
     )
-  """The Colony that the extension belongs to."""
+  """The Colony that the extension belongs to"""
   colony: Colony! @belongsTo(fields: ["colonyId"])
   """
-  The unique hash of the extension.
-
+  The unique hash of the extension
   The hash is generated like so: `keccak256(toUtf8Bytes(extensionName))`, where `extensionName` is the name of the extension contract file in the Colony Network
   """
   hash: String! @index(name: "byHash", queryField: "getExtensionsByHash")
-  """The address of the user who installed the extension."""
+  """The address of the user who installed the extension"""
   installedBy: String!
-  """The timestamp when the extension was installed."""
+  """The timestamp when the extension was installed"""
   installedAt: AWSTimestamp!
-  """Indicates whether the extension is deprecated."""
+  """Indicates whether the extension is deprecated"""
   isDeprecated: Boolean!
-  """Indicates whether the extension has been removed."""
+  """Indicates whether the extension has been removed"""
   isDeleted: Boolean!
-  """Indicates whether the extension has been initialized."""
+  """Indicates whether the extension has been initialized"""
   isInitialized: Boolean!
-  """The version number of the extension."""
+  """The version number of the extension"""
   version: Int!
+  """Map of parameters that extension was initialised with"""
   params: ExtensionParams
 }
 
-"""Represents the current version of an entity in the system."""
+"""Represents the current version of an entity in the system"""
 type CurrentVersion @model {
-  """Unique identifier for the CurrentVersion."""
+  """Unique identifier for the CurrentVersion"""
   id: ID!
-  """The key used to look up the current version."""
+  """The key used to look up the current version"""
   key: String! @index(name: "byKey", queryField: "getCurrentVersionByKey")
-  """The current version number."""
+  """The current version number"""
   version: Int!
 }
 
+"""
+The current inverse of the network fee (in wei)
+(divide 1 by it and get the actual network fee)
+"""
 type CurrentNetworkInverseFee @model {
+  """Unique identifier for the network fee"""
   id: ID!
+  """The inverse fee"""
   inverseFee: String!
 }
 
-"""Represents an action performed within a Colony."""
+"""Represents an action performed within a Colony"""
 type ColonyAction @model {
-  """Unique identifier for the ColonyAction."""
+  """Unique identifier for the ColonyAction"""
   id: ID!
-  """The identifier of the Colony that the action belongs to."""
+  """The identifier of the Colony that the action belongs to"""
   colonyId: ID!
     @index(
       name: "byColony"
       queryField: "getActionsByColony"
       sortKeyFields: ["createdAt"]
     )
-  """The Colony that the action belongs to."""
+  """The Colony that the action belongs to"""
   colony: Colony! @belongsTo(fields: ["colonyId"])
-  """The type of action performed."""
+  """The type of action performed"""
   type: ColonyActionType!
-  """The block number where the action was recorded."""
+  """The block number where the action was recorded"""
   blockNumber: Int!
   isMotion: Boolean
+  """The internal database id of the motion"""
   motionId: ID
     @index(name: "byMotionId", queryField: "getColonyActionByMotionId")
+  """Expanded `ColonyMotion` for the corresponding `motionId`"""
   motionData: ColonyMotion @hasOne(fields: ["motionId"])
-  showInActionsList: Boolean! # True for (forced) actions. True for motions if staked above 10%
-  """The timestamp when the action was created."""
+  """
+  Whether to show the motion in the actions list
+  True for (forced) actions. True for motions if staked above 10%
+  """
+  showInActionsList: Boolean!
+  """The timestamp when the action was created"""
   createdAt: AWSDateTime!
-  """The Ethereum address of the action initiator. Can be a user, extension or colony."""
+  """The Ethereum address of the action initiator. Can be a user, extension or colony"""
   initiatorAddress: ID!
 
   # Action type specific fields which might be null
 
   # Amplify will automatically populate one of the following fields with related model if there is an initiator
-  """The User who initiated the action, if applicable."""
+  """The User who initiated the action, if applicable"""
   initiatorUser: User @hasOne(fields: ["initiatorAddress"])
-  """The ColonyExtension that initiated the action, if applicable."""
+  """The ColonyExtension that initiated the action, if applicable"""
   initiatorExtension: ColonyExtension @hasOne(fields: ["initiatorAddress"])
-  """The Colony that initiated the action, if applicable."""
+  """The Colony that initiated the action, if applicable"""
   initiatorColony: Colony @hasOne(fields: ["initiatorAddress"])
+  """The Token contract that initiated the action, if applicable"""
   initiatorToken: Token @hasOne(fields: ["initiatorAddress"])
 
   # Amplify will automatically populate one of the following fields with related model if there is an recipient
-  """The Ethereum address of the action recipient, if applicable."""
+  """The address of the action recipient, if applicable"""
   recipientAddress: ID
-  """The User who received the action, if applicable."""
+  """The User who received the action, if applicable"""
   recipientUser: User @hasOne(fields: ["recipientAddress"])
+  """The corresponding Colony which was involved the action, if applicable"""
   recipientColony: Colony @hasOne(fields: ["recipientAddress"])
+  """The corresponding extension which was involved the action, if applicable"""
   recipientExtension: ColonyExtension @hasOne(fields: ["recipientAddress"])
+  """The address of the token that was received the action, if applicable"""
   recipientToken: Token @hasOne(fields: ["recipientAddress"])
 
-  """The amount involved in the action, if applicable."""
+  """The amount involved in the action, if applicable"""
   amount: String
-  """The Ethereum address of the token involved in the action, if applicable."""
+  """The Ethereum address of the token involved in the action, if applicable"""
   tokenAddress: ID
-  """The Token involved in the action, if applicable."""
+  """The Token involved in the action, if applicable"""
   token: Token @hasOne(fields: ["tokenAddress"])
-  """The source Domain identifier, if applicable."""
+  """The source Domain identifier, if applicable"""
   fromDomainId: ID
-  """The source Domain of the action, if applicable."""
+  """The source Domain of the action, if applicable"""
   fromDomain: Domain @hasOne(fields: ["fromDomainId"])
-  """The target Domain identifier, if applicable."""
+  """The target Domain identifier, if applicable"""
   toDomainId: ID
-  """The target Domain of the action, if applicable."""
+  """The target Domain of the action, if applicable"""
   toDomain: Domain @hasOne(fields: ["toDomainId"])
   """The fundamental chain id"""
   fundamentalChainId: Int
-  """The resulting new Colony version, if applicable."""
+  """The resulting new Colony version, if applicable"""
   newColonyVersion: Int
+  """Identifier of domain metadata that is stored temporarily and commited to the database once the corresponding motion passes"""
   pendingDomainMetadataId: ID
+  """Domain metadata that is stored temporarily and commited to the database once the corresponding motion passes"""
   pendingDomainMetadata: DomainMetadata
     @hasOne(fields: ["pendingDomainMetadataId"])
+  """Identifier of Colony metadata that is stored temporarily and commited to the database once the corresponding motion passes"""
   pendingColonyMetadataId: ID
+  """Colony metadata that is stored temporarily and commited to the database once the corresponding motion passes"""
   pendingColonyMetadata: ColonyMetadata
     @hasOne(fields: ["pendingColonyMetadataId"])
+  """Corresponding domainId of the motion"""
   motionDomainId: Int
+  """Colony roles that are associated with the action"""
   roles: ColonyActionRoles
 
   # Required since some actions might have multiple event entries in the list
@@ -1251,49 +1470,81 @@ type ColonyAction @model {
   #
   # Roles Types:
   # [{ id: String, type: String, role: Number, setTo: boolean }]
+  """JSON string to pass custom, dynamic event data"""
   individualEvents: String
 }
 
-type ColonyActionRoles {
-  role_0: Boolean # recovery
-  role_1: Boolean # root
-  role_2: Boolean # arbitration
-  role_3: Boolean # architecture
-  role_5: Boolean # funding
-  role_6: Boolean # administration
-}
-
+"""Colony Roles that can be involved in an action"""
 # Roles have been set as role_<number> so we can more easily map them to their
 # actual contract counterpart on the client and block ingestor side(s)
-
-type ColonyRole @model {
-  id: ID! @index # colonyAddress_domainNativeId_userAddress_roles
-  domainId: ID!
-  domain: Domain! @hasOne(fields: ["domainId"])
-
-  targetAddress: ID # Amplify will automatically populate one of the following fields with related model if it finds one
-  targetUser: User @hasOne(fields: ["targetAddress"])
-  targetColony: Colony @hasOne(fields: ["targetAddress"])
-  targetExtension: ColonyExtension @hasOne(fields: ["targetAddress"])
-  targetToken: Token @hasOne(fields: ["targetAddress"])
-
-  latestBlock: Int!
-  role_0: Boolean # recovery
-  role_1: Boolean # root
-  role_2: Boolean # arbitration
-  role_3: Boolean # architecture
-  role_5: Boolean # funding
-  role_6: Boolean # administration
+type ColonyActionRoles {
+  """Recovery role"""
+  role_0: Boolean
+  """Root role"""
+  role_1: Boolean
+  """Arbitration role"""
+  role_2: Boolean
+  """Architecture role"""
+  role_3: Boolean
+  """Funding role"""
+  role_5: Boolean
+  """Administration role"""
+  role_6: Boolean
 }
 
+"""A snapshot of the current set of permissions a given address has in a given domain within a Colony"""
+type ColonyRole @model {
+  """
+  Unique identifier for the role snapshot
+  Format: `colonyAddress_domainNativeId_userAddress_roles`
+  """
+  id: ID! @index
+  """Unique identifier of the domain"""
+  domainId: ID!
+  """Expaneded `Domain` model, based on the `domainId` given"""
+  domain: Domain! @hasOne(fields: ["domainId"])
+
+  # Amplify will automatically populate one of the following fields with related model if it finds one
+  """Address of the agent the permission was set for"""
+  targetAddress: ID
+  """Will expand to a `User` model if permission was set for a user"""
+  targetUser: User @hasOne(fields: ["targetAddress"])
+  """Will expand to a `Colony` model if permission was set for another Colony"""
+  targetColony: Colony @hasOne(fields: ["targetAddress"])
+  """Will expand to a `ColonyExtension` model if permission was set for a Colony extension"""
+  targetExtension: ColonyExtension @hasOne(fields: ["targetAddress"])
+  """Will expand to a `Token` model if permission was set for a Token contract"""
+  targetToken: Token @hasOne(fields: ["targetAddress"])
+
+  """Block at which permissions were update last"""
+  latestBlock: Int!
+  """Recovery role"""
+  role_0: Boolean
+  """Root role"""
+  role_1: Boolean
+  """Arbitration role"""
+  role_2: Boolean
+  """Architecture role"""
+  role_3: Boolean
+  """Funding role"""
+  role_5: Boolean
+  """Administration role"""
+  role_6: Boolean
+}
+
+""""
+Snapshot of the user's full roles/permissions at a specific block
+"""
 # it's a model, not a type since this is designed to work outside of the main
 # colony model, or colony role model, as, by design it should be only used
 # in very specific cases
-#
-# This should take a snapshot of the user's full roles/permissions at a specific block
-
 type ColonyHistoricRole @model {
-  id: ID! # colonyAddress_domainNativeId_userAddress_blockNumber_roles
+  """
+  Unique identifier for the role snapshot
+  Format: `colonyAddress_domainNativeId_userAddress_blockNumber_roles`
+  """
+  id: ID! #
+  """Used for amplify sorting. Set to `SortedHistoricRole`"""
   # I HATE AMPLIFY SORTING! MAY IT DIE A THOUSAND DEATHS!
   #
   # @NOTE Always set to `type` to "SortedHistoricRole" to enable Amplify sorting, it DOES NOT WORK with `id`
@@ -1309,29 +1560,51 @@ type ColonyHistoricRole @model {
       sortKeyFields: ["createdAt"]
     )
 
+  """Unique identifier of the domain"""
   domainId: ID!
+  """Expaneded `Domain` model, based on the `domainId` given"""
   domain: Domain! @hasOne(fields: ["domainId"])
+  """Unique identifier of the Colony"""
   colonyId: ID!
+  """Expaneded `Colony` model, based on the `colonyId` given"""
   colony: Colony! @hasOne(fields: ["colonyId"])
 
-  targetAddress: ID # Amplify will automatically populate one of the following fields with related model if it finds one
+  # Amplify will automatically populate one of the following fields with related model if it finds one
+  """Address of the agent the permission was set for"""
+  targetAddress: ID
+  """Will expand to a `User` model if permission was set for a user"""
   targetUser: User @hasOne(fields: ["targetAddress"])
+  """Will expand to a `Colony` model if permission was set for another Colony"""
   targetColony: Colony @hasOne(fields: ["targetAddress"])
+  """Will expand to a `ColonyExtension` model if permission was set for a Colony extension"""
   targetExtension: ColonyExtension @hasOne(fields: ["targetAddress"])
+  """Will expand to a `Token` model if permission was set for a Token contract"""
   targetToken: Token @hasOne(fields: ["targetAddress"])
 
+  """Block at which the snapshot was taken"""
   blockNumber: Int!
-  role_0: Boolean # recovery
-  role_1: Boolean # root
-  role_2: Boolean # arbitration
-  role_3: Boolean # architecture
-  role_5: Boolean # funding
-  role_6: Boolean # administration
+  """Recovery role"""
+  role_0: Boolean
+  """Root role"""
+  role_1: Boolean
+  """Arbitration role"""
+  role_2: Boolean
+  """Architecture role"""
+  role_3: Boolean
+  """Funding role"""
+  role_5: Boolean
+  """Administration role"""
+  role_6: Boolean
+  """Timestamp at which the database entry was created"""
   createdAt: AWSDateTime!
 }
 
-# Model storing block ingestor stats, as key-value entries
+"""
+Model storing block ingestor stats, as key-value entries
+"""
 type IngestorStats @model {
+  """Unique identifier of the ingestore stats"""
   id: ID!
+  """JSON string to pass custom, dynamic values"""
   value: String!
 }

--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -8,109 +8,223 @@ input AMPLIFY {
 # https://docs.amplify.aws/cli-legacy/graphql-transformer/overview/#api-category-project-structure
 # but I never could get it to work
 
+"""
+Input data for fetching a token's information from DB or chain.
+"""
 input TokenFromEverywhereArguments {
+  """Address of the token on the blockchain."""
   tokenAddress: String!
 }
 
+"""
+Input data for fetching the list of members for a specific Colony.
+"""
 input MembersForColonyInput {
+  """Address of the Colony."""
   colonyAddress: String!
+  """Root hash for the reputation state."""
   rootHash: String
+  """ID of the domain within the Colony."""
   domainId: Int
+  """Sorting method to apply to the member list."""
   sortingMethod: SortingMethod
 }
 
+"""
+Input data for creating a unique user within the Colony Network. Use this instead of the automatically generated `CreateUserInput` input type.
+"""
 input CreateUniqueUserInput {
+  """Unique identifier for the user. This is the user's wallet address."""
   id: ID!
+  """The username."""
   name: String!
+  """Profile data for the user."""
   profile: ProfileInput
 }
 
+"""
+**Deprecated** Extra permissions for a user, stored during the registration process.
+"""
 enum EmailPermissions {
+  """Permission to send notifications to the user."""
   sendNotifications
+  """Person is registered and solved the captcha, they can use gasless transactions."""
   isHuman
 }
 
+"""
+Input data for a user's profile metadata.
+"""
 input ProfileMetadataInput {
+  """List of email permissions for the user."""
   emailPermissions: [String!]!
 }
 
+"""
+Input data for relevant chain metadata of a Colony (if applicable).
+"""
 input ChainMetadataInput {
+  """The network the Colony is deployed on."""
   network: Network
+  """The chain ID of the network."""
   chainId: Int!
+  """The transaction hash of the creation transaction."""
   transactionHash: String
+  """The log index of the creation transaction."""
   logIndex: Int
+  """The block number of the creation transaction."""
   blockNumber: Int
 }
 
+"""
+Input data for the status of a Colony's native token.
+
+Colonies can have different types of native tokens in various modes. Here we define some important properties that the dApp uses to enable or disable certain features or views. This is set when a Colony is created and can be changed later.
+"""
 input NativeTokenStatusInput {
+  """Whether the native token is unlocked."""
   unlocked: Boolean
+  """Whether the native token is mintable."""
   mintable: Boolean
+  """Whether the native token can be unlocked."""
   unlockable: Boolean
 }
 
+"""
+Input data for a Colony's status information.
+
+This is set when a Colony is created and can be changed later.
+"""
 input ColonyStatusInput {
+  """Status information for the Colony's native token."""
   nativeToken: NativeTokenStatusInput
+  """Whether the Colony is in recovery mode."""
   recovery: Boolean
 }
 
+"""
+Input data for creating a unique Colony within the Colony Network. Use this instead of the automatically generated `CreateColonyInput` input type.
+"""
 input CreateUniqueColonyInput {
+  """Unique identifier for the Colony. This is the Colony's contract address."""
   id: ID!
+  """Display name of the Colony."""
   name: String!
+  """Unique identifier for the Colony's native token (this is its address)."""
   colonyNativeTokenId: ID!
+  """Type of the Colony (regular or MetaColony)."""
   type: ColonyType
+  """Status information for the Colony."""
   status: ColonyStatusInput
+  """Metadata related to the Colony's creation on the blockchain."""
   chainMetadata: ChainMetadataInput!
+  """Version of the currently deployed Colony contract."""
   version: Int!
 }
 
+"""
+Input data to use when creating or changing a user profile
+"""
 input ProfileInput {
-  id: ID # nullable since resolver will use User / Colony id by default
+  """The unique identifier for the user profile."""
+  id: ID
+  """The URL of the user's avatar image."""
   avatar: String
+  """The URL of the user's thumbnail image."""
   thumbnail: String
+  """The display name of the user."""
   displayName: String
+  """A short description or biography of the user."""
   bio: String
+  """The user's location (e.g., city or country)."""
   location: String
+  """The user's personal or professional website."""
   website: AWSURL
+  """The user's email address."""
   email: AWSEmail
+  """Any additional metadata or settings related to the user profile."""
   meta: ProfileMetadataInput
 }
 
+"""
+Input data for a user's reputation within a Domain in a Colony. If no `domainId` is passed, the Root Domain is used.
+A `rootHash` can be provided, to get reputation at a certain point in the past.
+"""
 input GetUserReputationInput {
+  """The Ethereum wallet address of the user."""
   walletAddress: String!
+  """The Ethereum address of the Colony."""
   colonyAddress: String!
+  """The ID of the Domain within the Colony. If not provided, defaults to the Root Domain."""
   domainId: Int
+  """The root hash of the reputation tree at a specific point in time."""
   rootHash: String
 }
 
+"""
+Input data for updating an extension's information within a Colony, based on the Colony ID and extension hash.
+The hash is generated like so: `keccak256(toUtf8Bytes(extensionName))`, where `extensionName` is the name of the extension contract file in the Colony Network
+"""
 input UpdateExtensionByColonyAndHashInput {
+  """The unique identifier for the Colony."""
   colonyId: ID!
+  """The hash of the extension to be updated."""
   hash: String!
+  """A flag to indicate whether the extension is deprecated."""
   isDeprecated: Boolean
+  """A flag to indicate whether the extension is deleted."""
   isDeleted: Boolean
+  """A flag to indicate whether the extension is initialized."""
   isInitialized: Boolean
+  """The version of the extension."""
   version: Int
+  """The Ethereum address of the user who installed the extension."""
   installedBy: String
+  """The timestamp when the extension was installed."""
   installedAt: AWSTimestamp
 }
 
+"""
+Input data to store the latest available version of the core Colony contract and available extensions
+
+The extension hash is generated like so: `keccak256(toUtf8Bytes(extensionName))`, where `extensionName` is the name of the extension contract file in the Colony Network (e.g. `VotingReputation`)
+"""
 input SetCurrentVersionInput {
+  """COLONY for the Colony contract, extension hash for extensions"""
   key: String!
+  """Latest available version"""
   version: Int!
 }
 
+"""
+Return type for tokens gotten from DB or from chain.
+"""
 type TokenFromEverywhereReturn {
+  """List of tokens found"""
   items: [Token]
 }
 
+"""
+Input data for retrieving a user's reputation within the top domains of a Colony.
+"""
 input GetReputationForTopDomainsInput {
+  """The wallet address of the user."""
   walletAddress: String!
+  """The address of the Colony."""
   colonyAddress: String!
+  """The root hash of the reputation tree at a specific point in time."""
   rootHash: String
 }
 
+"""
+Input data for retrieving a user's token balance for a specific token.
+"""
 input GetUserTokenBalanceInput {
+  """The wallet address of the user."""
   walletAddress: String!
+  """The Colony address"""
   colonyAddress: String!
+  """The address of the token."""
   tokenAddress: String!
 }
 
@@ -133,20 +247,49 @@ input GetMotionTimeoutPeriodsInput {
   colonyAddress: String!
 }
 
+"""
+A type representing a user's reputation within a domain.
+"""
 type UserDomainReputation {
+  """The integer ID of the Domain within the Colony."""
   domainId: Int!
+  """The user's reputation within the domain, represented as a percentage."""
   reputationPercentage: String!
 }
 
+"""
+A return type that contains an array of UserDomainReputation items.
+"""
 type GetReputationForTopDomainsReturn {
+  """An array of UserDomainReputation items."""
   items: [UserDomainReputation!]
 }
 
+"""
+A return type representing the breakdown of a user's token balance.
+"""
 type GetUserTokenBalanceReturn {
-  balance: String # total balance, sum of inactive, locked and active
+  """The total token balance, including inactive, locked, and active balances."""
+  balance: String
+  """
+  The inactive portion of the user's token balance.
+  This is the balance of a token that is in a users wallet but can't be used by the Colony Network (e.g. for governance).
+  """
   inactiveBalance: String
+  """
+  The locked portion of the user's token balance.
+  This is the balance of a token that is staked (e.g. in motions).
+  """
   lockedBalance: String
+  """
+  The active portion of the user's token balance.
+  This is the balance that is approved for the Colony Network to use (e.g. for governance).
+  """
   activeBalance: String
+  """
+  The pending portion of the user's token balance.
+  These are tokens that have been sent to the wallet, but are inaccessible until all locks are cleared and then these tokens are claimed.
+  """
   pendingBalance: String
 }
 
@@ -157,12 +300,18 @@ type GetMotionTimeoutPeriodsReturn {
   timeLeftToEscalate: String!
 }
 
-# Definitions:
-# Member = User watching a Colony, with or without reputation
-# Contributor = User watching a Colony WITH reputation
-# Watcher = User watching a Colony WITHOUT reputation
+"""
+A return type representing the members of a Colony.
+
+Definitions:
+* Member = User watching a Colony, with or without reputation
+* Contributor = User watching a Colony WITH reputation
+* Watcher = User watching a Colony WITHOUT reputation
+"""
 type MembersForColonyReturn {
+  """User watching a Colony WITH reputation"""
   contributors: [Contributor!]
+  """User watching a Colony WITHOUT reputation"""
   watchers: [Watcher!]
 }
 
@@ -172,93 +321,165 @@ type VoterRewardsReturn {
   reward: String!
 }
 
+"""
+Variants of different token types a Colony can use.
+As Colonies can use multiple tokens and even own tokens (BYOT), we need to differentiate.
+"""
 enum TokenType {
+  """A (ERC20-compatible) token that was deployed with Colony. It has a few more features, like minting through the Colony itself"""
   COLONY
+  """An ERC20-compatible token"""
   ERC20
+  """The native token of the Chain used (e.g. ETH on mainnet or xDAI on Gnosis-Chain)"""
   CHAIN_NATIVE
 }
 
+
+"""
+Variants of supported Ethereum networks.
+"""
 enum Network {
+  """Local development network using Ganache."""
   GANACHE
+  """Ethereum Mainnet."""
   MAINNET
+  """Ethereum Goerli test network."""
   GOERLI
+  """Gnosis Chain network."""
   GNOSIS
+  """Fork of Gnosis Chain for QA purposes."""
   GNOSISFORK
 }
 
+"""
+Variants of available domain colors as used in the dApp.
+"""
 enum DomainColor {
+  """A light pink color."""
   LIGHT_PINK
+  """A pink color."""
   PINK
+  """A black color."""
   BLACK
+  """An emerald green color."""
   EMERALD_GREEN
+  """A blue color."""
   BLUE
+  """A yellow color."""
   YELLOW
+  """A red color."""
   RED
+  """A green color."""
   GREEN
+  """A pale indigo color."""
   PERIWINKLE
+  """A gold color."""
   GOLD
+  """An aqua color."""
   AQUA
+  """A blue-grey(ish) color."""
   BLUE_GREY
+  """A purple color."""
   PURPLE
+  """An orange color."""
   ORANGE
+  """A magenta color."""
   MAGENTA
+  """A purple-grey(ish) color."""
   PURPLE_GREY
 }
 
+"""
+Variants of Colony types.
+"""
 enum ColonyType {
+  """A regular Colony."""
   COLONY
+  """The MetaColony, which governs the entire Colony Network."""
   METACOLONY
 }
 
+"""
+Variants of Colony Network blockchain events.
+
+These can all happen in a Colony and will be interpreted by the dApp according to their types.
+"""
 enum ColonyActionType {
+  """A generic or unspecified Colony action."""
   GENERIC
   NULL_MOTION
+  """An action unrelated to the currently viewed Colony. """
   WRONG_COLONY
+  """An action related to a payment within a Colony."""
   PAYMENT
   PAYMENT_MOTION
+  """An action related to the recovery functionality of a Colony."""
   RECOVERY
+  """An action related to moving funds between domains."""
   MOVE_FUNDS
   MOVE_FUNDS_MOTION
+  """An action related to unlocking a token within a Colony."""
   UNLOCK_TOKEN
   UNLOCK_TOKEN_MOTION
+  """An action related to minting tokens within a Colony."""
   MINT_TOKENS
   MINT_TOKENS_MOTION
+  """An action related to creating a domain within a Colony."""
   CREATE_DOMAIN
   CREATE_DOMAIN_MOTION
+  """An action related to upgrading a Colony's version."""
   VERSION_UPGRADE
   VERSION_UPGRADE_MOTION
+  """An action related to editing a Colony's details."""
   COLONY_EDIT
   COLONY_EDIT_MOTION
+  """An action related to editing a domain's details."""
   EDIT_DOMAIN
   EDIT_DOMAIN_MOTION
+  """An action related to setting user roles within a Colony."""
   SET_USER_ROLES
   SET_USER_ROLES_MOTION
+  """An action related to a domain reputation penalty within a Colony (smite)."""
   EMIT_DOMAIN_REPUTATION_PENALTY
   EMIT_DOMAIN_REPUTATION_PENALTY_MOTION
+  """An action related to a domain reputation reward within a Colony."""
   EMIT_DOMAIN_REPUTATION_REWARD
   EMIT_DOMAIN_REPUTATION_REWARD_MOTION
 }
 
+"""
+Variants of sorting methods for a member list.
+"""
 enum SortingMethod {
+  """Sort members by highest reputation."""
   BY_HIGHEST_REP
+  """Sort members by lowest reputation."""
   BY_LOWEST_REP
+  """Sort members by having more permissions."""
   BY_MORE_PERMISSIONS
+  """Sort members by having fewer permissions."""
   BY_LESS_PERMISSIONS
 }
 
+"""Root query type."""
 type Query {
+  """Fetch a token's information. Tries to get the data from the DB first, if that fails, resolves to get data from chain"""
   getTokenFromEverywhere(
     input: TokenFromEverywhereArguments
   ): TokenFromEverywhereReturn @function(name: "fetchTokenFromChain-${env}")
+  """Retrieve a user's reputation within the top domains of a Colony."""
   getReputationForTopDomains(
     input: GetReputationForTopDomainsInput
   ): GetReputationForTopDomainsReturn
     @function(name: "getReputationForTopDomains-${env}")
+  """Retrieve a user's reputation within a specific domain in a Colony."""
   getUserReputation(input: GetUserReputationInput): String
     @function(name: "getUserReputation-${env}")
+  """Retrieve a user's token balance for a specific token."""
   getUserTokenBalance(
     input: GetUserTokenBalanceInput
   ): GetUserTokenBalanceReturn @function(name: "getUserTokenBalance-${env}")
+  """Fetch the list of members for a specific Colony."""
   getMembersForColony(input: MembersForColonyInput): MembersForColonyReturn
     @function(name: "getMembersForColony-${env}")
   getMotionState(input: GetMotionStateInput): Int!
@@ -271,115 +492,210 @@ type Query {
     @function(name: "fetchMotionTimeoutPeriods-${env}")
 }
 
+"""
+Root mutation type.
+"""
 type Mutation {
+  """Create a unique user within the Colony Network. Use this instead of the automatically generated `createUser` mutation"""
   createUniqueUser(input: CreateUniqueUserInput): User
     @function(name: "createUniqueUser-${env}")
+  """Create a unique Colony within the Colony Network. Use this instead of the automatically generate `createColony` mutation"""
   createUniqueColony(input: CreateUniqueColonyInput): Colony
     @function(name: "createUniqueColony-${env}")
+  """Updates the latest available version of a Colony or an extension"""
   setCurrentVersion(input: SetCurrentVersionInput): Boolean
     @function(name: "setCurrentVersion-${env}")
+  """
+  Update an extension's details for a specific Colony.
+
+  The extension hash is generated like so: `keccak256(toUtf8Bytes(extensionName))`, where `extensionName` is the name of the extension contract file in the Colony Network (e.g. `VotingReputation`)
+  """
   updateExtensionByColonyAndHash(
     input: UpdateExtensionByColonyAndHashInput
   ): ColonyExtension @function(name: "updateExtensionByColonyAndHash-${env}")
 }
 
+"""
+Represents a user's profile within the Colony Network.
+"""
 type Profile @model {
+  """Unique identifier for the user's profile."""
   id: ID!
+  """URL of the user's avatar image."""
   avatar: String
+  """URL of the user's thumbnail image."""
   thumbnail: String
+  """Display name of the user."""
   displayName: String
+  """User's bio information."""
   bio: String
+  """User's location information."""
   location: String
+  """URL of the user's website."""
   website: AWSURL
+  """User's email address."""
   email: AWSEmail @index(name: "byEmail", queryField: "getProfileByEmail")
+  """Metadata associated with the user's profile."""
   meta: ProfileMetadata
 }
 
+"""
+Represents the status of a Colony's native token.
+
+Colonies can have different types of native tokens in various modes. Here we define some important properties that the dApp uses to enable or disable certain features or views. This is set when a Colony is created and can be changed later.
+"""
 type NativeTokenStatus {
-  unlocked: Boolean # If it's already unlocked
-  mintable: Boolean # User has permissions to mint new tokens
-  unlockable: Boolean # Token can be unlocked
+  """Whether the native token is unlocked."""
+  unlocked: Boolean
+  """Whether the user has permissions to mint new tokens."""
+  mintable: Boolean
+  """Whether the native token can be unlocked."""
+  unlockable: Boolean
 }
 
+"""
+Represents the status of a Colony.
+
+This contains important meta information about the Colony's token and other fundamental settings
+"""
 type ColonyStatus {
+  """Status information for the Colony's native token."""
   nativeToken: NativeTokenStatus
-  recovery: Boolean # if it's in recovery mode
+  """Whether the Colony is in recovery mode."""
+  recovery: Boolean
 }
 
-# Applies to both Colonies Tokens and Events, but not all fields are revlant to all
-# It does not apply to user accounts as they can live on all networks
+"""
+Represents metadata related to a blockchain event.
+
+Applies to Colonies, Tokens and Events, but not all fields are revlant to all
+It does not apply to user accounts as they can live on all networks
+"""
 type ChainMetadata {
+  """The network the event occurred on."""
   network: Network
+  """The chain ID of the event."""
   chainId: Int!
+  """The transaction hash of the event."""
   transactionHash: String
+  """The log index of the event."""
   logIndex: Int
+  """The block number of the event."""
   blockNumber: Int
 }
 
+"""
+Represents metadata for a user's profile. Mostly user specific settings.
+"""
 type ProfileMetadata {
+  """List of email permissions for the user."""
   emailPermissions: [String!]!
 }
 
+"""
+Represents a contributor within the Colony Network.
+
+A contributor is a Colony member who has reputation.
+"""
 type Contributor {
+  """Wallet address of the contributor."""
   address: String!
+  """User data associated with the contributor."""
   user: User
+  """Reputation percentage of the contributor (of all reputation within the Colony)."""
   reputationPercentage: String
+  """Reputation amount of the contributor (as an absolute number)."""
   reputationAmount: String
 }
 
+"""
+Represents a watcher within the Colony Network.
+
+A watcher is a Colony member who doesn't have reputation.
+"""
 type Watcher {
+  """Wallet address of the watcher."""
   address: String!
+  """User data associated with the watcher."""
   user: User
 }
 
+"""Represents an ERC20-compatible token that is used by Colonies and users."""
 type Token @model {
+  """Unique identifier for the token (contract address)."""
   id: ID!
     @index(name: "byAddress", queryField: "getTokenByAddress")
     @index(sortKeyFields: ["createdAt"]) # contract address
+  """Name of the token."""
   name: String!
+  """Symbol of the token."""
   symbol: String!
+  """Decimal precision of the token."""
   decimals: Int!
+  """Type of the token. See `TokenType` for more information"""
   type: TokenType @index(name: "byType", queryField: "getTokensByType")
+  """List of colonies using the token."""
   colonies: [Colony] @manyToMany(relationName: "ColonyTokens")
+  """List of users using the token."""
   users: [User] @manyToMany(relationName: "UserTokens")
+  """URL of the token's avatar image (logo)."""
   avatar: String
+  """URL of the token's thumbnail image (Small logo)."""
   thumbnail: String
+  """Metadata related to the chain of the token."""
   chainMetadata: ChainMetadata!
+  """Timestamp of the token model's creation in the database."""
   createdAt: AWSDateTime!
 }
 
-type ColonyID {
-  id: ID!
-}
-
+"""
+Represents a Colony within the Colony Network.
+"""
 type Colony @model {
-  id: ID! @index(name: "byAddress", queryField: "getColonyByAddress") # colony contract address
+  """Unique identifier for the Colony (contract address)."""
+  id: ID! @index(name: "byAddress", queryField: "getColonyByAddress")
+  """(Short) name of the Colony."""
   name: String! @index(name: "byName", queryField: "getColonyByName")
+  """The unique address of the native token of the Colony."""
   nativeTokenId: ID!
     @index(name: "byNativeTokenId", queryField: "getColoniesByNativeTokenId")
+  """The native token of the Colony."""
   nativeToken: Token! @hasOne(fields: ["nativeTokenId"])
+  """List of tokens that are used within the Colony."""
   tokens: [Token] @manyToMany(relationName: "ColonyTokens")
+  """Status information for the Colony."""
   status: ColonyStatus
+  """List of domains of the Colony."""
   domains: [Domain] @hasMany(indexName: "byColony", fields: ["id"])
-  watchers: [User] @manyToMany(relationName: "WatchedColonies") # colony subscriptions
+  """List of users watching the Colony."""
+  watchers: [User] @manyToMany(relationName: "WatchedColonies")
+  """List of Colony funds claims for all ERC20 tokens."""
   # NOTE: Could not merge these two fields properly
   # Ideally we would merge data from these two into one field, but I couldn't do that
   # meaning we'll have to merge this data in-app (or not at all, works either way)
-  # If you have a better idea, on how to merged them, I'll all ears...
-  fundsClaims: [ColonyFundsClaim] @hasMany # All ERC20 token claims
-  # Native chain token claims (eg: Token 0x0000...0000)
+  # If you have a better idea, on how to merged them, I'll all ears..
+  fundsClaims: [ColonyFundsClaim] @hasMany
+  """List of native chain token claims (e.g., Token 0x0000...0000: ETH, xDAI, etc.)."""
   # This is not an array since only a single token type can be returned
   chainFundsClaim: ColonyChainFundsClaim
     @function(name: "fetchColonyNativeFundsClaim-${env}")
+  """Type of the Colony (Regular or Metacolony)."""
   type: ColonyType @index(name: "byType", queryField: "getColonyByType")
-  # Returns a list token balances for each domain and each token that the colony has
+  """Returns a list token balances for each domain and each token that the colony has."""
   balances: ColonyBalances @function(name: "fetchColonyBalances-${env}")
+  """Metadata related to the chain of the Colony."""
   chainMetadata: ChainMetadata!
+  """List of extensions installed in the Colony."""
   extensions: [ColonyExtension!] @hasMany(indexName: "byColony", fields: ["id"])
+  """Version of the Colony."""
   version: Int!
+  """List of actions that happened within the Colony."""
   actions: [ColonyAction] @hasMany
+  """List of motions within the Colony that have unclaimed stakes."""
   motionsWithUnclaimedStakes: [ColonyUnclaimedStake!]
+  """Metadata of the Colony."""
   metadata: ColonyMetadata @hasOne(fields: ["id"])
+  """List of all roles within the Colony"""
   # @TODO This should not be fetched upfront
   # It should be retrieved on demand at the earliest occasion it's needed
   # ie: when opening a UAC modal
@@ -396,33 +712,60 @@ type PendingModifiedTokenAddresses {
   removed: [String!]
 }
 
+"""
+Represents metadata for a Colony.
+"""
 type ColonyMetadata @model {
-  id: ID! # colony contract address
+  """Unique identifier for the Colony (contract address)."""
+  id: ID!
+  """Display name of the Colony."""
   displayName: String!
+  """URL of the Colony's avatar image."""
   avatar: String
+  """URL of the Colony's thumbnail image."""
   thumbnail: String
+  """List of Colony metadata changelog entries."""
   changelog: [ColonyMetadataChangelog!]
   isWhitelistActivated: Boolean
   whitelistedAddresses: [String!]
   modifiedTokenAddresses: PendingModifiedTokenAddresses # only present on pendingColonyMetadata for consumption in block ingestor
 }
 
+"""
+Represents a changelog entry for Colony metadata.
+
+This is used to traverse through the history of metadata values and consolidate them into a final state.
+"""
 type ColonyMetadataChangelog {
+  """Transaction hash associated with the changelog entry."""
   transactionHash: String!
+  """Display name of the Colony before the change."""
   oldDisplayName: String!
+  """Display name of the Colony after the change."""
   newDisplayName: String!
+  """Indicates whether the avatar has changed."""
   hasAvatarChanged: Boolean!
   hasWhitelistChanged: Boolean!
   haveTokensChanged: Boolean!
 }
 
+"""
+Represents a User within the Colony Network.
+"""
 type User @model {
-  id: ID! @index(name: "byAddress", queryField: "getUserByAddress") # wallet address
+  """Unique identifier for the user (wallet address)."""
+  id: ID! @index(name: "byAddress", queryField: "getUserByAddress")
+  """(Short) name of the user."""
   name: String! @index(name: "byName", queryField: "getUserByName")
+  """List of tokens the user is using."""
   tokens: [Token] @manyToMany(relationName: "UserTokens")
+  """Profile ID associated with the user."""
   profileId: ID
+  """Profile information of the user."""
   profile: Profile @hasOne(fields: ["profileId"])
+  """List of Colonies the user is watching."""
   watchlist: [Colony] @manyToMany(relationName: "WatchedColonies") # colony subscriptions
+  """List of stakes the User made"""
   stakes: [ColonyStake!]! @hasMany(indexName: "byUserAddress", fields: ["id"])
 }
 
@@ -440,55 +783,122 @@ type ColonyStake @model {
   totalAmount: String!
 }
 
+"""
+Represents a Domain within the Colony Network.
+"""
 type Domain @model {
-  id: ID! # We have to self-manage this and keep it the following format: colonyAddress_nativeId
+  """
+  Unique identifier for the Domain.
+
+  This should be in the following format: `colonyAddress_nativeId`
+  The native id is the auto-incrementing integer that is assigned to a domain from the contract on creation
+  """
+  # Has to be self-managed
+  id: ID!
+  """Colony ID associated with the Domain."""
   colonyId: ID! @index(name: "byColony")
+  """Colony associated with the Domain."""
   colony: Colony! @belongsTo(fields: ["colonyId"])
+  """
+  Native ID of the Domain.
+
+  The native id is the auto-incrementing integer that is assigned to a domain from the contract on creation
+  """
   nativeId: Int!
+  """
+  Native funding pot ID of the Domain.
+
+  The native funding pot ID is assigned to a domain from the contract on creation
+  """
   nativeFundingPotId: Int!
+  """
+  Native skill ID of the Domain.
+
+  The native skill ID is assigned to a domain from the contract on creation
+  """
   nativeSkillId: Int!
+  """Indicates whether the Domain is the root domain (ID 1)"""
   isRoot: Boolean!
+  """Metadata of the Domain."""
   metadata: DomainMetadata @hasOne(fields: ["id"])
 }
 
+"""
+Represents metadata for a Domain.
+"""
 type DomainMetadata @model {
-  id: ID! # This field is referenced by Domain id, so has to be in the same format: colonyAddress_nativeId
+  """
+  Unique identifier for the Domain metadata.
+  This field is referenced by Domain id, so has to be in the same format: colonyAddress_nativeId
+  """
+  id: ID!
+  """Name of the Domain."""
   name: String!
+  """Description of the Domain."""
   description: String!
+  """Color associated with the Domain."""
   color: DomainColor!
+  """List of Domain metadata changelog entries."""
   changelog: [DomainMetadataChangelog!]
 }
 
+"""
+Represents a changelog entry for Domain metadata.
+"""
 type DomainMetadataChangelog {
+  """Transaction hash associated with the changelog entry."""
   transactionHash: String!
+  """Name of the Domain before the change."""
   oldName: String!
+  """Name of the Domain after the change."""
   newName: String!
+  """Color of the Domain before the change."""
   oldColor: DomainColor!
+  """Color of the Domain after the change."""
   newColor: DomainColor!
+  """Description of the Domain before the change."""
   oldDescription: String!
+  """Description of the Domain after the change."""
   newDescription: String!
 }
 
+"""
+Represents a Colony Funds Claim for all ERC20 tokens (except native chain tokens)
+"""
 type ColonyFundsClaim @model {
+  """Unique identifier for the Colony Funds Claim."""
   id: ID! @index(sortKeyFields: ["createdAt"])
+  """Token associated with the Colony Funds Claim."""
   token: Token! @hasOne
+  """Block number when the Funds Claim was created."""
   createdAtBlock: Int!
+  """Timestamp when the Funds Claim was created."""
   createdAt: AWSDateTime!
+  """Amount claimed in the Colony Funds Claim."""
   amount: String!
 }
 
-# This is really not elegant, but there's no other proper solution, as you can't
-# return the Token @hadOne relationship from the lambda function
-# Note that we don't need token details for the values that we're fetching (since
-# it's implied), but it would have been nice not to have to basically repeat the type
+"""
+Represents a native Colony Chain Funds Claim
+
+E.g., Token 0x0000...0000: ETH, xDAI, etc.
+"""
 type ColonyChainFundsClaim {
+  """Unique identifier for the Colony Chain Funds Claim."""
   id: ID!
+  """Block number when the Chain Funds Claim was created."""
   createdAtBlock: Int!
+  """Timestamp when the Chain Funds Claim was created."""
   createdAt: AWSDateTime!
+  """Timestamp when the Chain Funds Claim was last updated."""
   updatedAt: AWSDateTime!
+  """Amount claimed in the Colony Chain Funds Claim."""
   amount: String!
 }
 
+"""
+Represents a Colony balance for a specific domain and token.
+"""
 # This is not a @model since it will only be returned by a lambda function
 # so don't need to create tables for them
 # Note that we also need input types since it treats the `balances` as available
@@ -496,19 +906,34 @@ type ColonyChainFundsClaim {
 # you'd never actually be able to read that data since the return is overwritten
 # by the lambda function
 type ColonyBalance {
+  """Unique identifier for the Colony Balance."""
   id: ID!
+  """Balance of the specific token in the domain."""
   balance: String!
+  """Domain associated with the Colony Balance."""
   domain: Domain
-  # Note that for the chain native token, name and symbol are empty
+  """
+  Token associated with the Colony Balance.
+  Note that for the chain native token, name and symbol are empty.
+  """
   token: Token!
 }
+
+"""Represents a collection of Colony balances."""
 type ColonyBalances {
+  """List of Colony balances."""
   items: [ColonyBalance]
 }
+
+"""Input type for specifying a Domain."""
 input DomainInput {
+  """Unique identifier for the Domain."""
   id: ID!
 }
+
+"""Input type for specifying a Token."""
 input TokenInput {
+  """Unique identifier for the Token."""
   id: ID!
 }
 
@@ -630,27 +1055,41 @@ type ColonyMotion @model {
   messages: [MotionMessage!]! @hasMany(indexName: "byMotionId", fields: ["id"])
 }
 
+"""
+Represents an event triggered by a smart contract within the Colony Network.
+"""
 # This will store the relevant events we care about for a particular colony
 # Altough it might also hold events emmited by other clients (eg: network or token)
 # but are event pertaining to a colony
 # Generally you'd want to use this from a block ingenstor, after you've processed
 # data from an event, also save that even for future use
 type ContractEvent @model {
-  id: ID! #chainID_transactionHash_logIndex
+  """
+  Unique identifier for the Contract Event, in the format chainID_transactionHash_logIndex.
+  """
+  id: ID!
+  """Name of the event."""
   # i'm debating if this should be a enum or not, but this was you don't have to
   # update this schema every time you want to start tracking a new event
   name: String!
+  """The unique signature of the event."""
   signature: String!
+  """Metadata associated with the event's chain."""
   chainMetadata: ChainMetadata!
-  # Note that they are not required, meaning that at any point, one or more, even
-  # all of them might not be set
+  """Optional association with a Colony."""
   colony: Colony @hasOne
+  """Optional association with a Token."""
   token: Token @hasOne
+  """Optional association with a Domain."""
   domain: Domain @hasOne
+  """Optional association with a User."""
   user: User @hasOne
-  agent: String! # who initiated the event
-  target: String! # who was on the receiving end of it
-  encodedArguments: String # basically a JSON string
+  """Address of the agent who initiated the event."""
+  agent: String!
+  """Address of the target contract on the receiving end of the event."""
+  target: String!
+  """Optional encoded arguments as a JSON string."""
+  encodedArguments: String
 }
 
 type VotingReputationParams {
@@ -669,28 +1108,49 @@ type ExtensionParams {
   votingReputation: VotingReputationParams
 }
 
+"""
+Represents a single extension installed on a Colony.
+"""
 type ColonyExtension @model {
+  """Unique identifier for the ColonyExtension."""
   id: ID!
+  """The identifier of the Colony that the extension belongs to (the Colony's address)"""
   colonyId: ID!
     @index(
       name: "byColony"
       sortKeyFields: ["hash"]
       queryField: "getExtensionByColonyAndHash"
     )
+  """The Colony that the extension belongs to."""
   colony: Colony! @belongsTo(fields: ["colonyId"])
+  """
+  The unique hash of the extension.
+
+  The hash is generated like so: `keccak256(toUtf8Bytes(extensionName))`, where `extensionName` is the name of the extension contract file in the Colony Network
+  """
   hash: String! @index(name: "byHash", queryField: "getExtensionsByHash")
+  """The address of the user who installed the extension."""
   installedBy: String!
+  """The timestamp when the extension was installed."""
   installedAt: AWSTimestamp!
+  """Indicates whether the extension is deprecated."""
   isDeprecated: Boolean!
+  """Indicates whether the extension has been removed."""
   isDeleted: Boolean!
+  """Indicates whether the extension has been initialized."""
   isInitialized: Boolean!
+  """The version number of the extension."""
   version: Int!
   params: ExtensionParams
 }
 
+"""Represents the current version of an entity in the system."""
 type CurrentVersion @model {
+  """Unique identifier for the CurrentVersion."""
   id: ID!
+  """The key used to look up the current version."""
   key: String! @index(name: "byKey", queryField: "getCurrentVersionByKey")
+  """The current version number."""
   version: Int!
 }
 
@@ -699,46 +1159,70 @@ type CurrentNetworkInverseFee @model {
   inverseFee: String!
 }
 
+"""Represents an action performed within a Colony."""
 type ColonyAction @model {
-  # Required fields common for all actions
+  """Unique identifier for the ColonyAction."""
   id: ID!
+  """The identifier of the Colony that the action belongs to."""
   colonyId: ID!
     @index(
       name: "byColony"
       queryField: "getActionsByColony"
       sortKeyFields: ["createdAt"]
     )
+  """The Colony that the action belongs to."""
   colony: Colony! @belongsTo(fields: ["colonyId"])
+  """The type of action performed."""
   type: ColonyActionType!
+  """The block number where the action was recorded."""
   blockNumber: Int!
   isMotion: Boolean
   motionId: ID
     @index(name: "byMotionId", queryField: "getColonyActionByMotionId")
   motionData: ColonyMotion @hasOne(fields: ["motionId"])
   showInActionsList: Boolean! # True for (forced) actions. True for motions if staked above 10%
+  """The timestamp when the action was created."""
   createdAt: AWSDateTime!
+  """The Ethereum address of the action initiator. Can be a user, extension or colony."""
   initiatorAddress: ID!
+
   # Action type specific fields which might be null
+
   # Amplify will automatically populate one of the following fields with related model if there is an initiator
+  """The User who initiated the action, if applicable."""
   initiatorUser: User @hasOne(fields: ["initiatorAddress"])
+  """The ColonyExtension that initiated the action, if applicable."""
   initiatorExtension: ColonyExtension @hasOne(fields: ["initiatorAddress"])
+  """The Colony that initiated the action, if applicable."""
   initiatorColony: Colony @hasOne(fields: ["initiatorAddress"])
   initiatorToken: Token @hasOne(fields: ["initiatorAddress"])
 
-  recipientAddress: ID # Amplify will automatically populate one of the following fields with related model if there is an recipient
+  # Amplify will automatically populate one of the following fields with related model if there is an recipient
+  """The Ethereum address of the action recipient, if applicable."""
+  recipientAddress: ID
+  """The User who received the action, if applicable."""
   recipientUser: User @hasOne(fields: ["recipientAddress"])
   recipientColony: Colony @hasOne(fields: ["recipientAddress"])
   recipientExtension: ColonyExtension @hasOne(fields: ["recipientAddress"])
   recipientToken: Token @hasOne(fields: ["recipientAddress"])
 
+  """The amount involved in the action, if applicable."""
   amount: String
+  """The Ethereum address of the token involved in the action, if applicable."""
   tokenAddress: ID
+  """The Token involved in the action, if applicable."""
   token: Token @hasOne(fields: ["tokenAddress"])
+  """The source Domain identifier, if applicable."""
   fromDomainId: ID
+  """The source Domain of the action, if applicable."""
   fromDomain: Domain @hasOne(fields: ["fromDomainId"])
+  """The target Domain identifier, if applicable."""
   toDomainId: ID
+  """The target Domain of the action, if applicable."""
   toDomain: Domain @hasOne(fields: ["toDomainId"])
+  """The fundamental chain id"""
   fundamentalChainId: Int
+  """The resulting new Colony version, if applicable."""
   newColonyVersion: Int
   pendingDomainMetadataId: ID
   pendingDomainMetadata: DomainMetadata

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -33,49 +33,79 @@ export type Scalars = {
   AWSURL: string;
 };
 
+/**
+ * Represents metadata related to a blockchain event
+ * Applies to Colonies, Tokens and Events, but not all fields are revlant to all
+ * It does not apply to user accounts as they can live on all networks
+ */
 export type ChainMetadata = {
   __typename?: 'ChainMetadata';
+  /** The block number of the event */
   blockNumber?: Maybe<Scalars['Int']>;
+  /** The chain ID of the event */
   chainId: Scalars['Int'];
+  /** The log index of the event */
   logIndex?: Maybe<Scalars['Int']>;
+  /** The network the event occurred on */
   network?: Maybe<Network>;
+  /** The transaction hash of the event */
   transactionHash?: Maybe<Scalars['String']>;
 };
 
+/** Input data for relevant chain metadata of a Colony (if applicable) */
 export type ChainMetadataInput = {
+  /** The block number of the creation transaction */
   blockNumber?: InputMaybe<Scalars['Int']>;
+  /** The chain ID of the network */
   chainId: Scalars['Int'];
+  /** The log index of the creation transaction */
   logIndex?: InputMaybe<Scalars['Int']>;
+  /** The network the Colony is deployed on */
   network?: InputMaybe<Network>;
+  /** The transaction hash of the creation transaction */
   transactionHash?: InputMaybe<Scalars['String']>;
 };
 
+/** Represents a Colony within the Colony Network */
 export type Colony = {
   __typename?: 'Colony';
   actions?: Maybe<ModelColonyActionConnection>;
+  /** Returns a list token balances for each domain and each token that the colony has */
   balances?: Maybe<ColonyBalances>;
+  /** List of native chain token claims (e.g., Token 0x0000...0000: ETH, xDAI, etc.) */
   chainFundsClaim?: Maybe<ColonyChainFundsClaim>;
+  /** Metadata related to the chain of the Colony */
   chainMetadata: ChainMetadata;
   createdAt: Scalars['AWSDateTime'];
   domains?: Maybe<ModelDomainConnection>;
   extensions?: Maybe<ModelColonyExtensionConnection>;
   fundsClaims?: Maybe<ModelColonyFundsClaimConnection>;
+  /** Unique identifier for the Colony (contract address) */
   id: Scalars['ID'];
+  /** Metadata of the Colony */
   metadata?: Maybe<ColonyMetadata>;
+  /** List of motions within the Colony that have unclaimed stakes */
   motionsWithUnclaimedStakes?: Maybe<Array<ColonyUnclaimedStake>>;
+  /** (Short) name of the Colony */
   name: Scalars['String'];
+  /** The native token of the Colony */
   nativeToken: Token;
+  /** The unique address of the native token of the Colony */
   nativeTokenId: Scalars['ID'];
   roles?: Maybe<ModelColonyRoleConnection>;
+  /** Status information for the Colony */
   status?: Maybe<ColonyStatus>;
   tokens?: Maybe<ModelColonyTokensConnection>;
+  /** Type of the Colony (Regular or Metacolony) */
   type?: Maybe<ColonyType>;
   updatedAt: Scalars['AWSDateTime'];
+  /** Version of the Colony */
   version: Scalars['Int'];
   watchers?: Maybe<ModelWatchedColoniesConnection>;
 };
 
 
+/** Represents a Colony within the Colony Network */
 export type ColonyActionsArgs = {
   filter?: InputMaybe<ModelColonyActionFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -84,6 +114,7 @@ export type ColonyActionsArgs = {
 };
 
 
+/** Represents a Colony within the Colony Network */
 export type ColonyDomainsArgs = {
   filter?: InputMaybe<ModelDomainFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -92,6 +123,7 @@ export type ColonyDomainsArgs = {
 };
 
 
+/** Represents a Colony within the Colony Network */
 export type ColonyExtensionsArgs = {
   filter?: InputMaybe<ModelColonyExtensionFilterInput>;
   hash?: InputMaybe<ModelStringKeyConditionInput>;
@@ -101,6 +133,7 @@ export type ColonyExtensionsArgs = {
 };
 
 
+/** Represents a Colony within the Colony Network */
 export type ColonyFundsClaimsArgs = {
   filter?: InputMaybe<ModelColonyFundsClaimFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -109,6 +142,7 @@ export type ColonyFundsClaimsArgs = {
 };
 
 
+/** Represents a Colony within the Colony Network */
 export type ColonyRolesArgs = {
   filter?: InputMaybe<ModelColonyRoleFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -117,6 +151,7 @@ export type ColonyRolesArgs = {
 };
 
 
+/** Represents a Colony within the Colony Network */
 export type ColonyTokensArgs = {
   filter?: InputMaybe<ModelColonyTokensFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -125,6 +160,7 @@ export type ColonyTokensArgs = {
 };
 
 
+/** Represents a Colony within the Colony Network */
 export type ColonyWatchersArgs = {
   filter?: InputMaybe<ModelWatchedColoniesFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -132,55 +168,101 @@ export type ColonyWatchersArgs = {
   sortDirection?: InputMaybe<ModelSortDirection>;
 };
 
+/** Represents an action performed within a Colony */
 export type ColonyAction = {
   __typename?: 'ColonyAction';
+  /** The amount involved in the action, if applicable */
   amount?: Maybe<Scalars['String']>;
+  /** The block number where the action was recorded */
   blockNumber: Scalars['Int'];
+  /** The Colony that the action belongs to */
   colony: Colony;
   colonyActionsId?: Maybe<Scalars['ID']>;
+  /** The identifier of the Colony that the action belongs to */
   colonyId: Scalars['ID'];
+  /** The timestamp when the action was created */
   createdAt: Scalars['AWSDateTime'];
+  /** The source Domain of the action, if applicable */
   fromDomain?: Maybe<Domain>;
+  /** The source Domain identifier, if applicable */
   fromDomainId?: Maybe<Scalars['ID']>;
+  /** The fundamental chain id */
   fundamentalChainId?: Maybe<Scalars['Int']>;
+  /** Unique identifier for the ColonyAction */
   id: Scalars['ID'];
+  /** JSON string to pass custom, dynamic event data */
   individualEvents?: Maybe<Scalars['String']>;
+  /** The Ethereum address of the action initiator. Can be a user, extension or colony */
   initiatorAddress: Scalars['ID'];
+  /** The Colony that initiated the action, if applicable */
   initiatorColony?: Maybe<Colony>;
+  /** The ColonyExtension that initiated the action, if applicable */
   initiatorExtension?: Maybe<ColonyExtension>;
+  /** The Token contract that initiated the action, if applicable */
   initiatorToken?: Maybe<Token>;
+  /** The User who initiated the action, if applicable */
   initiatorUser?: Maybe<User>;
   isMotion?: Maybe<Scalars['Boolean']>;
+  /** Expanded `ColonyMotion` for the corresponding `motionId` */
   motionData?: Maybe<ColonyMotion>;
+  /** Corresponding domainId of the motion */
   motionDomainId?: Maybe<Scalars['Int']>;
+  /** The internal database id of the motion */
   motionId?: Maybe<Scalars['ID']>;
+  /** The resulting new Colony version, if applicable */
   newColonyVersion?: Maybe<Scalars['Int']>;
+  /** Colony metadata that is stored temporarily and commited to the database once the corresponding motion passes */
   pendingColonyMetadata?: Maybe<ColonyMetadata>;
+  /** Identifier of Colony metadata that is stored temporarily and commited to the database once the corresponding motion passes */
   pendingColonyMetadataId?: Maybe<Scalars['ID']>;
+  /** Domain metadata that is stored temporarily and commited to the database once the corresponding motion passes */
   pendingDomainMetadata?: Maybe<DomainMetadata>;
+  /** Identifier of domain metadata that is stored temporarily and commited to the database once the corresponding motion passes */
   pendingDomainMetadataId?: Maybe<Scalars['ID']>;
+  /** The address of the action recipient, if applicable */
   recipientAddress?: Maybe<Scalars['ID']>;
+  /** The corresponding Colony which was involved the action, if applicable */
   recipientColony?: Maybe<Colony>;
+  /** The corresponding extension which was involved the action, if applicable */
   recipientExtension?: Maybe<ColonyExtension>;
+  /** The address of the token that was received the action, if applicable */
   recipientToken?: Maybe<Token>;
+  /** The User who received the action, if applicable */
   recipientUser?: Maybe<User>;
+  /** Colony roles that are associated with the action */
   roles?: Maybe<ColonyActionRoles>;
+  /**
+   * Whether to show the motion in the actions list
+   * True for (forced) actions. True for motions if staked above 10%
+   */
   showInActionsList: Scalars['Boolean'];
+  /** The target Domain of the action, if applicable */
   toDomain?: Maybe<Domain>;
+  /** The target Domain identifier, if applicable */
   toDomainId?: Maybe<Scalars['ID']>;
+  /** The Token involved in the action, if applicable */
   token?: Maybe<Token>;
+  /** The Ethereum address of the token involved in the action, if applicable */
   tokenAddress?: Maybe<Scalars['ID']>;
+  /** The type of action performed */
   type: ColonyActionType;
   updatedAt: Scalars['AWSDateTime'];
 };
 
+/** Colony Roles that can be involved in an action */
 export type ColonyActionRoles = {
   __typename?: 'ColonyActionRoles';
+  /** Recovery role */
   role_0?: Maybe<Scalars['Boolean']>;
+  /** Root role */
   role_1?: Maybe<Scalars['Boolean']>;
+  /** Arbitration role */
   role_2?: Maybe<Scalars['Boolean']>;
+  /** Architecture role */
   role_3?: Maybe<Scalars['Boolean']>;
+  /** Funding role */
   role_5?: Maybe<Scalars['Boolean']>;
+  /** Administration role */
   role_6?: Maybe<Scalars['Boolean']>;
 };
 
@@ -193,40 +275,79 @@ export type ColonyActionRolesInput = {
   role_6?: InputMaybe<Scalars['Boolean']>;
 };
 
+/**
+ * Variants of Colony Network blockchain events
+ *
+ * These can all happen in a Colony and will be interpreted by the dApp according to their types
+ */
 export enum ColonyActionType {
+  /** An action related to editing a Colony's details */
   ColonyEdit = 'COLONY_EDIT',
+  /** An action related to editing a Colony's details via a motion */
   ColonyEditMotion = 'COLONY_EDIT_MOTION',
+  /** An action related to creating a domain within a Colony */
   CreateDomain = 'CREATE_DOMAIN',
+  /** An action related to creating a domain within a Colony via a motion */
   CreateDomainMotion = 'CREATE_DOMAIN_MOTION',
+  /** An action related to editing a domain's details */
   EditDomain = 'EDIT_DOMAIN',
+  /** An action related to editing a domain's details via a motion */
   EditDomainMotion = 'EDIT_DOMAIN_MOTION',
+  /** An action related to a domain reputation penalty within a Colony (smite) */
   EmitDomainReputationPenalty = 'EMIT_DOMAIN_REPUTATION_PENALTY',
+  /** An action related to a domain reputation penalty within a Colony (smite) via a motion */
   EmitDomainReputationPenaltyMotion = 'EMIT_DOMAIN_REPUTATION_PENALTY_MOTION',
+  /** An action related to a domain reputation reward within a Colony */
   EmitDomainReputationReward = 'EMIT_DOMAIN_REPUTATION_REWARD',
+  /** An action related to a domain reputation reward within a Colony via a motion */
   EmitDomainReputationRewardMotion = 'EMIT_DOMAIN_REPUTATION_REWARD_MOTION',
+  /** A generic or unspecified Colony action */
   Generic = 'GENERIC',
+  /** An action related to minting tokens within a Colony */
   MintTokens = 'MINT_TOKENS',
+  /** An action related to minting tokens within a Colony via a motion */
   MintTokensMotion = 'MINT_TOKENS_MOTION',
+  /** An action related to moving funds between domains */
   MoveFunds = 'MOVE_FUNDS',
+  /** An action related to moving funds between domains via a motion */
   MoveFundsMotion = 'MOVE_FUNDS_MOTION',
+  /** An motion action placeholder that should not be used */
   NullMotion = 'NULL_MOTION',
+  /** An action related to a payment within a Colony */
   Payment = 'PAYMENT',
+  /** An action related to a payment that was created via a motion within a Colony */
   PaymentMotion = 'PAYMENT_MOTION',
+  /** An action related to the recovery functionality of a Colony */
   Recovery = 'RECOVERY',
+  /** An action related to setting user roles within a Colony */
   SetUserRoles = 'SET_USER_ROLES',
+  /** An action related to setting user roles within a Colony via a motion */
   SetUserRolesMotion = 'SET_USER_ROLES_MOTION',
+  /** An action related to unlocking a token within a Colony */
   UnlockToken = 'UNLOCK_TOKEN',
+  /** An action related to unlocking a token within a Colony via a motion */
   UnlockTokenMotion = 'UNLOCK_TOKEN_MOTION',
+  /** An action related to upgrading a Colony's version */
   VersionUpgrade = 'VERSION_UPGRADE',
+  /** An action related to upgrading a Colony's version via a motion */
   VersionUpgradeMotion = 'VERSION_UPGRADE_MOTION',
+  /** An action unrelated to the currently viewed Colony  */
   WrongColony = 'WRONG_COLONY'
 }
 
+/** Represents a Colony balance for a specific domain and token */
 export type ColonyBalance = {
   __typename?: 'ColonyBalance';
+  /** Balance of the specific token in the domain */
   balance: Scalars['String'];
+  /** Domain associated with the Colony Balance */
   domain?: Maybe<Domain>;
+  /** Unique identifier for the Colony Balance */
   id: Scalars['ID'];
+  /**
+   * Token associated with the Colony Balance
+   * Note that for the chain native token, name and symbol are empty
+   */
   token: Token;
 };
 
@@ -237,8 +358,10 @@ export type ColonyBalanceInput = {
   token: TokenInput;
 };
 
+/** Represents a collection of Colony balances */
 export type ColonyBalances = {
   __typename?: 'ColonyBalances';
+  /** List of Colony balances */
   items?: Maybe<Array<Maybe<ColonyBalance>>>;
 };
 
@@ -246,12 +369,21 @@ export type ColonyBalancesInput = {
   items?: InputMaybe<Array<InputMaybe<ColonyBalanceInput>>>;
 };
 
+/**
+ * Represents a native Colony Chain Funds Claim
+ * E.g., Token 0x0000...0000: ETH, xDAI, etc
+ */
 export type ColonyChainFundsClaim = {
   __typename?: 'ColonyChainFundsClaim';
+  /** Amount claimed in the Colony Chain Funds Claim */
   amount: Scalars['String'];
+  /** Timestamp when the Chain Funds Claim was created */
   createdAt: Scalars['AWSDateTime'];
+  /** Block number when the Chain Funds Claim was created */
   createdAtBlock: Scalars['Int'];
+  /** Unique identifier for the Colony Chain Funds Claim */
   id: Scalars['ID'];
+  /** Timestamp when the Chain Funds Claim was last updated */
   updatedAt: Scalars['AWSDateTime'];
 };
 
@@ -263,85 +395,149 @@ export type ColonyChainFundsClaimInput = {
   updatedAt?: InputMaybe<Scalars['AWSDateTime']>;
 };
 
+/** Represents a single extension installed on a Colony */
 export type ColonyExtension = {
   __typename?: 'ColonyExtension';
+  /** The Colony that the extension belongs to */
   colony: Colony;
+  /** The identifier of the Colony that the extension belongs to (the Colony's address) */
   colonyId: Scalars['ID'];
   createdAt: Scalars['AWSDateTime'];
+  /**
+   * The unique hash of the extension
+   * The hash is generated like so: `keccak256(toUtf8Bytes(extensionName))`, where `extensionName` is the name of the extension contract file in the Colony Network
+   */
   hash: Scalars['String'];
+  /** Unique identifier for the ColonyExtension */
   id: Scalars['ID'];
+  /** The timestamp when the extension was installed */
   installedAt: Scalars['AWSTimestamp'];
+  /** The address of the user who installed the extension */
   installedBy: Scalars['String'];
+  /** Indicates whether the extension has been removed */
   isDeleted: Scalars['Boolean'];
+  /** Indicates whether the extension is deprecated */
   isDeprecated: Scalars['Boolean'];
+  /** Indicates whether the extension has been initialized */
   isInitialized: Scalars['Boolean'];
+  /** Map of parameters that extension was initialised with */
   params?: Maybe<ExtensionParams>;
   updatedAt: Scalars['AWSDateTime'];
+  /** The version number of the extension */
   version: Scalars['Int'];
 };
 
+/** Represents a Colony Funds Claim for all ERC20 tokens (except native chain tokens) */
 export type ColonyFundsClaim = {
   __typename?: 'ColonyFundsClaim';
+  /** Amount claimed in the Colony Funds Claim */
   amount: Scalars['String'];
   colonyFundsClaimTokenId: Scalars['ID'];
   colonyFundsClaimsId?: Maybe<Scalars['ID']>;
+  /** Timestamp when the Funds Claim was created */
   createdAt: Scalars['AWSDateTime'];
+  /** Block number when the Funds Claim was created */
   createdAtBlock: Scalars['Int'];
+  /** Unique identifier for the Colony Funds Claim */
   id: Scalars['ID'];
+  /** Token associated with the Colony Funds Claim */
   token: Token;
   updatedAt: Scalars['AWSDateTime'];
 };
 
+/**
+ * "
+ * Snapshot of the user's full roles/permissions at a specific block
+ */
 export type ColonyHistoricRole = {
   __typename?: 'ColonyHistoricRole';
+  /** Block at which the snapshot was taken */
   blockNumber: Scalars['Int'];
+  /** Expaneded `Colony` model, based on the `colonyId` given */
   colony: Colony;
+  /** Unique identifier of the Colony */
   colonyId: Scalars['ID'];
+  /** Timestamp at which the database entry was created */
   createdAt: Scalars['AWSDateTime'];
+  /** Expaneded `Domain` model, based on the `domainId` given */
   domain: Domain;
+  /** Unique identifier of the domain */
   domainId: Scalars['ID'];
+  /**
+   * Unique identifier for the role snapshot
+   * Format: `colonyAddress_domainNativeId_userAddress_blockNumber_roles`
+   */
   id: Scalars['ID'];
+  /** Recovery role */
   role_0?: Maybe<Scalars['Boolean']>;
+  /** Root role */
   role_1?: Maybe<Scalars['Boolean']>;
+  /** Arbitration role */
   role_2?: Maybe<Scalars['Boolean']>;
+  /** Architecture role */
   role_3?: Maybe<Scalars['Boolean']>;
+  /** Funding role */
   role_5?: Maybe<Scalars['Boolean']>;
+  /** Administration role */
   role_6?: Maybe<Scalars['Boolean']>;
+  /** Address of the agent the permission was set for */
   targetAddress?: Maybe<Scalars['ID']>;
+  /** Will expand to a `Colony` model if permission was set for another Colony */
   targetColony?: Maybe<Colony>;
+  /** Will expand to a `ColonyExtension` model if permission was set for a Colony extension */
   targetExtension?: Maybe<ColonyExtension>;
+  /** Will expand to a `Token` model if permission was set for a Token contract */
   targetToken?: Maybe<Token>;
+  /** Will expand to a `User` model if permission was set for a user */
   targetUser?: Maybe<User>;
+  /** Used for amplify sorting. Set to `SortedHistoricRole` */
   type: Scalars['String'];
   updatedAt: Scalars['AWSDateTime'];
 };
 
-export type ColonyId = {
-  __typename?: 'ColonyID';
-  id: Scalars['ID'];
-};
-
+/** Represents metadata for a Colony */
 export type ColonyMetadata = {
   __typename?: 'ColonyMetadata';
+  /** URL of the Colony's avatar image */
   avatar?: Maybe<Scalars['String']>;
+  /** List of Colony metadata changelog entries */
   changelog?: Maybe<Array<ColonyMetadataChangelog>>;
   createdAt: Scalars['AWSDateTime'];
+  /** Display name of the Colony */
   displayName: Scalars['String'];
+  /** Unique identifier for the Colony (contract address) */
   id: Scalars['ID'];
+  /** The address book feature (aka Whitelist is active for this Colony) */
   isWhitelistActivated?: Maybe<Scalars['Boolean']>;
+  /**
+   * Token addresses that were modified in a previous action (motion)
+   * Only present on pendingColonyMetadata for consumption in block ingestor
+   */
   modifiedTokenAddresses?: Maybe<PendingModifiedTokenAddresses>;
+  /** URL of the Colony's thumbnail image */
   thumbnail?: Maybe<Scalars['String']>;
   updatedAt: Scalars['AWSDateTime'];
+  /** List of addresses that are in the address book */
   whitelistedAddresses?: Maybe<Array<Scalars['String']>>;
 };
 
+/**
+ * Represents a changelog entry for Colony metadata
+ * This is used to traverse through the history of metadata values and consolidate them into a final state
+ */
 export type ColonyMetadataChangelog = {
   __typename?: 'ColonyMetadataChangelog';
+  /** Indicates whether the avatar has changed */
   hasAvatarChanged: Scalars['Boolean'];
+  /** Whether entries in the address book (whitelist) have changed */
   hasWhitelistChanged: Scalars['Boolean'];
+  /** Whether tokens have been added or removed from the Colony's token list */
   haveTokensChanged: Scalars['Boolean'];
+  /** Display name of the Colony after the change */
   newDisplayName: Scalars['String'];
+  /** Display name of the Colony before the change */
   oldDisplayName: Scalars['String'];
+  /** Transaction hash associated with the changelog entry */
   transactionHash: Scalars['String'];
 };
 
@@ -354,34 +550,68 @@ export type ColonyMetadataChangelogInput = {
   transactionHash: Scalars['String'];
 };
 
+/** Represents a Motion within a Colony */
 export type ColonyMotion = {
   __typename?: 'ColonyMotion';
   createdAt: Scalars['AWSDateTime'];
+  /**
+   * Address of the VotingReputation extension
+   * Useful to check if we're viewing a "read-only" motion
+   */
   createdBy: Scalars['String'];
+  /** Simple flag indicating whether both sides of staking have been activated */
   hasObjection: Scalars['Boolean'];
+  /**
+   * The internal database id of the motion
+   * To ensure uniqueness, we format as: `chainId-votingRepExtnAddress_nativeMotionId`
+   */
   id: Scalars['ID'];
+  /** Whether the motion was finalized or not */
   isFinalized: Scalars['Boolean'];
   messages?: Maybe<ModelMotionMessageConnection>;
+  /** Expanded domain in which the motion was created */
   motionDomain: Domain;
+  /** Unique identifier of the motions domain in the database */
   motionDomainId: Scalars['ID'];
+  /** Staked sides of a motion */
   motionStakes: MotionStakes;
+  /** Quick access flages to check the current state of a motion in its lifecycle */
   motionStateHistory: MotionStateHistory;
+  /** The on chain id of the domain associated with the motion */
   nativeMotionDomainId: Scalars['String'];
+  /** The on chain id of the motion */
   nativeMotionId: Scalars['String'];
+  /**
+   * Stakes remaining to activate either side of the motion
+   * It's a tuple: `[nayRemaining, yayRemaining]`
+   */
   remainingStakes: Array<Scalars['String']>;
+  /** The amount of reputation that has submitted a vote */
   repSubmitted: Scalars['String'];
+  /** The total required stake for one side to be activated */
   requiredStake: Scalars['String'];
+  /** Total voting outcome for the motion (accumulated votes) */
   revealedVotes: MotionStakes;
+  /**
+   * The reputation root hash at the time of the creation of the motion
+   * Used for calculating a user's max stake in client
+   */
   rootHash: Scalars['String'];
+  /** The total amount of reputation (among all users) that can vote for this motion */
   skillRep: Scalars['String'];
+  /** List of staker rewards users will be receiving for a motion */
   stakerRewards: Array<StakerRewards>;
   updatedAt: Scalars['AWSDateTime'];
+  /** The minimum stake that a user has to provide for it to be accepted */
   userMinStake: Scalars['String'];
+  /** List of stakes that users have made for a motion */
   usersStakes: Array<UserStakes>;
+  /** A list of all of the votes cast within in the motion */
   voterRecord: Array<VoterRecord>;
 };
 
 
+/** Represents a Motion within a Colony */
 export type ColonyMotionMessagesArgs = {
   createdAt?: InputMaybe<ModelStringKeyConditionInput>;
   filter?: InputMaybe<ModelMotionMessageFilterInput>;
@@ -390,46 +620,90 @@ export type ColonyMotionMessagesArgs = {
   sortDirection?: InputMaybe<ModelSortDirection>;
 };
 
+/** A snapshot of the current set of permissions a given address has in a given domain within a Colony */
 export type ColonyRole = {
   __typename?: 'ColonyRole';
   colonyRolesId?: Maybe<Scalars['ID']>;
   createdAt: Scalars['AWSDateTime'];
+  /** Expaneded `Domain` model, based on the `domainId` given */
   domain: Domain;
+  /** Unique identifier of the domain */
   domainId: Scalars['ID'];
+  /**
+   * Unique identifier for the role snapshot
+   * Format: `colonyAddress_domainNativeId_userAddress_roles`
+   */
   id: Scalars['ID'];
+  /** Block at which permissions were update last */
   latestBlock: Scalars['Int'];
+  /** Recovery role */
   role_0?: Maybe<Scalars['Boolean']>;
+  /** Root role */
   role_1?: Maybe<Scalars['Boolean']>;
+  /** Arbitration role */
   role_2?: Maybe<Scalars['Boolean']>;
+  /** Architecture role */
   role_3?: Maybe<Scalars['Boolean']>;
+  /** Funding role */
   role_5?: Maybe<Scalars['Boolean']>;
+  /** Administration role */
   role_6?: Maybe<Scalars['Boolean']>;
+  /** Address of the agent the permission was set for */
   targetAddress?: Maybe<Scalars['ID']>;
+  /** Will expand to a `Colony` model if permission was set for another Colony */
   targetColony?: Maybe<Colony>;
+  /** Will expand to a `ColonyExtension` model if permission was set for a Colony extension */
   targetExtension?: Maybe<ColonyExtension>;
+  /** Will expand to a `Token` model if permission was set for a Token contract */
   targetToken?: Maybe<Token>;
+  /** Will expand to a `User` model if permission was set for a user */
   targetUser?: Maybe<User>;
   updatedAt: Scalars['AWSDateTime'];
 };
 
+/**
+ * Keeps track of the current amount a user has staked in a colony
+ * When a user stakes, totalAmount increases. When a user reclaims their stake, totalAmount decreases.
+ */
 export type ColonyStake = {
   __typename?: 'ColonyStake';
+  /** Unique identifier for the Colony */
   colonyId: Scalars['ID'];
   createdAt: Scalars['AWSDateTime'];
+  /**
+   * Unique identifier for the stake
+   * Format: `<userId>_<colonyId>`
+   */
   id: Scalars['ID'];
+  /** Total staked amount */
   totalAmount: Scalars['String'];
   updatedAt: Scalars['AWSDateTime'];
+  /** Unique identifier for the user */
   userId: Scalars['ID'];
 };
 
+/**
+ * Represents the status of a Colony
+ *
+ * This contains important meta information about the Colony's token and other fundamental settings
+ */
 export type ColonyStatus = {
   __typename?: 'ColonyStatus';
+  /** Status information for the Colony's native token */
   nativeToken?: Maybe<NativeTokenStatus>;
+  /** Whether the Colony is in recovery mode */
   recovery?: Maybe<Scalars['Boolean']>;
 };
 
+/**
+ * Input data for a Colony's status information
+ *
+ * This is set when a Colony is created and can be changed later
+ */
 export type ColonyStatusInput = {
+  /** Status information for the Colony's native token */
   nativeToken?: InputMaybe<NativeTokenStatusInput>;
+  /** Whether the Colony is in recovery mode */
   recovery?: InputMaybe<Scalars['Boolean']>;
 };
 
@@ -444,14 +718,20 @@ export type ColonyTokens = {
   updatedAt: Scalars['AWSDateTime'];
 };
 
+/** Variants of Colony types */
 export enum ColonyType {
+  /** A regular Colony */
   Colony = 'COLONY',
+  /** The MetaColony, which governs the entire Colony Network */
   Metacolony = 'METACOLONY'
 }
 
+/** Unclaimed staking rewards for a motion */
 export type ColonyUnclaimedStake = {
   __typename?: 'ColonyUnclaimedStake';
+  /** The on chain id of the motion */
   motionId: Scalars['String'];
+  /** List of unclaimed staking rewards for that motion */
   unclaimedRewards: Array<StakerRewards>;
 };
 
@@ -460,32 +740,53 @@ export type ColonyUnclaimedStakeInput = {
   unclaimedRewards: Array<StakerRewardsInput>;
 };
 
+/** Represents an event triggered by a smart contract within the Colony Network */
 export type ContractEvent = {
   __typename?: 'ContractEvent';
+  /** Address of the agent who initiated the event */
   agent: Scalars['String'];
+  /** Metadata associated with the event's chain */
   chainMetadata: ChainMetadata;
+  /** Optional association with a Colony */
   colony?: Maybe<Colony>;
   contractEventColonyId?: Maybe<Scalars['ID']>;
   contractEventDomainId?: Maybe<Scalars['ID']>;
   contractEventTokenId?: Maybe<Scalars['ID']>;
   contractEventUserId?: Maybe<Scalars['ID']>;
   createdAt: Scalars['AWSDateTime'];
+  /** Optional association with a Domain */
   domain?: Maybe<Domain>;
+  /** Optional encoded arguments as a JSON string */
   encodedArguments?: Maybe<Scalars['String']>;
+  /** Unique identifier for the Contract Event, in the format chainID_transactionHash_logIndex */
   id: Scalars['ID'];
+  /** Name of the event */
   name: Scalars['String'];
+  /** The unique signature of the event */
   signature: Scalars['String'];
+  /** Address of the target contract on the receiving end of the event */
   target: Scalars['String'];
+  /** Optional association with a Token */
   token?: Maybe<Token>;
   updatedAt: Scalars['AWSDateTime'];
+  /** Optional association with a User */
   user?: Maybe<User>;
 };
 
+/**
+ * Represents a contributor within the Colony Network
+ *
+ * A contributor is a Colony member who has reputation
+ */
 export type Contributor = {
   __typename?: 'Contributor';
+  /** Wallet address of the contributor */
   address: Scalars['String'];
+  /** Reputation amount of the contributor (as an absolute number) */
   reputationAmount?: Maybe<Scalars['String']>;
+  /** Reputation percentage of the contributor (of all reputation within the Colony) */
   reputationPercentage?: Maybe<Scalars['String']>;
+  /** User data associated with the contributor */
   user?: Maybe<User>;
 };
 
@@ -707,19 +1008,31 @@ export type CreateTokenInput = {
   type?: InputMaybe<TokenType>;
 };
 
+/** Input data for creating a unique Colony within the Colony Network. Use this instead of the automatically generated `CreateColonyInput` input type */
 export type CreateUniqueColonyInput = {
+  /** Metadata related to the Colony's creation on the blockchain */
   chainMetadata: ChainMetadataInput;
+  /** Unique identifier for the Colony's native token (this is its address) */
   colonyNativeTokenId: Scalars['ID'];
+  /** Unique identifier for the Colony. This is the Colony's contract address */
   id: Scalars['ID'];
+  /** Display name of the Colony */
   name: Scalars['String'];
+  /** Status information for the Colony */
   status?: InputMaybe<ColonyStatusInput>;
+  /** Type of the Colony (regular or MetaColony) */
   type?: InputMaybe<ColonyType>;
+  /** Version of the currently deployed Colony contract */
   version: Scalars['Int'];
 };
 
+/** Input data for creating a unique user within the Colony Network Use this instead of the automatically generated `CreateUserInput` input type */
 export type CreateUniqueUserInput = {
+  /** Unique identifier for the user. This is the user's wallet address */
   id: Scalars['ID'];
+  /** The username */
   name: Scalars['String'];
+  /** Profile data for the user */
   profile?: InputMaybe<ProfileInput>;
 };
 
@@ -741,20 +1054,30 @@ export type CreateWatchedColoniesInput = {
   userID: Scalars['ID'];
 };
 
+/**
+ * The current inverse of the network fee (in wei)
+ * (divide 1 by it and get the actual network fee)
+ */
 export type CurrentNetworkInverseFee = {
   __typename?: 'CurrentNetworkInverseFee';
   createdAt: Scalars['AWSDateTime'];
+  /** Unique identifier for the network fee */
   id: Scalars['ID'];
+  /** The inverse fee */
   inverseFee: Scalars['String'];
   updatedAt: Scalars['AWSDateTime'];
 };
 
+/** Represents the current version of an entity in the system */
 export type CurrentVersion = {
   __typename?: 'CurrentVersion';
   createdAt: Scalars['AWSDateTime'];
+  /** Unique identifier for the CurrentVersion */
   id: Scalars['ID'];
+  /** The key used to look up the current version */
   key: Scalars['String'];
   updatedAt: Scalars['AWSDateTime'];
+  /** The current version number */
   version: Scalars['Int'];
 };
 
@@ -846,62 +1169,120 @@ export type DeleteWatchedColoniesInput = {
   id: Scalars['ID'];
 };
 
+/** Represents a Domain within the Colony Network */
 export type Domain = {
   __typename?: 'Domain';
+  /** Colony associated with the Domain */
   colony: Colony;
+  /** Colony ID associated with the Domain */
   colonyId: Scalars['ID'];
   createdAt: Scalars['AWSDateTime'];
+  /**
+   * Unique identifier for the Domain
+   * This should be in the following format: `colonyAddress_nativeId`
+   * The native id is the auto-incrementing integer that is assigned to a domain from the contract on creation
+   */
   id: Scalars['ID'];
+  /** Indicates whether the Domain is the root domain (ID 1) */
   isRoot: Scalars['Boolean'];
+  /** Metadata of the Domain */
   metadata?: Maybe<DomainMetadata>;
+  /**
+   * Native funding pot ID of the Domain
+   * The native funding pot ID is assigned to a domain from the contract on creation
+   */
   nativeFundingPotId: Scalars['Int'];
+  /**
+   * Native ID of the Domain
+   * The native id is the auto-incrementing integer that is assigned to a domain from the contract on creation
+   */
   nativeId: Scalars['Int'];
+  /**
+   * Native skill ID of the Domain
+   * The native skill ID is assigned to a domain from the contract on creation
+   */
   nativeSkillId: Scalars['Int'];
   updatedAt: Scalars['AWSDateTime'];
 };
 
+/** Variants of available domain colors as used in the dApp */
 export enum DomainColor {
+  /** An aqua color */
   Aqua = 'AQUA',
+  /** A black color */
   Black = 'BLACK',
+  /** A blue color */
   Blue = 'BLUE',
+  /** A blue-grey(ish) color */
   BlueGrey = 'BLUE_GREY',
+  /** An emerald green color */
   EmeraldGreen = 'EMERALD_GREEN',
+  /** A gold color */
   Gold = 'GOLD',
+  /** A green color */
   Green = 'GREEN',
+  /** A light pink color */
   LightPink = 'LIGHT_PINK',
+  /** A magenta color */
   Magenta = 'MAGENTA',
+  /** An orange color */
   Orange = 'ORANGE',
+  /** A pale indigo color */
   Periwinkle = 'PERIWINKLE',
+  /** A pink color */
   Pink = 'PINK',
+  /** A purple color */
   Purple = 'PURPLE',
+  /** A purple-grey(ish) color */
   PurpleGrey = 'PURPLE_GREY',
+  /** A red color */
   Red = 'RED',
+  /** A yellow color */
   Yellow = 'YELLOW'
 }
 
+/** Input type for specifying a Domain */
 export type DomainInput = {
+  /** Unique identifier for the Domain */
   id: Scalars['ID'];
 };
 
+/** Represents metadata for a Domain */
 export type DomainMetadata = {
   __typename?: 'DomainMetadata';
+  /** List of Domain metadata changelog entries */
   changelog?: Maybe<Array<DomainMetadataChangelog>>;
+  /** Color associated with the Domain */
   color: DomainColor;
   createdAt: Scalars['AWSDateTime'];
+  /** Description of the Domain */
   description: Scalars['String'];
+  /**
+   * Unique identifier for the Domain metadata
+   * This field is referenced by Domain id, so has to be in the same format: colonyAddress_nativeId
+   */
   id: Scalars['ID'];
+  /** Name of the Domain */
   name: Scalars['String'];
   updatedAt: Scalars['AWSDateTime'];
 };
 
+/** Represents a changelog entry for Domain metadata */
 export type DomainMetadataChangelog = {
   __typename?: 'DomainMetadataChangelog';
+  /** Color of the Domain after the change */
   newColor: DomainColor;
+  /** Description of the Domain after the change */
   newDescription: Scalars['String'];
+  /** Name of the Domain after the change */
   newName: Scalars['String'];
+  /** Color of the Domain before the change */
   oldColor: DomainColor;
+  /** Description of the Domain before the change */
   oldDescription: Scalars['String'];
+  /** Name of the Domain before the change */
   oldName: Scalars['String'];
+  /** Transaction hash associated with the changelog entry */
   transactionHash: Scalars['String'];
 };
 
@@ -915,13 +1296,18 @@ export type DomainMetadataChangelogInput = {
   transactionHash: Scalars['String'];
 };
 
+/** **Deprecated** Extra permissions for a user, stored during the registration process */
 export enum EmailPermissions {
+  /** Person is registered and solved the captcha, they can use gasless transactions */
   IsHuman = 'isHuman',
+  /** Permission to send notifications to the user */
   SendNotifications = 'sendNotifications'
 }
 
+/** Map of parameters that extensions are initialised with */
 export type ExtensionParams = {
   __typename?: 'ExtensionParams';
+  /** Initialization parameters for the `VotingReputation` extension */
   votingReputation?: Maybe<VotingReputationParams>;
 };
 
@@ -929,84 +1315,159 @@ export type ExtensionParamsInput = {
   votingReputation?: InputMaybe<VotingReputationParamsInput>;
 };
 
+/** Input data for retrieving the state of a motion (i.e. the current period) */
 export type GetMotionStateInput = {
+  /** The Ethereum address of the Colony */
   colonyAddress: Scalars['String'];
+  /** The internal id of the motion in the database */
   databaseMotionId: Scalars['String'];
+  /** The hash of the associated transaction */
   transactionHash: Scalars['String'];
 };
 
+/** Input data for retrieving the timeout of the current period the motion is in */
 export type GetMotionTimeoutPeriodsInput = {
+  /** The Ethereum address of the user who voted */
   colonyAddress: Scalars['String'];
+  /** The on chain id of the motion */
   motionId: Scalars['String'];
 };
 
+/**
+ * A return type that contains the timeout periods the motion can be in
+ * Represented via a string-integer in milliseconds. Will report 0 for periods that are elapsed and will show the accumulated time for later periods
+ */
 export type GetMotionTimeoutPeriodsReturn = {
   __typename?: 'GetMotionTimeoutPeriodsReturn';
+  /** Time left in escalation period */
   timeLeftToEscalate: Scalars['String'];
+  /** Time left in reveal period */
   timeLeftToReveal: Scalars['String'];
+  /** Time left in staking period */
   timeLeftToStake: Scalars['String'];
+  /** Time left in voting period */
   timeLeftToVote: Scalars['String'];
 };
 
+/** Input data for retrieving a user's reputation within the top domains of a Colony */
 export type GetReputationForTopDomainsInput = {
+  /** The address of the Colony */
   colonyAddress: Scalars['String'];
+  /** The root hash of the reputation tree at a specific point in time */
   rootHash?: InputMaybe<Scalars['String']>;
+  /** The wallet address of the user */
   walletAddress: Scalars['String'];
 };
 
+/** A return type that contains an array of UserDomainReputation items */
 export type GetReputationForTopDomainsReturn = {
   __typename?: 'GetReputationForTopDomainsReturn';
+  /** An array of UserDomainReputation items */
   items?: Maybe<Array<UserDomainReputation>>;
 };
 
+/**
+ * Input data for a user's reputation within a Domain in a Colony. If no `domainId` is passed, the Root Domain is used
+ * A `rootHash` can be provided, to get reputation at a certain point in the past
+ */
 export type GetUserReputationInput = {
+  /** The Ethereum address of the Colony */
   colonyAddress: Scalars['String'];
+  /** The ID of the Domain within the Colony. If not provided, defaults to the Root Domain */
   domainId?: InputMaybe<Scalars['Int']>;
+  /** The root hash of the reputation tree at a specific point in time */
   rootHash?: InputMaybe<Scalars['String']>;
+  /** The Ethereum wallet address of the user */
   walletAddress: Scalars['String'];
 };
 
+/** Input data for retrieving a user's token balance for a specific token */
 export type GetUserTokenBalanceInput = {
+  /** The Colony address */
   colonyAddress: Scalars['String'];
+  /** The address of the token */
   tokenAddress: Scalars['String'];
+  /** The wallet address of the user */
   walletAddress: Scalars['String'];
 };
 
+/** A return type representing the breakdown of a user's token balance */
 export type GetUserTokenBalanceReturn = {
   __typename?: 'GetUserTokenBalanceReturn';
+  /**
+   * The active portion of the user's token balance
+   * This is the balance that is approved for the Colony Network to use (e.g. for governance)
+   */
   activeBalance?: Maybe<Scalars['String']>;
+  /** The total token balance, including inactive, locked, and active balances */
   balance?: Maybe<Scalars['String']>;
+  /**
+   * The inactive portion of the user's token balance
+   * This is the balance of a token that is in a users wallet but can't be used by the Colony Network (e.g. for governance)
+   */
   inactiveBalance?: Maybe<Scalars['String']>;
+  /**
+   * The locked portion of the user's token balance
+   * This is the balance of a token that is staked (e.g. in motions)
+   */
   lockedBalance?: Maybe<Scalars['String']>;
+  /**
+   * The pending portion of the user's token balance
+   * These are tokens that have been sent to the wallet, but are inaccessible until all locks are cleared and then these tokens are claimed
+   */
   pendingBalance?: Maybe<Scalars['String']>;
 };
 
+/** Input data for retrieving the voting rewards for a user within a finished motion */
 export type GetVoterRewardsInput = {
+  /** The Ethereum address of the Colony */
   colonyAddress: Scalars['String'];
+  /** The on chain id of the motion */
   motionId: Scalars['String'];
+  /** The on chain id of the domain in which the motion was created */
   nativeMotionDomainId: Scalars['String'];
+  /** The root hash of the reputation tree at the time the motion was created */
   rootHash: Scalars['String'];
+  /** The Ethereum address of the user who voted */
   voterAddress: Scalars['String'];
 };
 
+/** Model storing block ingestor stats, as key-value entries */
 export type IngestorStats = {
   __typename?: 'IngestorStats';
   createdAt: Scalars['AWSDateTime'];
+  /** Unique identifier of the ingestore stats */
   id: Scalars['ID'];
   updatedAt: Scalars['AWSDateTime'];
+  /** JSON string to pass custom, dynamic values */
   value: Scalars['String'];
 };
 
+/** Input data for fetching the list of members for a specific Colony */
 export type MembersForColonyInput = {
+  /** Address of the Colony */
   colonyAddress: Scalars['String'];
+  /** ID of the domain within the Colony */
   domainId?: InputMaybe<Scalars['Int']>;
+  /** Root hash for the reputation state */
   rootHash?: InputMaybe<Scalars['String']>;
+  /** Sorting method to apply to the member list */
   sortingMethod?: InputMaybe<SortingMethod>;
 };
 
+/**
+ * A return type representing the members of a Colony
+ *
+ * Definitions:
+ * * Member = User watching a Colony, with or without reputation
+ * * Contributor = User watching a Colony WITH reputation
+ * * Watcher = User watching a Colony WITHOUT reputation
+ */
 export type MembersForColonyReturn = {
   __typename?: 'MembersForColonyReturn';
+  /** User watching a Colony WITH reputation */
   contributors?: Maybe<Array<Contributor>>;
+  /** User watching a Colony WITHOUT reputation */
   watchers?: Maybe<Array<Watcher>>;
 };
 
@@ -2127,67 +2588,113 @@ export type ModelWatchedColoniesFilterInput = {
   userID?: InputMaybe<ModelIdInput>;
 };
 
+/** A status update message for a motion (will appear in the motion's timeline) */
 export type MotionMessage = {
   __typename?: 'MotionMessage';
+  /** Token amount relevant to the status update (if applicable) */
   amount?: Maybe<Scalars['String']>;
+  /** Timestamp of when the status update was created in the database */
   createdAt: Scalars['AWSDateTime'];
   id: Scalars['ID'];
+  /**
+   * Wallet address of the initiator of the status update
+   * The zero address is used for messages that don't have an initiator (system messages)
+   */
   initiatorAddress: Scalars['ID'];
+  /** Extended user object for given initiatorAddress */
   initiatorUser?: Maybe<User>;
+  /** Unique id for the message */
   messageKey: Scalars['String'];
+  /** The internal database id of the motion */
   motionId: Scalars['ID'];
+  /** Internal name of the status update event (e.g. `MotionCreated`, `MotionStaked`, etc.) */
   name: Scalars['String'];
   updatedAt: Scalars['AWSDateTime'];
+  /** Cast vote attached to the status update (if applicable) */
   vote?: Maybe<Scalars['String']>;
 };
 
+/** Input used to create a motion status update message */
 export type MotionMessageInput = {
+  /** Token amount relevant to the status update (if applicable) */
   amount?: InputMaybe<Scalars['String']>;
+  /**
+   * Wallet address of the initiator of the status update
+   * The zero address is used for messages that don't have an initiator (system messages)
+   */
   initiatorAddress: Scalars['String'];
+  /** Unique id for the message */
   messageKey: Scalars['String'];
+  /** Internal name of the status update event (e.g. `MotionCreated`, `MotionStaked`, etc.) */
   name: Scalars['String'];
+  /** Cast vote attached to the status update (if applicable) */
   vote?: InputMaybe<Scalars['String']>;
 };
 
+/** Staked sides of a motion */
 export type MotionStakeValues = {
   __typename?: 'MotionStakeValues';
+  /** Number of votes against this motion */
   nay: Scalars['String'];
+  /** Number of votes for this motion */
   yay: Scalars['String'];
 };
 
+/** Input type for modifying the staked side of a motion */
 export type MotionStakeValuesInput = {
+  /** Number of votes against this motion */
   nay: Scalars['String'];
+  /** Number of votes for this motion */
   yay: Scalars['String'];
 };
 
+/** Staked sides of a motion */
 export type MotionStakes = {
   __typename?: 'MotionStakes';
+  /** Values in percentage of the total stakes */
   percentage: MotionStakeValues;
+  /** Absolute values denominated in the native token */
   raw: MotionStakeValues;
 };
 
+/** Input used to modify the staked sides of a motion */
 export type MotionStakesInput = {
+  /** Values in percentage of the total stakes */
   percentage: MotionStakeValuesInput;
+  /** Absolute values denominated in the native token */
   raw: MotionStakeValuesInput;
 };
 
+/** Quick access flages to check the current state of a motion in its lifecycle */
 export type MotionStateHistory = {
   __typename?: 'MotionStateHistory';
+  /** Whether the motion has failed */
   hasFailed: Scalars['Boolean'];
+  /** Whether the motion has failed and cannot be finalized (e.g. if it doesn't get staked) */
   hasFailedNotFinalizable: Scalars['Boolean'];
+  /** Whether the motion has passed */
   hasPassed: Scalars['Boolean'];
+  /** Voting period is elapsed */
   hasVoted: Scalars['Boolean'];
+  /** Motion is in reveal phase (votes are being revealed) */
   inRevealPhase: Scalars['Boolean'];
 };
 
+/** Input used to change the current state of a motion */
 export type MotionStateHistoryInput = {
+  /** Whether the motion has failed */
   hasFailed: Scalars['Boolean'];
+  /** Whether the motion has failed and cannot be finalized (e.g. if it doesn't get staked) */
   hasFailedNotFinalizable: Scalars['Boolean'];
+  /** Whether the motion has passed */
   hasPassed: Scalars['Boolean'];
+  /** Voting period is elapsed */
   hasVoted: Scalars['Boolean'];
+  /** Motion is in reveal phase (votes are being revealed) */
   inRevealPhase: Scalars['Boolean'];
 };
 
+/** Root mutation type */
 export type Mutation = {
   __typename?: 'Mutation';
   createColony?: Maybe<Colony>;
@@ -2209,7 +2716,9 @@ export type Mutation = {
   createMotionMessage?: Maybe<MotionMessage>;
   createProfile?: Maybe<Profile>;
   createToken?: Maybe<Token>;
+  /** Create a unique Colony within the Colony Network. Use this instead of the automatically generated `createColony` mutation */
   createUniqueColony?: Maybe<Colony>;
+  /** Create a unique user within the Colony Network. Use this instead of the automatically generated `createUser` mutation */
   createUniqueUser?: Maybe<User>;
   createUser?: Maybe<User>;
   createUserTokens?: Maybe<UserTokens>;
@@ -2236,6 +2745,7 @@ export type Mutation = {
   deleteUser?: Maybe<User>;
   deleteUserTokens?: Maybe<UserTokens>;
   deleteWatchedColonies?: Maybe<WatchedColonies>;
+  /** Updates the latest available version of a Colony or an extension */
   setCurrentVersion?: Maybe<Scalars['Boolean']>;
   updateColony?: Maybe<Colony>;
   updateColonyAction?: Maybe<ColonyAction>;
@@ -2252,6 +2762,10 @@ export type Mutation = {
   updateCurrentVersion?: Maybe<CurrentVersion>;
   updateDomain?: Maybe<Domain>;
   updateDomainMetadata?: Maybe<DomainMetadata>;
+  /**
+   * Update an extension's details for a specific Colony
+   * The extension hash is generated like so: `keccak256(toUtf8Bytes(extensionName))`, where `extensionName` is the name of the extension contract file in the Colony Network (e.g. `VotingReputation`)
+   */
   updateExtensionByColonyAndHash?: Maybe<ColonyExtension>;
   updateIngestorStats?: Maybe<IngestorStats>;
   updateMotionMessage?: Maybe<MotionMessage>;
@@ -2263,445 +2777,539 @@ export type Mutation = {
 };
 
 
+/** Root mutation type */
 export type MutationCreateColonyArgs = {
   condition?: InputMaybe<ModelColonyConditionInput>;
   input: CreateColonyInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateColonyActionArgs = {
   condition?: InputMaybe<ModelColonyActionConditionInput>;
   input: CreateColonyActionInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateColonyExtensionArgs = {
   condition?: InputMaybe<ModelColonyExtensionConditionInput>;
   input: CreateColonyExtensionInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateColonyFundsClaimArgs = {
   condition?: InputMaybe<ModelColonyFundsClaimConditionInput>;
   input: CreateColonyFundsClaimInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateColonyHistoricRoleArgs = {
   condition?: InputMaybe<ModelColonyHistoricRoleConditionInput>;
   input: CreateColonyHistoricRoleInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateColonyMetadataArgs = {
   condition?: InputMaybe<ModelColonyMetadataConditionInput>;
   input: CreateColonyMetadataInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateColonyMotionArgs = {
   condition?: InputMaybe<ModelColonyMotionConditionInput>;
   input: CreateColonyMotionInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateColonyRoleArgs = {
   condition?: InputMaybe<ModelColonyRoleConditionInput>;
   input: CreateColonyRoleInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateColonyStakeArgs = {
   condition?: InputMaybe<ModelColonyStakeConditionInput>;
   input: CreateColonyStakeInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateColonyTokensArgs = {
   condition?: InputMaybe<ModelColonyTokensConditionInput>;
   input: CreateColonyTokensInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateContractEventArgs = {
   condition?: InputMaybe<ModelContractEventConditionInput>;
   input: CreateContractEventInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateCurrentNetworkInverseFeeArgs = {
   condition?: InputMaybe<ModelCurrentNetworkInverseFeeConditionInput>;
   input: CreateCurrentNetworkInverseFeeInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateCurrentVersionArgs = {
   condition?: InputMaybe<ModelCurrentVersionConditionInput>;
   input: CreateCurrentVersionInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateDomainArgs = {
   condition?: InputMaybe<ModelDomainConditionInput>;
   input: CreateDomainInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateDomainMetadataArgs = {
   condition?: InputMaybe<ModelDomainMetadataConditionInput>;
   input: CreateDomainMetadataInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateIngestorStatsArgs = {
   condition?: InputMaybe<ModelIngestorStatsConditionInput>;
   input: CreateIngestorStatsInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateMotionMessageArgs = {
   condition?: InputMaybe<ModelMotionMessageConditionInput>;
   input: CreateMotionMessageInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateProfileArgs = {
   condition?: InputMaybe<ModelProfileConditionInput>;
   input: CreateProfileInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateTokenArgs = {
   condition?: InputMaybe<ModelTokenConditionInput>;
   input: CreateTokenInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateUniqueColonyArgs = {
   input?: InputMaybe<CreateUniqueColonyInput>;
 };
 
 
+/** Root mutation type */
 export type MutationCreateUniqueUserArgs = {
   input?: InputMaybe<CreateUniqueUserInput>;
 };
 
 
+/** Root mutation type */
 export type MutationCreateUserArgs = {
   condition?: InputMaybe<ModelUserConditionInput>;
   input: CreateUserInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateUserTokensArgs = {
   condition?: InputMaybe<ModelUserTokensConditionInput>;
   input: CreateUserTokensInput;
 };
 
 
+/** Root mutation type */
 export type MutationCreateWatchedColoniesArgs = {
   condition?: InputMaybe<ModelWatchedColoniesConditionInput>;
   input: CreateWatchedColoniesInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteColonyArgs = {
   condition?: InputMaybe<ModelColonyConditionInput>;
   input: DeleteColonyInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteColonyActionArgs = {
   condition?: InputMaybe<ModelColonyActionConditionInput>;
   input: DeleteColonyActionInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteColonyExtensionArgs = {
   condition?: InputMaybe<ModelColonyExtensionConditionInput>;
   input: DeleteColonyExtensionInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteColonyFundsClaimArgs = {
   condition?: InputMaybe<ModelColonyFundsClaimConditionInput>;
   input: DeleteColonyFundsClaimInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteColonyHistoricRoleArgs = {
   condition?: InputMaybe<ModelColonyHistoricRoleConditionInput>;
   input: DeleteColonyHistoricRoleInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteColonyMetadataArgs = {
   condition?: InputMaybe<ModelColonyMetadataConditionInput>;
   input: DeleteColonyMetadataInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteColonyMotionArgs = {
   condition?: InputMaybe<ModelColonyMotionConditionInput>;
   input: DeleteColonyMotionInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteColonyRoleArgs = {
   condition?: InputMaybe<ModelColonyRoleConditionInput>;
   input: DeleteColonyRoleInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteColonyStakeArgs = {
   condition?: InputMaybe<ModelColonyStakeConditionInput>;
   input: DeleteColonyStakeInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteColonyTokensArgs = {
   condition?: InputMaybe<ModelColonyTokensConditionInput>;
   input: DeleteColonyTokensInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteContractEventArgs = {
   condition?: InputMaybe<ModelContractEventConditionInput>;
   input: DeleteContractEventInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteCurrentNetworkInverseFeeArgs = {
   condition?: InputMaybe<ModelCurrentNetworkInverseFeeConditionInput>;
   input: DeleteCurrentNetworkInverseFeeInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteCurrentVersionArgs = {
   condition?: InputMaybe<ModelCurrentVersionConditionInput>;
   input: DeleteCurrentVersionInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteDomainArgs = {
   condition?: InputMaybe<ModelDomainConditionInput>;
   input: DeleteDomainInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteDomainMetadataArgs = {
   condition?: InputMaybe<ModelDomainMetadataConditionInput>;
   input: DeleteDomainMetadataInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteIngestorStatsArgs = {
   condition?: InputMaybe<ModelIngestorStatsConditionInput>;
   input: DeleteIngestorStatsInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteMotionMessageArgs = {
   condition?: InputMaybe<ModelMotionMessageConditionInput>;
   input: DeleteMotionMessageInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteProfileArgs = {
   condition?: InputMaybe<ModelProfileConditionInput>;
   input: DeleteProfileInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteTokenArgs = {
   condition?: InputMaybe<ModelTokenConditionInput>;
   input: DeleteTokenInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteUserArgs = {
   condition?: InputMaybe<ModelUserConditionInput>;
   input: DeleteUserInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteUserTokensArgs = {
   condition?: InputMaybe<ModelUserTokensConditionInput>;
   input: DeleteUserTokensInput;
 };
 
 
+/** Root mutation type */
 export type MutationDeleteWatchedColoniesArgs = {
   condition?: InputMaybe<ModelWatchedColoniesConditionInput>;
   input: DeleteWatchedColoniesInput;
 };
 
 
+/** Root mutation type */
 export type MutationSetCurrentVersionArgs = {
   input?: InputMaybe<SetCurrentVersionInput>;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateColonyArgs = {
   condition?: InputMaybe<ModelColonyConditionInput>;
   input: UpdateColonyInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateColonyActionArgs = {
   condition?: InputMaybe<ModelColonyActionConditionInput>;
   input: UpdateColonyActionInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateColonyExtensionArgs = {
   condition?: InputMaybe<ModelColonyExtensionConditionInput>;
   input: UpdateColonyExtensionInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateColonyFundsClaimArgs = {
   condition?: InputMaybe<ModelColonyFundsClaimConditionInput>;
   input: UpdateColonyFundsClaimInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateColonyHistoricRoleArgs = {
   condition?: InputMaybe<ModelColonyHistoricRoleConditionInput>;
   input: UpdateColonyHistoricRoleInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateColonyMetadataArgs = {
   condition?: InputMaybe<ModelColonyMetadataConditionInput>;
   input: UpdateColonyMetadataInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateColonyMotionArgs = {
   condition?: InputMaybe<ModelColonyMotionConditionInput>;
   input: UpdateColonyMotionInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateColonyRoleArgs = {
   condition?: InputMaybe<ModelColonyRoleConditionInput>;
   input: UpdateColonyRoleInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateColonyStakeArgs = {
   condition?: InputMaybe<ModelColonyStakeConditionInput>;
   input: UpdateColonyStakeInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateColonyTokensArgs = {
   condition?: InputMaybe<ModelColonyTokensConditionInput>;
   input: UpdateColonyTokensInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateContractEventArgs = {
   condition?: InputMaybe<ModelContractEventConditionInput>;
   input: UpdateContractEventInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateCurrentNetworkInverseFeeArgs = {
   condition?: InputMaybe<ModelCurrentNetworkInverseFeeConditionInput>;
   input: UpdateCurrentNetworkInverseFeeInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateCurrentVersionArgs = {
   condition?: InputMaybe<ModelCurrentVersionConditionInput>;
   input: UpdateCurrentVersionInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateDomainArgs = {
   condition?: InputMaybe<ModelDomainConditionInput>;
   input: UpdateDomainInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateDomainMetadataArgs = {
   condition?: InputMaybe<ModelDomainMetadataConditionInput>;
   input: UpdateDomainMetadataInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateExtensionByColonyAndHashArgs = {
   input?: InputMaybe<UpdateExtensionByColonyAndHashInput>;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateIngestorStatsArgs = {
   condition?: InputMaybe<ModelIngestorStatsConditionInput>;
   input: UpdateIngestorStatsInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateMotionMessageArgs = {
   condition?: InputMaybe<ModelMotionMessageConditionInput>;
   input: UpdateMotionMessageInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateProfileArgs = {
   condition?: InputMaybe<ModelProfileConditionInput>;
   input: UpdateProfileInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateTokenArgs = {
   condition?: InputMaybe<ModelTokenConditionInput>;
   input: UpdateTokenInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateUserArgs = {
   condition?: InputMaybe<ModelUserConditionInput>;
   input: UpdateUserInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateUserTokensArgs = {
   condition?: InputMaybe<ModelUserTokensConditionInput>;
   input: UpdateUserTokensInput;
 };
 
 
+/** Root mutation type */
 export type MutationUpdateWatchedColoniesArgs = {
   condition?: InputMaybe<ModelWatchedColoniesConditionInput>;
   input: UpdateWatchedColoniesInput;
 };
 
+/**
+ * Represents the status of a Colony's native token
+ * Colonies can have different types of native tokens in various modes. Here we define some important properties that the dApp uses to enable or disable certain features or views. This is set when a Colony is created and can be changed later
+ */
 export type NativeTokenStatus = {
   __typename?: 'NativeTokenStatus';
+  /** Whether the user has permissions to mint new tokens */
   mintable?: Maybe<Scalars['Boolean']>;
+  /** Whether the native token can be unlocked */
   unlockable?: Maybe<Scalars['Boolean']>;
+  /** Whether the native token is unlocked */
   unlocked?: Maybe<Scalars['Boolean']>;
 };
 
+/**
+ * Input data for the status of a Colony's native token
+ *
+ * Colonies can have different types of native tokens in various modes. Here we define some important properties that the dApp uses to enable or disable certain features or views. This is set when a Colony is created and can be changed later
+ */
 export type NativeTokenStatusInput = {
+  /** Whether the native token is mintable */
   mintable?: InputMaybe<Scalars['Boolean']>;
+  /** Whether the native token can be unlocked */
   unlockable?: InputMaybe<Scalars['Boolean']>;
+  /** Whether the native token is unlocked */
   unlocked?: InputMaybe<Scalars['Boolean']>;
 };
 
+/** Variants of supported Ethereum networks */
 export enum Network {
+  /** Local development network using Ganache */
   Ganache = 'GANACHE',
+  /** Gnosis Chain network */
   Gnosis = 'GNOSIS',
+  /** Fork of Gnosis Chain for QA purposes */
   Gnosisfork = 'GNOSISFORK',
+  /** Ethereum Goerli test network */
   Goerli = 'GOERLI',
+  /** Ethereum Mainnet */
   Mainnet = 'MAINNET'
 }
 
+/** Colony token modifications that are stored temporarily and commited to the database once the corresponding motion passes */
 export type PendingModifiedTokenAddresses = {
   __typename?: 'PendingModifiedTokenAddresses';
+  /** List of tokens that were added to the Colony's token list */
   added?: Maybe<Array<Scalars['String']>>;
+  /** List of tokens that were removed from the Colony's token list */
   removed?: Maybe<Array<Scalars['String']>>;
 };
 
@@ -2710,42 +3318,67 @@ export type PendingModifiedTokenAddressesInput = {
   removed?: InputMaybe<Array<Scalars['String']>>;
 };
 
+/** Represents a user's profile within the Colony Network */
 export type Profile = {
   __typename?: 'Profile';
+  /** URL of the user's avatar image */
   avatar?: Maybe<Scalars['String']>;
+  /** User's bio information */
   bio?: Maybe<Scalars['String']>;
   createdAt: Scalars['AWSDateTime'];
+  /** Display name of the user */
   displayName?: Maybe<Scalars['String']>;
+  /** User's email address */
   email?: Maybe<Scalars['AWSEmail']>;
+  /** Unique identifier for the user's profile */
   id: Scalars['ID'];
+  /** User's location information */
   location?: Maybe<Scalars['String']>;
+  /** Metadata associated with the user's profile */
   meta?: Maybe<ProfileMetadata>;
+  /** URL of the user's thumbnail image */
   thumbnail?: Maybe<Scalars['String']>;
   updatedAt: Scalars['AWSDateTime'];
+  /** URL of the user's website */
   website?: Maybe<Scalars['AWSURL']>;
 };
 
+/** Input data to use when creating or changing a user profile */
 export type ProfileInput = {
+  /** The URL of the user's avatar image */
   avatar?: InputMaybe<Scalars['String']>;
+  /** A short description or biography of the user. */
   bio?: InputMaybe<Scalars['String']>;
+  /** The display name of the user */
   displayName?: InputMaybe<Scalars['String']>;
+  /** The user's email address */
   email?: InputMaybe<Scalars['AWSEmail']>;
+  /** The unique identifier for the user profile */
   id?: InputMaybe<Scalars['ID']>;
+  /** The user's location (e.g., city or country) */
   location?: InputMaybe<Scalars['String']>;
+  /** Any additional metadata or settings related to the user profile */
   meta?: InputMaybe<ProfileMetadataInput>;
+  /** The URL of the user's thumbnail image */
   thumbnail?: InputMaybe<Scalars['String']>;
+  /** The user's personal or professional website */
   website?: InputMaybe<Scalars['AWSURL']>;
 };
 
+/** Represents metadata for a user's profile. Mostly user specific settings */
 export type ProfileMetadata = {
   __typename?: 'ProfileMetadata';
+  /** List of email permissions for the user */
   emailPermissions: Array<Scalars['String']>;
 };
 
+/** Input data for a user's profile metadata */
 export type ProfileMetadataInput = {
+  /** List of email permissions for the user */
   emailPermissions: Array<Scalars['String']>;
 };
 
+/** Root query type */
 export type Query = {
   __typename?: 'Query';
   getActionsByColony?: Maybe<ModelColonyActionConnection>;
@@ -2775,24 +3408,32 @@ export type Query = {
   getExtensionByColonyAndHash?: Maybe<ModelColonyExtensionConnection>;
   getExtensionsByHash?: Maybe<ModelColonyExtensionConnection>;
   getIngestorStats?: Maybe<IngestorStats>;
+  /** Fetch the list of members for a specific Colony */
   getMembersForColony?: Maybe<MembersForColonyReturn>;
   getMotionMessage?: Maybe<MotionMessage>;
   getMotionMessageByMotionId?: Maybe<ModelMotionMessageConnection>;
+  /** Get the state of a motion (i.e. the current period) */
   getMotionState: Scalars['Int'];
+  /** Get the timeout for the current period of a motion */
   getMotionTimeoutPeriods?: Maybe<GetMotionTimeoutPeriodsReturn>;
   getProfile?: Maybe<Profile>;
   getProfileByEmail?: Maybe<ModelProfileConnection>;
+  /** Retrieve a user's reputation within the top domains of a Colony */
   getReputationForTopDomains?: Maybe<GetReputationForTopDomainsReturn>;
   getToken?: Maybe<Token>;
   getTokenByAddress?: Maybe<ModelTokenConnection>;
+  /** Fetch a token's information. Tries to get the data from the DB first, if that fails, resolves to get data from chain */
   getTokenFromEverywhere?: Maybe<TokenFromEverywhereReturn>;
   getTokensByType?: Maybe<ModelTokenConnection>;
   getUser?: Maybe<User>;
   getUserByAddress?: Maybe<ModelUserConnection>;
   getUserByName?: Maybe<ModelUserConnection>;
+  /** Retrieve a user's reputation within a specific domain in a Colony */
   getUserReputation?: Maybe<Scalars['String']>;
+  /** Retrieve a user's token balance for a specific token */
   getUserTokenBalance?: Maybe<GetUserTokenBalanceReturn>;
   getUserTokens?: Maybe<UserTokens>;
+  /** Get the voting reward for a user and a motion */
   getVoterRewards?: Maybe<VoterRewardsReturn>;
   getWatchedColonies?: Maybe<WatchedColonies>;
   listColonies?: Maybe<ModelColonyConnection>;
@@ -2820,6 +3461,7 @@ export type Query = {
 };
 
 
+/** Root query type */
 export type QueryGetActionsByColonyArgs = {
   colonyId: Scalars['ID'];
   createdAt?: InputMaybe<ModelStringKeyConditionInput>;
@@ -2830,6 +3472,7 @@ export type QueryGetActionsByColonyArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetColoniesByNativeTokenIdArgs = {
   filter?: InputMaybe<ModelColonyFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -2839,16 +3482,19 @@ export type QueryGetColoniesByNativeTokenIdArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetColonyArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetColonyActionArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetColonyActionByMotionIdArgs = {
   filter?: InputMaybe<ModelColonyActionFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -2858,6 +3504,7 @@ export type QueryGetColonyActionByMotionIdArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetColonyByAddressArgs = {
   filter?: InputMaybe<ModelColonyFilterInput>;
   id: Scalars['ID'];
@@ -2867,6 +3514,7 @@ export type QueryGetColonyByAddressArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetColonyByNameArgs = {
   filter?: InputMaybe<ModelColonyFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -2876,6 +3524,7 @@ export type QueryGetColonyByNameArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetColonyByTypeArgs = {
   filter?: InputMaybe<ModelColonyFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -2885,21 +3534,25 @@ export type QueryGetColonyByTypeArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetColonyExtensionArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetColonyFundsClaimArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetColonyHistoricRoleArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetColonyHistoricRoleByDateArgs = {
   createdAt?: InputMaybe<ModelStringKeyConditionInput>;
   filter?: InputMaybe<ModelColonyHistoricRoleFilterInput>;
@@ -2910,26 +3563,31 @@ export type QueryGetColonyHistoricRoleByDateArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetColonyMetadataArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetColonyMotionArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetColonyRoleArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetColonyStakeArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetColonyStakeByUserAddressArgs = {
   colonyId?: InputMaybe<ModelIdKeyConditionInput>;
   filter?: InputMaybe<ModelColonyStakeFilterInput>;
@@ -2940,26 +3598,31 @@ export type QueryGetColonyStakeByUserAddressArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetColonyTokensArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetContractEventArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetCurrentNetworkInverseFeeArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetCurrentVersionArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetCurrentVersionByKeyArgs = {
   filter?: InputMaybe<ModelCurrentVersionFilterInput>;
   key: Scalars['String'];
@@ -2969,16 +3632,19 @@ export type QueryGetCurrentVersionByKeyArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetDomainArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetDomainMetadataArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetExtensionByColonyAndHashArgs = {
   colonyId: Scalars['ID'];
   filter?: InputMaybe<ModelColonyExtensionFilterInput>;
@@ -2989,6 +3655,7 @@ export type QueryGetExtensionByColonyAndHashArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetExtensionsByHashArgs = {
   filter?: InputMaybe<ModelColonyExtensionFilterInput>;
   hash: Scalars['String'];
@@ -2998,21 +3665,25 @@ export type QueryGetExtensionsByHashArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetIngestorStatsArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetMembersForColonyArgs = {
   input?: InputMaybe<MembersForColonyInput>;
 };
 
 
+/** Root query type */
 export type QueryGetMotionMessageArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetMotionMessageByMotionIdArgs = {
   createdAt?: InputMaybe<ModelStringKeyConditionInput>;
   filter?: InputMaybe<ModelMotionMessageFilterInput>;
@@ -3023,21 +3694,25 @@ export type QueryGetMotionMessageByMotionIdArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetMotionStateArgs = {
   input?: InputMaybe<GetMotionStateInput>;
 };
 
 
+/** Root query type */
 export type QueryGetMotionTimeoutPeriodsArgs = {
   input?: InputMaybe<GetMotionTimeoutPeriodsInput>;
 };
 
 
+/** Root query type */
 export type QueryGetProfileArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetProfileByEmailArgs = {
   email: Scalars['AWSEmail'];
   filter?: InputMaybe<ModelProfileFilterInput>;
@@ -3047,16 +3722,19 @@ export type QueryGetProfileByEmailArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetReputationForTopDomainsArgs = {
   input?: InputMaybe<GetReputationForTopDomainsInput>;
 };
 
 
+/** Root query type */
 export type QueryGetTokenArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetTokenByAddressArgs = {
   filter?: InputMaybe<ModelTokenFilterInput>;
   id: Scalars['ID'];
@@ -3066,11 +3744,13 @@ export type QueryGetTokenByAddressArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetTokenFromEverywhereArgs = {
   input?: InputMaybe<TokenFromEverywhereArguments>;
 };
 
 
+/** Root query type */
 export type QueryGetTokensByTypeArgs = {
   filter?: InputMaybe<ModelTokenFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3080,11 +3760,13 @@ export type QueryGetTokensByTypeArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetUserArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetUserByAddressArgs = {
   filter?: InputMaybe<ModelUserFilterInput>;
   id: Scalars['ID'];
@@ -3094,6 +3776,7 @@ export type QueryGetUserByAddressArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetUserByNameArgs = {
   filter?: InputMaybe<ModelUserFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3103,31 +3786,37 @@ export type QueryGetUserByNameArgs = {
 };
 
 
+/** Root query type */
 export type QueryGetUserReputationArgs = {
   input?: InputMaybe<GetUserReputationInput>;
 };
 
 
+/** Root query type */
 export type QueryGetUserTokenBalanceArgs = {
   input?: InputMaybe<GetUserTokenBalanceInput>;
 };
 
 
+/** Root query type */
 export type QueryGetUserTokensArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryGetVoterRewardsArgs = {
   input?: InputMaybe<GetVoterRewardsInput>;
 };
 
 
+/** Root query type */
 export type QueryGetWatchedColoniesArgs = {
   id: Scalars['ID'];
 };
 
 
+/** Root query type */
 export type QueryListColoniesArgs = {
   filter?: InputMaybe<ModelColonyFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3135,6 +3824,7 @@ export type QueryListColoniesArgs = {
 };
 
 
+/** Root query type */
 export type QueryListColonyActionsArgs = {
   filter?: InputMaybe<ModelColonyActionFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3142,6 +3832,7 @@ export type QueryListColonyActionsArgs = {
 };
 
 
+/** Root query type */
 export type QueryListColonyExtensionsArgs = {
   filter?: InputMaybe<ModelColonyExtensionFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3149,6 +3840,7 @@ export type QueryListColonyExtensionsArgs = {
 };
 
 
+/** Root query type */
 export type QueryListColonyFundsClaimsArgs = {
   filter?: InputMaybe<ModelColonyFundsClaimFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3156,6 +3848,7 @@ export type QueryListColonyFundsClaimsArgs = {
 };
 
 
+/** Root query type */
 export type QueryListColonyHistoricRolesArgs = {
   filter?: InputMaybe<ModelColonyHistoricRoleFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3163,6 +3856,7 @@ export type QueryListColonyHistoricRolesArgs = {
 };
 
 
+/** Root query type */
 export type QueryListColonyMetadataArgs = {
   filter?: InputMaybe<ModelColonyMetadataFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3170,6 +3864,7 @@ export type QueryListColonyMetadataArgs = {
 };
 
 
+/** Root query type */
 export type QueryListColonyMotionsArgs = {
   filter?: InputMaybe<ModelColonyMotionFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3177,6 +3872,7 @@ export type QueryListColonyMotionsArgs = {
 };
 
 
+/** Root query type */
 export type QueryListColonyRolesArgs = {
   filter?: InputMaybe<ModelColonyRoleFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3184,6 +3880,7 @@ export type QueryListColonyRolesArgs = {
 };
 
 
+/** Root query type */
 export type QueryListColonyStakesArgs = {
   filter?: InputMaybe<ModelColonyStakeFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3191,6 +3888,7 @@ export type QueryListColonyStakesArgs = {
 };
 
 
+/** Root query type */
 export type QueryListColonyTokensArgs = {
   filter?: InputMaybe<ModelColonyTokensFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3198,6 +3896,7 @@ export type QueryListColonyTokensArgs = {
 };
 
 
+/** Root query type */
 export type QueryListContractEventsArgs = {
   filter?: InputMaybe<ModelContractEventFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3205,6 +3904,7 @@ export type QueryListContractEventsArgs = {
 };
 
 
+/** Root query type */
 export type QueryListCurrentNetworkInverseFeesArgs = {
   filter?: InputMaybe<ModelCurrentNetworkInverseFeeFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3212,6 +3912,7 @@ export type QueryListCurrentNetworkInverseFeesArgs = {
 };
 
 
+/** Root query type */
 export type QueryListCurrentVersionsArgs = {
   filter?: InputMaybe<ModelCurrentVersionFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3219,6 +3920,7 @@ export type QueryListCurrentVersionsArgs = {
 };
 
 
+/** Root query type */
 export type QueryListDomainMetadataArgs = {
   filter?: InputMaybe<ModelDomainMetadataFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3226,6 +3928,7 @@ export type QueryListDomainMetadataArgs = {
 };
 
 
+/** Root query type */
 export type QueryListDomainsArgs = {
   filter?: InputMaybe<ModelDomainFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3233,6 +3936,7 @@ export type QueryListDomainsArgs = {
 };
 
 
+/** Root query type */
 export type QueryListIngestorStatsArgs = {
   filter?: InputMaybe<ModelIngestorStatsFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3240,6 +3944,7 @@ export type QueryListIngestorStatsArgs = {
 };
 
 
+/** Root query type */
 export type QueryListMotionMessagesArgs = {
   filter?: InputMaybe<ModelMotionMessageFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3247,6 +3952,7 @@ export type QueryListMotionMessagesArgs = {
 };
 
 
+/** Root query type */
 export type QueryListProfilesArgs = {
   filter?: InputMaybe<ModelProfileFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3254,6 +3960,7 @@ export type QueryListProfilesArgs = {
 };
 
 
+/** Root query type */
 export type QueryListTokensArgs = {
   filter?: InputMaybe<ModelTokenFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3261,6 +3968,7 @@ export type QueryListTokensArgs = {
 };
 
 
+/** Root query type */
 export type QueryListUserTokensArgs = {
   filter?: InputMaybe<ModelUserTokensFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3268,6 +3976,7 @@ export type QueryListUserTokensArgs = {
 };
 
 
+/** Root query type */
 export type QueryListUsersArgs = {
   filter?: InputMaybe<ModelUserFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3275,34 +3984,55 @@ export type QueryListUsersArgs = {
 };
 
 
+/** Root query type */
 export type QueryListWatchedColoniesArgs = {
   filter?: InputMaybe<ModelWatchedColoniesFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
   nextToken?: InputMaybe<Scalars['String']>;
 };
 
+/**
+ * Input data to store the latest available version of the core Colony contract and available extensions
+ *
+ * The extension hash is generated like so: `keccak256(toUtf8Bytes(extensionName))`, where `extensionName` is the name of the extension contract file in the Colony Network (e.g. `VotingReputation`)
+ */
 export type SetCurrentVersionInput = {
+  /** COLONY for the Colony contract, extension hash for extensions */
   key: Scalars['String'];
+  /** Latest available version */
   version: Scalars['Int'];
 };
 
+/** Variants of sorting methods for a member list */
 export enum SortingMethod {
+  /** Sort members by highest reputation */
   ByHighestRep = 'BY_HIGHEST_REP',
+  /** Sort members by having fewer permissions */
   ByLessPermissions = 'BY_LESS_PERMISSIONS',
+  /** Sort members by lowest reputation */
   ByLowestRep = 'BY_LOWEST_REP',
+  /** Sort members by having more permissions */
   ByMorePermissions = 'BY_MORE_PERMISSIONS'
 }
 
+/** Staker rewards of a user for a motion */
 export type StakerRewards = {
   __typename?: 'StakerRewards';
+  /** The user's wallet address */
   address: Scalars['String'];
+  /** Whether the voter reward is already claimed or not */
   isClaimed: Scalars['Boolean'];
+  /** Rewards associated with the staked sides of a motion */
   rewards: MotionStakeValues;
 };
 
+/** Input used to modify the staker rewards of a user for a motion */
 export type StakerRewardsInput = {
+  /** The user's wallet address */
   address: Scalars['String'];
+  /** Whether the voter reward is already claimed or not */
   isClaimed: Scalars['Boolean'];
+  /** Rewards associated with the staked sides of a motion */
   rewards: MotionStakeValuesInput;
 };
 
@@ -3706,23 +4436,34 @@ export type SubscriptionOnUpdateWatchedColoniesArgs = {
   filter?: InputMaybe<ModelSubscriptionWatchedColoniesFilterInput>;
 };
 
+/** Represents an ERC20-compatible token that is used by Colonies and users */
 export type Token = {
   __typename?: 'Token';
+  /** URL of the token's avatar image (logo) */
   avatar?: Maybe<Scalars['String']>;
+  /** Metadata related to the chain of the token */
   chainMetadata: ChainMetadata;
   colonies?: Maybe<ModelColonyTokensConnection>;
+  /** Timestamp of the token model's creation in the database */
   createdAt: Scalars['AWSDateTime'];
+  /** Decimal precision of the token */
   decimals: Scalars['Int'];
+  /** Unique identifier for the token (contract address) */
   id: Scalars['ID'];
+  /** Name of the token */
   name: Scalars['String'];
+  /** Symbol of the token */
   symbol: Scalars['String'];
+  /** URL of the token's thumbnail image (Small logo) */
   thumbnail?: Maybe<Scalars['String']>;
+  /** Type of the token. See `TokenType` for more information */
   type?: Maybe<TokenType>;
   updatedAt: Scalars['AWSDateTime'];
   users?: Maybe<ModelUserTokensConnection>;
 };
 
 
+/** Represents an ERC20-compatible token that is used by Colonies and users */
 export type TokenColoniesArgs = {
   filter?: InputMaybe<ModelColonyTokensFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3731,6 +4472,7 @@ export type TokenColoniesArgs = {
 };
 
 
+/** Represents an ERC20-compatible token that is used by Colonies and users */
 export type TokenUsersArgs = {
   filter?: InputMaybe<ModelUserTokensFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3738,22 +4480,35 @@ export type TokenUsersArgs = {
   sortDirection?: InputMaybe<ModelSortDirection>;
 };
 
+/** Input data for fetching a token's information from DB or chain */
 export type TokenFromEverywhereArguments = {
+  /** Address of the token on the blockchain */
   tokenAddress: Scalars['String'];
 };
 
+/** Return type for tokens gotten from DB or from chain */
 export type TokenFromEverywhereReturn = {
   __typename?: 'TokenFromEverywhereReturn';
+  /** List of tokens found */
   items?: Maybe<Array<Maybe<Token>>>;
 };
 
+/** Input type for specifying a Token */
 export type TokenInput = {
+  /** Unique identifier for the Token */
   id: Scalars['ID'];
 };
 
+/**
+ * Variants of different token types a Colony can use
+ * As Colonies can use multiple tokens and even own tokens (BYOT), we need to differentiate
+ */
 export enum TokenType {
+  /** The native token of the Chain used (e.g. ETH on mainnet or xDAI on Gnosis-Chain) */
   ChainNative = 'CHAIN_NATIVE',
+  /** A (ERC20-compatible) token that was deployed with Colony. It has a few more features, like minting through the Colony itself */
   Colony = 'COLONY',
+  /** An ERC20-compatible token */
   Erc20 = 'ERC20'
 }
 
@@ -3935,14 +4690,26 @@ export type UpdateDomainMetadataInput = {
   name?: InputMaybe<Scalars['String']>;
 };
 
+/**
+ * Input data for updating an extension's information within a Colony, based on the Colony ID and extension hash
+ * The hash is generated like so: `keccak256(toUtf8Bytes(extensionName))`, where `extensionName` is the name of the extension contract file in the Colony Network
+ */
 export type UpdateExtensionByColonyAndHashInput = {
+  /** The unique identifier for the Colony */
   colonyId: Scalars['ID'];
+  /** The hash of the extension to be updated */
   hash: Scalars['String'];
+  /** The timestamp when the extension was installed */
   installedAt?: InputMaybe<Scalars['AWSTimestamp']>;
+  /** The Ethereum address of the user who installed the extension */
   installedBy?: InputMaybe<Scalars['String']>;
+  /** A flag to indicate whether the extension is deleted */
   isDeleted?: InputMaybe<Scalars['Boolean']>;
+  /** A flag to indicate whether the extension is deprecated */
   isDeprecated?: InputMaybe<Scalars['Boolean']>;
+  /** A flag to indicate whether the extension is initialized */
   isInitialized?: InputMaybe<Scalars['Boolean']>;
+  /** The version of the extension */
   version?: InputMaybe<Scalars['Int']>;
 };
 
@@ -4004,12 +4771,17 @@ export type UpdateWatchedColoniesInput = {
   userID?: InputMaybe<Scalars['ID']>;
 };
 
+/** Represents a User within the Colony Network */
 export type User = {
   __typename?: 'User';
   createdAt: Scalars['AWSDateTime'];
+  /** Unique identifier for the user (wallet address) */
   id: Scalars['ID'];
+  /** (Short) name of the user */
   name: Scalars['String'];
+  /** Profile information of the user */
   profile?: Maybe<Profile>;
+  /** Profile ID associated with the user */
   profileId?: Maybe<Scalars['ID']>;
   stakes?: Maybe<ModelColonyStakeConnection>;
   tokens?: Maybe<ModelUserTokensConnection>;
@@ -4018,6 +4790,7 @@ export type User = {
 };
 
 
+/** Represents a User within the Colony Network */
 export type UserStakesArgs = {
   colonyId?: InputMaybe<ModelIdKeyConditionInput>;
   filter?: InputMaybe<ModelColonyStakeFilterInput>;
@@ -4027,6 +4800,7 @@ export type UserStakesArgs = {
 };
 
 
+/** Represents a User within the Colony Network */
 export type UserTokensArgs = {
   filter?: InputMaybe<ModelUserTokensFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -4035,6 +4809,7 @@ export type UserTokensArgs = {
 };
 
 
+/** Represents a User within the Colony Network */
 export type UserWatchlistArgs = {
   filter?: InputMaybe<ModelWatchedColoniesFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -4042,20 +4817,29 @@ export type UserWatchlistArgs = {
   sortDirection?: InputMaybe<ModelSortDirection>;
 };
 
+/** A type representing a user's reputation within a domain */
 export type UserDomainReputation = {
   __typename?: 'UserDomainReputation';
+  /** The integer ID of the Domain within the Colony */
   domainId: Scalars['Int'];
+  /** The user's reputation within the domain, represented as a percentage */
   reputationPercentage: Scalars['String'];
 };
 
+/** Stakes that a user has made for a motion */
 export type UserStakes = {
   __typename?: 'UserStakes';
+  /** The user's wallet address */
   address: Scalars['String'];
+  /** Stake values */
   stakes: MotionStakes;
 };
 
+/** Input used to modify the stakes of a user for a motion */
 export type UserStakesInput = {
+  /** The user's wallet address */
   address: Scalars['String'];
+  /** Stake values */
   stakes: MotionStakesInput;
 };
 
@@ -4070,35 +4854,74 @@ export type UserTokens = {
   userID: Scalars['ID'];
 };
 
+/** A voter record of a user for a motion */
 export type VoterRecord = {
   __typename?: 'VoterRecord';
+  /** The user's wallet address */
   address: Scalars['String'];
+  /**
+   * The actual vote (yay or nay)
+   * nullable since we don't know the vote until it's revealed
+   */
   vote?: Maybe<Scalars['Int']>;
+  /** The voting weight denominated by the user's reputation */
   voteCount: Scalars['String'];
 };
 
+/** Input used to modify a voter record of a user for a motion */
 export type VoterRecordInput = {
+  /** The user's wallet address */
   address: Scalars['String'];
+  /**
+   * The actual vote (yay or nay)
+   * nullable since we don't know the vote until it's revealed
+   */
   vote?: InputMaybe<Scalars['Int']>;
+  /** The voting weight denominated by the user's reputation */
   voteCount: Scalars['String'];
 };
 
+/**
+ * A return type that contains the voting reward for a user and a motion
+ * `min` and `max` specify the potential reward range when the actual reward is unknown (before the _reveal_ phase)
+ */
 export type VoterRewardsReturn = {
   __typename?: 'VoterRewardsReturn';
+  /**
+   * The maximum possible reward amount
+   * Only useful before the _reveal_ phase, when the actual amount is known
+   */
   max: Scalars['String'];
+  /**
+   * The minimum possible reward amount
+   * Only useful before the _reveal_ phase, when the actual amount is known
+   */
   min: Scalars['String'];
+  /** The actual reward amount */
   reward: Scalars['String'];
 };
 
+/**
+ * Parameters that were set when installing the VotingReputation extension
+ * For more info see [here](https://docs.colony.io/colonysdk/api/classes/VotingReputation#extension-parameters)
+ */
 export type VotingReputationParams = {
   __typename?: 'VotingReputationParams';
+  /** Time that the escalation period will last (in seconds) */
   escalationPeriod: Scalars['String'];
+  /** Percentage of the total reputation that voted should end the voting period */
   maxVoteFraction: Scalars['String'];
+  /** Time that the reveal period will last (in seconds) */
   revealPeriod: Scalars['String'];
+  /** Time that the staking period will last (in seconds) */
   stakePeriod: Scalars['String'];
+  /** Time that the voting period will last (in seconds) */
   submitPeriod: Scalars['String'];
+  /** Percentage of the team's reputation that needs to be staked ot activate either side of the motion */
   totalStakeFraction: Scalars['String'];
+  /** Minimum percentage of the total stake that each user has to provide */
   userMinStakeFraction: Scalars['String'];
+  /** Percentage of the losing side's stake that is awarded to the voters */
   voterRewardFraction: Scalars['String'];
 };
 
@@ -4124,9 +4947,16 @@ export type WatchedColonies = {
   userID: Scalars['ID'];
 };
 
+/**
+ * Represents a watcher within the Colony Network
+ *
+ * A watcher is a Colony member who doesn't have reputation
+ */
 export type Watcher = {
   __typename?: 'Watcher';
+  /** Wallet address of the watcher */
   address: Scalars['String'];
+  /** User data associated with the watcher */
   user?: Maybe<User>;
 };
 
@@ -4353,13 +5183,6 @@ export type GetMembersForColonyQueryVariables = Exact<{
 
 
 export type GetMembersForColonyQuery = { __typename?: 'Query', getMembersForColony?: { __typename?: 'MembersForColonyReturn', contributors?: Array<{ __typename?: 'Contributor', address: string, reputationPercentage?: string | null, reputationAmount?: string | null, user?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null } | null }> | null, watchers?: Array<{ __typename?: 'Watcher', address: string, user?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null } | null }> | null } | null };
-
-export type GetDomainNameQueryVariables = Exact<{
-  id: Scalars['ID'];
-}>;
-
-
-export type GetDomainNameQuery = { __typename?: 'Query', getDomain?: { __typename?: 'Domain', metadata?: { __typename?: 'DomainMetadata', name: string } | null } | null };
 
 export type GetMotionStateQueryVariables = Exact<{
   input: GetMotionStateInput;
@@ -5825,43 +6648,6 @@ export function useGetMembersForColonyLazyQuery(baseOptions?: Apollo.LazyQueryHo
 export type GetMembersForColonyQueryHookResult = ReturnType<typeof useGetMembersForColonyQuery>;
 export type GetMembersForColonyLazyQueryHookResult = ReturnType<typeof useGetMembersForColonyLazyQuery>;
 export type GetMembersForColonyQueryResult = Apollo.QueryResult<GetMembersForColonyQuery, GetMembersForColonyQueryVariables>;
-export const GetDomainNameDocument = gql`
-    query GetDomainName($id: ID!) {
-  getDomain(id: $id) {
-    metadata {
-      name
-    }
-  }
-}
-    `;
-
-/**
- * __useGetDomainNameQuery__
- *
- * To run a query within a React component, call `useGetDomainNameQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetDomainNameQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetDomainNameQuery({
- *   variables: {
- *      id: // value for 'id'
- *   },
- * });
- */
-export function useGetDomainNameQuery(baseOptions: Apollo.QueryHookOptions<GetDomainNameQuery, GetDomainNameQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetDomainNameQuery, GetDomainNameQueryVariables>(GetDomainNameDocument, options);
-      }
-export function useGetDomainNameLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetDomainNameQuery, GetDomainNameQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetDomainNameQuery, GetDomainNameQueryVariables>(GetDomainNameDocument, options);
-        }
-export type GetDomainNameQueryHookResult = ReturnType<typeof useGetDomainNameQuery>;
-export type GetDomainNameLazyQueryHookResult = ReturnType<typeof useGetDomainNameLazyQuery>;
-export type GetDomainNameQueryResult = Apollo.QueryResult<GetDomainNameQuery, GetDomainNameQueryVariables>;
 export const GetMotionStateDocument = gql`
     query GetMotionState($input: GetMotionStateInput!) {
   getMotionState(input: $input)

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -453,13 +453,13 @@ export type ColonyHistoricRole = {
   __typename?: 'ColonyHistoricRole';
   /** Block at which the snapshot was taken */
   blockNumber: Scalars['Int'];
-  /** Expaneded `Colony` model, based on the `colonyId` given */
+  /** Expanded `Colony` model, based on the `colonyId` given */
   colony: Colony;
   /** Unique identifier of the Colony */
   colonyId: Scalars['ID'];
   /** Timestamp at which the database entry was created */
   createdAt: Scalars['AWSDateTime'];
-  /** Expaneded `Domain` model, based on the `domainId` given */
+  /** Expanded `Domain` model, based on the `domainId` given */
   domain: Domain;
   /** Unique identifier of the domain */
   domainId: Scalars['ID'];


### PR DESCRIPTION
## Description

This PR adds schema annotations to all types and models that are not auto-generated. This is to be able to create a markdown documentation for the team and external developers. The annotations will also find their way into the TypeScript types generated (meaning they will show up in the developer's IDE) and the GraphiQL explorer.

**New stuff** ✨

* Added annotations for the amplify schema file

**Changes** 🏗

* Adjust the codegen to use a local file loader instead of passing the string (which seems to be only useful for small schemas or testing purposes)

## TODO

- [x] Ask dApp team about missing annotations that I couldn't figure out (all `???` occurrences)
- [x] ~~Add annotations for the custom queries and mutations in `src/graphql`~~ (these are actually not taken into account
- [ ] Discuss `[needs input]` flags when PR is reviewed

