### PR TITLE
Fix `isClaimed` and `hasUserVoted` state in motions

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/ClaimMotionStakes.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/ClaimMotionStakes.css
@@ -1,0 +1,3 @@
+.claimLabel {
+  color: var(--dark);
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/ClaimMotionStakes.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/ClaimMotionStakes.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace ClaimMotionStakesCssNamespace {
+  export interface IClaimMotionStakesCss {
+    claimLabel: string;
+  }
+}
+
+declare const ClaimMotionStakesCssModule: ClaimMotionStakesCssNamespace.IClaimMotionStakesCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: ClaimMotionStakesCssNamespace.IClaimMotionStakesCss;
+};
+
+export = ClaimMotionStakesCssModule;

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/ClaimMotionStakes.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/ClaimMotionStakes.tsx
@@ -4,6 +4,8 @@ import DetailItem from '~shared/DetailsWidget/DetailItem';
 import { MotionData } from '~types';
 import { useClaimWidgetConfig } from '~hooks';
 
+import styles from './ClaimMotionStakes.css';
+
 const displayName = `common.ColonyActions.ActionDetailsPage.DefaultMotion.ClaimMotionStakes`;
 
 interface ClaimMotionStakesProps {
@@ -11,16 +13,23 @@ interface ClaimMotionStakesProps {
   startPollingAction: (pollInterval: number) => void;
 }
 
+export type ClaimMotionStakesStyles = typeof styles;
+
 const ClaimMotionStakes = ({
   motionData,
   startPollingAction,
 }: ClaimMotionStakesProps) => {
-  const config = useClaimWidgetConfig(motionData, startPollingAction);
+  const config = useClaimWidgetConfig(motionData, startPollingAction, styles);
 
   return (
     <div>
-      {config.map(({ label, item }) => (
-        <DetailItem label={label} item={item} key={label} />
+      {config.map(({ label, labelStyles, item }) => (
+        <DetailItem
+          label={label}
+          labelStyles={labelStyles}
+          item={item}
+          key={label as string} // safe casting as we don't interpolate complex values in useClaimWidgetConfig
+        />
       ))}
     </div>
   );

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/useVotingWidgetUpdate.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/useVotingWidgetUpdate.ts
@@ -19,6 +19,14 @@ export const useVotingWidgetUpdate = (
     setHasUserVoted(true);
   }
 
+  useEffect(() => {
+    if (!user) {
+      setHasUserVoted(false);
+    } else {
+      setHasUserVoted(!!currentVotingRecord);
+    }
+  }, [user, currentVotingRecord]);
+
   // if user's vote count increased, db has been updated, stop polling
   if (currentVotingRecord?.voteCount !== prevRecord?.voteCount) {
     stopPollingAction();

--- a/src/components/shared/DetailsWidget/DetailItem.tsx
+++ b/src/components/shared/DetailsWidget/DetailItem.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
 import { PopperOptions } from 'react-popper-tooltip';
+import classNames from 'classnames';
 
 import QuestionMarkTooltip from '~shared/QuestionMarkTooltip';
 import { Message, UniversalMessageValues } from '~types';
@@ -12,6 +13,7 @@ const displayName = 'DetailsWidget.DetailItem';
 export interface DetailItemProps {
   label: Message;
   labelValues?: UniversalMessageValues;
+  labelStyles?: string;
   item: ReactNode;
   tooltipText?: Message;
   tooltipStyles?: string;
@@ -21,13 +23,14 @@ export interface DetailItemProps {
 const DetailItem = ({
   label,
   labelValues,
+  labelStyles,
   item,
   tooltipText,
   tooltipStyles = styles.tooltip,
   tooltipPopperOptions,
 }: DetailItemProps) => (
   <div className={styles.item}>
-    <div className={styles.label}>
+    <div className={classNames(styles.label, labelStyles)}>
       {formatText(label, labelValues)}
       {tooltipText && (
         <QuestionMarkTooltip


### PR DESCRIPTION
## Description

This PR keeps the `hasUserVoted` and `isClaimed` state in sync with the user, so that it's accurate after a user switches account or logs out.

I've also thrown in a small presentational fix by emboldening the "Claim your tokens" detail in the ClaimWidget.

**Changes** 🏗

*  sync `hasUserVoted` and `isClaimed` state with the user
*  embolden the "Claim your tokens" detail 

