### PR TITLE
Wire in escalate button

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionCountdown/EscalateButton/EscalateButton.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionCountdown/EscalateButton/EscalateButton.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
+import { BigNumber } from 'ethers';
 
 import { ActionButton } from '~shared/Button';
 import QuestionMarkTooltip from '~shared/QuestionMarkTooltip';
 import { ActionTypes } from '~redux';
 import { mapPayload } from '~utils/actions';
-import { Address } from '~types';
-import { useColonyContext } from '~hooks';
+import { useAppContext, useColonyContext } from '~hooks';
+import { EscalateMotionPayload } from '~redux/sagas/motions/escalateMotion';
 
 import styles from './EscalateButton.css';
 
@@ -25,22 +26,26 @@ const MSG = defineMessages({
 });
 
 interface EscalateButtonProps {
-  motionId: number;
-  userAddress: Address;
+  motionId: string;
 }
 
-const EscalateButton = ({ motionId, userAddress }: EscalateButtonProps) => {
+const EscalateButton = ({ motionId }: EscalateButtonProps) => {
   const { colony } = useColonyContext();
+  const { user } = useAppContext();
 
   if (!colony) {
     return null;
   }
 
-  const escalateTransform = mapPayload(() => ({
-    colony: colony.colonyAddress,
-    motionId,
-    userAddress,
-  }));
+  const escalateTransform = mapPayload(() => {
+    const payload: EscalateMotionPayload = {
+      colonyAddress: colony.colonyAddress ?? '',
+      motionId: BigNumber.from(motionId),
+      userAddress: user?.walletAddress ?? '',
+    };
+
+    return payload;
+  });
 
   return (
     <div className={styles.escalation}>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionCountdown/MotionCountdown.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionCountdown/MotionCountdown.css
@@ -6,3 +6,7 @@
 .votingCountdownContainer {
   justify-content: flex-end;
 }
+
+.escalateContainer {
+  column-gap: 10px;
+}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionCountdown/MotionCountdown.css.d.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionCountdown/MotionCountdown.css.d.ts
@@ -1,6 +1,7 @@
 declare namespace MotionCountdownCssNamespace {
   export interface IMotionCountdownCss {
     countdownContainer: string;
+    escalateContainer: string;
     votingCountdownContainer: string;
   }
 }

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionCountdown/MotionCountdown.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionCountdown/MotionCountdown.tsx
@@ -1,46 +1,18 @@
 import React from 'react';
 import classNames from 'classnames';
+import { Id } from '@colony/colony-js';
 
 import CountDownTimer from '~common/ColonyActions/CountDownTimer';
 import { MotionState } from '~utils/colonyMotions';
 import { MotionData } from '~types';
-import { RefetchMotionState } from '~hooks';
+import { RefetchMotionState, useAppContext } from '~hooks';
 
 import VotingProgress from './VotingProgress';
+import EscalateButton from './EscalateButton';
 
 import styles from './MotionCountdown.css';
 
 const displayName = 'common.ColonyActions.ActionDetailsPage.MotionCountdown';
-
-// const getMotionStakeData = () => {
-//   const totalYAYStaked = 10;
-//   const totalNAYStakes = 10;
-//   const userStakeYay = 10;
-//   const userStakeNay = 10;
-//   const requiredStake = 50;
-//   return {
-//     totalStaked: {
-//       YAY: totalYAYStaked.toString(),
-//       NAY: totalNAYStakes.toString(),
-//     },
-//     userStake: {
-//       YAY: userStakeYay.toString(),
-//       NAY: userStakeNay.toString(),
-//     },
-//     requiredStake,
-//   };
-// };
-
-// const getIsFullyNayStaked = () => {
-//   const motionStakeData = getMotionStakeData();
-
-//   const requiredStake = BigNumber.from(
-//     motionStakeData?.requiredStake || 0,
-//   ).toString();
-
-//   const totalNayStake = BigNumber.from(motionStakeData?.totalStaked.NAY || 0);
-//   return totalNayStake.gte(requiredStake);
-// };
 
 interface MotionCountdownProps {
   motionState: MotionState;
@@ -50,39 +22,40 @@ interface MotionCountdownProps {
 
 const MotionCountdown = ({
   motionState,
+  motionData: { motionDomainId, motionId, motionStakes },
   motionData,
   refetchMotionState,
 }: MotionCountdownProps) => {
+  const { user } = useAppContext();
+
   const isMotionFinished =
     motionState === MotionState.Passed ||
     motionState === MotionState.Failed ||
     motionState === MotionState.FailedNotFinalizable;
 
-  // const showEscalateButton
-  //   motionDomain !== Id.RootDomain &&
-  //   user?.profile &&
-  //   motionState === MotionState.Escalation;
-
   const showVotingProgress = motionState === MotionState.Voting;
+  const showEscalateButton =
+    !!user &&
+    motionState === MotionState.Escalation &&
+    Number(motionDomainId) !== Id.RootDomain;
 
   return (
     <div
       className={classNames(styles.countdownContainer, {
         [styles.votingCountdownContainer]: showVotingProgress,
+        [styles.escalateContainer]: showEscalateButton,
       })}
     >
       {!isMotionFinished && (
         <CountDownTimer
           motionState={motionState}
           refetchMotionState={refetchMotionState}
-          motionId={motionData.motionId}
-          motionStakes={motionData.motionStakes}
+          motionId={motionId}
+          motionStakes={motionStakes}
         />
       )}
       {showVotingProgress && <VotingProgress motionData={motionData} />}
-      {/* {showEscalateButton && (
-        <EscalateButton motionId={motionId} userAddress={user?.walletAddress} />
-      )} */}
+      {showEscalateButton && <EscalateButton motionId={motionId} />}
     </div>
   );
 };

--- a/src/redux/sagas/motions/escalateMotion.ts
+++ b/src/redux/sagas/motions/escalateMotion.ts
@@ -18,6 +18,9 @@ import {
 } from '../transactions';
 import { transactionReady } from '../../actionCreators';
 
+export type EscalateMotionPayload =
+  Action<ActionTypes.MOTION_ESCALATE>['payload'];
+
 function* escalateMotion({
   meta,
   payload: { userAddress, colonyAddress, motionId },


### PR DESCRIPTION
## Description

This PR wires in the escalate button. It is disabled (intentionally) so just a ui / code check.

![escalate](https://user-images.githubusercontent.com/64402732/231771576-52857988-6be1-4302-8bfa-2eadf5b7d293.png)

## Testing

Easiest way to test this is to manually set the `networkMotionState` to `4` in `DefaultMotion.tsx` (at `getMotionState`), and then set `showEscalateButton` to `true` at `MotionCountdown.tsx`

No special set up needed, just get yourself over to the motions page.

**Changes** 🏗

* Tweaks to escalate button

Resolves #407 
