### PR TITLE
Fix inability to claim rewards when motion fails without vote

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -116,6 +116,7 @@ input GetUserTokenBalanceInput {
 input GetMotionStateInput {
   motionId: Int!
   colonyAddress: String!
+  transactionHash: String!
 }
 
 input GetVoterRewardsInput {
@@ -455,9 +456,19 @@ input TokenInput {
   id: ID!
 }
 
+input MotionStakeValuesInput {
+  yay: String!
+  nay: String!
+}
+
 type MotionStakeValues {
   yay: String!
   nay: String!
+}
+
+input MotionStakesInput {
+  raw: MotionStakeValuesInput!
+  percentage: MotionStakeValuesInput!
 }
 
 type MotionStakes {
@@ -465,9 +476,20 @@ type MotionStakes {
   percentage: MotionStakeValues!
 }
 
+input UserStakesInput {
+  address: String!
+  stakes: MotionStakesInput!
+}
+
 type UserStakes {
   address: String!
   stakes: MotionStakes!
+}
+
+input StakerRewardsInput {
+  address: String!
+  rewards: MotionStakeValuesInput!
+  isClaimed: Boolean!
 }
 
 type StakerRewards {
@@ -476,10 +498,36 @@ type StakerRewards {
   isClaimed: Boolean!
 }
 
+input VoterRecordInput {
+  address: String!
+  voteCount: String!
+  vote: Int # nullable since we don't know the vote until it's revealed
+}
+
 type VoterRecord {
   address: String!
   voteCount: String!
   vote: Int # nullable since we don't know the vote until it's revealed
+}
+
+# Duplicate of MotionData type, required to mutate the motionData in `fetchMotionState` lamda
+input MotionDataInput {
+  motionId: String! # to ensure uniqueness, we format as: chainId-votingRepExtnAddress_nativeMotionId
+  nativeMotionId: String!
+  usersStakes: [UserStakesInput!]!
+  stakerRewards: [StakerRewardsInput!]!
+  motionStakes: MotionStakesInput!
+  remainingStakes: [String!]! # tuple [nayRemaining, yayRemaining]
+  userMinStake: String!
+  requiredStake: String!
+  rootHash: String! # For calculating user's max stake in client
+  motionDomainId: String! # native domain id
+  isFinalized: Boolean!
+  createdBy: String! # voting rep extn address. Useful to check if we're viewing a "read-only" motion
+  voterRecord: [VoterRecordInput!]!
+  revealedVotes: MotionStakesInput! ## I.e. MotionVotes (same type)
+  repSubmitted: String!
+  skillRep: String!
 }
 
 type MotionData {

--- a/amplify/backend/function/fetchMotionState/src/graphql.js
+++ b/amplify/backend/function/fetchMotionState/src/graphql.js
@@ -1,0 +1,78 @@
+const motionStakesFragment = /* GraphQL */ `
+  fragment MotionStakeValues on MotionStakeValues {
+    yay
+    nay
+  }
+`;
+
+module.exports = {
+  getColonyAction: /* GraphQL */ `
+    ${motionStakesFragment}
+    query GetColonyAction($id: ID!) {
+      getColonyAction(id: $id) {
+        motionData {
+          motionId
+          nativeMotionId
+          motionStakes {
+            raw {
+              ...MotionStakeValues
+            }
+            percentage {
+              ...MotionStakeValues
+            }
+          }
+          usersStakes {
+            address
+            stakes {
+              raw {
+                ...MotionStakeValues
+              }
+              percentage {
+                ...MotionStakeValues
+              }
+            }
+          }
+          remainingStakes
+          userMinStake
+          requiredStake
+          rootHash
+          motionDomainId
+          stakerRewards {
+            address
+            rewards {
+              yay
+              nay
+            }
+            isClaimed
+          }
+          isFinalized
+          voterRecord {
+            address
+            voteCount
+            vote
+          }
+          revealedVotes {
+            raw {
+              yay
+              nay
+            }
+            percentage {
+              yay
+              nay
+            }
+          }
+          skillRep
+          repSubmitted
+          createdBy
+        }
+      }
+    }
+  `,
+  updateColonyAction: /* GraphQL */ `
+    mutation UpdateColonyAction($id: ID!, $motionData: MotionDataInput!) {
+      updateColonyAction(input: { id: $id, motionData: $motionData }) {
+        id
+      }
+    }
+  `,
+};

--- a/amplify/backend/function/fetchMotionState/src/index.js
+++ b/amplify/backend/function/fetchMotionState/src/index.js
@@ -1,10 +1,42 @@
-const { getLatestMotionState } = require('./utils');
+const { MotionState } = require('@colony/colony-js');
+const {
+  getLatestMotionState,
+  updateStakerRewardsInDB,
+  getMotionData,
+} = require('./utils');
+
 /**
  * @type {import('@types/aws-lambda').APIGatewayProxyHandler}
  */
 exports.handler = async (event) => {
-  const { motionId, colonyAddress } = event.arguments?.input || {};
+  const { motionId, colonyAddress, transactionHash } =
+    event.arguments?.input || {};
   /* Get latest motion state from chain */
   const motionState = await getLatestMotionState(colonyAddress, motionId);
+  /*
+   * Check if we need to update staker rewards
+   * This ensures the rewards are present in the event a motion fails before going to a vote,
+   * so the side that has objected can reclaim their stake.
+   */
+  if (motionState === MotionState.Failed) {
+    const motionData = await getMotionData(transactionHash);
+    if (motionData) {
+      const {
+        motionStakes: {
+          percentage: { yay: yayPercent },
+        },
+      } = motionData;
+
+      // Motion did not go to a vote
+      if (yayPercent !== '100') {
+        await updateStakerRewardsInDB(
+          colonyAddress,
+          transactionHash,
+          motionData,
+        );
+      }
+    }
+  }
+
   return motionState;
 };

--- a/amplify/backend/function/fetchMotionState/src/package-lock.json
+++ b/amplify/backend/function/fetchMotionState/src/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@colony/colony-js": "^6.3.5",
-        "ethers": "^5.1.3"
+        "ethers": "^5.1.3",
+        "node-fetch": "2.6.7"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.92"

--- a/amplify/backend/function/fetchMotionState/src/package.json
+++ b/amplify/backend/function/fetchMotionState/src/package.json
@@ -9,6 +9,8 @@
   },
   "dependencies": {
     "@colony/colony-js": "^6.3.5",
-    "ethers": "^5.1.3"
+    "ethers": "^5.1.3",
+    "node-fetch": "2.6.7"
+
   }
 }

--- a/amplify/backend/function/fetchMotionState/src/utils.js
+++ b/amplify/backend/function/fetchMotionState/src/utils.js
@@ -1,10 +1,15 @@
-const { providers } = require('ethers');
+const { providers, BigNumber } = require('ethers');
 const {
   getColonyNetworkClient,
   Network,
   Extension,
 } = require('@colony/colony-js');
+const { default: fetch, Request } = require('node-fetch');
 
+const { getColonyAction, updateColonyAction } = require('./graphql.js');
+
+const API_KEY = 'da2-fakeApiId123456';
+const GRAPHQL_URI = 'http://localhost:20002/graphql';
 const RPC_URL = 'http://network-contracts.docker:8545'; // this needs to be extended to all supported networks
 const {
   etherRouterAddress: networkAddress,
@@ -33,4 +38,129 @@ const getLatestMotionState = async (colonyAddress, motionId) => {
   return votingReputationClient.getMotionState(motionId);
 };
 
-module.exports = { getLatestMotionState };
+const graphqlRequest = async (queryOrMutation, variables) => {
+  const options = {
+    method: 'POST',
+    headers: {
+      'x-api-key': API_KEY,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: queryOrMutation,
+      variables,
+    }),
+  };
+
+  const request = new Request(GRAPHQL_URI, options);
+
+  let body;
+  let response;
+
+  try {
+    response = await fetch(request);
+    body = await response.json();
+    return body;
+  } catch (error) {
+    /*
+     * Something went wrong... obviously
+     */
+    console.error(error);
+    return null;
+  }
+};
+
+const getMotionData = async (transactionHash) => {
+  const { data: actionData } = await graphqlRequest(getColonyAction, {
+    id: transactionHash,
+  });
+
+  if (!actionData) {
+    console.error(
+      'Could not find motion in db. This is a bug and should be investigated.',
+    );
+  }
+
+  return actionData?.getColonyAction?.motionData;
+};
+
+const getStakerReward = async (motionId, userAddress, colonyAddress) => {
+  const votingReputationClient = await getVotingClient(colonyAddress);
+
+  /*
+   * If **anyone** staked on a side, calling the rewards function returns 0 if there's no reward (even for
+   * a user who didnd't stake).
+   *
+   * But calling the rewards function on a side where **no one** has voted
+   * will result in an error being thrown.
+   *
+   * Hence the try/catch.
+   */
+  let stakingRewardYay = BigNumber.from(0);
+  let stakingRewardNay = BigNumber.from(0);
+  try {
+    [stakingRewardYay] = await votingReputationClient.getStakerReward(
+      motionId,
+      userAddress,
+      1,
+    );
+  } catch (error) {
+    // We don't care to catch the error since we fallback to it's initial value
+  }
+  try {
+    [stakingRewardNay] = await votingReputationClient.getStakerReward(
+      motionId,
+      userAddress,
+      0,
+    );
+  } catch (error) {
+    // silent error
+  }
+
+  return {
+    address: userAddress,
+    rewards: {
+      nay: stakingRewardNay.toString(),
+      yay: stakingRewardYay.toString(),
+    },
+    isClaimed: false,
+  };
+};
+
+const updateStakerRewardsInDB = async (
+  colonyAddress,
+  transactionHash,
+  motionData,
+) => {
+  const { nativeMotionId, usersStakes, stakerRewards } = motionData;
+
+  const updatedStakerRewards = await Promise.all(
+    // For every user who staked
+    usersStakes.map(async ({ address: stakerAddress }) => {
+      // Check if they have already had their reward calculated
+      const existingStakerReward = stakerRewards.find(
+        ({ address }) => address === stakerAddress,
+      );
+
+      // If not, get their reward
+      if (!existingStakerReward) {
+        return getStakerReward(nativeMotionId, stakerAddress, colonyAddress);
+      }
+
+      return existingStakerReward;
+    }),
+  );
+
+  await graphqlRequest(updateColonyAction, {
+    id: transactionHash,
+    motionData: {
+      ...motionData,
+      stakerRewards: updatedStakerRewards,
+    },
+  });
+};
+
+module.exports = {
+  getLatestMotionState,
+  updateStakerRewardsInDB,
+  getMotionData,
+};

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -653,6 +653,7 @@ export type ExtensionParamsInput = {
 export type GetMotionStateInput = {
   colonyAddress: Scalars['String'];
   motionId: Scalars['Int'];
+  transactionHash: Scalars['String'];
 };
 
 export type GetReputationForTopDomainsInput = {

--- a/src/hooks/useGetColonyAction.ts
+++ b/src/hooks/useGetColonyAction.ts
@@ -19,6 +19,7 @@ const useGetColonyAction = (colony?: Colony | null) => {
     loading: loadingAction,
     startPolling: startPollingForAction,
     stopPolling: stopPollingForAction,
+    refetch: refetchAction,
   } = useGetColonyActionQuery({
     skip: skipQuery,
     variables: {
@@ -53,7 +54,12 @@ const useGetColonyAction = (colony?: Colony | null) => {
       input: {
         colonyAddress: colony?.colonyAddress ?? '',
         motionId: Number(action?.motionData?.motionId),
+        transactionHash: transactionHash ?? '',
       },
+    },
+    onCompleted: () => {
+      /* Keeps action data in sync when staker rewards are updated by this query */
+      refetchAction();
     },
   });
 


### PR DESCRIPTION
## Description

This PR fixes a problem with staker rewards not being present in the db in the event where a motion fails before it goes to a vote. Previously, I was exclusively populating staker rewards via the block ingestor (when a motion is finalized). 

However, it's also necessary in the event that the motion failed without going to a vote. If this happens, there is no specific event emitted via the contracts to let us know, so I have updated the `fetchMotionState` lamda we already have to check and update the db with staker rewards in the event the motion has failed without going to a vote. 

![motionFailsNoVote](https://user-images.githubusercontent.com/64402732/231828484-89f63b39-3e0f-4eb5-87c7-4b75344587c5.png)

## To Test

Get yourself set up (see instructions in #380) and create a motion.
Stake / object, but don't: 
stake in favour 100% (so the motion doesn't pass)
stake in favour 100% and object 100% (so we don't trigger a vote).

Fast forward in time:

```
curl -X POST --data '{"jsonrpc":"2.0","method":"evm_increaseTime","params":[3600],"id":1}' localhost:8545
curl -X POST --data '{"jsonrpc":"2.0","method":"evm_mine","params":[],"id":1}' localhost:8545

```

It's one hour in the example above, change that to however long you set up the voting rep extn to stake for. Refresh the browser. 

You should see:

1. The motion has failed
2. You are able to claim your rewards
3. Claiming your reward and refreshing doesn't change the information presented to you (i.e. stake, winnings, and total are all the same as before). 

If you test this with multiple users, keep #392 in mind and refresh the browser when switching

**Changes** 🏗

* Update `fetchMotionState` lamda to check if we need to update the staker rewards if the motion fails before going to a vote

Resolves #406
