### PR TITLE
Add UnlockToken and VersionUpgrade motion support

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=797ad393334273dcff585c3066ff58c23dc62d64
+ENV BLOCK_INGESTOR_HASH=28064f699907391974dee8ba65eeff20ae31cd4f
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/common/ColonyActions/ActionDetailsPage/staticMaps.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/staticMaps.ts
@@ -97,6 +97,7 @@ export const ACTIONS_EVENTS: ActionsEventsMap = {
   [ColonyActionType.SetUserRolesMotion]: MOTION_EVENTS,
   [ColonyActionType.PaymentMotion]: MOTION_EVENTS,
   [ColonyActionType.MoveFundsMotion]: MOTION_EVENTS,
+  [ColonyActionType.VersionUpgradeMotion]: MOTION_EVENTS,
   [ColonyActionType.EmitDomainReputationPenaltyMotion]: MOTION_EVENTS,
   [ColonyActionType.EmitDomainReputationRewardMotion]: MOTION_EVENTS,
 };

--- a/src/components/common/ColonyActions/ColonyActions.tsx
+++ b/src/components/common/ColonyActions/ColonyActions.tsx
@@ -299,7 +299,11 @@ const ColonyActions = (/* { ethDomainId }: Props */) => {
         text="Test Edit Colony"
       />
       <ActionButton
-        actionType={ActionTypes.ACTION_VERSION_UPGRADE}
+        actionType={
+          isMotion
+            ? ActionTypes.ROOT_MOTION
+            : ActionTypes.ACTION_VERSION_UPGRADE
+        }
         error={ActionTypes.ACTION_VERSION_UPGRADE_ERROR}
         success={ActionTypes.ACTION_VERSION_UPGRADE_SUCCESS}
         transform={pipe(
@@ -307,6 +311,8 @@ const ColonyActions = (/* { ethDomainId }: Props */) => {
             colonyAddress: colony.colonyAddress,
             colonyName: colony.name,
             version: colony.version,
+            operationName: RootMotionMethodNames.Upgrade,
+            motionParams: [colony.version],
           }),
           withMeta({ navigate }),
         )}

--- a/src/components/shared/DetailsWidget/detailsWidgetConfig.tsx
+++ b/src/components/shared/DetailsWidget/detailsWidgetConfig.tsx
@@ -98,20 +98,6 @@ interface DetailItemConfig {
   item: ReactNode;
 }
 
-const getMotionDetailItem = (colony: Colony, motionDomainId?: number) => {
-  const motionDomain = findDomainByNativeId(
-    Number(motionDomainId ?? 1),
-    colony,
-  );
-  return {
-    label: MSG.motionDomain,
-    labelValues: undefined,
-    item: motionDomain?.metadata && (
-      <TeamDetail domainMetadata={motionDomain.metadata} />
-    ),
-  };
-};
-
 const getDetailItemsMap = (
   colony: Colony,
   {
@@ -122,12 +108,18 @@ const getDetailItemsMap = (
     amount,
     recipient,
     token,
+    motionData,
   }: // roles,
   ColonyAction,
 ): { [key in Exclude<ActionPageDetails, 'Permissions'>]: DetailItemConfig } => {
   const shortenedHash = getShortenedHash(transactionHash || '');
   const recipientWalletAddress = recipient?.walletAddress;
   const isSmiteAction = type === ColonyActionType.EmitDomainReputationPenalty;
+  const motionDomain = findDomainByNativeId(
+    Number(motionData?.motionDomainId ?? 1),
+    colony,
+  );
+
   return {
     [ActionPageDetails.Type]: {
       label: MSG.actionType,
@@ -216,6 +208,13 @@ const getDetailItemsMap = (
       labelValues: undefined,
       item: colony.metadata?.displayName,
     },
+    [ActionPageDetails.Motion]: {
+      label: MSG.motionDomain,
+      labelValues: undefined,
+      item: motionDomain?.metadata && (
+        <TeamDetail domainMetadata={motionDomain.metadata} />
+      ),
+    },
     [ActionPageDetails.Generic]: {
       label: MSG.transactionHash,
       labelValues: undefined,
@@ -237,19 +236,12 @@ const getDetailItems = (
 ): DetailItemConfig[] => {
   const detailItemsMap = getDetailItemsMap(colony, actionData);
   const detailItemKeys = getDetailItemsKeys(actionData.type);
-  const motionDetailItem = getMotionDetailItem(
-    colony,
-    actionData.fromDomain?.nativeId,
-  );
+
   const detailItems = detailItemKeys
-    .map((itemKey) => detailItemsMap[itemKey])
-    .filter((detail) => !!detail.item);
+    .map<DetailItemConfig | undefined>((itemKey) => detailItemsMap[itemKey])
+    .filter((detail) => !!detail?.item);
 
-  if (actionData.isMotion) {
-    detailItems.splice(1, 0, motionDetailItem);
-  }
-
-  return detailItems;
+  return detailItems as DetailItemConfig[];
 };
 
 export default getDetailItems;

--- a/src/components/shared/DetailsWidget/detailsWidgetConfig.tsx
+++ b/src/components/shared/DetailsWidget/detailsWidgetConfig.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
 import { defineMessages, MessageDescriptor } from 'react-intl';
+import { Id } from '@colony/colony-js';
 
 import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import Numeral from '~shared/Numeral';
@@ -116,7 +117,7 @@ const getDetailItemsMap = (
   const recipientWalletAddress = recipient?.walletAddress;
   const isSmiteAction = type === ColonyActionType.EmitDomainReputationPenalty;
   const motionDomain = findDomainByNativeId(
-    Number(motionData?.motionDomainId ?? 1),
+    Number(motionData?.motionDomainId ?? Id.RootDomain),
     colony,
   );
 
@@ -239,9 +240,9 @@ const getDetailItems = (
 
   const detailItems = detailItemKeys
     .map<DetailItemConfig | undefined>((itemKey) => detailItemsMap[itemKey])
-    .filter((detail) => !!detail?.item);
+    .filter((detail): detail is DetailItemConfig => !!detail?.item);
 
-  return detailItems as DetailItemConfig[];
+  return detailItems;
 };
 
 export default getDetailItems;

--- a/src/utils/colonyActions.ts
+++ b/src/utils/colonyActions.ts
@@ -30,7 +30,12 @@ export enum ActionPageDetails {
   ReputationChange = 'ReputationChange',
   Author = 'Author',
   Generic = 'Generic',
+  Motion = 'Motion',
 }
+
+const MOTION_SUFFIX = 'MOTION';
+const isMotion = (actionType: ColonyActionType) =>
+  actionType.includes(MOTION_SUFFIX);
 
 export const getDetailItemsKeys = (actionType: ColonyActionType) => {
   switch (true) {
@@ -51,10 +56,19 @@ export const getDetailItemsKeys = (actionType: ColonyActionType) => {
       ];
     }
     case actionType.includes(ColonyActionType.UnlockToken): {
-      return [ActionPageDetails.Type, ActionPageDetails.Domain];
+      return [
+        ActionPageDetails.Type,
+        isMotion(actionType)
+          ? ActionPageDetails.Motion
+          : ActionPageDetails.Domain,
+      ];
     }
     case actionType.includes(ColonyActionType.MintTokens): {
-      return [ActionPageDetails.Type, ActionPageDetails.Amount];
+      return [
+        ActionPageDetails.Type,
+        isMotion(actionType) ? ActionPageDetails.Motion : '',
+        ActionPageDetails.Amount,
+      ];
     }
     case actionType.includes(ColonyActionType.CreateDomain): {
       return [


### PR DESCRIPTION
## Description

This PR makes a few small adjustments that enable testing of the other motions that use the rootMotion saga:

1. Unlock token
2. VersionUpgrade

It also updates the logic in the DetailsWidget so we can control whether the Motion item gets appended to the widget or replaces another item.

![unlock-token](https://user-images.githubusercontent.com/64402732/232808898-22e6aab5-2517-4dda-b1b3-70600b9d1cf3.png)


## Testing

Install voting rep extn
Give yourself reputation

1. Unlock Token: via the UAC, unlock your token
2. VersionUpgrade: via the testing button on ColonyHome, upgrade the version

Resolves  #428
