### PR TITLE
Wire up motion countdown timer in action list

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionCountdown/MotionCountdown.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionCountdown/MotionCountdown.tsx
@@ -3,7 +3,10 @@ import classNames from 'classnames';
 import { Id } from '@colony/colony-js';
 
 import CountDownTimer from '~common/ColonyActions/CountDownTimer';
-import { MotionState } from '~utils/colonyMotions';
+import {
+  MotionState,
+  shouldDisplayMotionCountdownTime,
+} from '~utils/colonyMotions';
 import { MotionData } from '~types';
 import { RefetchMotionState, useAppContext } from '~hooks';
 
@@ -28,10 +31,8 @@ const MotionCountdown = ({
 }: MotionCountdownProps) => {
   const { user } = useAppContext();
 
-  const isMotionFinished =
-    motionState === MotionState.Passed ||
-    motionState === MotionState.Failed ||
-    motionState === MotionState.FailedNotFinalizable;
+  const showMotionCountdownTimer =
+    shouldDisplayMotionCountdownTime(motionState);
 
   const showVotingProgress = motionState === MotionState.Voting;
   const showEscalateButton =
@@ -46,7 +47,7 @@ const MotionCountdown = ({
         [styles.escalateContainer]: showEscalateButton,
       })}
     >
-      {!isMotionFinished && (
+      {showMotionCountdownTimer && (
         <CountDownTimer
           motionState={motionState}
           refetchMotionState={refetchMotionState}

--- a/src/components/common/ColonyActions/ActionsListItem/ActionsListItem.tsx
+++ b/src/components/common/ColonyActions/ActionsListItem/ActionsListItem.tsx
@@ -7,10 +7,11 @@ import ListItem, { ListItemStatus } from '~shared/ListItem';
 import { ColonyAction } from '~types';
 import { useColonyContext } from '~hooks';
 
+import CountDownTimer from '../CountDownTimer';
 import { getActionTitleValues } from '../helpers';
 
 import ActionsListItemMeta from './ActionsListItemMeta';
-import { useMotionTag } from './helpers';
+import { useMotionStatusDisplay } from './helpers';
 
 const displayName = 'common.ColonyActions.ActionsListItem';
 
@@ -26,18 +27,6 @@ const userAvatarPopoverOptions = {
     },
   ],
 };
-
-// const isFullyNayStaked = (totalNayStake?: string, requiredStake?: string) =>
-//   BigNumber.from(totalNayStake || 0).gte(BigNumber.from(requiredStake || 0));
-
-// const shouldDisplayCountDownTimer = (motionId, motionState) => {
-//   const isMotionFinished =
-//     motionState === MotionState.Passed ||
-//     motionState === MotionState.Failed ||
-//     motionState === MotionState.FailedNoFinalizable;
-
-//   return motionId && !isMotionFinished;
-// };
 
 interface Props {
   item: ColonyAction;
@@ -61,13 +50,14 @@ const ActionsListItem = ({
   const handleActionRedirect = () =>
     navigate(`/colony/${colony?.name}/tx/${transactionHash}`);
 
-  // const displayCountdownTimer = shouldDisplayCountDownTimer(
-  //   motionId,
-  //   motionState,
-  // );
-
   const status = ListItemStatus.Defused;
-  const MotionTag = useMotionTag(isMotion, motionData);
+
+  const {
+    motionState,
+    MotionTag,
+    showMotionCountdownTimer,
+    refetchMotionState,
+  } = useMotionStatusDisplay(isMotion, motionData);
 
   return (
     <ListItem
@@ -81,13 +71,15 @@ const ActionsListItem = ({
       }
       createdAt={createdAt}
       extra={
-        null // displayCountdownTimer && (
-        //   <CountdownTimer
-        //     state={motionState as MotionState}
-        //     motionId={Number(motionId)}
-        //     isFullyNayStaked={isFullyNayStaked(totalNayStake, requiredStake)}
-        //   />
-        // )
+        showMotionCountdownTimer &&
+        motionData && (
+          <CountDownTimer
+            motionState={motionState}
+            motionId={motionData.motionId}
+            motionStakes={motionData.motionStakes}
+            refetchMotionState={refetchMotionState}
+          />
+        )
       }
       meta={<ActionsListItemMeta fromDomain={fromDomain ?? undefined} />}
       onClick={handleActionRedirect}

--- a/src/components/common/ColonyActions/ActionsListItem/helpers.ts
+++ b/src/components/common/ColonyActions/ActionsListItem/helpers.ts
@@ -2,32 +2,13 @@ import { useGetMotionStateQuery } from '~gql';
 import { useColonyContext, useEnabledExtensions } from '~hooks';
 import { motionTags } from '~shared/Tag';
 import { MotionData } from '~types';
-import { getMotionState } from '~utils/colonyMotions';
+import { MotionState, getMotionState } from '~utils/colonyMotions';
 
-export const useMotionTag = (
-  isMotion?: boolean | null,
-  motionData?: MotionData | null,
+const getMotionTag = (
+  networkMotionState: number | null | undefined,
+  isMotion: boolean | null | undefined,
+  motionData: MotionData | null | undefined,
 ) => {
-  const { colony } = useColonyContext();
-  const { isVotingReputationEnabled } = useEnabledExtensions();
-  const { data: motionStateData, loading: loadingMotionState } =
-    useGetMotionStateQuery({
-      skip: !isMotion || !motionData || !colony,
-      variables: {
-        input: {
-          colonyAddress: colony?.colonyAddress ?? '',
-          motionId: Number(motionData?.motionId),
-        },
-      },
-    });
-
-  const networkMotionState = motionStateData?.getMotionState;
-
-  // No tag while loading motion state or voting rep not enabled
-  if (loadingMotionState || !isVotingReputationEnabled) {
-    return () => null;
-  }
-
   // If not motion, then forced action
   if (!isMotion) {
     return motionTags.Forced;
@@ -40,5 +21,49 @@ export const useMotionTag = (
   // If no motion state / data, display as invalid
   return motionTags.Invalid;
 
-  // TODO: handle case where motion is from now-uninstalled voting rep version.
+  // @TODO: handle case where motion is from now-uninstalled voting rep version.
+};
+
+export const useMotionStatusDisplay = (
+  isMotion: boolean | null | undefined,
+  motionData: MotionData | null | undefined,
+) => {
+  const { isVotingReputationEnabled } = useEnabledExtensions();
+  const { colony } = useColonyContext();
+
+  const {
+    data: motionStateData,
+    loading: loadingMotionState,
+    refetch: refetchMotionState,
+  } = useGetMotionStateQuery({
+    skip: !isMotion || !motionData || !colony,
+    variables: {
+      input: {
+        colonyAddress: colony?.colonyAddress ?? '',
+        motionId: Number(motionData?.motionId),
+      },
+    },
+  });
+  const networkMotionState = motionStateData?.getMotionState;
+
+  const showMotionTag = !loadingMotionState && isVotingReputationEnabled;
+  const MotionTag = showMotionTag ? getMotionTag(networkMotionState, isMotion, motionData) : () => null;
+
+  const motionState =
+    networkMotionState && motionData
+      ? getMotionState(networkMotionState, motionData)
+      : MotionState.Invalid;
+
+  const showMotionCountdownTimer =
+    motionState !== MotionState.Passed &&
+    motionState !== MotionState.Failed &&
+    motionState !== MotionState.FailedNotFinalizable &&
+    motionState !== MotionState.Invalid;
+
+  return {
+    motionState,
+    MotionTag,
+    showMotionCountdownTimer,
+    refetchMotionState,
+  };
 };

--- a/src/components/common/ColonyActions/ActionsListItem/helpers.ts
+++ b/src/components/common/ColonyActions/ActionsListItem/helpers.ts
@@ -2,25 +2,22 @@ import { useGetMotionStateQuery } from '~gql';
 import { useColonyContext, useEnabledExtensions } from '~hooks';
 import { motionTags } from '~shared/Tag';
 import { MotionData } from '~types';
-import { MotionState, getMotionState } from '~utils/colonyMotions';
+import {
+  MotionState,
+  getMotionState,
+  shouldDisplayMotionCountdownTime,
+} from '~utils/colonyMotions';
 
 const getMotionTag = (
-  networkMotionState: number | null | undefined,
   isMotion: boolean | null | undefined,
-  motionData: MotionData | null | undefined,
+  motionState: MotionState,
 ) => {
   // If not motion, then forced action
   if (!isMotion) {
     return motionTags.Forced;
   }
 
-  if (networkMotionState && motionData) {
-    return motionTags[getMotionState(networkMotionState, motionData)];
-  }
-
-  // If no motion state / data, display as invalid
-  return motionTags.Invalid;
-
+  return motionTags[motionState];
   // @TODO: handle case where motion is from now-uninstalled voting rep version.
 };
 
@@ -47,18 +44,16 @@ export const useMotionStatusDisplay = (
   const networkMotionState = motionStateData?.getMotionState;
 
   const showMotionTag = !loadingMotionState && isVotingReputationEnabled;
-  const MotionTag = showMotionTag ? getMotionTag(networkMotionState, isMotion, motionData) : () => null;
 
   const motionState =
     networkMotionState && motionData
       ? getMotionState(networkMotionState, motionData)
       : MotionState.Invalid;
 
+  const MotionTag = showMotionTag ? getMotionTag(isMotion, motionState) : () => null;
+
   const showMotionCountdownTimer =
-    motionState !== MotionState.Passed &&
-    motionState !== MotionState.Failed &&
-    motionState !== MotionState.FailedNotFinalizable &&
-    motionState !== MotionState.Invalid;
+    shouldDisplayMotionCountdownTime(motionState);
 
   return {
     motionState,

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -157,3 +157,9 @@ export const getUpdatedDecodedMotionRoles = (
 
   return updatedRoles;
 };
+
+export const shouldDisplayMotionCountdownTime = (motionState: MotionState) =>
+  motionState !== MotionState.Passed &&
+  motionState !== MotionState.Failed &&
+  motionState !== MotionState.FailedNotFinalizable &&
+  motionState !== MotionState.Invalid;


### PR DESCRIPTION
To test just follow the same process for #367 or #410. 

Once you have rep, you can turn the monitor off and just create a bunch of motions with 2 users or more and advance the motion phases via staking/voting YAY and/or NAY like so:
![FireShot Capture 841 - Colony CDapp - localhost](https://user-images.githubusercontent.com/18473896/233489323-7321d063-976b-455d-bc08-28462aca8470.png)

The timer should only show for the motion states above.

Resolves #416 
