### PR TITLE
Add user reputation to motion messages

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/ActionDetailsPageFeed/MotionDetailsPageEvent/MotionEventData.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/ActionDetailsPageFeed/MotionDetailsPageEvent/MotionEventData.tsx
@@ -6,6 +6,7 @@ import {
   useGetMotionEventTitleValues,
   TransactionMeta,
 } from '~common/ColonyActions';
+
 import EventData from '../EventData';
 
 import { MotionDetailsPageEventProps } from './MotionDetailsPageEvent';
@@ -18,7 +19,8 @@ type MotionEventDataProps = Pick<
 >;
 
 const MotionEventData = ({
-  actionData: { createdAt, transactionHash, motionData, type },
+  actionData: { createdAt, transactionHash },
+  actionData,
   motionMessageData,
   eventName,
 }: MotionEventDataProps) => {
@@ -35,8 +37,7 @@ const MotionEventData = ({
           values={useGetMotionEventTitleValues(
             eventName,
             motionMessageData,
-            type,
-            motionData,
+            actionData,
           )}
         />
       }

--- a/src/components/common/ColonyActions/helpers/getEventTitleValues.ts
+++ b/src/components/common/ColonyActions/helpers/getEventTitleValues.ts
@@ -5,8 +5,6 @@ import {
   ColonyAndExtensionsEvents,
   MotionMessage,
   SystemMessages,
-  MotionData,
-  ColonyActionType,
 } from '~types';
 
 import {
@@ -213,13 +211,11 @@ export const getActionEventTitleValues = (
 export const useGetMotionEventTitleValues = (
   eventName: ColonyAndExtensionsEvents | SystemMessages,
   motionMessageData: MotionMessage,
-  actionType: ColonyActionType,
-  motionData?: MotionData | null,
+  actionData: ColonyAction,
 ) => {
   const updatedItem = useMapMotionEventToExpectedFormat(
     motionMessageData,
-    actionType,
-    motionData,
+    actionData,
   );
   const keys = EVENT_TYPE_MESSAGE_KEYS_MAP[eventName] ?? DEFAULT_KEYS;
   return generateMessageValues(updatedItem, keys, {

--- a/src/components/common/ColonyActions/helpers/itemStyles.css
+++ b/src/components/common/ColonyActions/helpers/itemStyles.css
@@ -18,3 +18,8 @@
   border: 1px solid var(--text-disabled);
   border-radius: var(--radius-large);
 }
+
+.reputation {
+  display: inline-block;
+  margin-left: 4px;
+}

--- a/src/components/common/ColonyActions/helpers/itemStyles.css.d.ts
+++ b/src/components/common/ColonyActions/helpers/itemStyles.css.d.ts
@@ -1,6 +1,7 @@
 declare namespace ItemStylesCssNamespace {
   export interface IItemStylesCss {
     highlight: string;
+    reputation: string;
     titleDecoration: string;
     userDecoration: string;
     voteResultsWrapper: string;

--- a/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
+++ b/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
@@ -10,9 +10,8 @@ import {
   ColonyActionType,
   DomainMetadata,
   MotionMessage,
-  MotionData,
 } from '~types';
-import { useColonyContext } from '~hooks';
+import { useColonyContext, useUserReputation } from '~hooks';
 import { MotionVote } from '~utils/colonyMotions';
 import { intl } from '~utils/intl';
 import { formatReputationChange } from '~utils/reputation';
@@ -30,6 +29,7 @@ import {
 import { useGetUserByAddressQuery } from '~gql';
 import { VoteResults } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VoteOutcome/VoteResults';
 import { VotingWidgetHeading } from '~common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget';
+import MemberReputation from '~shared/MemberReputation';
 
 import { getDomainMetadataChangesValue } from './getDomainMetadataChanges';
 import { getColonyMetadataChangesValue } from './getColonyMetadataChanges';
@@ -170,9 +170,14 @@ export const mapActionEventToExpectedFormat = (
 
 export const useMapMotionEventToExpectedFormat = (
   motionMessageData: MotionMessage,
-  actionType: ColonyActionType,
-  motionData?: MotionData | null,
+  actionData: ColonyAction,
 ) => {
+  const {
+    colonyAddress,
+    fromDomain,
+    motionData,
+    type: actionType,
+  } = actionData;
   const { colony } = useColonyContext();
   const { data } = useGetUserByAddressQuery({
     skip: !motionMessageData?.initiatorAddress || !motionData,
@@ -180,6 +185,12 @@ export const useMapMotionEventToExpectedFormat = (
       address: motionMessageData?.initiatorAddress ?? '',
     },
   });
+  const initiatorUserReputation = useUserReputation(
+    colonyAddress,
+    motionMessageData.initiatorAddress,
+    fromDomain?.nativeId,
+    motionData?.rootHash,
+  );
   if (!motionData) {
     return {};
   }
@@ -218,14 +229,30 @@ export const useMapMotionEventToExpectedFormat = (
       </div>
     ),
     initiator: (
-      <span className={styles.userDecoration}>
-        <FriendlyName user={initiatorUser} autoShrinkAddress />
-      </span>
+      <>
+        <span className={styles.userDecoration}>
+          <FriendlyName user={initiatorUser} autoShrinkAddress />
+        </span>
+        <div className={styles.reputation}>
+          <MemberReputation
+            userReputation={initiatorUserReputation?.userReputation}
+            totalReputation={initiatorUserReputation?.totalReputation}
+          />
+        </div>
+      </>
     ),
     staker: (
-      <span className={styles.userDecoration}>
-        <FriendlyName user={initiatorUser} autoShrinkAddress />
-      </span>
+      <>
+        <span className={styles.userDecoration}>
+          <FriendlyName user={initiatorUser} autoShrinkAddress />
+        </span>
+        <div className={styles.reputation}>
+          <MemberReputation
+            userReputation={initiatorUserReputation?.userReputation}
+            totalReputation={initiatorUserReputation?.totalReputation}
+          />
+        </div>
+      </>
     ),
   };
 };

--- a/src/hooks/useUserReputation.ts
+++ b/src/hooks/useUserReputation.ts
@@ -5,14 +5,14 @@ import { ADDRESS_ZERO } from '~constants';
 import { useGetUserReputationQuery } from '~gql';
 
 interface UseUserReputationHook {
-  userReputation?: string;
-  totalReputation?: string;
+  userReputation: string | undefined;
+  totalReputation: string | undefined;
   loading: boolean;
 }
 
 const useUserReputation = (
-  colonyAddress?: Address,
-  walletAddress?: Address,
+  colonyAddress: Address | null | undefined,
+  walletAddress: Address | null | undefined,
   domainId = Id.RootDomain,
   rootHash?: string,
 ): UseUserReputationHook => {


### PR DESCRIPTION
In order to test this, just make sure to go through the whole motion flow and see if the name of the user displays the correct reputation amount. Also, make sure we are using the correct root hash to get the reputation, or in other words, that the reputation of the users in past motions doesn't change, it should stay the same as the time the motion was created.

![FireShot Capture 025 - Colony CDapp - localhost](https://user-images.githubusercontent.com/18473896/235230356-cdc76b6a-f482-4d08-a06b-2284244e82e0.png)
![FireShot Capture 026 - Colony CDapp - localhost](https://user-images.githubusercontent.com/18473896/235230369-d2b5dd55-819a-46ee-b142-5bb247365897.png)


Resolves #420 
