### PR TITLE
Hide Motion widget when voting rep uninstalled

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -114,9 +114,8 @@ input GetUserTokenBalanceInput {
 }
 
 input GetMotionStateInput {
-  motionId: Int!
   colonyAddress: String!
-  transactionHash: String
+  transactionHash: String!
 }
 
 input GetVoterRewardsInput {
@@ -150,9 +149,9 @@ type GetUserTokenBalanceReturn {
 }
 
 type GetMotionTimeoutPeriodsReturn {
-  timeLeftToStake: String!,
-  timeLeftToVote: String!,
-  timeLeftToReveal: String!,
+  timeLeftToStake: String!
+  timeLeftToVote: String!
+  timeLeftToReveal: String!
   timeLeftToEscalate: String!
 }
 
@@ -260,12 +259,13 @@ type Query {
   ): GetUserTokenBalanceReturn @function(name: "getUserTokenBalance")
   getMembersForColony(input: MembersForColonyInput): MembersForColonyReturn
     @function(name: "getMembersForColony")
-  getMotionState(input: GetMotionStateInput): Int
+  getMotionState(input: GetMotionStateInput): Int!
     @function(name: "fetchMotionState")
   getVoterRewards(input: GetVoterRewardsInput): VoterRewardsReturn
     @function(name: "fetchVoterRewards")
-  getMotionTimeoutPeriods(input: GetMotionTimeoutPeriodsInput): GetMotionTimeoutPeriodsReturn
-    @function(name: "fetchMotionTimeoutPeriods")
+  getMotionTimeoutPeriods(
+    input: GetMotionTimeoutPeriodsInput
+  ): GetMotionTimeoutPeriodsReturn @function(name: "fetchMotionTimeoutPeriods")
 }
 
 type Mutation {
@@ -686,5 +686,6 @@ type ColonyAction @model {
   fundamentalChainId: Int
   newColonyVersion: Int
   pendingDomainMetadataId: ID
-  pendingDomainMetadata: DomainMetadata @hasOne(fields: ["pendingDomainMetadataId"])
+  pendingDomainMetadata: DomainMetadata
+    @hasOne(fields: ["pendingDomainMetadataId"])
 }

--- a/amplify/backend/function/fetchMotionState/src/index.js
+++ b/amplify/backend/function/fetchMotionState/src/index.js
@@ -9,17 +9,16 @@ const {
  * @type {import('@types/aws-lambda').APIGatewayProxyHandler}
  */
 exports.handler = async (event) => {
-  const { motionId, colonyAddress, transactionHash } =
-    event.arguments?.input || {};
+  const { colonyAddress, transactionHash } = event.arguments?.input || {};
   /* Get latest motion state from chain */
-  const motionState = await getLatestMotionState(colonyAddress, motionId);
+  const motionData = await getMotionData(transactionHash);
+  const motionState = await getLatestMotionState(colonyAddress, motionData);
   /*
    * Check if we need to update staker rewards
    * This ensures the rewards are present in the event a motion fails before going to a vote,
    * so the side that has objected can reclaim their stake.
    */
   if (transactionHash && motionState === MotionState.Failed) {
-    const motionData = await getMotionData(transactionHash);
     if (motionData) {
       const {
         motionStakes: {

--- a/amplify/backend/function/fetchMotionState/src/utils.js
+++ b/amplify/backend/function/fetchMotionState/src/utils.js
@@ -38,19 +38,17 @@ const getLatestMotionState = async (
   colonyAddress,
   { nativeMotionId, createdBy },
 ) => {
-  let motionState = MotionState.Null;
   try {
     const votingReputationClient = await getVotingClient(colonyAddress);
     const isDeprecated = await votingReputationClient.getDeprecated();
     /* Only fetch state for a motion that was created by the current (active) installation of the voting rep extn */
     if (!isDeprecated && votingReputationClient.address === createdBy) {
-      motionState = votingReputationClient.getMotionState(nativeMotionId);
+      return votingReputationClient.getMotionState(nativeMotionId);
     }
+    return MotionState.Null;
   } catch {
-    /* This will fail if the voting reputation extn is not installed, in which case we return 0. */
+    return MotionState.Null;
   }
-
-  return motionState;
 };
 
 const graphqlRequest = async (queryOrMutation, variables) => {

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=a0b8868f3cb26f869711d7e92f4cf4b5560140fd
+ENV BLOCK_INGESTOR_HASH=c0cc772dc1b4b4a2aefeb447d073e8458e194dac
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/common/ColonyActions/ActionDetailsPage/ActionDetailsPage.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/ActionDetailsPage.tsx
@@ -51,8 +51,7 @@ const ActionDetailsPage = () => {
   const isMotion = action?.isMotion;
   const createdAt = action?.createdAt;
   const isInvalidMotion =
-    (isMotion && !action.motionData) ||
-    (isMotion && (motionState === null || motionState === undefined));
+    (isMotion && !action.motionData) || (isMotion && motionState === undefined);
 
   const isInvalidTransaction =
     isInvalidTransactionHash ||

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionCountdown/MotionCountdown.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionCountdown/MotionCountdown.tsx
@@ -5,7 +5,7 @@ import { Id } from '@colony/colony-js';
 import CountDownTimer from '~common/ColonyActions/CountDownTimer';
 import {
   MotionState,
-  shouldDisplayMotionCountdownTime,
+  useShouldDisplayMotionCountdownTime,
 } from '~utils/colonyMotions';
 import { MotionData } from '~types';
 import { RefetchMotionState, useAppContext } from '~hooks';
@@ -32,7 +32,7 @@ const MotionCountdown = ({
   const { user } = useAppContext();
 
   const showMotionCountdownTimer =
-    shouldDisplayMotionCountdownTime(motionState);
+    useShouldDisplayMotionCountdownTime(motionState);
 
   const showVotingProgress = motionState === MotionState.Voting;
   const showEscalateButton =

--- a/src/components/common/ColonyActions/ActionsListItem/ActionsListItem.tsx
+++ b/src/components/common/ColonyActions/ActionsListItem/ActionsListItem.tsx
@@ -57,7 +57,7 @@ const ActionsListItem = ({
     MotionTag,
     showMotionCountdownTimer,
     refetchMotionState,
-  } = useMotionStatusDisplay(isMotion, motionData);
+  } = useMotionStatusDisplay(isMotion, motionData, transactionHash);
 
   return (
     <ListItem

--- a/src/components/common/ColonyActions/ActionsListItem/ActionsListItem.tsx
+++ b/src/components/common/ColonyActions/ActionsListItem/ActionsListItem.tsx
@@ -6,12 +6,16 @@ import UserAvatar from '~shared/UserAvatar';
 import ListItem, { ListItemStatus } from '~shared/ListItem';
 import { ColonyAction } from '~types';
 import { useColonyContext } from '~hooks';
+import {
+  MotionState,
+  useShouldDisplayMotionCountdownTime,
+} from '~utils/colonyMotions';
 
 import CountDownTimer from '../CountDownTimer';
 import { getActionTitleValues } from '../helpers';
 
 import ActionsListItemMeta from './ActionsListItemMeta';
-import { useMotionStatusDisplay } from './helpers';
+import { useColonyMotionState, useMotionTag } from './helpers';
 
 const displayName = 'common.ColonyActions.ActionsListItem';
 
@@ -52,12 +56,15 @@ const ActionsListItem = ({
 
   const status = ListItemStatus.Defused;
 
-  const {
-    motionState,
-    MotionTag,
-    showMotionCountdownTimer,
-    refetchMotionState,
-  } = useMotionStatusDisplay(isMotion, motionData, transactionHash);
+  const { motionState, refetchMotionState } = useColonyMotionState(
+    isMotion,
+    motionData,
+    transactionHash,
+  );
+
+  const MotionTag = useMotionTag(isMotion, motionState);
+  const showMotionCountdownTimer =
+    useShouldDisplayMotionCountdownTime(motionState);
 
   return (
     <ListItem
@@ -74,7 +81,7 @@ const ActionsListItem = ({
         showMotionCountdownTimer &&
         motionData && (
           <CountDownTimer
-            motionState={motionState}
+            motionState={motionState as MotionState} // safe casting: if motionState is null, showMotionCountdownTimer will be false.
             motionId={motionData.motionId}
             motionStakes={motionData.motionStakes}
             refetchMotionState={refetchMotionState}

--- a/src/components/common/ColonyActions/ActionsListItem/helpers.ts
+++ b/src/components/common/ColonyActions/ActionsListItem/helpers.ts
@@ -1,7 +1,7 @@
 import { useGetMotionStateQuery } from '~gql';
 import { useColonyContext, useEnabledExtensions } from '~hooks';
 import { motionTags } from '~shared/Tag';
-import { MotionData } from '~types';
+import { Address, MotionData } from '~types';
 import {
   MotionState,
   getMotionState,
@@ -24,6 +24,7 @@ const getMotionTag = (
 export const useMotionStatusDisplay = (
   isMotion: boolean | null | undefined,
   motionData: MotionData | null | undefined,
+  transactionHash: Address,
 ) => {
   const { isVotingReputationEnabled } = useEnabledExtensions();
   const { colony } = useColonyContext();
@@ -37,7 +38,7 @@ export const useMotionStatusDisplay = (
     variables: {
       input: {
         colonyAddress: colony?.colonyAddress ?? '',
-        motionId: Number(motionData?.motionId),
+        transactionHash,
       },
     },
   });

--- a/src/components/common/ColonyActions/ActionsListItem/helpers.ts
+++ b/src/components/common/ColonyActions/ActionsListItem/helpers.ts
@@ -25,6 +25,11 @@ export const useColonyMotionState = (
     });
   const networkMotionState = motionStateData?.getMotionState;
 
+  /*
+   * We want a distinction between an invalid motion and a motion for which we don't currently have the motion state
+   * (else we'll see invalid when the motion state is loading). Hence assigning to null, not MotionState.Invalid.
+   */
+
   const motionState =
     networkMotionState !== undefined && motionData
       ? getMotionState(networkMotionState, motionData)

--- a/src/components/common/ColonyActions/helpers/getEventTitleValues.ts
+++ b/src/components/common/ColonyActions/helpers/getEventTitleValues.ts
@@ -6,7 +6,6 @@ import {
   MotionMessage,
   SystemMessages,
 } from '~types';
-import { useGetUserByAddressQuery } from '~gql';
 
 import {
   mapActionEventToExpectedFormat,
@@ -40,6 +39,7 @@ enum EventTitleMessageKeys {
   TokenSymbol = 'tokenSymbol',
   ToDomain = 'toDomain',
   TokensMinted = 'tokensMinted',
+  VotingTag = 'votingTag',
 }
 
 /* Maps eventType to message values as found in en-events.ts */
@@ -144,6 +144,7 @@ const EVENT_TYPE_MESSAGE_KEYS_MAP: {
     EventTitleMessageKeys.ObjectionTag,
     EventTitleMessageKeys.MotionTag,
   ],
+  [SystemMessages.MotionVotingPhase]: [EventTitleMessageKeys.VotingTag],
 };
 
 const DEFAULT_KEYS = [
@@ -187,17 +188,8 @@ export const useGetMotionEventTitleValues = (
   eventName: ColonyAndExtensionsEvents | SystemMessages,
   motionMessageData: MotionMessage,
 ) => {
-  const { data } = useGetUserByAddressQuery({
-    variables: {
-      address: motionMessageData.initiatorAddress || '',
-    },
-  });
-  const initiatorUser = data?.getUserByAddress?.items[0];
+  const updatedItem = useMapMotionEventToExpectedFormat(motionMessageData);
 
-  const updatedItem = useMapMotionEventToExpectedFormat(
-    initiatorUser,
-    motionMessageData,
-  );
   const keys = EVENT_TYPE_MESSAGE_KEYS_MAP[eventName] ?? DEFAULT_KEYS;
   return generateMessageValues(updatedItem, keys, {
     eventName,

--- a/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
+++ b/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
@@ -9,7 +9,6 @@ import {
   ColonyActionType,
   DomainMetadata,
   MotionMessage,
-  User,
 } from '~types';
 import { useColonyContext } from '~hooks';
 import { MotionVote } from '~utils/colonyMotions';
@@ -21,7 +20,9 @@ import {
   AmountTag,
   Motion as MotionTag,
   Objection as ObjectionTag,
+  Voting as VotingTag,
 } from '~shared/Tag';
+import { useGetUserByAddressQuery } from '~gql';
 
 import { getDomainMetadataChangesValue } from './getDomainMetadataChanges';
 import { getColonyMetadataChangesValue } from './getColonyMetadataChanges';
@@ -161,10 +162,16 @@ export const mapActionEventToExpectedFormat = (
 };
 
 export const useMapMotionEventToExpectedFormat = (
-  initiatorUser?: User | null,
   motionMessageData?: MotionMessage,
 ) => {
   const { colony } = useColonyContext();
+  const { data } = useGetUserByAddressQuery({
+    variables: {
+      address: motionMessageData?.initiatorAddress ?? '',
+    },
+  });
+
+  const initiatorUser = data?.getUserByAddress?.items[0];
 
   return {
     eventNameDecorated: <b>{motionMessageData?.name}</b>,
@@ -185,6 +192,7 @@ export const useMapMotionEventToExpectedFormat = (
       ),
     motionTag: <MotionTag />,
     objectionTag: <ObjectionTag />,
+    votingTag: <VotingTag />,
     initiator: (
       <span className={styles.userDecoration}>
         <FriendlyName user={initiatorUser} autoShrinkAddress />

--- a/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
+++ b/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
@@ -166,6 +166,7 @@ export const useMapMotionEventToExpectedFormat = (
 ) => {
   const { colony } = useColonyContext();
   const { data } = useGetUserByAddressQuery({
+    skip: !motionMessageData?.initiatorAddress,
     variables: {
       address: motionMessageData?.initiatorAddress ?? '',
     },

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -674,8 +674,7 @@ export type ExtensionParamsInput = {
 
 export type GetMotionStateInput = {
   colonyAddress: Scalars['String'];
-  motionId: Scalars['Int'];
-  transactionHash?: InputMaybe<Scalars['String']>;
+  transactionHash: Scalars['String'];
 };
 
 export type GetMotionTimeoutPeriodsInput = {
@@ -2073,7 +2072,7 @@ export type Query = {
   getDomainMetadata?: Maybe<DomainMetadata>;
   getExtensionByColonyAndHash?: Maybe<ModelColonyExtensionConnection>;
   getMembersForColony?: Maybe<MembersForColonyReturn>;
-  getMotionState?: Maybe<Scalars['Int']>;
+  getMotionState: Scalars['Int'];
   getMotionTimeoutPeriods?: Maybe<GetMotionTimeoutPeriodsReturn>;
   getProfile?: Maybe<Profile>;
   getProfileByEmail?: Maybe<ModelProfileConnection>;
@@ -3280,7 +3279,7 @@ export type GetMotionStateQueryVariables = Exact<{
 }>;
 
 
-export type GetMotionStateQuery = { __typename?: 'Query', getMotionState?: number | null };
+export type GetMotionStateQuery = { __typename?: 'Query', getMotionState: number };
 
 export type GetVoterRewardsQueryVariables = Exact<{
   input: GetVoterRewardsInput;

--- a/src/hooks/useGetColonyAction.ts
+++ b/src/hooks/useGetColonyAction.ts
@@ -57,7 +57,6 @@ const useGetColonyAction = (colony?: Colony | null) => {
     variables: {
       input: {
         colonyAddress: colony?.colonyAddress ?? '',
-        motionId: Number(action?.motionData?.motionId),
         transactionHash: transactionHash ?? '',
       },
     },

--- a/src/hooks/useGetColonyAction.ts
+++ b/src/hooks/useGetColonyAction.ts
@@ -53,7 +53,7 @@ const useGetColonyAction = (colony?: Colony | null) => {
     loading: loadingMotionState,
     refetch: refetchMotionState,
   } = useGetMotionStateQuery({
-    skip: !action?.motionData,
+    skip: !action?.motionData || skipQuery,
     variables: {
       input: {
         colonyAddress: colony?.colonyAddress ?? '',

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -8,6 +8,7 @@ import {
 import { isNil } from '~utils/lodash';
 import { getRolesForUserAndDomain } from '~redux/transformers';
 import { ActionUserRoles, MotionData, User } from '~types';
+import { useEnabledExtensions } from '~hooks';
 
 export enum MotionVote {
   Yay = 1,
@@ -158,8 +159,16 @@ export const getUpdatedDecodedMotionRoles = (
   return updatedRoles;
 };
 
-export const shouldDisplayMotionCountdownTime = (motionState: MotionState) =>
-  motionState !== MotionState.Passed &&
-  motionState !== MotionState.Failed &&
-  motionState !== MotionState.FailedNotFinalizable &&
-  motionState !== MotionState.Invalid;
+export const useShouldDisplayMotionCountdownTime = (
+  motionState: MotionState | null,
+) => {
+  const { isVotingReputationEnabled } = useEnabledExtensions();
+  return (
+    isVotingReputationEnabled &&
+    !!motionState &&
+    motionState !== MotionState.Passed &&
+    motionState !== MotionState.Failed &&
+    motionState !== MotionState.FailedNotFinalizable &&
+    motionState !== MotionState.Invalid
+  );
+};


### PR DESCRIPTION
## Description

This PR ensures that we "disable" motions that do not belong to the current installation of the voting rep extn.

By this, I mean that:

- You can still view the details, at their most recent state
- You can't interact with the motion via the widget (because it's not present)
- If a new voting rep extn is currently enabled, you will see an "invalid" tag; else, you won't see any tag (because we don't display motion tags when the voting rep extn isn't enabled).

This applies in the following cases:
* The voting rep extn is uninstalled
* The voting rep extn is deprecated
* The voting rep extn is installed, but not the same installation that created the motion

Note that this hasn't been specced so I'm just relying on showing the "invalid" tag for motions that don't belong to the currently installed voting extn. Improvements in this respect should probably wait for the new UI.


## Testing

Install voting rep extn. Give yourself some rep.
Create a motion, stake it so it shows up in the action list.
Uninstall voting rep 
Check that you can no longer interact with the motion widget on the motion page
Reinstall voting rep
Check that the motion is now tagged with "invalid"

You can also try by deprecating the voting rep instead of uninstalling it. They should work the same way. We ultimately trying to ensure you cannot interact with a motion that was not created by the currently installed (and enabled) voting rep extn, and that there's some feedback in the ui to indicate why.

**Changes** 🏗

* Ensure motions from old voting rep versions can't be interacted with (are "read-only")
* Refactor the logic to display the motion tag in ActionsListItem


Resolves  #357
