### PR TITLE
Update colony post finalize motion

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { StakerRewards } from '~gql';
-import { useAppContext } from '~hooks';
+import { useAppContext, useColonyContext } from '~hooks';
 import { ColonyAction, ColonyActionType, Address } from '~types';
 import { MotionState } from '~utils/colonyMotions';
 
@@ -42,8 +42,10 @@ const MotionPhaseWidget = ({
   ...rest
 }: MotionPhaseWidgetProps) => {
   const { user } = useAppContext();
+  const { refetchColony } = useColonyContext();
   const { motionData, type, amount, fromDomain } = actionData;
   const { stopPollingAction } = rest;
+
   if (!motionData) {
     /*
      * Will not happen. Undefined motion data will result in the invalid transaction view being
@@ -82,6 +84,9 @@ const MotionPhaseWidget = ({
           </div>
         );
       }
+
+      /* Update colony object when motion gets finalized. */
+      refetchColony();
 
       const isClaimed = isMotionClaimed(
         motionData.stakerRewards,


### PR DESCRIPTION
## Description

This PR refetches the colony data after finalizing a motion, so data like the added domain is instantly available without needing a broswer refresh.

**Changes** 🏗

* Expose colony refetch from context

## Testing

Run a motion through to completion (e.g. Create Domain). Once you hit finalize, go back to Colony Home without reloading the browser and your data (e.g. the new domain) should be there.

