### PR TITLE
Integrate motion components with Create Payment dialog

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=fedc006fca4ef824a5f8dd244be8475368c21386
+ENV BLOCK_INGESTOR_HASH=a6c7fc2575410de6270aea576bdd7fbb6e03132e
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=a6c7fc2575410de6270aea576bdd7fbb6e03132e
+ENV BLOCK_INGESTOR_HASH=3545f30c3cb40f4bb7f832593d657b56054ac331
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
+++ b/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
@@ -9,8 +9,6 @@ import { ActionHookForm as Form } from '~shared/Fields';
 import { ActionTypes } from '~redux/index';
 // import {
 //   useColonyFromNameQuery,
-//   useMembersSubscription,
-//   useNetworkContracts,
 // } from '~data/index';
 import { pipe, withMeta, mapPayload } from '~utils/actions';
 // import { getVerifiedUsers } from '~utils/verifiedRecipients';
@@ -73,10 +71,6 @@ const CreatePaymentDialog = ({
 
   const validationSchema = getValidationSchema(colony, networkInverseFee);
 
-  // const { data: colonyMembers } = useMembersSubscription({
-  //   variables: { colonyAddress },
-  // });
-
   /*
    * @NOTE This (extravagant) query retrieves the latest whitelist data.
    * Whitelist data from colony prop can be stale.
@@ -128,26 +122,19 @@ const CreatePaymentDialog = ({
         transform={transform}
         onSuccess={close}
       >
-        {({ watch }) => {
-          const forceActionvalue = watch('forceAction');
-          if (forceActionvalue !== isForce) {
-            setIsForce(forceActionvalue);
+        <DialogForm
+          back={() => callStep(prevStep)}
+          verifiedUsers={
+            colonyMembers // isWhitelistActivated ? verifiedUsers : ...
           }
-
-          return (
-            <DialogForm
-              back={() => callStep(prevStep)}
-              verifiedUsers={
-                colonyMembers // isWhitelistActivated ? verifiedUsers : ...
-              }
-              // showWhitelistWarning={showWarningForAddress(
-              //   values?.recipient?.walletAddress,
-              // )}
-              colony={colony}
-              enabledExtensionData={enabledExtensionData}
-            />
-          );
-        }}
+          // showWhitelistWarning={showWarningForAddress(
+          //   values?.recipient?.walletAddress,
+          // )}
+          colony={colony}
+          enabledExtensionData={enabledExtensionData}
+          handleIsForceChange={setIsForce}
+          isForce={isForce}
+        />
       </Form>
     </Dialog>
   );

--- a/src/components/common/Dialogs/CreatePaymentDialog/helpers.ts
+++ b/src/components/common/Dialogs/CreatePaymentDialog/helpers.ts
@@ -60,18 +60,20 @@ export const useCreatePaymentDialogStatus = (
   enabledExtensionData: EnabledExtensionData,
 ) => {
   const { watch } = useFormContext();
-  const fromDomain = watch('fromDomainId');
+  const { fromDomainId, motionDomainId } = watch();
   const { isOneTxPaymentEnabled } = enabledExtensionData;
   const {
     userHasPermission,
     disabledSubmit,
     disabledInput: defaultDisabledInput,
     canCreateMotion,
+    canOnlyForceAction,
   } = useActionDialogStatus(
     colony,
     requiredRoles,
-    [fromDomain],
+    [fromDomainId],
     enabledExtensionData,
+    motionDomainId,
   );
   const disabledInput = defaultDisabledInput || !isOneTxPaymentEnabled;
 
@@ -81,5 +83,6 @@ export const useCreatePaymentDialogStatus = (
     disabledSubmit,
     canCreateMotion,
     canCreatePayment: isOneTxPaymentEnabled,
+    canOnlyForceAction,
   };
 };


### PR DESCRIPTION
![FireShot Capture 016 - Colony CDapp - localhost](https://user-images.githubusercontent.com/18473896/234660352-42fadd65-693f-45b6-88fc-0955589aa80f.png)

Some things that deserve an explicit mention:
- If the colony/team doesn't have rep, an error message should appear and the form should be disabled except for the domain selector.
- You should be able to create a motion in the parent domain (Root) even if the targeted domain is a subdomain.
- You can now get reputation by making a payment action/motion, so no need to get it via truffle console.
- To test creating motions in a subdomain, now you should be able to create domains through the UAC.
- To get funds in a team to make a payment, you can force the Transfer Funds action through the UAC by manually changing the saga to the non-motion action type.

Related block-ingestor PR: https://github.com/JoinColony/block-ingestor/pull/66

Resolves #475 
