### PR TITLE
Integrate motion components with Mint Tokens dialog

### DIFF
--- a/src/components/common/Dialogs/MintTokenDialog/MintTokenDialog.tsx
+++ b/src/components/common/Dialogs/MintTokenDialog/MintTokenDialog.tsx
@@ -84,19 +84,13 @@ const MintTokenDialog = ({
         onSuccess={close}
         transform={transform}
       >
-        {({ watch }) => {
-          const forceActionValue = watch('forceAction');
-          if (forceActionValue !== isForce) {
-            setIsForce(forceActionValue);
-          }
-          return (
-            <MintTokenDialogForm
-              colony={colony}
-              back={prevStep && callStep ? () => callStep(prevStep) : undefined}
-              enabledExtensionData={enabledExtensionData}
-            />
-          );
-        }}
+        <MintTokenDialogForm
+          colony={colony}
+          back={prevStep && callStep ? () => callStep(prevStep) : undefined}
+          enabledExtensionData={enabledExtensionData}
+          handleIsForceChange={setIsForce}
+          isForce={isForce}
+        />
       </Form>
     </Dialog>
   );


### PR DESCRIPTION
![FireShot Capture 017 - Colony CDapp - localhost](https://user-images.githubusercontent.com/18473896/234677941-f5808903-080b-4e23-94e7-39237606dbd7.png)
![FireShot Capture 018 - Colony CDapp - localhost](https://user-images.githubusercontent.com/18473896/234677966-1a931982-34e8-44df-a217-e7ebe13ea96e.png)

Some things that deserve an explicit mention:
- If the colony doesn't have rep, an error message should appear and the form should be disabled.
- You can now get reputation by making a payment action, so no need to get it via truffle console.

Resolves #476 
