### PR TITLE
Integrate motion components with Transfer Funds dialog

### DIFF
--- a/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialog.tsx
+++ b/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialog.tsx
@@ -82,19 +82,13 @@ const TransferFundsDialog = ({
         onSuccess={close}
         transform={transform}
       >
-        {({ watch }) => {
-          const forceActionValue = watch('forceAction');
-          if (forceActionValue !== isForce) {
-            setIsForce(forceActionValue);
-          }
-          return (
-            <TransferFundsDialogForm
-              colony={colony}
-              back={prevStep && callStep ? () => callStep(prevStep) : undefined}
-              enabledExtensionData={enabledExtensionData}
-            />
-          );
-        }}
+        <TransferFundsDialogForm
+          colony={colony}
+          back={prevStep && callStep ? () => callStep(prevStep) : undefined}
+          enabledExtensionData={enabledExtensionData}
+          handleIsForceChange={setIsForce}
+          isForce={isForce}
+        />
       </Form>
     </Dialog>
   );

--- a/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
+++ b/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
@@ -21,7 +21,6 @@ import {
 } from '../Messages';
 import TokenAmountInput from '../TokenAmountInput';
 import DomainFundSelectorSection from '../DomainFundSelectorSection';
-
 import { useTransferFundsDialogStatus } from './helpers';
 
 import styles from './TransferFundsDialogForm.css';


### PR DESCRIPTION
![FireShot Capture 020 - Colony CDapp - localhost](https://user-images.githubusercontent.com/18473896/234683230-8a987136-606d-45cb-82b9-6801df1d7af5.png)

![FireShot Capture 019 - Colony CDapp - localhost](https://user-images.githubusercontent.com/18473896/234683211-274f733f-54ab-421a-a171-4080fab538c0.png)

Some things that deserve an explicit mention:
- If the colony doesn't have rep, an error message should appear and the form should be disabled.
- You can now get reputation by making a payment action, so no need to get it via truffle console.
- You can get funds in a team by creating/forcing a transfer funds action.

Resolves #477 
