### PR TITLE
Integrate motion components with Unlock Token dialog

### DIFF
--- a/src/components/common/Dialogs/UnlockTokenDialog/UnlockTokenDialog.tsx
+++ b/src/components/common/Dialogs/UnlockTokenDialog/UnlockTokenDialog.tsx
@@ -67,19 +67,13 @@ const UnlockTokenDialog = ({
         onSuccess={close}
         transform={transform}
       >
-        {({ watch }) => {
-          const forceActionValue = watch('forceAction');
-          if (forceActionValue !== isForce) {
-            setIsForce(forceActionValue);
-          }
-          return (
-            <UnlockTokenForm
-              colony={colony}
-              back={prevStep && callStep ? () => callStep(prevStep) : undefined}
-              enabledExtensionData={enabledExtensionData}
-            />
-          );
-        }}
+        <UnlockTokenForm
+          colony={colony}
+          back={prevStep && callStep ? () => callStep(prevStep) : undefined}
+          enabledExtensionData={enabledExtensionData}
+          handleIsForceChange={setIsForce}
+          isForce={isForce}
+        />
       </Form>
     </Dialog>
   );


### PR DESCRIPTION
![FireShot Capture 021 - Colony CDapp - localhost](https://user-images.githubusercontent.com/18473896/234688019-7cd394e0-cb84-48f4-b396-c62c39d79b15.png)
![FireShot Capture 022 - Colony CDapp - localhost](https://user-images.githubusercontent.com/18473896/234688031-261646c2-17b1-4f76-8c5c-570db3c1bf8c.png)

Some things that deserve an explicit mention:
- If the colony doesn't have rep, an error message should appear and the form should be disabled.
- You can now get reputation by making a payment action, so no need to get it via truffle console.

Resolves #478 
