### PR TITLE
Add Motion Functionality to Manage Rep Dialog

### DIFF
--- a/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
+++ b/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Decimal from 'decimal.js';
 
 import Numeral from '~shared/Numeral';
 import FriendlyName from '~shared/FriendlyName';
@@ -87,7 +88,7 @@ export const mapColonyActionToExpectedFormat = (
     tokenSymbol: actionData.token?.symbol,
     reputationChangeNumeral: actionData.amount && (
       <Numeral
-        value={actionData.amount}
+        value={new Decimal(actionData.amount).abs()}
         decimals={getTokenDecimalsWithFallback(colony?.nativeToken.decimals)}
       />
     ),

--- a/src/components/common/ColonyHome/ColonyDomainSelector/ColonyDomainSelector.tsx
+++ b/src/components/common/ColonyHome/ColonyDomainSelector/ColonyDomainSelector.tsx
@@ -17,7 +17,7 @@ import CreateDomainButton from './CreateDomainButton';
 import styles from './ColonyDomainSelector.css';
 
 interface FormValues {
-  filteredDomainId: string;
+  filteredDomainId: number;
 }
 
 interface Props {
@@ -87,7 +87,7 @@ const ColonyDomainSelector = ({
   return (
     <Form<FormValues>
       defaultValues={{
-        filteredDomainId: String(filteredDomainId),
+        filteredDomainId,
       }}
       onSubmit={() => {}}
     >

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/ManageReputationContainer.tsx
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/ManageReputationContainer.tsx
@@ -91,7 +91,6 @@ const ManageReputationContainer = ({
           domainId: filteredDomainId || Id.RootDomain,
           user: selectedUser,
           motionDomainId: (isSmiteAction && filteredDomainId) || Id.RootDomain,
-          amount: '',
           annotation: '',
         }}
         actionType={actionType}

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/ManageReputationContainer.tsx
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/ManageReputationContainer.tsx
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
-import { string, object, number, boolean, InferType } from 'yup';
 import { Id } from '@colony/colony-js';
 import { useNavigate } from 'react-router-dom';
-import { defineMessages } from 'react-intl';
 
 import Decimal from 'decimal.js';
 import Dialog from '~shared/Dialog';
@@ -19,42 +17,9 @@ import { AwardAndSmiteDialogProps } from '../types';
 
 import { getManageReputationDialogPayload } from './helpers';
 
+import { FormValues, defaultValidationSchema } from './validation';
+
 const displayName = 'common.ManageReputationContainer';
-
-const MSG = defineMessages({
-  amountZero: {
-    id: `${displayName}.amountZero`,
-    defaultMessage: 'Amount must be greater than zero',
-  },
-  maxAmount: {
-    id: `${displayName}.maxAmount`,
-    defaultMessage: "Amount must be less than the user's reputation",
-  },
-});
-
-const defaultValidationSchema = object()
-  .shape({
-    domainId: number().required(),
-    user: object().shape({
-      walletAddress: string().address().required(),
-    }),
-    amount: string()
-      .required()
-      .test(
-        'more-than-zero',
-        () => MSG.amountZero,
-        (value) => {
-          const numberWithoutCommas = (value || '0').replace(/,/g, ''); // @TODO: Remove this once the fix for FormattedInputComponent value is introduced.
-          return !new Decimal(numberWithoutCommas).isZero();
-        },
-      ),
-    annotation: string().max(4000),
-    forceAction: boolean(),
-    motionDomainId: number(),
-  })
-  .defined();
-
-type FormValues = InferType<typeof defaultValidationSchema>;
 
 const ManageReputationContainer = ({
   colony: { nativeToken },

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/ManageReputationContainer.tsx
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/ManageReputationContainer.tsx
@@ -83,7 +83,6 @@ const ManageReputationContainer = ({
   // const { isWhitelistActivated } = colony;
   const selectedUser = useSelectedUser(allColonyMembers);
   //   isWhitelistActivated ? verifiedUsers : colonyWatchers,
-
   return (
     <Dialog cancel={cancel}>
       <Form<FormValues>
@@ -91,7 +90,7 @@ const ManageReputationContainer = ({
           forceAction: false,
           domainId: filteredDomainId || Id.RootDomain,
           user: selectedUser,
-          motionDomainId: Id.RootDomain,
+          motionDomainId: (isSmiteAction && filteredDomainId) || Id.RootDomain,
           amount: '',
           annotation: '',
         }}

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/helpers.ts
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/helpers.ts
@@ -1,14 +1,19 @@
 import Decimal from 'decimal.js';
+import { BigNumber } from 'ethers';
 
 import { useGetMembersForColonyQuery } from '~gql';
 import { Address, Colony, Contributor, MemberUser, Watcher } from '~types';
+import { ManageReputationMotionPayload } from '~redux/sagas/motions/manageReputationMotion';
+
 import { notMaybe } from '~utils/arrays';
+
+import { FormValues } from './validation';
 
 export const getManageReputationDialogPayload = (
   colony: Colony,
   isSmiteAction: boolean,
   nativeTokenDecimals: number,
-  { amount, domainId, annotation, user, motionDomainId },
+  { amount, domainId, annotation, user, motionDomainId }: FormValues,
 ) => {
   const reputationChangeAmount = new Decimal(amount)
     .mul(new Decimal(10).pow(nativeTokenDecimals))
@@ -19,12 +24,12 @@ export const getManageReputationDialogPayload = (
     colonyAddress: colony.colonyAddress,
     colonyName: colony.name,
     domainId,
-    userAddress: user.walletAddress,
-    annotationMessage: annotation,
-    amount: reputationChangeAmount.toString(),
     motionDomainId,
+    userAddress: user?.walletAddress ?? '',
+    annotationMessage: annotation,
+    amount: BigNumber.from(reputationChangeAmount.toString()),
     isSmitingReputation: isSmiteAction,
-  };
+  } as ManageReputationMotionPayload;
 };
 
 export const useGetColonyMembers = (colonyAddress?: Address | null) => {

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/helpers.ts
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/helpers.ts
@@ -1,6 +1,8 @@
 import Decimal from 'decimal.js';
 
-import { Colony } from '~types';
+import { useGetMembersForColonyQuery } from '~gql';
+import { Address, Colony, Contributor, Watcher } from '~types';
+import { notMaybe } from '~utils/arrays';
 
 export const getManageReputationDialogPayload = (
   colony: Colony,
@@ -17,10 +19,26 @@ export const getManageReputationDialogPayload = (
     colonyAddress: colony.colonyAddress,
     colonyName: colony.name,
     domainId,
-    walletAddress: user.walletAddress,
+    userAddress: user.walletAddress,
     annotationMessage: annotation,
     amount: reputationChangeAmount.toString(),
     motionDomainId,
     isSmitingReputation: isSmiteAction,
   };
+};
+
+export const useGetColonyMembers = (colonyAddress?: Address | null) => {
+  const { data } = useGetMembersForColonyQuery({
+    skip: !colonyAddress,
+    variables: {
+      input: {
+        colonyAddress: colonyAddress ?? '',
+      },
+    },
+  });
+
+  const watchers = data?.getMembersForColony?.watchers ?? [];
+  const contributors = data?.getMembersForColony?.contributors ?? [];
+  const allMembers: (Watcher | Contributor)[] = [...watchers, ...contributors];
+  return allMembers.map((member) => member.user).filter(notMaybe);
 };

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/helpers.ts
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/helpers.ts
@@ -2,7 +2,7 @@ import Decimal from 'decimal.js';
 import { BigNumber } from 'ethers';
 
 import { useGetMembersForColonyQuery } from '~gql';
-import { Address, Colony, Contributor, MemberUser, Watcher } from '~types';
+import { Address, Colony, Member, MemberUser } from '~types';
 import { ManageReputationMotionPayload } from '~redux/sagas/motions/manageReputationMotion';
 
 import { notMaybe } from '~utils/arrays';
@@ -44,6 +44,6 @@ export const useGetColonyMembers = (colonyAddress?: Address | null) => {
 
   const watchers = data?.getMembersForColony?.watchers ?? [];
   const contributors = data?.getMembersForColony?.contributors ?? [];
-  const allMembers: (Watcher | Contributor)[] = [...watchers, ...contributors];
+  const allMembers: Member[] = [...watchers, ...contributors];
   return allMembers.map((member) => member.user).filter<MemberUser>(notMaybe);
 };

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/helpers.ts
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/helpers.ts
@@ -1,7 +1,7 @@
 import Decimal from 'decimal.js';
 
 import { useGetMembersForColonyQuery } from '~gql';
-import { Address, Colony, Contributor, Watcher } from '~types';
+import { Address, Colony, Contributor, MemberUser, Watcher } from '~types';
 import { notMaybe } from '~utils/arrays';
 
 export const getManageReputationDialogPayload = (
@@ -40,5 +40,5 @@ export const useGetColonyMembers = (colonyAddress?: Address | null) => {
   const watchers = data?.getMembersForColony?.watchers ?? [];
   const contributors = data?.getMembersForColony?.contributors ?? [];
   const allMembers: (Watcher | Contributor)[] = [...watchers, ...contributors];
-  return allMembers.map((member) => member.user).filter(notMaybe);
+  return allMembers.map((member) => member.user).filter<MemberUser>(notMaybe);
 };

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/validation.ts
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/validation.ts
@@ -1,0 +1,51 @@
+import Decimal from 'decimal.js';
+import { InferType, boolean, number, object, string } from 'yup';
+
+import { intl } from '~utils/intl';
+
+const { formatMessage } = intl({
+  amountZero: 'Amount must be greater than zero',
+  maxAmount: "Amount must be less than the user's reputation",
+});
+
+const amountValidation = string()
+  .required()
+  .test(
+    'more-than-zero',
+    () => formatMessage({ id: 'amountZero' }),
+    (value) => {
+      const numberWithoutCommas = (value || '0').replace(/,/g, ''); // @TODO: Remove this once the fix for FormattedInputComponent value is introduced.
+      return !new Decimal(numberWithoutCommas).isZero();
+    },
+  );
+
+export const defaultValidationSchema = object()
+  .shape({
+    domainId: number().required(),
+    user: object().shape({
+      walletAddress: string().address().required(),
+    }),
+    amount: amountValidation,
+    annotation: string().max(4000),
+    forceAction: boolean(),
+    motionDomainId: number(),
+  })
+  .defined();
+
+export const getAmountValidationSchema = (schemaUserReputation: number) =>
+  object()
+    .shape({
+      amount: amountValidation.test(
+        'less-than-user-reputation',
+        () => formatMessage({ id: 'maxAmount' }),
+        (value) => {
+          const numberWithoutCommas = (value || '0').replace(/,/g, ''); // @TODO: Remove this once the fix for FormattedInputComponent value is introduced.
+          return !new Decimal(numberWithoutCommas).greaterThan(
+            schemaUserReputation,
+          );
+        },
+      ),
+    })
+    .required();
+
+export type FormValues = InferType<typeof defaultValidationSchema>;

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/validation.ts
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/validation.ts
@@ -27,8 +27,8 @@ export const defaultValidationSchema = object()
     }),
     amount: amountValidation,
     annotation: string().max(4000),
-    forceAction: boolean(),
-    motionDomainId: number(),
+    forceAction: boolean().defined(),
+    motionDomainId: number().defined(),
   })
   .defined();
 

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/validation.ts
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/validation.ts
@@ -1,23 +1,6 @@
-import Decimal from 'decimal.js';
 import { InferType, boolean, number, object, string } from 'yup';
 
-import { intl } from '~utils/intl';
-
-const { formatMessage } = intl({
-  amountZero: 'Amount must be greater than zero',
-  maxAmount: "Amount must be less than the user's reputation",
-});
-
-const amountValidation = string()
-  .required()
-  .test(
-    'more-than-zero',
-    () => formatMessage({ id: 'amountZero' }),
-    (value) => {
-      const numberWithoutCommas = (value || '0').replace(/,/g, ''); // @TODO: Remove this once the fix for FormattedInputComponent value is introduced.
-      return !new Decimal(numberWithoutCommas).isZero();
-    },
-  );
+const amountValidation = number().required().moreThan(0);
 
 export const defaultValidationSchema = object()
   .shape({
@@ -35,16 +18,7 @@ export const defaultValidationSchema = object()
 export const getAmountValidationSchema = (schemaUserReputation: number) =>
   object()
     .shape({
-      amount: amountValidation.test(
-        'less-than-user-reputation',
-        () => formatMessage({ id: 'maxAmount' }),
-        (value) => {
-          const numberWithoutCommas = (value || '0').replace(/,/g, ''); // @TODO: Remove this once the fix for FormattedInputComponent value is introduced.
-          return !new Decimal(numberWithoutCommas).greaterThan(
-            schemaUserReputation,
-          );
-        },
-      ),
+      amount: amountValidation.max(schemaUserReputation),
     })
     .required();
 

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
@@ -139,6 +139,7 @@ const ManageReputationDialogForm = ({
     requiredRoles,
     [domainId],
     enabledExtensionData,
+    domainId,
   );
 
   const { userReputation } = useUserReputation(
@@ -269,7 +270,7 @@ const ManageReputationDialogForm = ({
               name="domainId"
               appearance={{ theme: 'grey', width: 'fluid' }}
               renderActiveOption={renderActiveOption}
-              disabled={!userHasPermission}
+              disabled={!userHasPermission || canOnlyForceAction}
             />
           </div>
         </div>

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
@@ -114,15 +114,13 @@ const ManageReputationDialogForm = ({
   setIsForce,
 }: Props) => {
   const { watch, trigger } = useFormContext();
-  const forceAction = watch('forceAction');
+  const { domainId, motionDomainId, user: selectedUser, forceAction } = watch();
 
   useEffect(() => {
     if (forceAction !== isForce) {
       setIsForce(forceAction);
     }
   }, [forceAction, isForce, setIsForce]);
-
-  const { domainId, user: selectedUser } = watch();
 
   const requiredRoles = [
     isSmiteAction ? ColonyRole.Arbitration : ColonyRole.Root,
@@ -139,7 +137,7 @@ const ManageReputationDialogForm = ({
     requiredRoles,
     [domainId],
     enabledExtensionData,
-    domainId,
+    motionDomainId,
   );
 
   const { userReputation } = useUserReputation(
@@ -307,7 +305,7 @@ const ManageReputationDialogForm = ({
         <DialogSection>
           <NotEnoughReputation
             appearance={{ marginTop: 'negative' }}
-            domainId={Number(domainId)}
+            domainId={Number(motionDomainId)}
           />
         </DialogSection>
       )}

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
@@ -120,7 +120,7 @@ const ManageReputationDialogForm = ({
     if (forceAction !== isForce) {
       setIsForce(forceAction);
     }
-  });
+  }, [forceAction, isForce, setIsForce]);
 
   const { domainId, user: selectedUser } = watch();
 
@@ -215,6 +215,7 @@ const ManageReputationDialogForm = ({
             enabledExtensionData.isVotingReputationEnabled
           }
           isRootMotion={!isSmiteAction}
+          selectedDomainId={selectedDomain?.nativeId}
         >
           {!isSmiteAction && (
             <div className={styles.warningContainer}>

--- a/src/components/shared/DetailsWidget/ReputationChangeDetail/ReputationChangeDetail.tsx
+++ b/src/components/shared/DetailsWidget/ReputationChangeDetail/ReputationChangeDetail.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Decimal from 'decimal.js';
 
 import Numeral from '~shared/Numeral';
 import { formatReputationChange } from '~utils/reputation';
@@ -17,7 +18,7 @@ const ReputationChangeDetail = ({
   decimals,
 }: ReputationChangeDetailProps) => (
   <div className={styles.main}>
-    <Numeral value={reputationChange} decimals={decimals} />
+    <Numeral value={new Decimal(reputationChange).abs()} decimals={decimals} />
     <span>
       {formatReputationChange(reputationChange, decimals) === '1'
         ? 'pt'

--- a/src/components/shared/Fields/Input/HookForm/FormattedInputComponent.tsx
+++ b/src/components/shared/Fields/Input/HookForm/FormattedInputComponent.tsx
@@ -43,14 +43,16 @@ const MSG = defineMessages({
 
 interface MaxButtonProps {
   handleClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  disabled?: boolean;
 }
 
-export const MaxButton = ({ handleClick }: MaxButtonProps) => (
+export const MaxButton = ({ handleClick, disabled }: MaxButtonProps) => (
   <Button
     className={styles.hookFormMaxButton}
     dataTest="inputMaxButton"
     onClick={handleClick}
     text={MSG.max}
+    disabled={disabled}
   />
 );
 
@@ -66,6 +68,7 @@ const HookFormFormattedInputComponent = ({
   name,
   value,
   onChange,
+  disabled,
   ...restInputProps
 }: HookFormFormattedInputComponentProps) => {
   const { setValue } = useFormContext();
@@ -116,10 +119,12 @@ const HookFormFormattedInputComponent = ({
       {maxButtonParams && (
         <MaxButton
           handleClick={(e) => handleMaxButtonClick(e, maxButtonParams)}
+          disabled={disabled}
         />
       )}
       <Cleave
         {...restInputProps}
+        disabled={disabled}
         value={value}
         name={name}
         key={dynamicCleaveOptionKey}

--- a/src/components/shared/MemberReputation/MemberReputation.css
+++ b/src/components/shared/MemberReputation/MemberReputation.css
@@ -31,7 +31,8 @@
   transform: translate(0, -50%);
 }
 
-.icon svg {
+/* Increase specificity */
+.icon.icon svg {
   position: absolute;
   top: 0;
   left: 0;

--- a/src/hooks/useColonyHasReputation.ts
+++ b/src/hooks/useColonyHasReputation.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from 'ethers';
 import { ADDRESS_ZERO } from '~constants';
 import { useGetUserReputationQuery } from '~gql';
 
@@ -15,7 +16,9 @@ const useColonyHasReputation = (
     },
   });
 
-  return loading || (!!data?.getUserReputation && !error);
+  const rep = BigNumber.from(data?.getUserReputation ?? 0);
+
+  return loading || (!rep.isZero() && !error);
 };
 
 export default useColonyHasReputation;

--- a/src/hooks/useColonyHasReputation.ts
+++ b/src/hooks/useColonyHasReputation.ts
@@ -4,7 +4,7 @@ import { useGetUserReputationQuery } from '~gql';
 const useColonyHasReputation = (
   colonyAddress: string,
   reputationDomain?: number,
-) => {
+): boolean => {
   const { data, error, loading } = useGetUserReputationQuery({
     variables: {
       input: {

--- a/src/hooks/useDialogActionPermissions.ts
+++ b/src/hooks/useDialogActionPermissions.ts
@@ -14,7 +14,7 @@ const useDialogActionPermissions = (
   requiredRoles: ColonyRole[],
   requiredRolesDomains: number[],
   requiredRepDomain?: number,
-) => {
+): [boolean, boolean] => {
   const { wallet } = useAppContext();
   const { watch } = useFormContext();
   const forceAction = watch('forceAction');

--- a/src/hooks/useSelectedUser.ts
+++ b/src/hooks/useSelectedUser.ts
@@ -1,27 +1,18 @@
-// import { useMemo } from 'react';
+import { User } from '~types';
+import useAppContext from './useAppContext';
 
-// import { AnyUser, useLoggedInUser } from '~data/index';
+const useSelectedUser = (colonyUsers: User[]) => {
+  const { user } = useAppContext();
 
-/*
- * @TODO This needs to be addressed and either refactored or removed
- */
+  const [firstSubscriber, secondSubscriber] = colonyUsers;
 
-// export const useSelectedUser = (colonyUsers: AnyUser[]) => {
-//   const { walletAddress: loggedInUserWalletAddress } = useLoggedInUser();
+  if (!secondSubscriber) {
+    return firstSubscriber;
+  }
 
-//   return useMemo(() => {
-//     const [firstSubscriber, secondSubscriber] = colonyUsers;
-
-//     if (!secondSubscriber) {
-//       return firstSubscriber;
-//     }
-
-//     return firstSubscriber.profile.walletAddress === loggedInUserWalletAddress
-//       ? secondSubscriber
-//       : firstSubscriber;
-//   }, [colonyUsers, loggedInUserWalletAddress]);
-// };
-
-const useSelectedUser = (...args) => args;
+  return firstSubscriber?.walletAddress === user?.walletAddress
+    ? secondSubscriber
+    : firstSubscriber;
+};
 
 export default useSelectedUser;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,14 @@ import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import ReactModal from 'react-modal';
 import { Logger } from 'ethers/lib.esm/utils';
+import Decimal from 'decimal.js';
 
 import './styles/main.css';
 
 import Entry from './Entry';
 import store from '~redux/createReduxStore';
+
+Decimal.set({ toExpPos: 78 });
 
 Logger.setLogLevel(Logger.levels.ERROR);
 

--- a/src/redux/sagas/motions/manageReputationMotion.ts
+++ b/src/redux/sagas/motions/manageReputationMotion.ts
@@ -4,6 +4,7 @@ import {
   getChildIndex,
   getPermissionProofs,
   ColonyRole,
+  Id,
 } from '@colony/colony-js';
 import { AddressZero } from '@ethersproject/constants';
 
@@ -22,6 +23,9 @@ import {
   getTxChannel,
 } from '../transactions';
 import { transactionReady } from '../../actionCreators';
+
+export type ManageReputationMotionPayload =
+  Action<ActionTypes.MOTION_MANAGE_REPUTATION>['payload'];
 
 function* manageReputationMotion({
   payload: {
@@ -81,7 +85,7 @@ function* manageReputationMotion({
       getChildIndex,
       colonyClient,
       motionDomainId,
-      domainId,
+      isSmitingReputation ? domainId : Id.RootDomain,
     );
 
     const { skillId } = yield call(

--- a/src/redux/types/actions/motion.ts
+++ b/src/redux/types/actions/motion.ts
@@ -227,7 +227,7 @@ export type MotionActionTypes =
         domainId: number;
         userAddress: Address;
         amount: BigNumber;
-        motionDomainId: string;
+        motionDomainId: number;
         annotationMessage?: string;
         isSmitingReputation?: boolean;
       },

--- a/src/utils/arrays/index.ts
+++ b/src/utils/arrays/index.ts
@@ -159,6 +159,8 @@ export const arrayToObject = (arr: any[]) =>
 // To filter arrays
 export const notUndefined = <T>(x: T | undefined): x is T => x !== undefined;
 export const notNull = <T>(x: T | null): x is T => x !== null;
+export const notMaybe = <T>(x: T | null | undefined): x is T =>
+  x !== null && x !== undefined;
 
 export const immutableSort = <T>(
   arr: T[],

--- a/src/utils/reputation.ts
+++ b/src/utils/reputation.ts
@@ -46,6 +46,7 @@ export const formatReputationChange = (
   reputationChange: string,
   decimals: number,
 ) => {
-  const value = adjustConvertedValue(new Decimal(reputationChange), decimals);
-  return getFormattedNumeralValue(value, reputationChange);
+  const absoluteChange = new Decimal(reputationChange).abs();
+  const value = adjustConvertedValue(absoluteChange, decimals);
+  return getFormattedNumeralValue(value, absoluteChange);
 };


### PR DESCRIPTION
## Description

This PR makes it possible to create an Award / Smite Rep motion via the UAC.
It also makes some small refactors to the ManageReputation Dialog components, like moving validation logic to a separate file.

![smite-rep](https://user-images.githubusercontent.com/64402732/234937132-1b2dda70-93dc-47f2-a502-6aa8de0b9e94.png)

![award-rep](https://user-images.githubusercontent.com/64402732/234937676-96b0b35c-77f7-45cd-8b5e-8ccace6a9205.png)


## Testing

Install voting rep. 
c.setArchitectureRole(1, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", '<voting-rep-extn-address>', 1, true)

You should:

- Not be able to submit the form without rep. (i.e. you see the NotEnoughRep and form is disabled).

After adding rep, you should be able to award/smite rep in any combination of domain and subdomain that is possible via the ui. (i.e from the subdomain in the subdomain, from root in root, or from root in the subdomain).

**Changes** 🏗

* Wire in motion components with Award/Smite
* Display reputation penalty as positive value in ActionTitle and DetailsWidget (like in Dapp)


Resolves #479
