### PR TITLE
Integrate motion components with NetworkContractUpgradeDialog

### DIFF
--- a/src/components/common/Dialogs/NetworkContractUpgradeDialog/NetworkContractUpgradeDialog.tsx
+++ b/src/components/common/Dialogs/NetworkContractUpgradeDialog/NetworkContractUpgradeDialog.tsx
@@ -68,19 +68,13 @@ const NetworkContractUpgradeDialog = ({
         transform={transform}
         onSuccess={close}
       >
-        {({ getValues }) => {
-          const values = getValues();
-          if (values.forceAction !== isForce) {
-            setIsForce(values.forceAction);
-          }
-          return (
-            <DialogForm
-              colony={colony}
-              back={prevStep && callStep ? () => callStep(prevStep) : undefined}
-              enabledExtensionData={enabledExtensionData}
-            />
-          );
-        }}
+        <DialogForm
+          colony={colony}
+          back={prevStep && callStep ? () => callStep(prevStep) : undefined}
+          enabledExtensionData={enabledExtensionData}
+          handleIsForceChange={setIsForce}
+          isForce={isForce}
+        />
       </Form>
     </Dialog>
   );


### PR DESCRIPTION
![FireShot Capture 023 - Colony CDapp - localhost](https://user-images.githubusercontent.com/18473896/234917226-7a10af72-9603-4cbc-ae38-ca48a4bf1a43.png)
![FireShot Capture 024 - Colony CDapp - localhost](https://user-images.githubusercontent.com/18473896/234917242-51f16da1-d8d7-47ff-af82-dd344f8aec47.png)

- To test, you can follow the instructions to add a new colony version detailed here: https://github.com/JoinColony/colonyCDapp/pull/313
- If the colony doesn't have rep, an error message should appear and the form should be disabled.
- You can now get reputation by making a payment action, so no need to get it via truffle console.

Resolves #482 
