### PR TITLE
Fix colony redirect

### DIFF
--- a/src/components/common/CreateColonyWizard/StepConfirmTransactions.tsx
+++ b/src/components/common/CreateColonyWizard/StepConfirmTransactions.tsx
@@ -123,7 +123,9 @@ const StepConfirmTransactions = ({ wizardValues: { colonyName } }: Props) => {
     getGroupStatus(newestGroup) === TRANSACTION_STATUSES.SUCCEEDED &&
     getGroupKey(newestGroup) === 'group.createColony'
   ) {
-    return <Navigate to={`/colony/${colonyName}`} />;
+    return (
+      <Navigate to={`/colony/${colonyName}`} state={{ isRedirect: true }} />
+    );
   }
 
   const createColonyTxGroup = findTransactionGroupByKey(


### PR DESCRIPTION
## Description

Fix to the redirect to ColonyHome from Colony creation wizard. Changing the network policy in #485 has surfaced a race condition after creating a colony via the wizard. 

`cache-and-network` appears to behave differently to `network-only`, in that now, we're not getting a loading state that persists  long enough for the colony to be populated in the db. Previously, it seems we were being shown a loading state that endured just enough for the redirect to be successful (margins are small here, for the record).

Anyway, to be absolutely sure we don't redirect to 404 when there is actually the colony in the db, I've implemented the same polling strategy as at the ActionDetailsPage. 

**Changes** 🏗

* Poll for colony inside colony context. 

Resolves #498
