### PR TITLE
Fix incorrect domain balance in finalize motion

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/FinalizeMotion/FinalizeMotion.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/FinalizeMotion/FinalizeMotion.tsx
@@ -6,7 +6,7 @@ import DetailItem from '~shared/DetailsWidget/DetailItem';
 import { MiniSpinnerLoader } from '~shared/Preloaders';
 import { MotionData } from '~types';
 import { useColonyContext } from '~hooks';
-import { getDomainBalance } from '~utils/domains';
+import { getBalanceForTokenAndDomain } from '~utils/tokens';
 
 import FinalizeButton from './FinalizeButton';
 
@@ -38,6 +38,7 @@ const MSG = defineMessages({
 
 export interface FinalizeMotionProps {
   amount?: string | null;
+  tokenAddress?: string | null;
   motionData: MotionData;
   requiresDomainFunds: boolean;
   startPollingAction: (pollingInterval: number) => void;
@@ -46,6 +47,7 @@ export interface FinalizeMotionProps {
 
 const FinalizeMotion = ({
   amount,
+  tokenAddress,
   motionData: { motionDomainId, motionId },
   requiresDomainFunds,
   startPollingAction,
@@ -64,7 +66,11 @@ const FinalizeMotion = ({
     );
   }
 
-  const domainBalance = getDomainBalance(motionDomainId, balances);
+  const domainBalance = getBalanceForTokenAndDomain(
+    balances,
+    tokenAddress ?? '',
+    Number(motionDomainId),
+  );
 
   const isFinalizable =
     !requiresDomainFunds ||

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
@@ -43,7 +43,7 @@ const MotionPhaseWidget = ({
 }: MotionPhaseWidgetProps) => {
   const { user } = useAppContext();
   const { refetchColony } = useColonyContext();
-  const { motionData, type, amount, fromDomain } = actionData;
+  const { motionData, type, amount, fromDomain, tokenAddress } = actionData;
   const { stopPollingAction } = rest;
 
   if (!motionData) {
@@ -72,6 +72,7 @@ const MotionPhaseWidget = ({
           <div>
             <FinalizeMotion
               amount={amount}
+              tokenAddress={tokenAddress}
               motionData={motionData}
               requiresDomainFunds={
                 !!fromDomain &&

--- a/src/utils/domains.ts
+++ b/src/utils/domains.ts
@@ -41,20 +41,3 @@ export const getDomainOptions = (colonyDomains: Domain[]) =>
     })) || [],
     ['value'],
   );
-
-/**
- * Get a specific domain balance from the array of Colony balances.
- */
-export const getDomainBalance = (
-  nativeDomainId: number | string,
-  balances?: Colony['balances'] | null,
-) => {
-  const { balance } =
-    balances?.items
-      ?.filter(notNull)
-      .find(
-        ({ domain: { nativeId } }) => nativeId === Number(nativeDomainId),
-      ) || {};
-
-  return balance;
-};


### PR DESCRIPTION
## Description

This pr fixes a bug with fetching the domain balance when we finalize a motion. I wasn't discriminating by the token address, so was getting the wrong token balance. 

**Changes** 🏗

* Find domain balance by domain **and** token address

Resolves #502
