### PR TITLE
Fix motion refetching without data

### DIFF
--- a/src/hooks/useGetColonyAction.ts
+++ b/src/hooks/useGetColonyAction.ts
@@ -68,8 +68,10 @@ const useGetColonyAction = (colony?: Colony | null) => {
 
   /* Ensures motion state is kept in sync with motion data */
   useEffect(() => {
-    refetchMotionState();
-  }, [actionData, refetchMotionState]);
+    if (action?.motionData) {
+      refetchMotionState();
+    }
+  }, [action?.motionData, refetchMotionState]);
 
   return {
     isInvalidTransactionHash: !isValidTx,


### PR DESCRIPTION
## Description

I was seeing the following lamda error caused by an effect refetching motion state without checking if there's any motion data. This PR fixes it.

![lamda-err](https://user-images.githubusercontent.com/64402732/235643040-4e7e4154-7e32-4dda-bc17-13e28fe0ff80.png)

**Changes** 🏗

* Don't refetch motion state without motion data
