### PR TITLE
Update user logout to allow for user switching

### DIFF
--- a/src/redux/sagas/users/index.ts
+++ b/src/redux/sagas/users/index.ts
@@ -150,6 +150,7 @@ function* usernameCreate({
 
 function* userLogout() {
   try {
+    removeContext(ContextModule.ColonyManager);
     removeContext(ContextModule.Wallet);
     clearLastWallet();
 


### PR DESCRIPTION
Removing the colony manager's context on logout is something that we do in the Dapp and it seems like it would be required for us to do here as well in order to avoid using a manager instance with an outdated signer.

You should be able to go through the whole motion flow without having to reload the page when you switch users. I haven't noticed any drawbacks/side effects from us removing this context on logout.

Resolves #392 
