### PR TITLE
Refactor sagas to use createGroupTransaction utility

### DIFF
--- a/src/redux/sagas/actions/createDomain.ts
+++ b/src/redux/sagas/actions/createDomain.ts
@@ -1,8 +1,8 @@
-import { call, fork, put, takeEvery } from 'redux-saga/effects';
+import { call, put, takeEvery } from 'redux-saga/effects';
 import { ClientType, Id } from '@colony/colony-js';
 import { Action, ActionTypes, AllActions } from '~redux';
 import {
-  createTransaction,
+  createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../transactions';
@@ -56,17 +56,7 @@ function* createDomainAction({
       // 'annotateCreateDomainAction',
     ]);
 
-    const createGroupTransaction = ({ id, index }, config) =>
-      fork(createTransaction, id, {
-        ...config,
-        group: {
-          key: batchKey,
-          id: metaId,
-          index,
-        },
-      });
-
-    yield createGroupTransaction(createDomain, {
+    yield createGroupTransaction(createDomain, batchKey, meta, {
       context: ClientType.ColonyClient,
       methodName: 'addDomainWithProofs(uint256)',
       identifier: colonyAddress,

--- a/src/redux/sagas/actions/editColony.ts
+++ b/src/redux/sagas/actions/editColony.ts
@@ -1,11 +1,11 @@
-import { call, fork, put, takeEvery } from 'redux-saga/effects';
+import { call, put, takeEvery } from 'redux-saga/effects';
 import { ClientType } from '@colony/colony-js';
 
 import { ContextModule, getContext } from '~context';
 import { Action, ActionTypes, AllActions } from '~redux';
 
 import {
-  createTransaction,
+  createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../transactions';
@@ -61,17 +61,7 @@ function* editColonyAction({
       'annotateEditColonyAction',
     ]);
 
-    const createGroupTransaction = ({ id, index }, config) =>
-      fork(createTransaction, id, {
-        ...config,
-        group: {
-          key: batchKey,
-          id: metaId,
-          index,
-        },
-      });
-
-    yield createGroupTransaction(editColony, {
+    yield createGroupTransaction(editColony, batchKey, meta, {
       context: ClientType.ColonyClient,
       methodName: 'editColony',
       identifier: colonyAddress,

--- a/src/redux/sagas/actions/editDomain.ts
+++ b/src/redux/sagas/actions/editDomain.ts
@@ -1,4 +1,4 @@
-import { call, fork, put, takeEvery } from 'redux-saga/effects';
+import { call, put, takeEvery } from 'redux-saga/effects';
 import { ClientType } from '@colony/colony-js';
 
 import { ContextModule, getContext } from '~context';
@@ -11,7 +11,7 @@ import {
 import { getDomainDatabaseId } from '~utils/domains';
 
 import {
-  createTransaction,
+  createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../transactions';
@@ -57,17 +57,7 @@ function* editDomainAction({
       // 'annotateEditDomainAction',
     ]);
 
-    const createGroupTransaction = ({ id, index }, config) =>
-      fork(createTransaction, id, {
-        ...config,
-        group: {
-          key: batchKey,
-          id: metaId,
-          index,
-        },
-      });
-
-    yield createGroupTransaction(editDomain, {
+    yield createGroupTransaction(editDomain, batchKey, meta, {
       context: ClientType.ColonyClient,
       methodName: 'editDomainWithProofs',
       identifier: colonyAddress,

--- a/src/redux/sagas/actions/unlockToken.ts
+++ b/src/redux/sagas/actions/unlockToken.ts
@@ -1,11 +1,11 @@
-import { call, fork, put, takeEvery } from 'redux-saga/effects';
+import { call, put, takeEvery } from 'redux-saga/effects';
 import { ClientType } from '@colony/colony-js';
 
 // import { ContextModule, getContext } from '~context';
 import { Action, ActionTypes, AllActions } from '~redux';
 
 import {
-  createTransaction,
+  createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../transactions';
@@ -34,22 +34,9 @@ function* tokenUnlockAction({
     ]);
 
     /*
-     * Create a grouped transaction
-     */
-    const createGroupTransaction = ({ id, index }, config) =>
-      fork(createTransaction, id, {
-        ...config,
-        group: {
-          key: batchKey,
-          id: metaId,
-          index,
-        },
-      });
-
-    /*
      * Add the tokenUnlock transaction to the group
      */
-    yield createGroupTransaction(tokenUnlock, {
+    yield createGroupTransaction(tokenUnlock, batchKey, meta, {
       context: ClientType.ColonyClient,
       methodName: 'unlockToken',
       identifier: colonyAddress,

--- a/src/redux/sagas/extensions/extensionEnable.ts
+++ b/src/redux/sagas/extensions/extensionEnable.ts
@@ -2,7 +2,7 @@ import { all, call, put, takeEvery } from 'redux-saga/effects';
 
 import { ActionTypes } from '../../actionTypes';
 import { Action } from '../../types/actions';
-import { getTxChannel } from '../transactions';
+import { createGroupTransaction, getTxChannel } from '../transactions';
 import {
   modifyParams,
   putError,
@@ -34,20 +34,26 @@ function* extensionEnable({
         channels,
         transactionChannels,
         transactionChannels: { initialise },
-        createGroupTransaction,
       } = yield setupEnablingGroupTransactions(
         meta.id,
         initParams,
         extensionId,
       );
 
+      const batchKey = 'enableExtensions';
+
       yield all(
         Object.keys(transactionChannels).map((channelName) =>
-          createGroupTransaction(transactionChannels[channelName], {
-            identifier: colonyAddress,
-            methodName: channelName,
-            ...channels[channelName],
-          }),
+          createGroupTransaction(
+            transactionChannels[channelName],
+            batchKey,
+            meta,
+            {
+              identifier: colonyAddress,
+              methodName: channelName,
+              ...channels[channelName],
+            },
+          ),
         ),
       );
 

--- a/src/redux/sagas/motions/escalateMotion.ts
+++ b/src/redux/sagas/motions/escalateMotion.ts
@@ -1,4 +1,4 @@
-import { call, fork, put, takeEvery } from 'redux-saga/effects';
+import { call, put, takeEvery } from 'redux-saga/effects';
 import { ClientType, Id } from '@colony/colony-js';
 import { AddressZero } from '@ethersproject/constants';
 
@@ -7,7 +7,7 @@ import { AllActions, Action } from '../../types/actions';
 import { putError, takeFrom, getColonyManager } from '../utils';
 
 import {
-  createTransaction,
+  createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../transactions';
@@ -46,17 +46,7 @@ function* escalateMotion({
 
     const batchKey = 'escalateMotion';
 
-    const createGroupTransaction = ({ id, index }, config) =>
-      fork(createTransaction, id, {
-        ...config,
-        group: {
-          key: batchKey,
-          id: meta.id,
-          index,
-        },
-      });
-
-    yield createGroupTransaction(escalateMotionTransaction, {
+    yield createGroupTransaction(escalateMotionTransaction, batchKey, meta, {
       context: ClientType.VotingReputationClient,
       methodName: 'escalateMotionWithProofs',
       identifier: colonyAddress,

--- a/src/redux/sagas/motions/finalizeMotion.ts
+++ b/src/redux/sagas/motions/finalizeMotion.ts
@@ -1,4 +1,4 @@
-import { call, fork, put, takeEvery } from 'redux-saga/effects';
+import { call, put, takeEvery } from 'redux-saga/effects';
 import { AnyVotingReputationClient, ClientType } from '@colony/colony-js';
 import { BigNumber } from 'ethers';
 
@@ -7,7 +7,7 @@ import { AllActions, Action } from '../../types/actions';
 import { getColonyManager, putError, takeFrom } from '../utils';
 
 import {
-  createTransaction,
+  createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../transactions';
@@ -62,17 +62,7 @@ function* finalizeMotion({
 
     const batchKey = 'finalizeMotion';
 
-    const createGroupTransaction = ({ id, index }, config) =>
-      fork(createTransaction, id, {
-        ...config,
-        group: {
-          key: batchKey,
-          id: meta.id,
-          index,
-        },
-      });
-
-    yield createGroupTransaction(finalizeMotionTransaction, {
+    yield createGroupTransaction(finalizeMotionTransaction, batchKey, meta, {
       context: ClientType.VotingReputationClient,
       methodName: 'finalizeMotion',
       identifier: colonyAddress,

--- a/src/redux/sagas/utils/enableExtensionHelpers.ts
+++ b/src/redux/sagas/utils/enableExtensionHelpers.ts
@@ -1,10 +1,9 @@
-import { fork } from 'redux-saga/effects';
 import { BigNumber } from 'ethers';
 
 import { TxConfig } from '~types';
 import { ContextModule, getContext, setContext } from '~context';
 
-import { createTransaction, createTransactionChannels } from '~redux/sagas';
+import { createTransactionChannels } from '~redux/sagas';
 
 export type Channel = Omit<TxConfig, 'methodName'>;
 
@@ -53,20 +52,10 @@ export function* setupEnablingGroupTransactions(
       metaId,
       Object.keys(channels),
     );
-    const createGroupTransaction = ({ id, index }, config) =>
-      fork(createTransaction, id, {
-        ...config,
-        group: {
-          key: 'enableExtension',
-          id: metaId,
-          index,
-        },
-      });
 
     return {
       channels,
       transactionChannels,
-      createGroupTransaction,
     };
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
## Description

Spring cleaning. All sagas that were copy/pasting the function definition of `createGroupTransaction` are now using the same function.

## Testing

I have tested by ensuring all the affected sagas still behave as intended.

Resolves #344
