### PR TITLE
Fix gas station message

### DIFF
--- a/src/components/frame/GasStation/MessageCardDetails/MessageCardDetails.css
+++ b/src/components/frame/GasStation/MessageCardDetails/MessageCardDetails.css
@@ -67,3 +67,8 @@
 .cancelDecision {
   composes: cancelDecision from '../TransactionCard/GroupedTransactionCard.css';
 }
+
+.messageContent {
+  word-break: break-word;
+  white-space: break-spaces;
+}

--- a/src/components/frame/GasStation/MessageCardDetails/MessageCardDetails.css.d.ts
+++ b/src/components/frame/GasStation/MessageCardDetails/MessageCardDetails.css.d.ts
@@ -7,6 +7,7 @@ declare namespace MessageCardDetailsCssNamespace {
     confirmationButtonsWrapper: string;
     description: string;
     main: string;
+    messageContent: string;
     stateFailed: string;
     stateIsShowingCancelConfirmation: string;
     stateSucceeded: string;

--- a/src/components/frame/GasStation/MessageCardDetails/MessageCardDetails.tsx
+++ b/src/components/frame/GasStation/MessageCardDetails/MessageCardDetails.tsx
@@ -108,7 +108,7 @@ const MessageCardDetails = ({
                 </div>
               )}
             </span>
-            {messageContent}
+            <span className={styles.messageContent}>{messageContent}</span>
           </div>
         </Card>
       </CardList>

--- a/src/redux/sagas/motions/voteMotion.ts
+++ b/src/redux/sagas/motions/voteMotion.ts
@@ -57,7 +57,7 @@ function* voteMotion({
       votingReputationClient.address
     } Motion ID: ${motionId.toNumber()}`;
 
-    const signature = yield signMessage('motionRevealVote', message);
+    const signature = yield signMessage('motionVote', message);
     const hash = utils.solidityKeccak256(
       ['bytes', 'uint256'],
       [utils.keccak256(signature), vote],


### PR DESCRIPTION
## Description

This PR fixes a problem with the gas station message content not being wrapped correctly. It also fixes a mistake with the message title for the vote motion message, which was using the reveal vote message.

In the gas station, you should now see when voting / revealing:
![entropy-msg](https://user-images.githubusercontent.com/64402732/236819294-e49e1e93-8896-41d6-896f-9c4746fa5129.png)

![reveal-motion](https://user-images.githubusercontent.com/64402732/236819663-0ba362f4-d97c-4686-a420-b6eb479aafc0.png)

Resolves #515
