### PR TITLE
Fix/qa contributors watchers

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -345,7 +345,7 @@ type ColonyMetadataChangelog {
 
 type User @model {
   id: ID! @index(name: "byAddress", queryField: "getUserByAddress") # wallet address
-  name: String! @index(name: "byName", queryField: "getUserByName")
+  name: String @index(name: "byName", queryField: "getUserByName")
   tokens: [Token] @manyToMany(relationName: "UserTokens")
   profileId: ID
   profile: Profile @hasOne(fields: ["profileId"])

--- a/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
+++ b/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AddressZero } from '@ethersproject/constants';
 
 import Numeral from '~shared/Numeral';
 import FriendlyName from '~shared/FriendlyName';
@@ -17,6 +18,7 @@ import {
   formatRolesTitle,
   getColonyRoleSetTitleValues,
 } from '~utils/colonyActions';
+import MaskedAddress from '~shared/MaskedAddress';
 
 import { getDomainMetadataChangesValue } from './getDomainMetadataChanges';
 import { getColonyMetadataChangesValue } from './getColonyMetadataChanges';
@@ -74,8 +76,11 @@ export const mapColonyActionToExpectedFormat = (
     ),
     recipient: (
       <span className={styles.titleDecoration}>
-        {/* @TODO All all the other recipient types, and the fallback */}
-        <FriendlyName user={actionData.recipientUser} autoShrinkAddress />
+        {actionData.recipientUser ? (
+          <FriendlyName user={actionData.recipientUser} autoShrinkAddress />
+        ) : (
+          <MaskedAddress address={actionData.recipientAddress || AddressZero} />
+        )}
       </span>
     ),
     toDomain:
@@ -138,8 +143,11 @@ export const mapColonyEventToExpectedFormat = (
     ),
     recipient: (
       <span className={styles.userDecoration}>
-        {/* @TODO All all the other recipient types, and the fallback */}
-        <FriendlyName user={actionData.recipientUser} autoShrinkAddress />
+        {actionData.recipientUser ? (
+          <FriendlyName user={actionData.recipientUser} autoShrinkAddress />
+        ) : (
+          <MaskedAddress address={actionData.recipientAddress || AddressZero} />
+        )}
       </span>
     ),
     isSmiteAction:

--- a/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -146,6 +146,7 @@ Props) => {
           </div>
         )} */}
         {recipient &&
+          recipient.name &&
           isConfusing(recipient.name || recipient.profile?.displayName) && (
             <ConfusableWarning
               walletAddress={recipient.walletAddress}

--- a/src/components/common/Members/MembersList/MemberInfo/MemberInfo.tsx
+++ b/src/components/common/Members/MembersList/MemberInfo/MemberInfo.tsx
@@ -35,7 +35,7 @@ const MemberInfo = ({ isWhitelisted, user }: Props) => {
           {displayName}
         </span>
       )}
-      {user && (
+      {user && user.name && (
         <span className={styles.username}>
           <UserMention hasLink={false} user={user} />
         </span>

--- a/src/components/common/Members/filterMembers.ts
+++ b/src/components/common/Members/filterMembers.ts
@@ -15,7 +15,7 @@ const filterMemberBySearchTerm = (
       member?.user?.walletAddress
         ?.toLowerCase()
         .includes(searchTerm.toLowerCase()) ||
-      member?.user?.name.toLowerCase().includes(searchTerm.toLowerCase()))
+      member?.user?.name?.toLowerCase().includes(searchTerm.toLowerCase()))
   );
 };
 

--- a/src/components/shared/SingleUserPicker/SingleUserPicker.tsx
+++ b/src/components/shared/SingleUserPicker/SingleUserPicker.tsx
@@ -215,7 +215,7 @@ const SingleUserPicker = ({
                   disabled={disabled}
                   data-test={valueDataTest}
                 >
-                  {value.profile.displayName ||
+                  {value.profile?.displayName ||
                     value.name ||
                     value.walletAddress}
                 </button>

--- a/src/components/shared/SingleUserPicker/utils.ts
+++ b/src/components/shared/SingleUserPicker/utils.ts
@@ -18,7 +18,7 @@ export const filterUserSelection = (
 
   const filteredUsers = data.filter(
     (user) =>
-      user?.name.toLowerCase().includes(filterValue.toLowerCase()) ||
+      user?.name?.toLowerCase().includes(filterValue.toLowerCase()) ||
       user?.walletAddress.toLowerCase().includes(filterValue.toLowerCase()) ||
       user?.profile?.displayName
         ?.toLowerCase()

--- a/src/components/shared/UserAvatar/UserAvatar.tsx
+++ b/src/components/shared/UserAvatar/UserAvatar.tsx
@@ -74,7 +74,7 @@ const UserAvatar = ({
   );
 
   if (showLink && user) {
-    return <Link to={`/user/${user.name.toLowerCase()}`}>{avatar}</Link>;
+    return <Link to={`/user/${user.name?.toLowerCase()}`}>{avatar}</Link>;
   }
 
   return avatar;

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -581,7 +581,7 @@ export type CreateUniqueUserInput = {
 
 export type CreateUserInput = {
   id?: InputMaybe<Scalars['ID']>;
-  name: Scalars['String'];
+  name?: InputMaybe<Scalars['String']>;
   profileId?: InputMaybe<Scalars['ID']>;
 };
 
@@ -3175,7 +3175,7 @@ export type User = {
   __typename?: 'User';
   createdAt: Scalars['AWSDateTime'];
   id: Scalars['ID'];
-  name: Scalars['String'];
+  name?: Maybe<Scalars['String']>;
   profile?: Maybe<Profile>;
   profileId?: Maybe<Scalars['ID']>;
   tokens?: Maybe<ModelUserTokensConnection>;
@@ -3266,11 +3266,11 @@ export type UserFragment = { __typename?: 'User', name: string, walletAddress: s
 
 export type ProfileFragment = { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null };
 
-export type MemberUserFragment = { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null };
+export type MemberUserFragment = { __typename?: 'User', name?: string | null, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null };
 
-export type ContributorFragment = { __typename?: 'Contributor', reputationPercentage?: string | null, reputationAmount?: string | null, user?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null } | null };
+export type ContributorFragment = { __typename?: 'Contributor', reputationPercentage?: string | null, reputationAmount?: string | null, user?: { __typename?: 'User', name?: string | null, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null } | null };
 
-export type WatcherFragment = { __typename?: 'Watcher', user?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null } | null };
+export type WatcherFragment = { __typename?: 'Watcher', user?: { __typename?: 'User', name?: string | null, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null } | null };
 
 export type CreateUniqueColonyMutationVariables = Exact<{
   input: CreateUniqueColonyInput;
@@ -3412,7 +3412,7 @@ export type GetMembersForColonyQueryVariables = Exact<{
 }>;
 
 
-export type GetMembersForColonyQuery = { __typename?: 'Query', getMembersForColony?: { __typename?: 'MembersForColonyReturn', contributors?: Array<{ __typename?: 'Contributor', reputationPercentage?: string | null, reputationAmount?: string | null, user?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null } | null }> | null, watchers?: Array<{ __typename?: 'Watcher', user?: { __typename?: 'User', name: string, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null } | null }> | null } | null };
+export type GetMembersForColonyQuery = { __typename?: 'Query', getMembersForColony?: { __typename?: 'MembersForColonyReturn', contributors?: Array<{ __typename?: 'Contributor', reputationPercentage?: string | null, reputationAmount?: string | null, user?: { __typename?: 'User', name?: string | null, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null } | null }> | null, watchers?: Array<{ __typename?: 'Watcher', user?: { __typename?: 'User', name?: string | null, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null } | null } | null }> | null } | null };
 
 export type GetCurrentNetworkInverseFeeQueryVariables = Exact<{ [key: string]: never; }>;
 


### PR DESCRIPTION
This fixes the issues with contributors and watchers not loading and not being able to select a user in the `SingleUserPicker`. Its now also possible to paste an address in the SingleUserPicker.

Its currently possible for a user that has not yet joined a colony to have reputation in that colony or as well as any non-user address. This causes problems as this "user" will only have an address and no name or user profile.


This fix makes the following changes:
- Make name not required
- Add extra checks for name and profile
- Fallback to recipientAddress for actions if there is no user