### PR TITLE
Misc fixes for QA

### DIFF
--- a/amplify/backend/function/createUniqueColony/src/index.js
+++ b/amplify/backend/function/createUniqueColony/src/index.js
@@ -21,6 +21,7 @@ exports.handler = async (event) => {
     type = 'COLONY',
     version,
     chainMetadata,
+    status,
   } = event.arguments?.input || {};
 
   /*
@@ -131,6 +132,7 @@ exports.handler = async (event) => {
         type,
         chainMetadata,
         version,
+        status,
       },
     },
     GRAPHQL_URI,

--- a/src/components/common/ColonyHome/ColonyDomainDescription/ColonyDomainDescription.tsx
+++ b/src/components/common/ColonyHome/ColonyDomainDescription/ColonyDomainDescription.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 
 import ColorTag from '~shared/ColorTag';
 
@@ -17,22 +17,6 @@ const displayName = 'common.ColonyHome.ColonyDomainDescription';
 const ColonyDomainDescription = ({ currentDomainId }: Props) => {
   const { colony } = useColonyContext();
 
-  /*
-   * @TODO a proper color transformation
-   * This was just quickly thrown together to ensure it works
-   * Maybe even change the gql scalar type ?
-   */
-  const transformColor = useCallback((domainColor) => {
-    const colorMap = {
-      0: 0, // Light Pink
-      LIGHTPINK: 0,
-      5: 5, // Yellow
-      RED: 6,
-      ORANGE: 13,
-    };
-    return colorMap[domainColor];
-  }, []);
-
   if (!colony || currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID) {
     return null;
   }
@@ -43,7 +27,7 @@ const ColonyDomainDescription = ({ currentDomainId }: Props) => {
   return (
     <div className={styles.main}>
       <div className={styles.name}>
-        <ColorTag color={transformColor(color) || 0} />
+        {color && <ColorTag color={color} />}
         <span>{name}</span>
       </div>
       {description && <div className={styles.description}>{description}</div>}

--- a/src/components/common/Dialogs/ManageFundsDialog/ManageFundsDialog.tsx
+++ b/src/components/common/Dialogs/ManageFundsDialog/ManageFundsDialog.tsx
@@ -7,7 +7,7 @@ import IndexModal from '~shared/IndexModal';
 import { WizardDialogType, useTransformer, useAppContext } from '~hooks';
 
 import { getAllUserRoles } from '~transformers';
-import { hasRoot } from '~utils/checks'; // canFund
+import { canFund, hasRoot } from '~utils/checks';
 
 const displayName = 'common.ManageFundsDialog';
 
@@ -116,13 +116,13 @@ const ManageFundsDialog = ({
 
   const { isVotingReputationEnabled } = enabledExtensionData;
 
-  // const canMoveFunds = canFund(allUserRoles);
-  // const canUserMintNativeToken = isVotingReputationEnabled
-  //   ? colony.status?.nativeToken?.mintable
-  //   : hasRoot(allUserRoles) && colony.status?.nativeToken?.mintable;
-  // const canUserUnlockNativeToken = isVotingReputationEnabled
-  //   ? colony.status?.nativeToken?.unlockable
-  //   : hasRoot(allUserRoles) && colony.status?.nativeToken?.unlockable;
+  const canMoveFunds = canFund(allUserRoles);
+  const canUserMintNativeToken = isVotingReputationEnabled
+    ? colony.status?.nativeToken?.mintable
+    : hasRoot(allUserRoles) && colony.status?.nativeToken?.mintable;
+  const canUserUnlockNativeToken = isVotingReputationEnabled
+    ? colony.status?.nativeToken?.unlockable
+    : hasRoot(allUserRoles) && colony.status?.nativeToken?.unlockable;
 
   const canManageTokens = hasRoot(allUserRoles);
 
@@ -131,7 +131,7 @@ const ManageFundsDialog = ({
       title: MSG.transferFundsTitle,
       description: MSG.transferFundsDescription,
       icon: 'emoji-world-globe',
-      permissionRequired: false, // !canMoveFunds || isVotingReputationEnabled,
+      permissionRequired: !canMoveFunds || isVotingReputationEnabled,
       permissionInfoText: MSG.permissionsListText,
       permissionInfoTextValues: {
         permissionsList: <FormattedMessage {...MSG.paymentPermissionsList} />,
@@ -143,7 +143,7 @@ const ManageFundsDialog = ({
       title: MSG.mintTokensTitle,
       description: MSG.mintTokensDescription,
       icon: 'emoji-seed-sprout',
-      permissionRequired: false, // !canUserMintNativeToken,
+      permissionRequired: !canUserMintNativeToken,
       permissionInfoText: MSG.permissionsListText,
       permissionInfoTextValues: {
         permissionsList: (
@@ -184,7 +184,7 @@ const ManageFundsDialog = ({
       description: MSG.unlockTokensDescription,
       icon: 'emoji-padlock',
       onClick: () => callStep(nextStepUnlockToken),
-      permissionRequired: false, // !canUserUnlockNativeToken,
+      permissionRequired: !canUserUnlockNativeToken,
       permissionInfoText: MSG.permissionsListText,
       permissionInfoTextValues: {
         permissionsList: (
@@ -194,7 +194,7 @@ const ManageFundsDialog = ({
       dataTest: 'unlockTokenDialogIndexItem',
     },
   ];
-  // @TODO: Uncomment code here when "status" is implemented as this filters menu items based on that. (Mint and Unlock token actions)
+
   const filteredItems =
     colony?.status?.nativeToken?.mintable &&
     colony?.status?.nativeToken?.unlockable
@@ -204,12 +204,12 @@ const ManageFundsDialog = ({
             icon === 'emoji-padlock' &&
             !colony?.status?.nativeToken?.unlockable
           ) {
-            return true; // false
+            return false;
           }
-          return true; // !(
-          //   icon === 'emoji-seed-sprout' &&
-          //   !colony.status?.nativeToken?.mintable
-          // );
+          return !(
+            icon === 'emoji-seed-sprout' &&
+            !colony.status?.nativeToken?.mintable
+          );
         });
   return (
     <IndexModal

--- a/src/components/common/Dialogs/UnlockTokenDialog/UnlockTokenForm.tsx
+++ b/src/components/common/Dialogs/UnlockTokenDialog/UnlockTokenForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
-import { ColonyRole, Id } from '@colony/colony-js';
+import { ColonyRole } from '@colony/colony-js';
 
 import ExternalLink from '~shared/ExternalLink';
 import {
@@ -13,8 +13,6 @@ import {
 import { Annotations } from '~shared/Fields';
 // import NotEnoughReputation from '~dashboard/NotEnoughReputation';
 
-import { useActionDialogStatus } from '~hooks';
-
 import { TOKEN_UNLOCK_INFO } from '~constants/externalUrls';
 
 import {
@@ -22,6 +20,8 @@ import {
   CannotCreateMotionMessage,
   PermissionRequiredInfo,
 } from '../Messages';
+
+import { useUnlockTokenDialogStatus } from './helpers';
 
 import styles from './UnlockTokenForm.css';
 
@@ -64,16 +64,13 @@ const UnlockTokenForm = ({
   back,
   enabledExtensionData,
 }: ActionDialogProps) => {
-  const { userHasPermission, disabledInput, disabledSubmit, canCreateMotion } =
-    useActionDialogStatus(
-      colony,
-      requiredRoles,
-      [Id.RootDomain],
-      enabledExtensionData,
-    );
-  // @TODO: Integrate those checks into another hook that uses useActionDialogStatus internally, when the data is made available.
-  // const isNativeTokenLocked = !!colony?.nativeToken?.unlocked;
-  // const canUserUnlockNativeToken = hasRootPermission && status?.nativeToken?.unlockable && isNativeTokenLocked;
+  const {
+    userHasPermission,
+    disabledInput,
+    disabledSubmit,
+    canCreateMotion,
+    isNativeTokenUnlocked,
+  } = useUnlockTokenDialogStatus(colony, requiredRoles, enabledExtensionData);
 
   return (
     <>
@@ -88,16 +85,15 @@ const UnlockTokenForm = ({
         </DialogSection>
       )}
       <DialogSection appearance={{ theme: 'sidePadding' }}>
-        {/* {isNativeTokenLocked ? (
+        {!isNativeTokenUnlocked ? (
           <FormattedMessage {...MSG.description} />
         ) : (
           <div className={styles.unlocked}>
             <FormattedMessage {...MSG.unlockedDescription} />
           </div>
-        )} */}
-        <FormattedMessage {...MSG.description} />
+        )}
       </DialogSection>
-      {true && ( // isNativeTokenLocked
+      {!isNativeTokenUnlocked && (
         <>
           <DialogSection appearance={{ theme: 'sidePadding' }}>
             <div className={styles.note}>
@@ -119,7 +115,7 @@ const UnlockTokenForm = ({
           </DialogSection>
         </>
       )}
-      {!userHasPermission && ( // && isNativeTokenLocked
+      {!userHasPermission && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <NoPermissionMessage requiredPermissions={requiredRoles} />
         </DialogSection>

--- a/src/components/common/Dialogs/UnlockTokenDialog/helpers.ts
+++ b/src/components/common/Dialogs/UnlockTokenDialog/helpers.ts
@@ -1,3 +1,6 @@
+import { ColonyRole, Id } from '@colony/colony-js';
+
+import { EnabledExtensionData, useActionDialogStatus } from '~hooks';
 import { RootMotionMethodNames } from '~redux';
 import { Colony } from '~types';
 
@@ -11,3 +14,29 @@ export const getUnlockTokenDialogPayload = (
   motionParams: [],
   colonyName: colony?.name,
 });
+
+export const useUnlockTokenDialogStatus = (
+  colony: Colony,
+  requiredRoles: ColonyRole[],
+  enabledExtensionData: EnabledExtensionData,
+) => {
+  const {
+    userHasPermission,
+    disabledInput,
+    disabledSubmit: defaultDisabledSubmit,
+    canCreateMotion,
+  } = useActionDialogStatus(
+    colony,
+    requiredRoles,
+    [Id.RootDomain],
+    enabledExtensionData,
+  );
+  const isNativeTokenUnlocked = !!colony?.status?.nativeToken?.unlocked;
+  return {
+    userHasPermission,
+    disabledInput,
+    disabledSubmit: defaultDisabledSubmit || isNativeTokenUnlocked,
+    canCreateMotion,
+    isNativeTokenUnlocked,
+  };
+};

--- a/src/components/frame/TokenActivation/TokensTab/ChangeTokenStateForm.tsx
+++ b/src/components/frame/TokenActivation/TokensTab/ChangeTokenStateForm.tsx
@@ -146,6 +146,11 @@ const ChangeTokenStateForm = ({
                 }}
                 maxButtonParams={{
                   maxAmount: tokenBalanceInEthers,
+                  options: {
+                    shouldTouch: true,
+                    shouldValidate: true,
+                    shouldDirty: true,
+                  },
                 }}
                 dataTest="activateTokensInput"
               />

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -71,7 +71,7 @@ export const GNOSIS_NETWORK: NetworkInfo = {
   chainId: 100,
   shortName: 'xDai',
   displayENSDomain: 'joincolony.colonyxdai',
-  blockExplorerName: 'Blockscout',
+  blockExplorerName: 'Gnosisscan',
   blockExplorerUrl: 'https://blockscout.com/poa/xdai',
   tokenExplorerLink: 'https://blockscout.com/poa/xdai/tokens',
   contractAddressLink: 'https://blockscout.com/poa/xdai/address',

--- a/src/redux/sagas/colony/colonyCreate.ts
+++ b/src/redux/sagas/colony/colonyCreate.ts
@@ -310,6 +310,11 @@ function* colonyCreate({
         );
       }
       const network: EthersNetwork = yield colonyManager.provider.getNetwork();
+      const colonyClient = yield colonyManager.getClient(
+        ClientType.ColonyClient,
+        colonyAddress,
+      );
+      const isTokenLocked = yield colonyClient.tokenClient.locked();
 
       /*
        * Create colony in db
@@ -327,6 +332,13 @@ function* colonyCreate({
             version: toNumber(currentColonyVersion),
             chainMetadata: {
               chainId: network.chainId,
+            },
+            status: {
+              nativeToken: {
+                unlockable: tokenChoice === 'create',
+                unlocked: !isTokenLocked,
+                mintable: tokenChoice === 'create',
+              },
             },
           },
         },
@@ -401,10 +413,6 @@ function* colonyCreate({
        * Create root domain in the database
        * @NOTE: This is a temporary solution and this mutation should be called by block-ingestor on ColonyAdded event
        */
-      const colonyClient = yield colonyManager.getClient(
-        ClientType.ColonyClient,
-        colonyAddress,
-      );
       const [skillId, fundingPotId] = yield colonyClient.getDomain(
         Id.RootDomain,
       );

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -70,13 +70,13 @@ export const getUserRolesForDomain = (
   );
 
   if (excludeInherited && userRolesInAnyDomain) {
-    return convertRolesToArray(userRolesInRootDomain);
+    return convertRolesToArray(userRolesInAnyDomain);
   }
 
-  if (!excludeInherited && userRolesInAnyDomain && userRolesInRootDomain) {
+  if (!excludeInherited && (userRolesInAnyDomain || userRolesInRootDomain)) {
     return Array.from(
       new Set([
-        ...convertRolesToArray(userRolesInRootDomain),
+        ...convertRolesToArray(userRolesInAnyDomain),
         ...convertRolesToArray(userRolesInRootDomain),
       ]),
     );

--- a/src/utils/external/index.ts
+++ b/src/utils/external/index.ts
@@ -110,9 +110,22 @@ export const getBlockExplorerLink = ({
     return `https://blockscout.com/poa/${network}/${xdaiLinkType}/${addressOrHash}`;
   }
   const tld = network === 'tobalaba' ? 'com' : 'io';
-  const networkSubdomain =
-    network === 'homestead' || network === Network.Mainnet ? '' : `${network}.`;
-  return `https://${networkSubdomain}etherscan.${tld}/${linkType}/${addressOrHash}`;
+
+  let baseURL = '';
+
+  if (network === Network.Gnosis) {
+    // @NOTE: I'm making this URL as dynamic as possible as there are other networks (like Polygon)
+    // that we may include, in the "multi-chain" future, that use the same base URL pattern
+    baseURL = `${network}scan`;
+  } else {
+    const networkSubdomain =
+      network === 'homestead' || network === Network.Mainnet
+        ? ''
+        : `${network}.`;
+    baseURL = `${networkSubdomain}etherscan`;
+  }
+
+  return `https://${baseURL}.${tld}/${linkType}/${addressOrHash}`;
 };
 
 export const getNetworkReleaseLink = () => `${NETWORK_RELEASES}/${LATEST_TAG}`;


### PR DESCRIPTION
- Fixed the max button on the token action popover not triggering the validation/dirtying/touching logic, therefore the submit button not enabling.
- Updated `getBlockExplorerLink` to return a valid Gnosis Chain block explorer link.
- Updated `ColonyDomainDescription`'s outdated way of getting the domain's color.
- Updated `getUserRolesForDomain` logic to catch the inherited domain permissions correctly.
- Added native token status logic to track if the token is mintable, unlockable, or if it has been unlocked already (The `unlocked` status needs https://github.com/JoinColony/block-ingestor/pull/75 to work properly)
