### PR TITLE
Fixing icon weight and overflowing

### DIFF
--- a/.storybook/main.css
+++ b/.storybook/main.css
@@ -21,7 +21,7 @@
   }
 
   svg:not([class]) {
-    @apply fill-current stroke-current;
+    @apply fill-current stroke-none;
   }
 
   #root {

--- a/src/components/common/Extensions/SubNavigation/SubNavigationItem/SubNavigationItem.module.css
+++ b/src/components/common/Extensions/SubNavigation/SubNavigationItem/SubNavigationItem.module.css
@@ -17,7 +17,7 @@
     @apply text-blue-400 cursor-pointer;
 
     & svg {
-      @apply fill-blue-400 stroke-blue-400;
+      @apply fill-blue-400;
     }
   }
 }
@@ -26,6 +26,6 @@
   @apply text-blue-400 font-semibold text-md;
 
   & svg {
-    @apply fill-blue-400 stroke-blue-400;
+    @apply fill-blue-400;
   }
 }

--- a/src/components/common/Extensions/SubNavigation/SubNavigationItem/SubNavigationItemMobile.module.css
+++ b/src/components/common/Extensions/SubNavigation/SubNavigationItem/SubNavigationItemMobile.module.css
@@ -13,7 +13,7 @@
     @apply text-blue-400 cursor-pointer;
 
     & svg {
-      @apply fill-blue-400 stroke-blue-400;
+      @apply fill-blue-400;
     }
   }
 }
@@ -22,7 +22,7 @@
   @apply text-blue-400 font-semibold text-sm;
 
   & svg {
-    @apply fill-blue-400 stroke-blue-400;
+    @apply fill-blue-400;
   }
 }
 

--- a/src/components/common/Extensions/SupportingDocuments/LinkWrapper.tsx
+++ b/src/components/common/Extensions/SupportingDocuments/LinkWrapper.tsx
@@ -22,7 +22,7 @@ const LinkWrapper: FC<LinkWrapperProps> = ({ isDoubleLinkVisible }) => {
             appearance={{ size: 'tiny' }}
             name="file-text"
             title={{ id: 'file-text' }}
-            className="group-hover:[&>svg]:stroke-blue-400 w-3 h-3"
+            className="group-hover:[&>svg]:fill-blue-400 w-3 h-3"
           />
           <Link key={item.url} to={item.url} className="font-normal text-sm text-gray-600 hover:text-blue-400 ml-2">
             {formatMessage({ id: item.text })}

--- a/src/components/shared/Extensions/Avatar/Avatar.module.css
+++ b/src/components/shared/Extensions/Avatar/Avatar.module.css
@@ -27,11 +27,11 @@
 }
 
 .placeholderIcon {
-  @apply w-full h-full [&_svg]:fill-current [&_svg]:stroke-current opacity-50;
+  @apply w-full h-full [&_svg]:fill-current [&_svg]:stroke-none opacity-50;
 }
 
 .placeholderIconNotSet {
-  @apply w-full h-full [&_svg]:fill-current [&_svg]:stroke-current opacity-100;
+  @apply w-full h-full [&_svg]:fill-current [&_svg]:stroke-none opacity-100;
 }
 
 .image {

--- a/src/components/shared/Icon/Icon.module.css
+++ b/src/components/shared/Icon/Icon.module.css
@@ -35,9 +35,9 @@
 }
 
 .themePrimary {
-  @apply inline-block [&_svg]:fill-current [&_svg]:stroke-current;
+  @apply inline-block [&_svg]:fill-current [&_svg]:stroke-none;
 }
 
 .themeInvert {
-  @apply inline-block [&_svg]:fill-current [&_svg]:stroke-current;
+  @apply inline-block [&_svg]:fill-current [&_svg]:stroke-none;
 }

--- a/src/styles/main.global.css
+++ b/src/styles/main.global.css
@@ -24,7 +24,7 @@
   }
 
   svg:not([class]) {
-    @apply fill-current stroke-current;
+    @apply fill-current stroke-none;
   }
 
   #root {


### PR DESCRIPTION
## Description

This small PR fixes the icon weight issue and the overflowing of icons, which is cutting off icons due to the weight. This was being caused by stroke being applied which was not needed.

Image showing incorrect icon weight and clipping:

![image](https://github.com/JoinColony/colonyCDapp/assets/33682027/9b9b5db0-dcdf-4ed3-bdcd-3742143b2aea)

Image showing updates from this PR including correct weight and without clipping:

![image](https://github.com/JoinColony/colonyCDapp/assets/33682027/a4b164a9-2277-4e6b-ab0d-0f15b51478f9)
