### PR TITLE
Get correct member data for ManageReputationContainer

### DIFF
--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
@@ -181,7 +181,7 @@ const ManageReputationDialogForm = ({
 
   const formattedData = verifiedUsers.map((user) => ({
     ...user,
-    id: user,
+    id: user.walletAddress,
   }));
 
   return (

--- a/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
+++ b/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
@@ -16,12 +16,10 @@ import { pipe, withMeta, mapPayload } from '~utils/actions';
 // import { getVerifiedUsers } from '~utils/verifiedRecipients';
 import { WizardDialogType, useNetworkInverseFee } from '~hooks';
 import { useGetMembersForColonyQuery } from '~gql';
+import { extractUsersFromColonyMemberData } from '~utils/members';
 
 import DialogForm from './CreatePaymentDialogForm';
-import {
-  extractUsersFromColonyMemberData,
-  getCreatePaymentDialogPayload,
-} from './helpers';
+import { getCreatePaymentDialogPayload } from './helpers';
 import getValidationSchema from './validation';
 
 const displayName = 'common.CreatePaymentDialog';

--- a/src/components/common/Dialogs/CreatePaymentDialog/helpers.ts
+++ b/src/components/common/Dialogs/CreatePaymentDialog/helpers.ts
@@ -2,21 +2,12 @@ import { ColonyRole } from '@colony/colony-js';
 import { useFormContext } from 'react-hook-form';
 
 import { useActionDialogStatus, EnabledExtensionData } from '~hooks';
-import { Colony, Member } from '~types';
-import { notNull, notUndefined } from '~utils/arrays';
+import { Colony } from '~types';
 import {
   calculateFee,
   getSelectedToken,
   getTokenDecimalsWithFallback,
 } from '~utils/tokens';
-
-export const extractUsersFromColonyMemberData = (
-  members: Member[] | null | undefined,
-) =>
-  members
-    ?.map((member) => member.user)
-    .filter(notNull)
-    .filter(notUndefined) || [];
 
 export const getCreatePaymentDialogPayload = (
   colony: Colony,

--- a/src/utils/members.ts
+++ b/src/utils/members.ts
@@ -1,0 +1,10 @@
+import { Member } from '~types';
+import { notNull, notUndefined } from '~utils/arrays';
+
+export const extractUsersFromColonyMemberData = (
+  members: Member[] | null | undefined,
+) =>
+  members
+    ?.map((member) => member.user)
+    .filter(notNull)
+    .filter(notUndefined) || [];


### PR DESCRIPTION
## Description

Replace empty watchers array with the results of GetMembersForColonyQuery so that the recipient dropdown in Smite and Award Reputation Dialogs have the correct user data.

**Changes** 🏗

move `extractUsersFromColonyMemberData` to utils

Test

Check that the recipient dropdown in Smite and Award Reputation Dialogs have the correct users populated.

Resolves #464
