### PR TITLE
Integrate Colony Edit dialog with motion components

### DIFF
--- a/src/components/common/Dialogs/EditColonyDetailsDialog/ColonyAvatarUploader.tsx
+++ b/src/components/common/Dialogs/EditColonyDetailsDialog/ColonyAvatarUploader.tsx
@@ -4,7 +4,7 @@ import { useFormContext } from 'react-hook-form';
 import { defineMessages } from 'react-intl';
 
 import {
-  getOptimisedAvatar,
+  getOptimisedAvatarUnder300KB,
   getOptimisedThumbnail,
 } from '~images/optimisation';
 import Avatar from '~shared/Avatar';
@@ -54,7 +54,7 @@ const ColonyAvatarUploader = ({
     setAvatarFileError(undefined);
 
     try {
-      const optimisedImage = await getOptimisedAvatar(file.file);
+      const optimisedImage = await getOptimisedAvatarUnder300KB(file.file);
       const optimisedThumbnail = await getOptimisedThumbnail(file.file);
       setValue('colonyAvatarImage', optimisedImage, { shouldDirty: true });
       setValue('colonyThumbnail', optimisedThumbnail);

--- a/src/components/common/Dialogs/EditColonyDetailsDialog/ColonyAvatarUploader.tsx
+++ b/src/components/common/Dialogs/EditColonyDetailsDialog/ColonyAvatarUploader.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { FileRejection } from 'react-dropzone';
+import { useFormContext } from 'react-hook-form';
+import { defineMessages } from 'react-intl';
+
+import {
+  getOptimisedAvatar,
+  getOptimisedThumbnail,
+} from '~images/optimisation';
+import Avatar from '~shared/Avatar';
+import AvatarUploader from '~shared/AvatarUploader';
+import { DropzoneErrors } from '~shared/AvatarUploader/helpers';
+import { getFileRejectionErrors } from '~shared/FileUpload/utils';
+import { Colony, SetStateFn } from '~types';
+import { FileReaderFile } from '~utils/fileReader/types';
+
+const displayName =
+  'common.EditColonyDetailsDialog.EditColonyDetailsDialogForm.ColonyAvatarUploader';
+
+const MSG = defineMessages({
+  logo: {
+    id: `${displayName}.logo`,
+    defaultMessage: 'Colony Logo (Optional)',
+  },
+});
+
+interface ColonyAvatarUploaderProps {
+  avatarFileError?: DropzoneErrors;
+  setAvatarFileError: SetStateFn;
+  disabledInput: boolean;
+  colony: Colony;
+}
+
+const ColonyAvatarUploader = ({
+  avatarFileError,
+  setAvatarFileError,
+  disabledInput,
+  colony: { colonyAddress, metadata, name: colonyName },
+}: ColonyAvatarUploaderProps) => {
+  const { setValue, watch } = useFormContext();
+  const { colonyAvatarImage } = watch();
+
+  const handleFileRemove = async () => {
+    setValue('colonyAvatarImage', null, { shouldDirty: true });
+    setValue('colonyThumbnail', null);
+    setAvatarFileError(undefined);
+  };
+
+  const handleFileRead = async (file: FileReaderFile) => {
+    if (!file) {
+      return;
+    }
+
+    setAvatarFileError(undefined);
+
+    try {
+      const optimisedImage = await getOptimisedAvatar(file.file);
+      const optimisedThumbnail = await getOptimisedThumbnail(file.file);
+      setValue('colonyAvatarImage', optimisedImage, { shouldDirty: true });
+      setValue('colonyThumbnail', optimisedThumbnail);
+    } catch (e) {
+      setAvatarFileError(DropzoneErrors.DEFAULT);
+    }
+  };
+
+  const handleFileReject = (rejectedFiles: FileRejection[]) => {
+    // Only care about first error
+    const fileError = getFileRejectionErrors(rejectedFiles)[0][0];
+    setAvatarFileError(fileError.code as DropzoneErrors); // these errors come from dropzone
+  };
+
+  return (
+    <AvatarUploader
+      disabled={disabledInput}
+      disableRemove={!colonyAvatarImage}
+      label={MSG.logo}
+      handleFileAccept={handleFileRead}
+      handleFileRemove={handleFileRemove}
+      handleFileReject={handleFileReject}
+      errorCode={avatarFileError}
+      avatarPlaceholder={
+        <Avatar
+          avatar={colonyAvatarImage}
+          seed={colonyAddress.toLowerCase()}
+          title={metadata?.displayName || colonyName || colonyAddress}
+          size="xl"
+        />
+      }
+    />
+  );
+};
+
+ColonyAvatarUploader.displayName = displayName;
+
+export default ColonyAvatarUploader;

--- a/src/components/common/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialog.tsx
+++ b/src/components/common/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialog.tsx
@@ -81,19 +81,13 @@ const EditColonyDetailsDialog = ({
         onSuccess={close}
         transform={transform}
       >
-        {({ getValues }) => {
-          const values = getValues();
-          if (values.forceAction !== isForce) {
-            setIsForce(values.forceAction);
-          }
-          return (
-            <EditColonyDetailsDialogForm
-              colony={colony}
-              back={() => callStep(prevStep)}
-              enabledExtensionData={enabledExtensionData}
-            />
-          );
-        }}
+        <EditColonyDetailsDialogForm
+          colony={colony}
+          back={() => callStep(prevStep)}
+          enabledExtensionData={enabledExtensionData}
+          isForce={isForce}
+          setIsForce={setIsForce}
+        />
       </Form>
     </Dialog>
   );

--- a/src/components/common/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialogForm.tsx
+++ b/src/components/common/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialogForm.tsx
@@ -3,26 +3,15 @@ import { defineMessages } from 'react-intl';
 import { ColonyRole, Id } from '@colony/colony-js';
 import { useFormContext } from 'react-hook-form';
 
-import AvatarUploader from '~shared/AvatarUploader';
 import {
   ActionDialogProps,
   DialogControls,
   DialogHeading,
   DialogSection,
 } from '~shared/Dialog';
-import {
-  Annotations,
-  HookFormInput as Input,
-  InputStatus,
-} from '~shared/Fields';
-import ColonyAvatar from '~shared/ColonyAvatar';
-import Avatar from '~shared/Avatar';
+import { Annotations, HookFormInput as Input } from '~shared/Fields';
+import { DropzoneErrors } from '~shared/AvatarUploader/helpers';
 import { useActionDialogStatus } from '~hooks';
-import {
-  getOptimisedAvatar,
-  getOptimisedThumbnail,
-} from '~images/optimisation';
-import { FileReaderFile } from '~utils/fileReader/types';
 import { SetStateFn } from '~types';
 
 import {
@@ -31,8 +20,7 @@ import {
   NotEnoughReputation,
   PermissionRequiredInfo,
 } from '../Messages';
-
-import styles from './EditColonyDetailsDialogForm.css';
+import ColonyAvatarUploader from './ColonyAvatarUploader';
 
 const displayName =
   'common.EditColonyDetailsDialog.EditColonyDetailsDialogForm';
@@ -70,15 +58,14 @@ interface EditColonyDetailsDialogFormProps extends ActionDialogProps {
 const EditColonyDetailsDialogForm = ({
   back,
   colony,
-  colony: { colonyAddress, metadata },
+  colony: { metadata },
   enabledExtensionData,
   isForce,
   setIsForce,
 }: EditColonyDetailsDialogFormProps) => {
-  const { setValue, watch } = useFormContext();
+  const { watch } = useFormContext();
   const { colonyAvatarImage, colonyDisplayName, forceAction } = watch();
-  const [showUploadedAvatar, setShowUploadedAvatar] = useState(false);
-  const [avatarFileError, setAvatarFileError] = useState(false);
+  const [avatarFileError, setAvatarFileError] = useState<DropzoneErrors>();
 
   useEffect(() => {
     if (forceAction !== isForce) {
@@ -98,36 +85,6 @@ const EditColonyDetailsDialogForm = ({
     [Id.RootDomain],
     enabledExtensionData,
   );
-
-  const handleFileRead = async (file: FileReaderFile) => {
-    if (!file) {
-      return;
-    }
-
-    try {
-      const optimisedImage = await getOptimisedAvatar(file.file);
-      const optimisedThumbnail = await getOptimisedThumbnail(file.file);
-      setValue('colonyAvatarImage', optimisedImage, { shouldDirty: true });
-      setValue('colonyThumbnail', optimisedThumbnail);
-      setShowUploadedAvatar(true);
-    } catch (e) {
-      setAvatarFileError(true);
-    }
-  };
-
-  const handleFileRemove = async () => {
-    setValue('colonyAvatarImage', null, { shouldDirty: true });
-    setValue('colonyThumbnail', null);
-    setShowUploadedAvatar(true);
-  };
-
-  /*
-   * This helps us hook into the internal file uplaoder error state,
-   * so that we can invalidate the form if the uploaded file format is incorrect
-   */
-  const handleFileReadError = async () => {
-    setAvatarFileError(true);
-  };
 
   const hasEditedColony =
     metadata?.displayName !== colonyDisplayName ||
@@ -152,51 +109,12 @@ const EditColonyDetailsDialogForm = ({
         </DialogSection>
       )}
       <DialogSection>
-        <AvatarUploader
-          avatar={showUploadedAvatar ? colonyAvatarImage : metadata?.avatar}
-          disabled={disabledInput}
-          label={MSG.logo}
-          handleFileAccept={handleFileRead}
-          handleFileRemove={handleFileRemove}
-          avatarPlaceholder={
-            <>
-              {showUploadedAvatar ? (
-                /*
-                 * If we have a currently uploaded avatar, **or** if we just remove it
-                 * show the default colony avatar, without values coming from the
-                 * colony.
-                 *
-                 * Note that in case of the avatar being removed, `avatarURL` will be
-                 * passed as `undefined` so that the blockies show.
-                 * This is intended functionality
-                 */
-                <Avatar
-                  avatar={colonyAvatarImage}
-                  seed={colonyAddress.toLowerCase()}
-                  title={metadata?.displayName || colony.name || colonyAddress}
-                  size="xl"
-                />
-              ) : (
-                /*
-                 * Show the colony hooked avatar. This is only visible until the
-                 * user interacts with avatar input for the first time
-                 */
-                <ColonyAvatar
-                  colony={colony}
-                  colonyAddress={colonyAddress}
-                  size="xl"
-                  preferThumbnail={false}
-                />
-              )}
-            </>
-          }
-          handleFileReject={handleFileReadError}
+        <ColonyAvatarUploader
+          colony={colony}
+          setAvatarFileError={setAvatarFileError}
+          disabledInput={disabledInput}
+          avatarFileError={avatarFileError}
         />
-        {avatarFileError && (
-          <div className={styles.avatarUploadError}>
-            <InputStatus error={MSG.invalidAvatarFormat} />
-          </div>
-        )}
       </DialogSection>
       <DialogSection>
         <Input
@@ -232,7 +150,7 @@ const EditColonyDetailsDialogForm = ({
       )}
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
         <DialogControls
-          disabled={disabledSubmit || avatarFileError || !hasEditedColony}
+          disabled={disabledSubmit || !!avatarFileError || !hasEditedColony}
           dataTest="confirmButton"
           onSecondaryButtonClick={back}
           isVotingReputationEnabled={

--- a/src/components/common/Dialogs/EditColonyDetailsDialog/helpers.ts
+++ b/src/components/common/Dialogs/EditColonyDetailsDialog/helpers.ts
@@ -14,8 +14,5 @@ export const getEditColonyDetailsDialogPayload = (
     typeof colonyThumbnail === 'string' || colonyThumbnail === null
       ? colonyThumbnail
       : colony.metadata?.thumbnail,
-  // verifiedAddresses: colonyData?.processedColony?.whitelistedAddresses,
   annotationMessage,
-  // isWhitelistActivated:
-  //   colonyData?.processedColony?.isWhitelistActivated,
 });

--- a/src/components/common/UserProfileEdit/UserAvatarUploader.tsx
+++ b/src/components/common/UserProfileEdit/UserAvatarUploader.tsx
@@ -5,7 +5,7 @@ import { FileRejection } from 'react-dropzone';
 import { useUpdateUserProfileMutation } from '~gql';
 import { useAppContext } from '~hooks';
 import {
-  getOptimisedAvatar,
+  getOptimisedAvatarUnder300KB,
   getOptimisedThumbnail,
 } from '~images/optimisation';
 import AvatarUploader from '~shared/AvatarUploader';
@@ -48,7 +48,9 @@ const UserAvatarUploader = ({
     }
 
     try {
-      const updatedAvatar = await getOptimisedAvatar(avatarFile?.file);
+      const updatedAvatar = await getOptimisedAvatarUnder300KB(
+        avatarFile?.file,
+      );
       const thumbnail = await getOptimisedThumbnail(avatarFile?.file);
 
       await updateAvatar({

--- a/src/components/shared/AvatarUploader/AvatarUploader.tsx
+++ b/src/components/shared/AvatarUploader/AvatarUploader.tsx
@@ -34,10 +34,10 @@ export interface Props
     > {
   /** Appearance object for both label and status */
   appearance?: Appearance;
-  /** Avatar image string */
-  avatar: AvatarProps['avatar'];
   /** Avatar to be wrapped by File uploader */
   avatarPlaceholder: React.ReactElement;
+  /** Disable the remove avatar button */
+  disableRemove?: boolean;
   /** An error message */
   errorCode?: DropzoneErrors;
   /** An object in the format: { "message": string} for display a custom error message */
@@ -96,9 +96,9 @@ const getPlaceholder = (
 
 const AvatarUploader = ({
   appearance,
-  avatar,
   avatarPlaceholder,
   disabled = false,
+  disableRemove,
   elementOnly,
   extra,
   handleFileAccept,
@@ -159,7 +159,7 @@ const AvatarUploader = ({
       {showButtons && (
         <UploadControls
           handleFileRemove={handleFileRemove}
-          disableRemove={!avatar || disabled}
+          disableRemove={disableRemove || disabled}
           disableChoose={disabled}
           open={open}
         />

--- a/src/components/shared/AvatarUploader/AvatarUploader.tsx
+++ b/src/components/shared/AvatarUploader/AvatarUploader.tsx
@@ -145,7 +145,6 @@ const AvatarUploader = ({
       <SingleFileUpload
         dropzoneRootStyles={showButtons ? styles : noButtonStyles}
         dropzoneOptions={{
-          maxSize: NO_MAX,
           disabled,
         }}
         handleFileAccept={handleFileAccept}

--- a/src/components/shared/AvatarUploader/AvatarUploader.tsx
+++ b/src/components/shared/AvatarUploader/AvatarUploader.tsx
@@ -4,15 +4,15 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import {
   CoreInputProps,
   InputLabel,
-  InputStatus,
+  HookFormInputStatus as InputStatus,
   InputComponentAppearance as Appearance,
 } from '~shared/Fields';
 import { SingleFileUpload, SingleFileUploadProps } from '~shared/FileUpload';
 import Icon from '~shared/Icon';
 import { formatText } from '~utils/intl';
-import { AvatarProps } from '~shared/Avatar';
-import { NO_MAX } from '~shared/FileUpload/limits';
+import { Message } from '~types';
 
+import { DropzoneErrors, getErrorMessage } from './helpers';
 import UploadControls from './UploadControls';
 
 import styles from './AvatarUploader.css';
@@ -24,33 +24,7 @@ const MSG = defineMessages({
     id: `${displayName}.dropNow`,
     defaultMessage: 'Drop now!',
   },
-  fileCompressionError: {
-    id: `${displayName}.fileCompressionError`,
-    defaultMessage:
-      'File could not be uploaded and may be corrupted. Try again with a different file.',
-  },
-  fileSizeError: {
-    id: `${displayName}.fileSizeError`,
-    defaultMessage: 'File is too large. Try again with a smaller image',
-  },
-  fileTypeError: {
-    id: `${displayName}.fileTypeError`,
-    defaultMessage:
-      'Unsupported file type. Accepted file types are: svg, jpg, png and webp',
-  },
 });
-
-const getErrorMessage = (errorMessage: string) => {
-  if (errorMessage.includes('file-invalid-type')) {
-    return MSG.fileTypeError;
-  }
-
-  if (errorMessage.includes('exceeded the maximum')) {
-    return MSG.fileSizeError;
-  }
-
-  return MSG.fileCompressionError;
-};
 
 export interface Props
   extends Pick<SingleFileUploadProps, 'handleFileAccept' | 'handleFileReject'>,
@@ -65,13 +39,17 @@ export interface Props
   /** Avatar to be wrapped by File uploader */
   avatarPlaceholder: React.ReactElement;
   /** An error message */
-  error?: string;
+  errorCode?: DropzoneErrors;
+  /** An object in the format: { "message": string} for display a custom error message */
+  customError?: Record<'message', string>;
   /** Function to handle the removal of the avatar */
   handleFileRemove?: (...args: any[]) => Promise<any>;
   /** If true, will display loading spinner */
   isLoading?: boolean;
   /** Display choose / remove buttons beneath Avatar */
   showButtons?: boolean;
+  /** The touched flag can control the visibility of the status / error message (i.e. will be hidden if not touched) */
+  touched?: boolean;
 }
 
 const DropNowOverlay = () => (
@@ -81,7 +59,7 @@ const DropNowOverlay = () => (
 );
 
 interface FileErrorProps {
-  error: string;
+  error: Message;
 }
 
 const FileError = ({ error }: FileErrorProps) => (
@@ -103,7 +81,7 @@ const LoadingOverlay = () => (
 const getPlaceholder = (
   isLoading: boolean,
   avatarPlaceholder: Props['avatarPlaceholder'],
-  error?: string,
+  error?: Message,
 ) => {
   if (error) {
     return <FileError error={error} />;
@@ -126,7 +104,8 @@ const AvatarUploader = ({
   handleFileAccept,
   handleFileReject,
   handleFileRemove,
-  error,
+  errorCode,
+  customError,
   help,
   helpValues,
   isLoading = false,
@@ -135,8 +114,10 @@ const AvatarUploader = ({
   showButtons = true,
   status,
   statusValues,
+  touched,
 }: Props) => {
   const dropzoneRef = useRef<{ open: () => void }>();
+
   const open = () => {
     // will be null if dropzone is disabled
     if (typeof dropzoneRef.current?.open === 'function') {
@@ -169,7 +150,7 @@ const AvatarUploader = ({
         }}
         handleFileAccept={handleFileAccept}
         handleFileReject={handleFileReject}
-        placeholder={getPlaceholder(isLoading, avatarPlaceholder, error)}
+        placeholder={getPlaceholder(isLoading, avatarPlaceholder, errorCode)}
         ref={dropzoneRef}
         dataTest="avatarUploaderDrop"
       >
@@ -183,13 +164,15 @@ const AvatarUploader = ({
           open={open}
         />
       )}
-      {error && (
+      {errorCode && (
         <div className={styles.inputStatus}>
           <InputStatus
             appearance={appearance}
             status={status}
             statusValues={statusValues}
-            error={getErrorMessage(error)}
+            error={getErrorMessage(errorCode)}
+            errorValues={customError}
+            touched={touched ?? !!errorCode}
           />
         </div>
       )}

--- a/src/components/shared/AvatarUploader/AvatarUploader.tsx
+++ b/src/components/shared/AvatarUploader/AvatarUploader.tsx
@@ -120,7 +120,7 @@ const AvatarUploader = ({
   appearance,
   avatar,
   avatarPlaceholder,
-  disabled,
+  disabled = false,
   elementOnly,
   extra,
   handleFileAccept,
@@ -178,7 +178,8 @@ const AvatarUploader = ({
       {showButtons && (
         <UploadControls
           handleFileRemove={handleFileRemove}
-          disableRemove={!avatar}
+          disableRemove={!avatar || disabled}
+          disableChoose={disabled}
           open={open}
         />
       )}

--- a/src/components/shared/AvatarUploader/UploadControls.tsx
+++ b/src/components/shared/AvatarUploader/UploadControls.tsx
@@ -10,6 +10,7 @@ interface UploadControlsProps
   extends Pick<AvatarUploaderProps, 'handleFileRemove'> {
   open: () => void;
   disableRemove: boolean;
+  disableChoose?: boolean;
 }
 
 const displayName = 'AvatarUploader.UploadControls';
@@ -17,6 +18,7 @@ const displayName = 'AvatarUploader.UploadControls';
 const UploadControls = ({
   handleFileRemove,
   disableRemove,
+  disableChoose = false,
   open,
 }: UploadControlsProps) => (
   <div className={styles.buttonContainer}>
@@ -30,6 +32,7 @@ const UploadControls = ({
     <Button
       text={{ id: 'button.choose' }}
       onClick={open}
+      disabled={disableChoose}
       dataTest="avatarUploaderChoose"
     />
   </div>

--- a/src/components/shared/AvatarUploader/helpers.ts
+++ b/src/components/shared/AvatarUploader/helpers.ts
@@ -1,0 +1,62 @@
+import { defineMessages } from 'react-intl';
+
+const displayName = 'AvatarUploader';
+
+const MSG = defineMessages({
+  fileCompressionError: {
+    id: `${displayName}.fileCompressionError`,
+    defaultMessage:
+      'File could not be uploaded and may be corrupted. Try again with a different file.',
+  },
+  fileSizeError: {
+    id: `${displayName}.fileSizeError`,
+    defaultMessage: 'File is too large. Try again with a smaller image',
+  },
+  fileTypeError: {
+    id: `${displayName}.fileTypeError`,
+    defaultMessage:
+      'Unsupported file type. Accepted file types are: svg, jpg, png and webp',
+  },
+  customError: {
+    id: `${displayName}.customError`,
+    defaultMessage: '{message}',
+  },
+});
+
+/**
+ * Dropzone errors from the source code: https://github.com/react-dropzone/react-dropzone/blob/master/src/utils/index.js
+ * With the addition of "Custom" so that we can pass a custom error to the AvatarUploader component,
+ * And "Default" to use the default message defined in this file (fileCompressionError).
+ */
+export enum DropzoneErrors {
+  INVALID = 'file-invalid-type',
+  TOO_LARGE = 'file-too-large',
+  // TOO_SMALL = 'file-too-small', // wire in as needed
+  // TOO_MANY = 'too-many-files',
+  CUSTOM = 'custom-error',
+  DEFAULT = 'default',
+}
+/**
+ * For a common set of error messages you can expect from the Avatar Uploader.
+ * To pass a custom error message, don't extend this function. Instead, pass it directly to the
+ * the AvatarUploader component.
+ */
+export const getErrorMessage = (errorCode: DropzoneErrors) => {
+  switch (errorCode) {
+    case DropzoneErrors.INVALID: {
+      return MSG.fileTypeError;
+    }
+    case DropzoneErrors.TOO_LARGE: {
+      return MSG.fileSizeError;
+    }
+    case DropzoneErrors.CUSTOM: {
+      return MSG.customError;
+    }
+
+    /* Extend here with too-small and too-many as needed */
+
+    default: {
+      return MSG.fileCompressionError;
+    }
+  }
+};

--- a/src/components/shared/Fields/InputStatus/HookForm/InputStatus.tsx
+++ b/src/components/shared/Fields/InputStatus/HookForm/InputStatus.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { getMainClasses } from '~utils/css';
 import { formatText } from '~utils/intl';
 import { HookFormInputProps } from '~shared/Fields/Input/HookForm';
-import { Message } from '~types';
+import { UniversalMessageValues, Message } from '~types';
 
 import styles from '../InputStatus.css';
 
@@ -16,6 +16,9 @@ interface HookFormInputStatusProps
   /** Error text (if applicable) */
   error?: Message;
 
+  /** Error message vaulues (if applicable) */
+  errorValues?: UniversalMessageValues;
+
   /** Has input field been touched? */
   touched?: boolean;
 }
@@ -25,6 +28,7 @@ const displayName = 'HookFormInputStatus';
 const HookFormInputStatus = ({
   appearance = {},
   error,
+  errorValues,
   isLoading,
   loadingAnnotation = '',
   status,
@@ -32,7 +36,7 @@ const HookFormInputStatus = ({
   touched,
 }: HookFormInputStatusProps) => {
   const { formatMessage } = useIntl();
-  const errorText = formatText(error);
+  const errorText = formatText(error, errorValues);
   const statusText = formatText(status, statusValues);
   const loadingText = formatMessage(
     { id: 'status.loading' },

--- a/src/components/shared/FileUpload/limits.ts
+++ b/src/components/shared/FileUpload/limits.ts
@@ -7,6 +7,4 @@ export const DEFAULT_MIME_TYPES = {
 
 export const DEFAULT_MAX_FILE_SIZE = 1048576; // 1MB
 
-export const NO_MAX = Infinity;
-
 export const DEFAULT_MAX_FILE_LIMIT = 10;

--- a/src/redux/types/actions/motion.ts
+++ b/src/redux/types/actions/motion.ts
@@ -162,7 +162,7 @@ export type MotionActionTypes =
   | ErrorActionType<ActionTypes.MOTION_EDIT_COLONY_ERROR, object>
   | ActionTypeWithMeta<
       ActionTypes.MOTION_EDIT_COLONY_SUCCESS,
-      MetaWithHistory<object>
+      MetaWithNavigate<object>
     >
   | UniqueActionType<
       ActionTypes.MOTION_MOVE_FUNDS,


### PR DESCRIPTION
## Description

This PR wires up the colony edit form with motion components.

![colonyedit](https://github.com/JoinColony/colonyCDapp/assets/64402732/7d6db07d-1fd9-4fb3-8f54-dda6904979c9)

## Testing

Create a motion to edit your colony. Avatar / displayname should be updated upon finalizing the motion. Try removing the avatar as well.

Also note that finalizing a motion to change the avatar only won't affect the colony's display name, even if the display name changed after the motion was created (and vice versa). 

For dialog specs see #433

**Changes** 🏗

* Adding motion components to colony edit form.

Resolves #433
