### PR TITLE
Mitigate reveal state race condition (motions)

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/FinalizeMotion/FinalizeMotion.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/FinalizeMotion/FinalizeMotion.tsx
@@ -57,8 +57,11 @@ const FinalizeMotion = ({
   const { balances } = colony || {};
   const [isPolling, setIsPolling] = useState(false);
 
-  /* Stop polling if dismounted */
-  useEffect(() => stopPollingAction, [stopPollingAction]);
+  /* Stop polling when mounted / dismounted */
+  useEffect(() => {
+    stopPollingAction();
+    return stopPollingAction;
+  }, [stopPollingAction]);
 
   if (isPolling) {
     return (

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
@@ -127,8 +127,6 @@ const MotionPhaseWidget = ({
       );
     }
 
-    /* Extend with other widgets as they get ported. */
-
     default: {
       return null;
     }

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/RevealWidget/useRevealWidgetUpdate.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/RevealWidget/useRevealWidgetUpdate.ts
@@ -31,7 +31,5 @@ export const useRevealWidgetUpdate = (
     setPrevVote(vote);
   }
 
-  useEffect(() => stopPollingAction, [stopPollingAction]);
-
   return { hasUserVoted, vote, userVoteRevealed, setUserVoteRevealed };
 };

--- a/src/components/common/ColonyActions/ActionDetailsPage/useGetColonyAction.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/useGetColonyAction.ts
@@ -34,8 +34,13 @@ export const useGetColonyAction = (colony?: Colony | null) => {
   });
 
   useEffect(() => {
+    /* Cancel polling if our loader times out. */
     const cancelPollingTimer = setTimeout(stopPollingForAction, pollingTimeout);
-    return () => clearTimeout(cancelPollingTimer);
+    return () => {
+      clearTimeout(cancelPollingTimer);
+      /*  Stop polling if user leaves ActionDetailsPage */
+      stopPollingForAction();
+    };
   }, [stopPollingForAction]);
 
   const { state: locationState } = useLocation();

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -86,6 +86,18 @@ export const getMotionState = (
           return MotionState.Passed;
         }
 
+        if (
+          BigNumber.from(yayVotes).isZero() &&
+          BigNumber.from(nayVotes).isZero()
+        ) {
+          /*
+           * If the motion is finalizable, and we have voted, and the revealed votes haven't yet been populated to the db,
+           * we shouldn't display a passed/failed tag as we don't yet know the vote outcome.
+           * Instead, we show the previous stage's tag, until the vote outcome is updated in the db.
+           */
+          return MotionState.Reveal;
+        }
+
         return MotionState.Failed;
       }
 


### PR DESCRIPTION
## Description

Per #569, very occasionally the fetchMotionState lamda gets called after the motion state becomes finalizable, but before the revealed votes have been populated to the db. This was having the effect of the wrong vote outcome being shown.

I have mitigated this by checking that the votes are indeed present as we expect before adding messages to the motion message feed. 

The root cause is still not certain. I have not been able to reproduce at all. I thought it might be due to the refetch occuring in the motion timer, but @ArmandoGraterol has not been able to verify this. In any case, if it happens again now, the user will be able to reload the browser, which will fetch the latest data and display everything as expected. 

## Test

To test, just run through the motion lifecycle and confirm the reveal to finalize phase works as expected. 

**Changes** 🏗

* Add checks for revealed votes


Resolves #569
