### PR TITLE
Add `useUserByNameOrAddress` hook

### DIFF
--- a/src/components/common/UserProfile/UserProfile.tsx
+++ b/src/components/common/UserProfile/UserProfile.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 
 import ProfileTemplate from '~frame/ProfileTemplate';
 import NotFoundRoute from '~routes/NotFoundRoute';
-import { useUserByName } from '~hooks';
+import { useUserByNameOrAddress } from '~hooks';
 
 import UserMeta from './UserMeta';
 import UserProfileSpinner from './UserProfileSpinner';
@@ -15,7 +15,7 @@ const displayName = 'common.UserProfile';
 
 const UserProfile = () => {
   const { username } = useParams();
-  const { user, loading, error } = useUserByName(username || '');
+  const { user, loading, error } = useUserByNameOrAddress(username || '');
 
   if (loading) {
     return <UserProfileSpinner />;

--- a/src/components/common/UserProfile/UserProfile.tsx
+++ b/src/components/common/UserProfile/UserProfile.tsx
@@ -15,7 +15,7 @@ const displayName = 'common.UserProfile';
 
 const UserProfile = () => {
   const { username } = useParams();
-  const { user, loading, error } = useUserByNameOrAddress(username || '');
+  const { user, error, loading } = useUserByNameOrAddress(username || '');
 
   if (loading) {
     return <UserProfileSpinner />;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -60,6 +60,7 @@ export { default as useColonyContractVersion } from './useColonyContractVersion'
 export { default as useNetworkInverseFee } from './useNetworkInverseFee';
 export { default as useUserByAddress } from './useUserByAddress';
 export { default as useUserByName } from './useUserByName';
+export { default as useUserByNameOrAddress } from './useUserByNameOrAddress';
 
 /* Used in cases where we need to memoize the transformed output of any data.
  * Transform function has to be pure, obviously

--- a/src/hooks/useUserByNameOrAddress.ts
+++ b/src/hooks/useUserByNameOrAddress.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import { ApolloError } from '@apollo/client';
+
+import { Address, User } from '~types';
+import {
+  GetUserByAddressDocument,
+  GetUserByAddressQuery,
+  GetUserByAddressQueryVariables,
+  GetUserByNameDocument,
+  GetUserByNameQuery,
+  GetUserByNameQueryVariables,
+} from '~gql';
+import { isAddress } from '~utils/web3';
+import { getContext, ContextModule } from '~context';
+
+type UserResponse = {
+  user?: User | null;
+  loading: boolean;
+  error?: ApolloError;
+};
+
+const getUserByName = async (name: string): Promise<UserResponse> => {
+  const apolloClient = getContext(ContextModule.ApolloClient);
+  const { data, loading, error } = await apolloClient.query<
+    GetUserByNameQuery,
+    GetUserByNameQueryVariables
+  >({
+    query: GetUserByNameDocument,
+    variables: {
+      name,
+    },
+  });
+
+  const user = data.getUserByName?.items[0];
+  return { user, loading, error };
+};
+
+const getUserByAddress = async (address: Address): Promise<UserResponse> => {
+  const apolloClient = getContext(ContextModule.ApolloClient);
+  const { data, error, loading } = await apolloClient.query<
+    GetUserByAddressQuery,
+    GetUserByAddressQueryVariables
+  >({
+    query: GetUserByAddressDocument,
+    variables: {
+      address,
+    },
+  });
+
+  const user = data.getUserByAddress?.items[0];
+  return { user, loading, error };
+};
+
+/*
+ * Can't conditionally call the codegen query hooks so querying GraphQL directly
+ */
+const useUserByNameOrAddress = (username: string) => {
+  const [user, setUser] = useState<User | null | undefined>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<ApolloError | undefined>();
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const {
+        user: userData,
+        loading: loadingData,
+        error: errorData,
+      } = isAddress(username)
+        ? await getUserByAddress(username)
+        : await getUserByName(username);
+      setError(errorData);
+      setUser(userData);
+      setLoading(loadingData);
+    };
+
+    fetchUser();
+  }, [username]);
+
+  return { user, loading, error };
+};
+
+export default useUserByNameOrAddress;

--- a/src/hooks/useUserByNameOrAddress.ts
+++ b/src/hooks/useUserByNameOrAddress.ts
@@ -1,82 +1,47 @@
-import { useEffect, useState } from 'react';
-import { ApolloError } from '@apollo/client';
-
-import { Address, User } from '~types';
-import {
-  GetUserByAddressDocument,
-  GetUserByAddressQuery,
-  GetUserByAddressQueryVariables,
-  GetUserByNameDocument,
-  GetUserByNameQuery,
-  GetUserByNameQueryVariables,
-} from '~gql';
-import { isAddress } from '~utils/web3';
-import { getContext, ContextModule } from '~context';
-
-type UserResponse = {
-  user?: User | null;
-  loading: boolean;
-  error?: ApolloError;
-};
-
-const getUserByName = async (name: string): Promise<UserResponse> => {
-  const apolloClient = getContext(ContextModule.ApolloClient);
-  const { data, loading, error } = await apolloClient.query<
-    GetUserByNameQuery,
-    GetUserByNameQueryVariables
-  >({
-    query: GetUserByNameDocument,
-    variables: {
-      name,
-    },
-  });
-
-  const user = data.getUserByName?.items[0];
-  return { user, loading, error };
-};
-
-const getUserByAddress = async (address: Address): Promise<UserResponse> => {
-  const apolloClient = getContext(ContextModule.ApolloClient);
-  const { data, error, loading } = await apolloClient.query<
-    GetUserByAddressQuery,
-    GetUserByAddressQueryVariables
-  >({
-    query: GetUserByAddressDocument,
-    variables: {
-      address,
-    },
-  });
-
-  const user = data.getUserByAddress?.items[0];
-  return { user, loading, error };
-};
+import { useGetUserByNameQuery, useGetUserByAddressQuery } from '~gql';
+import { isAddress as isAddressFunction } from '~utils/web3';
 
 /*
  * Can't conditionally call the codegen query hooks so querying GraphQL directly
  */
 const useUserByNameOrAddress = (username: string) => {
-  const [user, setUser] = useState<User | null | undefined>();
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<ApolloError | undefined>();
+  const isAddress = isAddressFunction(username);
 
-  useEffect(() => {
-    const fetchUser = async () => {
-      const {
-        user: userData,
-        loading: loadingData,
-        error: errorData,
-      } = isAddress(username)
-        ? await getUserByAddress(username)
-        : await getUserByName(username);
-      setError(errorData);
-      setUser(userData);
-      setLoading(loadingData);
-    };
+  const {
+    data: userData,
+    error: userError,
+    loading: userLoading,
+  } = useGetUserByNameQuery({
+    variables: {
+      name: username,
+    },
+    fetchPolicy: 'cache-and-network',
+    skip: isAddress,
+  });
 
-    fetchUser();
-  }, [username]);
+  const {
+    data: addressData,
+    error: addressError,
+    loading: addressLoading,
+  } = useGetUserByAddressQuery({
+    variables: {
+      address: username,
+    },
+    fetchPolicy: 'cache-and-network',
+    skip: !isAddress,
+  });
 
-  return { user, loading, error };
+  return isAddress
+    ? {
+        user: addressData?.getUserByAddress?.items[0],
+        error: addressError,
+        loading: addressLoading,
+      }
+    : {
+        user: userData?.getUserByName?.items[0],
+        error: userError,
+        loading: userLoading,
+      };
 };
 
 export default useUserByNameOrAddress;

--- a/src/hooks/useUserByNameOrAddress.ts
+++ b/src/hooks/useUserByNameOrAddress.ts
@@ -4,8 +4,8 @@ import { isAddress as isAddressFunction } from '~utils/web3';
 /*
  * Can't conditionally call the codegen query hooks so querying GraphQL directly
  */
-const useUserByNameOrAddress = (username: string) => {
-  const isAddress = isAddressFunction(username);
+const useUserByNameOrAddress = (userIdentifier: string) => {
+  const isAddress = isAddressFunction(userIdentifier);
 
   const {
     data: userData,
@@ -13,7 +13,7 @@ const useUserByNameOrAddress = (username: string) => {
     loading: userLoading,
   } = useGetUserByNameQuery({
     variables: {
-      name: username,
+      name: userIdentifier,
     },
     fetchPolicy: 'cache-and-network',
     skip: isAddress,
@@ -25,7 +25,7 @@ const useUserByNameOrAddress = (username: string) => {
     loading: addressLoading,
   } = useGetUserByAddressQuery({
     variables: {
-      address: username,
+      address: userIdentifier,
     },
     fetchPolicy: 'cache-and-network',
     skip: !isAddress,


### PR DESCRIPTION
## Description

* Adds userUserByNameOrAddress hook that only makes one query depending if the input is a username or an address

## Testing

Make sure a user can be loaded by both username or address in the route:

`/user/0x9dF24e73f40b2a911Eb254A8825103723E13209C`
`/user/a`

Resolves #512
