### PR TITLE
Set extension permissions on initialisation

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -151,6 +151,6 @@ export const ADDRESS_ZERO = ethersContants.AddressZero;
 
 export const GANACHE_LOCAL_RPC_URL = 'http://localhost:8545';
 
-export const isDev = process.env.NODE_ENV === 'development';
+export const isDev = process.env.NETWORK === 'ganache';
 
 export const STAKING_THRESHOLD = 10;

--- a/src/redux/sagas/extensions/extensionEnable.ts
+++ b/src/redux/sagas/extensions/extensionEnable.ts
@@ -1,7 +1,9 @@
 import { all, call, put, takeEvery } from 'redux-saga/effects';
 import { ClientType, Id } from '@colony/colony-js';
 
+import { isDev } from '~constants';
 import { intArrayToBytes32 } from '~utils/web3';
+
 import { ActionTypes } from '../../actionTypes';
 import { Action } from '../../types/actions';
 import { createGroupTransaction, getTxChannel } from '../transactions';
@@ -14,7 +16,6 @@ import {
   setupEnablingGroupTransactions,
   takeFrom,
 } from '../utils';
-import { isDev } from '~constants';
 
 function* extensionEnable({
   meta,

--- a/src/redux/types/actions/colony.ts
+++ b/src/redux/types/actions/colony.ts
@@ -1,5 +1,10 @@
 import { ActionTypes } from '~redux';
-import { Address, InstallableExtensionData, WithKey } from '~types';
+import {
+  Address,
+  InstallableExtensionData,
+  InstalledExtensionData,
+  WithKey,
+} from '~types';
 import { ActionType, ErrorActionType, UniqueActionType } from './index';
 
 export type ColonyActionTypes =
@@ -41,7 +46,14 @@ export type ColonyActionTypes =
     >
   | UniqueActionType<ActionTypes.EXTENSION_INSTALL_SUCCESS, object, object>
   | ErrorActionType<ActionTypes.EXTENSION_INSTALL_ERROR, object>
-  | UniqueActionType<ActionTypes.EXTENSION_ENABLE, any, WithKey>
+  | UniqueActionType<
+      ActionTypes.EXTENSION_ENABLE,
+      {
+        colonyAddress: Address;
+        extensionData: InstalledExtensionData;
+      },
+      WithKey
+    >
   | UniqueActionType<ActionTypes.EXTENSION_ENABLE_SUCCESS, object, object>
   | ErrorActionType<ActionTypes.EXTENSION_ENABLE_ERROR, object>
   | UniqueActionType<


### PR DESCRIPTION
## Description

This pr adds the logic to set extension permissions when an extension is enabled.

**Changes** 🏗

* Add permissions logic to enable extn saga


## Testing

1. Create a colony.
2. Install the voting rep extension. Ensure the rep extn address is picked up in the extension details widget (you will need to refresh the browser). (@jakubcolony We need to fix this before launching to production, since we can't expect users to know to refresh the browser after installing the extension. If you don't, the wrong extension address ("0x000...") gets passed to the block ingestor.)

3. Enable the voting rep extension. All permissions should be enabled, and thus you should be able to freely create, stake, and finalize motions.

Resolves #619
