### PR TITLE
Add filtering for 0 staking reward

### DIFF
--- a/amplify/backend/function/fetchMotionState/src/utils.js
+++ b/amplify/backend/function/fetchMotionState/src/utils.js
@@ -10,8 +10,6 @@ const {
   getColonyMotion,
   updateColonyMotion,
   createMotionMessage,
-  getColonyAction,
-  updateColonyAction,
   getColony,
   updateColony,
 } = require('./graphql.js');
@@ -194,9 +192,11 @@ const updateColonyUnclaimedStakes = async (
     ({ motionId }) => motionId === databaseMotionId,
   );
 
-  const unclaimedRewards = updatedStakerRewards.filter(
-    ({ isClaimed }) => !isClaimed,
-  );
+  const unclaimedRewards = updatedStakerRewards
+    .filter(({ isClaimed }) => !isClaimed)
+    .filter(
+      (stakerReward) => stakerReward.yay !== '0' || stakerReward.nay !== '0',
+    );
 
   if (!motionWithUnclaimedStake && unclaimedRewards.length) {
     motionsWithUnclaimedStakes.push({
@@ -224,7 +224,7 @@ const updateStakerRewardsInDB = async (colonyAddress, motionData) => {
 
   const updatedStakerRewards = await Promise.all(
     // For every user who staked
-    usersStakes.map(async ({ address: stakerAddress }) => {
+    usersStakes.map(({ address: stakerAddress }) => {
       // Check if they have already had their reward calculated
       const existingStakerReward = stakerRewards.find(
         ({ address }) => address === stakerAddress,

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=cd6cca3dd0133e9aaf026881d54d71e6fcfebc75
+ENV BLOCK_INGESTOR_HASH=619deb43a605d54806e3abecdeb70aa373a51d24
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=045580cd9c3306a3d75c5bbb5ad6492badd71548
+ENV BLOCK_INGESTOR_HASH=004e55b5ba9605f9fd3ff9b6e2aa61f73248d671
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=004e55b5ba9605f9fd3ff9b6e2aa61f73248d671
+ENV BLOCK_INGESTOR_HASH=cd6cca3dd0133e9aaf026881d54d71e6fcfebc75
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]


### PR DESCRIPTION
Fixed 0 staking rewards appearing in the stakes tab of the token activation popover.

To reproduce just enable the extension with a 50% voting reward, fully stake 1 side, lose with that same side, and then when you finalize the motion the reward should be 0 and no new claims should appear in the stake tab.

Block ingestor counterpart: https://github.com/JoinColony/block-ingestor/pull/85

Resolves #614 
