### PR TITLE
Replace link history if traveling between transactions

### DIFF
--- a/src/components/frame/TokenActivation/StakesTab/StakesListItem.tsx
+++ b/src/components/frame/TokenActivation/StakesTab/StakesListItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
+import { useLocation } from 'react-router-dom';
 
 import Link from '~shared/Link';
 import Numeral from '~shared/Numeral';
@@ -38,9 +39,15 @@ const StakesListItem = ({
   });
 
   const txHash = data?.getColonyActionByMotionId?.items[0]?.id ?? '';
+  const location = useLocation();
+  const replace = location.pathname.indexOf('/tx') !== -1;
+
   return (
     <li className={styles.stakesListItem}>
-      <Link to={txHash ? `/colony/${colonyName}/tx/${txHash}` : ''}>
+      <Link
+        replace={replace}
+        to={txHash ? `/colony/${colonyName}/tx/${txHash}` : ''}
+      >
         <div
           role="button"
           onClick={() => setIsOpen(false)}

--- a/src/components/frame/TokenActivation/StakesTab/StakesListItem.tsx
+++ b/src/components/frame/TokenActivation/StakesTab/StakesListItem.tsx
@@ -40,12 +40,12 @@ const StakesListItem = ({
 
   const txHash = data?.getColonyActionByMotionId?.items[0]?.id ?? '';
   const location = useLocation();
-  const replace = location.pathname.indexOf('/tx') !== -1;
+  const isMotionPage = location.pathname.indexOf('/tx') !== -1;
 
   return (
     <li className={styles.stakesListItem}>
       <Link
-        replace={replace}
+        replace={isMotionPage}
         to={txHash ? `/colony/${colonyName}/tx/${txHash}` : ''}
       >
         <div


### PR DESCRIPTION
## Description

This solves the issue that when linking from one motion to the next using go to motion from the stakes tab, each motion is added to the history stack and the back button goes back to the previous motion.

if linking to a motion when already on a motion, the history stack will be replaced instead of pushed and now the back button will go to the previous location in the stack before navigating between motions.

Resolves #602
