### PR TITLE
Update useClaimWidgetConfig to hide claim widget on motion failed

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/ClaimMotionStakes.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/ClaimMotionStakes.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import DetailItem from '~shared/DetailsWidget/DetailItem';
 import { ColonyMotion } from '~types';
 import { RefetchAction } from '~common/ColonyActions/ActionDetailsPage/useGetColonyAction';
+import { isEmpty } from '~utils/lodash';
 
 import useClaimWidgetConfig from './useClaimWidgetConfig';
 import styles from './ClaimMotionStakes.css';
@@ -28,6 +29,10 @@ const ClaimMotionStakes = ({
     refetchAction,
     styles,
   );
+
+  if (isEmpty(config)) {
+    return null;
+  }
 
   return (
     <div>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/useClaimWidgetConfig.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/useClaimWidgetConfig.tsx
@@ -5,7 +5,7 @@ import { useLocation } from 'react-router-dom';
 import Numeral from '~shared/Numeral';
 import { intl } from '~utils/intl';
 import { ClaimMotionRewardsPayload } from '~redux/sagas/motions/claimMotionRewards';
-import Button, { ActionButton } from '~shared/Button';
+import { ActionButton } from '~shared/Button';
 import { ActionTypes } from '~redux';
 import { useAppContext, useColonyContext } from '~hooks';
 import { DetailItemProps } from '~shared/DetailsWidget';
@@ -69,19 +69,7 @@ const useClaimWidgetConfig = (
     }
   }, [user, stakerReward]);
 
-  const claimItem = {
-    label: formatMessage({ id: 'label.claim' }),
-    labelStyles: styles.claimLabel,
-    item: (
-      <Button
-        appearance={{ theme: 'primary', size: 'medium' }}
-        text={{ id: 'button.claim' }}
-        disabled
-      />
-    ),
-  };
-
-  const config: DetailItemProps[] = [claimItem];
+  const config: DetailItemProps[] = [];
 
   // Return basic view if we have insufficient data
   if (!userStake || !stakerReward || !userAddress || !colonyAddress) {
@@ -121,17 +109,21 @@ const useClaimWidgetConfig = (
     transactionHash: getTransactionHashFromPathName(location.pathname),
   } as ClaimMotionRewardsPayload;
 
-  claimItem.item = (
-    <ActionButton
-      actionType={ActionTypes.MOTION_CLAIM}
-      values={claimPayload}
-      appearance={{ theme: 'primary', size: 'medium' }}
-      text={{ id: buttonTextId }}
-      disabled={!canClaimStakes}
-      dataTest="claimStakeButton"
-      onSuccess={handleClaimSuccess}
-    />
-  );
+  const claimItem = {
+    label: formatMessage({ id: 'label.claim' }),
+    labelStyles: styles.claimLabel,
+    item: (
+      <ActionButton
+        actionType={ActionTypes.MOTION_CLAIM}
+        values={claimPayload}
+        appearance={{ theme: 'primary', size: 'medium' }}
+        text={{ id: buttonTextId }}
+        disabled={!canClaimStakes}
+        dataTest="claimStakeButton"
+        onSuccess={handleClaimSuccess}
+      />
+    ),
+  };
 
   const stakeItem = {
     label: formatMessage({ id: 'label.stake' }),
@@ -168,7 +160,7 @@ const useClaimWidgetConfig = (
     ),
   };
 
-  config.push(stakeItem, winningsItem, totalItem);
+  config.push(claimItem, stakeItem, winningsItem, totalItem);
 
   return config;
 };

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/useClaimWidgetConfig.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/useClaimWidgetConfig.tsx
@@ -71,7 +71,7 @@ const useClaimWidgetConfig = (
 
   const config: DetailItemProps[] = [];
 
-  // Return basic view if we have insufficient data
+  // @NOTE: Hide details widget if we have insufficient data
   if (!userStake || !stakerReward || !userAddress || !colonyAddress) {
     return config;
   }


### PR DESCRIPTION
Hide the claim widget when the motion fails without staking or voting as there would be nothing to claim, so to test just create a motion and let the timer run out.

![FireShot Capture 065 - Colony CDapp - localhost](https://github.com/JoinColony/colonyCDapp/assets/18473896/187978e3-5995-4228-9e61-6ce676b342f4)

Resolves #603 
