### PR TITLE
Update Create Domain action payload

### DIFF
--- a/src/components/common/Dialogs/CreateDomainDialog/helpers.ts
+++ b/src/components/common/Dialogs/CreateDomainDialog/helpers.ts
@@ -4,5 +4,6 @@ export const getCreateDomainDialogPayload = (colony: Colony, payload) => ({
   ...payload,
   domainName: payload.teamName,
   isCreateDomain: true,
-  colony,
+  colonyAddress: colony.colonyAddress,
+  colonyName: colony.name,
 });

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -646,6 +646,11 @@ export type CreateDomainMetadataInput = {
   name: Scalars['String'];
 };
 
+export type CreateIngestorStatsInput = {
+  id?: InputMaybe<Scalars['ID']>;
+  value: Scalars['String'];
+};
+
 export type CreateMotionMessageInput = {
   amount?: InputMaybe<Scalars['String']>;
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
@@ -785,6 +790,10 @@ export type DeleteDomainInput = {
 };
 
 export type DeleteDomainMetadataInput = {
+  id: Scalars['ID'];
+};
+
+export type DeleteIngestorStatsInput = {
   id: Scalars['ID'];
 };
 
@@ -952,6 +961,14 @@ export type GetVoterRewardsInput = {
   nativeMotionDomainId: Scalars['String'];
   rootHash: Scalars['String'];
   voterAddress: Scalars['String'];
+};
+
+export type IngestorStats = {
+  __typename?: 'IngestorStats';
+  createdAt: Scalars['AWSDateTime'];
+  id: Scalars['ID'];
+  updatedAt: Scalars['AWSDateTime'];
+  value: Scalars['String'];
 };
 
 export type MembersForColonyInput = {
@@ -1490,6 +1507,27 @@ export type ModelIdInput = {
   size?: InputMaybe<ModelSizeInput>;
 };
 
+export type ModelIngestorStatsConditionInput = {
+  and?: InputMaybe<Array<InputMaybe<ModelIngestorStatsConditionInput>>>;
+  not?: InputMaybe<ModelIngestorStatsConditionInput>;
+  or?: InputMaybe<Array<InputMaybe<ModelIngestorStatsConditionInput>>>;
+  value?: InputMaybe<ModelStringInput>;
+};
+
+export type ModelIngestorStatsConnection = {
+  __typename?: 'ModelIngestorStatsConnection';
+  items: Array<Maybe<IngestorStats>>;
+  nextToken?: Maybe<Scalars['String']>;
+};
+
+export type ModelIngestorStatsFilterInput = {
+  and?: InputMaybe<Array<InputMaybe<ModelIngestorStatsFilterInput>>>;
+  id?: InputMaybe<ModelIdInput>;
+  not?: InputMaybe<ModelIngestorStatsFilterInput>;
+  or?: InputMaybe<Array<InputMaybe<ModelIngestorStatsFilterInput>>>;
+  value?: InputMaybe<ModelStringInput>;
+};
+
 export type ModelIntInput = {
   attributeExists?: InputMaybe<Scalars['Boolean']>;
   attributeType?: InputMaybe<ModelAttributeTypes>;
@@ -1812,6 +1850,13 @@ export type ModelSubscriptionIdInput = {
   notIn?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
 };
 
+export type ModelSubscriptionIngestorStatsFilterInput = {
+  and?: InputMaybe<Array<InputMaybe<ModelSubscriptionIngestorStatsFilterInput>>>;
+  id?: InputMaybe<ModelSubscriptionIdInput>;
+  or?: InputMaybe<Array<InputMaybe<ModelSubscriptionIngestorStatsFilterInput>>>;
+  value?: InputMaybe<ModelSubscriptionStringInput>;
+};
+
 export type ModelSubscriptionIntInput = {
   between?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
   eq?: InputMaybe<Scalars['Int']>;
@@ -2085,6 +2130,7 @@ export type Mutation = {
   createCurrentVersion?: Maybe<CurrentVersion>;
   createDomain?: Maybe<Domain>;
   createDomainMetadata?: Maybe<DomainMetadata>;
+  createIngestorStats?: Maybe<IngestorStats>;
   createMotionMessage?: Maybe<MotionMessage>;
   createProfile?: Maybe<Profile>;
   createToken?: Maybe<Token>;
@@ -2107,6 +2153,7 @@ export type Mutation = {
   deleteCurrentVersion?: Maybe<CurrentVersion>;
   deleteDomain?: Maybe<Domain>;
   deleteDomainMetadata?: Maybe<DomainMetadata>;
+  deleteIngestorStats?: Maybe<IngestorStats>;
   deleteMotionMessage?: Maybe<MotionMessage>;
   deleteProfile?: Maybe<Profile>;
   deleteToken?: Maybe<Token>;
@@ -2129,6 +2176,7 @@ export type Mutation = {
   updateDomain?: Maybe<Domain>;
   updateDomainMetadata?: Maybe<DomainMetadata>;
   updateExtensionByColonyAndHash?: Maybe<ColonyExtension>;
+  updateIngestorStats?: Maybe<IngestorStats>;
   updateMotionMessage?: Maybe<MotionMessage>;
   updateProfile?: Maybe<Profile>;
   updateToken?: Maybe<Token>;
@@ -2219,6 +2267,12 @@ export type MutationCreateDomainArgs = {
 export type MutationCreateDomainMetadataArgs = {
   condition?: InputMaybe<ModelDomainMetadataConditionInput>;
   input: CreateDomainMetadataInput;
+};
+
+
+export type MutationCreateIngestorStatsArgs = {
+  condition?: InputMaybe<ModelIngestorStatsConditionInput>;
+  input: CreateIngestorStatsInput;
 };
 
 
@@ -2352,6 +2406,12 @@ export type MutationDeleteDomainMetadataArgs = {
 };
 
 
+export type MutationDeleteIngestorStatsArgs = {
+  condition?: InputMaybe<ModelIngestorStatsConditionInput>;
+  input: DeleteIngestorStatsInput;
+};
+
+
 export type MutationDeleteMotionMessageArgs = {
   condition?: InputMaybe<ModelMotionMessageConditionInput>;
   input: DeleteMotionMessageInput;
@@ -2482,6 +2542,12 @@ export type MutationUpdateExtensionByColonyAndHashArgs = {
 };
 
 
+export type MutationUpdateIngestorStatsArgs = {
+  condition?: InputMaybe<ModelIngestorStatsConditionInput>;
+  input: UpdateIngestorStatsInput;
+};
+
+
 export type MutationUpdateMotionMessageArgs = {
   condition?: InputMaybe<ModelMotionMessageConditionInput>;
   input: UpdateMotionMessageInput;
@@ -2609,6 +2675,7 @@ export type Query = {
   getDomain?: Maybe<Domain>;
   getDomainMetadata?: Maybe<DomainMetadata>;
   getExtensionByColonyAndHash?: Maybe<ModelColonyExtensionConnection>;
+  getIngestorStats?: Maybe<IngestorStats>;
   getMembersForColony?: Maybe<MembersForColonyReturn>;
   getMotionMessage?: Maybe<MotionMessage>;
   getMotionMessageByMotionId?: Maybe<ModelMotionMessageConnection>;
@@ -2643,6 +2710,7 @@ export type Query = {
   listCurrentVersions?: Maybe<ModelCurrentVersionConnection>;
   listDomainMetadata?: Maybe<ModelDomainMetadataConnection>;
   listDomains?: Maybe<ModelDomainConnection>;
+  listIngestorStats?: Maybe<ModelIngestorStatsConnection>;
   listMotionMessages?: Maybe<ModelMotionMessageConnection>;
   listProfiles?: Maybe<ModelProfileConnection>;
   listTokens?: Maybe<ModelTokenConnection>;
@@ -2794,6 +2862,11 @@ export type QueryGetExtensionByColonyAndHashArgs = {
   limit?: InputMaybe<Scalars['Int']>;
   nextToken?: InputMaybe<Scalars['String']>;
   sortDirection?: InputMaybe<ModelSortDirection>;
+};
+
+
+export type QueryGetIngestorStatsArgs = {
+  id: Scalars['ID'];
 };
 
 
@@ -3020,6 +3093,13 @@ export type QueryListDomainsArgs = {
 };
 
 
+export type QueryListIngestorStatsArgs = {
+  filter?: InputMaybe<ModelIngestorStatsFilterInput>;
+  limit?: InputMaybe<Scalars['Int']>;
+  nextToken?: InputMaybe<Scalars['String']>;
+};
+
+
 export type QueryListMotionMessagesArgs = {
   filter?: InputMaybe<ModelMotionMessageFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3102,6 +3182,7 @@ export type Subscription = {
   onCreateCurrentVersion?: Maybe<CurrentVersion>;
   onCreateDomain?: Maybe<Domain>;
   onCreateDomainMetadata?: Maybe<DomainMetadata>;
+  onCreateIngestorStats?: Maybe<IngestorStats>;
   onCreateMotionMessage?: Maybe<MotionMessage>;
   onCreateProfile?: Maybe<Profile>;
   onCreateToken?: Maybe<Token>;
@@ -3122,6 +3203,7 @@ export type Subscription = {
   onDeleteCurrentVersion?: Maybe<CurrentVersion>;
   onDeleteDomain?: Maybe<Domain>;
   onDeleteDomainMetadata?: Maybe<DomainMetadata>;
+  onDeleteIngestorStats?: Maybe<IngestorStats>;
   onDeleteMotionMessage?: Maybe<MotionMessage>;
   onDeleteProfile?: Maybe<Profile>;
   onDeleteToken?: Maybe<Token>;
@@ -3142,6 +3224,7 @@ export type Subscription = {
   onUpdateCurrentVersion?: Maybe<CurrentVersion>;
   onUpdateDomain?: Maybe<Domain>;
   onUpdateDomainMetadata?: Maybe<DomainMetadata>;
+  onUpdateIngestorStats?: Maybe<IngestorStats>;
   onUpdateMotionMessage?: Maybe<MotionMessage>;
   onUpdateProfile?: Maybe<Profile>;
   onUpdateToken?: Maybe<Token>;
@@ -3218,6 +3301,11 @@ export type SubscriptionOnCreateDomainArgs = {
 
 export type SubscriptionOnCreateDomainMetadataArgs = {
   filter?: InputMaybe<ModelSubscriptionDomainMetadataFilterInput>;
+};
+
+
+export type SubscriptionOnCreateIngestorStatsArgs = {
+  filter?: InputMaybe<ModelSubscriptionIngestorStatsFilterInput>;
 };
 
 
@@ -3321,6 +3409,11 @@ export type SubscriptionOnDeleteDomainMetadataArgs = {
 };
 
 
+export type SubscriptionOnDeleteIngestorStatsArgs = {
+  filter?: InputMaybe<ModelSubscriptionIngestorStatsFilterInput>;
+};
+
+
 export type SubscriptionOnDeleteMotionMessageArgs = {
   filter?: InputMaybe<ModelSubscriptionMotionMessageFilterInput>;
 };
@@ -3418,6 +3511,11 @@ export type SubscriptionOnUpdateDomainArgs = {
 
 export type SubscriptionOnUpdateDomainMetadataArgs = {
   filter?: InputMaybe<ModelSubscriptionDomainMetadataFilterInput>;
+};
+
+
+export type SubscriptionOnUpdateIngestorStatsArgs = {
+  filter?: InputMaybe<ModelSubscriptionIngestorStatsFilterInput>;
 };
 
 
@@ -3680,6 +3778,11 @@ export type UpdateExtensionByColonyAndHashInput = {
   isDeprecated?: InputMaybe<Scalars['Boolean']>;
   isInitialized?: InputMaybe<Scalars['Boolean']>;
   version?: InputMaybe<Scalars['Int']>;
+};
+
+export type UpdateIngestorStatsInput = {
+  id: Scalars['ID'];
+  value?: InputMaybe<Scalars['String']>;
 };
 
 export type UpdateMotionMessageInput = {

--- a/src/redux/sagas/actions/createDomain.ts
+++ b/src/redux/sagas/actions/createDomain.ts
@@ -25,7 +25,8 @@ import { putError, takeFrom } from '../utils';
 
 function* createDomainAction({
   payload: {
-    colony,
+    colonyAddress,
+    colonyName,
     domainName,
     domainColor,
     domainPurpose,
@@ -60,7 +61,7 @@ function* createDomainAction({
     yield createGroupTransaction(createDomain, batchKey, meta, {
       context: ClientType.ColonyClient,
       methodName: 'addDomainWithProofs(uint256)',
-      identifier: colony.colonyAddress,
+      identifier: colonyAddress,
       params: [],
       ready: false,
     });
@@ -106,7 +107,7 @@ function* createDomainAction({
       mutation: CreateDomainMetadataDocument,
       variables: {
         input: {
-          id: getDomainDatabaseId(colony.colonyAddress, nativeDomainId),
+          id: getDomainDatabaseId(colonyAddress, nativeDomainId),
           name: domainName,
           color: domainColor,
           description: domainPurpose,
@@ -157,7 +158,7 @@ function* createDomainAction({
     });
 
     if (navigate) {
-      navigate(`/colony/${colony.name}/tx/${transactionHash}`, {
+      navigate(`/colony/${colonyName}/tx/${transactionHash}`, {
         state: { isRedirect: true },
       });
     }

--- a/src/redux/types/actions/colonyActions.ts
+++ b/src/redux/types/actions/colonyActions.ts
@@ -21,12 +21,13 @@ export type ColonyActionsActionTypes =
   | UniqueActionType<
       ActionTypes.ACTION_DOMAIN_CREATE,
       {
+        colonyAddress: Address;
+        colonyName: string;
         domainName: string;
         domainColor: DomainColor;
         domainPurpose: string;
         annotationMessage?: string;
         parentId?: number;
-        colony: Colony;
       },
       MetaWithNavigate<object>
     >


### PR DESCRIPTION
Fixed the create domain payload having a different structure than the one we use in the edit domain saga and create/edit domain motion saga.

You should be able to create "create/edit domain" actions and motions without problems.

Resolves #647 
