### PR TITLE
Add @index to extension hash field

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -655,7 +655,7 @@ type ColonyExtension @model {
       queryField: "getExtensionByColonyAndHash"
     )
   colony: Colony! @belongsTo(fields: ["colonyId"])
-  hash: String!
+  hash: String! @index(name: "byHash", queryField: "getExtensionsByHash")
   installedBy: String!
   installedAt: AWSTimestamp!
   isDeprecated: Boolean!

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -2675,6 +2675,7 @@ export type Query = {
   getDomain?: Maybe<Domain>;
   getDomainMetadata?: Maybe<DomainMetadata>;
   getExtensionByColonyAndHash?: Maybe<ModelColonyExtensionConnection>;
+  getExtensionsByHash?: Maybe<ModelColonyExtensionConnection>;
   getIngestorStats?: Maybe<IngestorStats>;
   getMembersForColony?: Maybe<MembersForColonyReturn>;
   getMotionMessage?: Maybe<MotionMessage>;
@@ -2859,6 +2860,15 @@ export type QueryGetExtensionByColonyAndHashArgs = {
   colonyId: Scalars['ID'];
   filter?: InputMaybe<ModelColonyExtensionFilterInput>;
   hash?: InputMaybe<ModelStringKeyConditionInput>;
+  limit?: InputMaybe<Scalars['Int']>;
+  nextToken?: InputMaybe<Scalars['String']>;
+  sortDirection?: InputMaybe<ModelSortDirection>;
+};
+
+
+export type QueryGetExtensionsByHashArgs = {
+  filter?: InputMaybe<ModelColonyExtensionFilterInput>;
+  hash: Scalars['String'];
   limit?: InputMaybe<Scalars['Int']>;
   nextToken?: InputMaybe<Scalars['String']>;
   sortDirection?: InputMaybe<ModelSortDirection>;


### PR DESCRIPTION
## Description

In block-ingestor#88, there's a need for fetching extensions by their hash and in such scenarios @index should help speed things up.