### PR TITLE
Update error message display conditional on staking slider

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSlider.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSlider.tsx
@@ -39,7 +39,8 @@ const StakingSlider = ({
     userMaxStake,
   } = useStakingSlider(isObjection);
 
-  const displayErrMsg = !!user && !isLoadingData && remainingToStake !== '0';
+  const displayErrMsg =
+    !!user && !isLoadingData && totalPercentageStaked !== 200;
   const displayLabel = displayErrMsg && enoughReputationToStakeMinimum;
 
   return (

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderLabel.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderLabel.tsx
@@ -65,7 +65,7 @@ const StakingSliderLabel = ({
           symbol={nativeTokenSymbol}
         />
       )}
-      {remainingToStake !== '0' && (
+      {enoughTokensToStakeMinimum && remainingToStake !== '0' && (
         <RequiredStakeMessage {...requiredStakeMessageProps} />
       )}
     </Tooltip>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderLabel.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderLabel.tsx
@@ -42,6 +42,7 @@ const StakingSliderLabel = ({
     userMinStake,
     nativeTokenDecimals,
     nativeTokenSymbol,
+    remainingToStake,
   },
   requiredStakeMessageProps,
   enoughTokensToStakeMinimum,
@@ -57,13 +58,14 @@ const StakingSliderLabel = ({
       placement="top"
       popperOptions={tooltipOptions}
     >
-      {!enoughTokensToStakeMinimum ? (
+      {!enoughTokensToStakeMinimum && (
         <MinimumStakeMessage
           userMinStake={userMinStake}
           decimals={nativeTokenDecimals}
           symbol={nativeTokenSymbol}
         />
-      ) : (
+      )}
+      {remainingToStake !== '0' && (
         <RequiredStakeMessage {...requiredStakeMessageProps} />
       )}
     </Tooltip>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/StakingValidationMessage.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/StakingValidationMessage.tsx
@@ -81,7 +81,7 @@ const StakingValidationMessage = ({
 
   const canStakeMore = userCanStakeMore(userMinStake, remainingToStake);
 
-  if (!canStakeMore) {
+  if (!canStakeMore && remainingToStake !== '0') {
     errorType = StakingValidationErrors.CantStakeMore;
   } else if (userNeedsMoreReputation) {
     errorType = StakingValidationErrors.MoreRepNeeded;


### PR DESCRIPTION
The error messages in the staking slider should work as always but now this shouldn't be reproducible:

```
Have two users. User 2 has 0 activated tokens.

User 1 stakes a motion 100%.
Then, switch to User 2.
The staking widget input is correctly disabled, but, there's no message to inform the user to activate their tokens.
```

Resolves #601 
