### PR TITLE
Fix: set minimum stake percentage to 1%

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=f7a6be295eca43b96395ecd2a8ebdde057ce72dd
+ENV BLOCK_INGESTOR_HASH=a778cf988ff43f4ecf6e707f2ebe4d5dfeaf4551
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]


### PR DESCRIPTION
## Description

Make sure the minimum user stake is always displayed as 1%

Block ingestor PR counterpart: https://github.com/JoinColony/block-ingestor/pull/91

Test:

Stake and object a motion with the minimum possible stake and make sure the percentage is 1% instead of 0% every place the user stake is displayed in the UI.

<img width="330" alt="Screenshot 2023-06-16 at 3 13 44 PM" src="https://github.com/JoinColony/colonyCDapp/assets/71563622/3c015749-f7bc-459f-9276-9e9f67feb9d1">
<img width="331" alt="Screenshot 2023-06-16 at 3 13 23 PM" src="https://github.com/JoinColony/colonyCDapp/assets/71563622/e74154fa-d140-4a05-bbde-ab8687afe693">
<img width="334" alt="Screenshot 2023-06-16 at 3 13 14 PM" src="https://github.com/JoinColony/colonyCDapp/assets/71563622/95782467-623d-48f0-9fe3-7e9162e9fc77">


Contributes to #648
