### PR TITLE
Misc/Motion fixes

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/DefaultMotion.css
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/DefaultMotion.css
@@ -16,7 +16,10 @@
   display: flex;
   flex-direction: column;
   grid-area: details;
-  row-gap: 100px;
+}
+
+.widgets > div:last-child {
+  margin-top: 100px;
 }
 
 @media screen and query700 {

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/MotionPhaseWidget.tsx
@@ -93,10 +93,10 @@ const MotionPhaseWidget = ({
       }
 
       return (
-        <div>
+        <>
           <ClaimMotionStakes motionData={motionData} {...rest} />
           <VoteOutcome actionData={actionData} />
-        </div>
+        </>
       );
     }
 

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSlider.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSlider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { useAppContext } from '~hooks';
@@ -47,15 +47,13 @@ const StakingSlider = ({
     !!user && !isLoadingData && totalPercentageStaked !== 200;
   const displayLabel = displayErrMsg && enoughReputationToStakeMinimum;
 
-  useEffect(() => {
-    const amount = watch(SLIDER_AMOUNT_KEY);
-    const userStakeLimitPercentage = userStakeLimitDecimal.times(100);
+  const amount = watch(SLIDER_AMOUNT_KEY);
+  const userStakeLimitPercentage = userStakeLimitDecimal.times(100);
 
-    if (userStakeLimitPercentage.lessThan(amount)) {
-      setLimitExceeded(true);
-      setValue(SLIDER_AMOUNT_KEY, userStakeLimitPercentage.toString());
-    }
-  }, [userStakeLimitDecimal, watch, setLimitExceeded, setValue]);
+  if (userStakeLimitPercentage.lessThan(amount)) {
+    setLimitExceeded(true);
+    setValue(SLIDER_AMOUNT_KEY, userStakeLimitPercentage.toString());
+  }
 
   return (
     <>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSlider.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSlider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { useAppContext } from '~hooks';
@@ -47,13 +47,15 @@ const StakingSlider = ({
     !!user && !isLoadingData && totalPercentageStaked !== 200;
   const displayLabel = displayErrMsg && enoughReputationToStakeMinimum;
 
-  const amount = watch(SLIDER_AMOUNT_KEY);
-  const userStakeLimitPercentage = userStakeLimitDecimal.times(100);
+  useEffect(() => {
+    const amount = watch(SLIDER_AMOUNT_KEY);
+    const userStakeLimitPercentage = userStakeLimitDecimal.times(100);
 
-  if (userStakeLimitPercentage.lessThan(amount)) {
-    setLimitExceeded(true);
-    setValue(SLIDER_AMOUNT_KEY, userStakeLimitPercentage.toString());
-  }
+    if (userStakeLimitPercentage.lessThan(amount)) {
+      setLimitExceeded(true);
+      setValue(SLIDER_AMOUNT_KEY, userStakeLimitPercentage.toString());
+    }
+  }, [userStakeLimitDecimal, watch, setLimitExceeded, setValue]);
 
   return (
     <>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSlider.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSlider.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useFormContext } from 'react-hook-form';
+
 import { useAppContext } from '~hooks';
 import { SetStateFn } from '~types';
 
 import {
+  SLIDER_AMOUNT_KEY,
   StakingSliderDescription,
   StakingSliderLabel,
   StakingValidationMessage,
@@ -38,10 +41,21 @@ const StakingSlider = ({
     enoughReputationToStakeMinimum,
     userMaxStake,
   } = useStakingSlider(isObjection);
+  const { watch, setValue } = useFormContext();
 
   const displayErrMsg =
     !!user && !isLoadingData && totalPercentageStaked !== 200;
   const displayLabel = displayErrMsg && enoughReputationToStakeMinimum;
+
+  useEffect(() => {
+    const amount = watch(SLIDER_AMOUNT_KEY);
+    const userStakeLimitPercentage = userStakeLimitDecimal.times(100);
+
+    if (userStakeLimitPercentage.lessThan(amount)) {
+      setLimitExceeded(true);
+      setValue(SLIDER_AMOUNT_KEY, userStakeLimitPercentage.toString());
+    }
+  }, [userStakeLimitDecimal, watch, setLimitExceeded, setValue]);
 
   return (
     <>

--- a/src/components/common/ColonyActions/helpers/itemStyles.css
+++ b/src/components/common/ColonyActions/helpers/itemStyles.css
@@ -19,6 +19,10 @@
   border-radius: var(--radius-large);
 }
 
+.voteResultsWrapper h4 {
+  padding-top: 0;
+}
+
 .reputation {
   display: inline-block;
   margin-left: 4px;

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
@@ -113,7 +113,7 @@ const ManageReputationDialogForm = ({
   isForce,
   setIsForce,
 }: Props) => {
-  const { watch, trigger } = useFormContext();
+  const { watch, trigger, setValue } = useFormContext();
   const { domainId, motionDomainId, user: selectedUser, forceAction } = watch();
 
   useEffect(() => {
@@ -168,6 +168,12 @@ const ManageReputationDialogForm = ({
 
   const selectedDomain = findDomainByNativeId(domainId, colony);
   const domainName = selectedDomain?.metadata?.name;
+
+  const handleDomainChange = (selectedDomainId: string) => {
+    if (isSmiteAction) {
+      setValue('motionDomainId', selectedDomainId);
+    }
+  };
 
   const renderActiveOption = (option) => {
     const value = option ? option.value : undefined;
@@ -270,6 +276,7 @@ const ManageReputationDialogForm = ({
               appearance={{ theme: 'grey', width: 'fluid' }}
               renderActiveOption={renderActiveOption}
               disabled={canOnlyForceAction}
+              onChange={handleDomainChange}
             />
           </div>
         </div>

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
@@ -130,8 +130,9 @@ const ManageReputationDialogForm = ({
     userHasPermission,
     disabledInput,
     disabledSubmit,
-    canCreateMotion,
     canOnlyForceAction,
+    hasMotionCompatibleVersion,
+    showPermissionErrors,
   } = useActionDialogStatus(
     colony,
     requiredRoles,
@@ -234,7 +235,7 @@ const ManageReputationDialogForm = ({
         </DialogHeading>
       </DialogSection>
       {!isSmiteAction && <hr className={styles.divider} />}
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection>
           <PermissionRequiredInfo requiredRoles={requiredRoles} />
         </DialogSection>
@@ -268,7 +269,7 @@ const ManageReputationDialogForm = ({
               name="domainId"
               appearance={{ theme: 'grey', width: 'fluid' }}
               renderActiveOption={renderActiveOption}
-              disabled={!userHasPermission || canOnlyForceAction}
+              disabled={canOnlyForceAction}
             />
           </div>
         </div>
@@ -292,7 +293,7 @@ const ManageReputationDialogForm = ({
           dataTest="reputationAnnotation"
         />
       </DialogSection>
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection>
           <NoPermissionMessage
             requiredPermissions={requiredRoles}
@@ -309,7 +310,7 @@ const ManageReputationDialogForm = ({
           />
         </DialogSection>
       )}
-      {!canCreateMotion && (
+      {!hasMotionCompatibleVersion && (
         <DialogSection>
           <CannotCreateMotionMessage />
         </DialogSection>

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
@@ -303,10 +303,11 @@ const ManageReputationDialogForm = ({
       )}
 
       {canOnlyForceAction && (
-        <DialogSection>
+        <DialogSection appearance={{ theme: 'sidePadding' }}>
           <NotEnoughReputation
             appearance={{ marginTop: 'negative' }}
             domainId={Number(motionDomainId)}
+            includeForceCopy={userHasPermission}
           />
         </DialogSection>
       )}

--- a/src/components/common/Dialogs/CreateDomainDialog/CreateDomainDialog.tsx
+++ b/src/components/common/Dialogs/CreateDomainDialog/CreateDomainDialog.tsx
@@ -32,10 +32,11 @@ const validationSchema = object()
   .shape({
     forceAction: boolean().defined(),
     teamName: string()
+      .trim()
       .max(20)
       .required(() => MSG.requiredFieldError),
     domainColor: string().notRequired(),
-    domainPurpose: string().max(90).notRequired(),
+    domainPurpose: string().trim().max(90).notRequired(),
     annotationMessage: string().max(4000).notRequired(),
     motionDomainId: number().defined(),
   })

--- a/src/components/common/Dialogs/CreateDomainDialog/CreateDomainDialogForm.tsx
+++ b/src/components/common/Dialogs/CreateDomainDialog/CreateDomainDialogForm.tsx
@@ -59,8 +59,9 @@ const CreateDomainDialogForm = ({
     userHasPermission,
     disabledInput,
     disabledSubmit,
-    canCreateMotion,
     canOnlyForceAction,
+    hasMotionCompatibleVersion,
+    showPermissionErrors,
   } = useActionDialogStatus(
     colony,
     requiredRoles,
@@ -85,7 +86,7 @@ const CreateDomainDialogForm = ({
           isRootMotion
         />
       </DialogSection>
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection>
           <PermissionRequiredInfo requiredRoles={requiredRoles} />
         </DialogSection>
@@ -114,7 +115,7 @@ const CreateDomainDialogForm = ({
           dataTest="createDomainAnnotation"
         />
       </DialogSection>
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <NoPermissionMessage
             requiredPermissions={requiredRoles}
@@ -127,7 +128,7 @@ const CreateDomainDialogForm = ({
           <NotEnoughReputation appearance={{ marginTop: 'negative' }} />
         </DialogSection>
       )}
-      {!canCreateMotion && (
+      {!hasMotionCompatibleVersion && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <CannotCreateMotionMessage />
         </DialogSection>

--- a/src/components/common/Dialogs/CreateDomainDialog/CreateDomainDialogForm.tsx
+++ b/src/components/common/Dialogs/CreateDomainDialog/CreateDomainDialogForm.tsx
@@ -125,7 +125,10 @@ const CreateDomainDialogForm = ({
       )}
       {canOnlyForceAction && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
-          <NotEnoughReputation appearance={{ marginTop: 'negative' }} />
+          <NotEnoughReputation
+            appearance={{ marginTop: 'negative' }}
+            includeForceCopy={userHasPermission}
+          />
         </DialogSection>
       )}
       {!hasMotionCompatibleVersion && (

--- a/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -206,6 +206,7 @@ Props) => {
           <NotEnoughReputation
             appearance={{ marginTop: 'negative' }}
             domainId={fromDomainId}
+            includeForceCopy={userHasPermission}
           />
         </DialogSection>
       )}

--- a/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -95,9 +95,10 @@ Props) => {
     userHasPermission,
     disabledSubmit,
     disabledInput,
-    canCreateMotion,
     canCreatePayment,
     canOnlyForceAction,
+    hasMotionCompatibleVersion,
+    showPermissionErrors,
   } = useCreatePaymentDialogStatus(colony, requiredRoles, enabledExtensionData);
 
   const formattedData = verifiedUsers.map((user) => ({
@@ -124,7 +125,7 @@ Props) => {
           selectedDomainId={fromDomainId}
         />
       </DialogSection>
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection>
           <PermissionRequiredInfo requiredRoles={requiredRoles} />
         </DialogSection>
@@ -188,7 +189,7 @@ Props) => {
           dataTest="paymentAnnotation"
         />
       </DialogSection>
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection>
           <NoPermissionMessage requiredPermissions={requiredRoles} />
         </DialogSection>
@@ -208,7 +209,7 @@ Props) => {
           />
         </DialogSection>
       )}
-      {!canCreateMotion && (
+      {!hasMotionCompatibleVersion && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <CannotCreateMotionMessage />
         </DialogSection>

--- a/src/components/common/Dialogs/CreatePaymentDialog/helpers.ts
+++ b/src/components/common/Dialogs/CreatePaymentDialog/helpers.ts
@@ -62,27 +62,19 @@ export const useCreatePaymentDialogStatus = (
   const { watch } = useFormContext();
   const { fromDomainId, motionDomainId } = watch();
   const { isOneTxPaymentEnabled } = enabledExtensionData;
-  const {
-    userHasPermission,
-    disabledSubmit,
-    disabledInput: defaultDisabledInput,
-    canCreateMotion,
-    canOnlyForceAction,
-  } = useActionDialogStatus(
-    colony,
-    requiredRoles,
-    [fromDomainId],
-    enabledExtensionData,
-    motionDomainId,
-  );
+  const { disabledInput: defaultDisabledInput, ...rest } =
+    useActionDialogStatus(
+      colony,
+      requiredRoles,
+      [fromDomainId],
+      enabledExtensionData,
+      motionDomainId,
+    );
   const disabledInput = defaultDisabledInput || !isOneTxPaymentEnabled;
 
   return {
-    userHasPermission,
+    ...rest,
     disabledInput,
-    disabledSubmit,
-    canCreateMotion,
     canCreatePayment: isOneTxPaymentEnabled,
-    canOnlyForceAction,
   };
 };

--- a/src/components/common/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialog.tsx
+++ b/src/components/common/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialog.tsx
@@ -31,7 +31,9 @@ const validationSchema = object()
     forceAction: boolean().defined(),
     colonyAvatarImage: string().nullable().defined(),
     colonyThumbnail: string().nullable().defined(),
-    colonyDisplayName: string().required(() => MSG.requiredFieldError),
+    colonyDisplayName: string()
+      .trim()
+      .required(() => MSG.requiredFieldError),
     annotationMessage: string().max(4000).defined(),
   })
   .defined();

--- a/src/components/common/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialogForm.tsx
+++ b/src/components/common/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialogForm.tsx
@@ -75,10 +75,11 @@ const EditColonyDetailsDialogForm = ({
 
   const {
     userHasPermission,
-    canCreateMotion,
     disabledInput,
     disabledSubmit,
     canOnlyForceAction,
+    hasMotionCompatibleVersion,
+    showPermissionErrors,
   } = useActionDialogStatus(
     colony,
     requiredRoles,
@@ -103,7 +104,7 @@ const EditColonyDetailsDialogForm = ({
           colony={colony}
         />
       </DialogSection>
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection>
           <PermissionRequiredInfo requiredRoles={requiredRoles} />
         </DialogSection>
@@ -133,7 +134,7 @@ const EditColonyDetailsDialogForm = ({
           disabled={disabledInput}
         />
       </DialogSection>
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection>
           <NoPermissionMessage requiredPermissions={requiredRoles} />
         </DialogSection>
@@ -143,7 +144,7 @@ const EditColonyDetailsDialogForm = ({
           <NotEnoughReputation appearance={{ marginTop: 'negative' }} />
         </DialogSection>
       )}
-      {!canCreateMotion && (
+      {!hasMotionCompatibleVersion && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <CannotCreateMotionMessage />
         </DialogSection>

--- a/src/components/common/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialogForm.tsx
+++ b/src/components/common/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialogForm.tsx
@@ -140,8 +140,11 @@ const EditColonyDetailsDialogForm = ({
         </DialogSection>
       )}
       {canOnlyForceAction && (
-        <DialogSection>
-          <NotEnoughReputation appearance={{ marginTop: 'negative' }} />
+        <DialogSection appearance={{ theme: 'sidePadding' }}>
+          <NotEnoughReputation
+            appearance={{ marginTop: 'negative' }}
+            includeForceCopy={userHasPermission}
+          />
         </DialogSection>
       )}
       {!hasMotionCompatibleVersion && (

--- a/src/components/common/Dialogs/EditDomainDialog/EditDomainDialog.tsx
+++ b/src/components/common/Dialogs/EditDomainDialog/EditDomainDialog.tsx
@@ -37,11 +37,12 @@ const validationSchema = object()
   .shape({
     forceAction: boolean().defined(),
     domainName: string()
+      .trim()
       .max(20)
       .required(() => MSG.requiredFieldError),
     domainId: number().required(),
     domainColor: string().defined(),
-    domainPurpose: string().max(90),
+    domainPurpose: string().trim().max(90),
     annotationMessage: string().max(4000),
     motionDomainId: number(),
   })

--- a/src/components/common/Dialogs/EditDomainDialog/EditDomainDialogForm.tsx
+++ b/src/components/common/Dialogs/EditDomainDialog/EditDomainDialogForm.tsx
@@ -77,8 +77,9 @@ const EditDomainDialogForm = ({
     userHasPermission,
     disabledSubmit,
     disabledInput,
-    canCreateMotion,
     canOnlyForceAction,
+    hasMotionCompatibleVersion,
+    showPermissionErrors,
   } = useEditDomainDialogStatus(
     colony,
     requiredRoles,
@@ -135,7 +136,7 @@ const EditDomainDialogForm = ({
           selectedDomainId={domainId}
         />
       </DialogSection>
-      {domainOptions.length > 0 && !userHasPermission && (
+      {domainOptions.length > 0 && showPermissionErrors && (
         <DialogSection>
           <PermissionRequiredInfo requiredRoles={requiredRoles} />
         </DialogSection>
@@ -177,7 +178,7 @@ const EditDomainDialogForm = ({
           dataTest="editDomainAnnotation"
         />
       </DialogSection>
-      {domainOptions.length > 0 && !userHasPermission && (
+      {domainOptions.length > 0 && showPermissionErrors && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <NoPermissionMessage
             requiredPermissions={[ColonyRole.Architecture]}
@@ -193,7 +194,7 @@ const EditDomainDialogForm = ({
           />
         </DialogSection>
       )}
-      {!canCreateMotion && (
+      {!hasMotionCompatibleVersion && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <CannotCreateMotionMessage />
         </DialogSection>

--- a/src/components/common/Dialogs/EditDomainDialog/EditDomainDialogForm.tsx
+++ b/src/components/common/Dialogs/EditDomainDialog/EditDomainDialogForm.tsx
@@ -191,6 +191,7 @@ const EditDomainDialogForm = ({
           <NotEnoughReputation
             appearance={{ marginTop: 'negative' }}
             domainId={domainId}
+            includeForceCopy={userHasPermission}
           />
         </DialogSection>
       )}

--- a/src/components/common/Dialogs/EditDomainDialog/helpers.ts
+++ b/src/components/common/Dialogs/EditDomainDialog/helpers.ts
@@ -29,11 +29,9 @@ export const useEditDomainDialogStatus = (
   } = useFormContext();
   const { domainId, motionDomainId } = watch();
   const {
-    userHasPermission,
     disabledSubmit: defaultDisabledSubmit,
     disabledInput: defaultDisabledInput,
-    canCreateMotion,
-    canOnlyForceAction,
+    ...rest
   } = useActionDialogStatus(
     colony,
     requiredRoles,
@@ -50,11 +48,9 @@ export const useEditDomainDialogStatus = (
   const disabledInput = defaultDisabledInput || domainOptions.length === 0;
 
   return {
-    userHasPermission,
+    ...rest,
     disabledInput,
     disabledSubmit,
-    canCreateMotion,
-    canOnlyForceAction,
   };
 };
 

--- a/src/components/common/Dialogs/MintTokenDialog/MintTokenDialogForm.tsx
+++ b/src/components/common/Dialogs/MintTokenDialog/MintTokenDialogForm.tsx
@@ -159,7 +159,7 @@ const MintTokenDialogForm = ({
       )}
       {canOnlyForceAction && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
-          <NotEnoughReputation />
+          <NotEnoughReputation includeForceCopy={userHasPermission} />
         </DialogSection>
       )}
       {!hasMotionCompatibleVersion && (

--- a/src/components/common/Dialogs/MintTokenDialog/MintTokenDialogForm.tsx
+++ b/src/components/common/Dialogs/MintTokenDialog/MintTokenDialogForm.tsx
@@ -71,8 +71,9 @@ const MintTokenDialogForm = ({
     userHasPermission,
     disabledInput,
     disabledSubmit,
-    canCreateMotion,
     canOnlyForceAction,
+    hasMotionCompatibleVersion,
+    showPermissionErrors,
   } = useActionDialogStatus(
     colony,
     requiredRoles,
@@ -118,7 +119,7 @@ const MintTokenDialogForm = ({
           isRootMotion
         />
       </DialogSection>
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <PermissionRequiredInfo requiredRoles={requiredRoles} />
         </DialogSection>
@@ -151,7 +152,7 @@ const MintTokenDialogForm = ({
           />
         </div>
       </DialogSection>
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <NoPermissionMessage requiredPermissions={requiredRoles} />
         </DialogSection>
@@ -161,7 +162,7 @@ const MintTokenDialogForm = ({
           <NotEnoughReputation />
         </DialogSection>
       )}
-      {!canCreateMotion && (
+      {!hasMotionCompatibleVersion && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <CannotCreateMotionMessage />
         </DialogSection>

--- a/src/components/common/Dialogs/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.tsx
+++ b/src/components/common/Dialogs/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.tsx
@@ -64,12 +64,13 @@ const NetworkContractUpgradeDialogForm = ({
   const forceAction = watch('forceAction');
   const {
     userHasPermission,
-    canCreateMotion,
     disabledSubmit,
     disabledInput,
     hasLegacyRecoveryRole,
     isLoadingLegacyRecoveryRole,
     canOnlyForceAction,
+    hasMotionCompatibleVersion,
+    showPermissionErrors,
   } = useNetworkContractUpgradeDialogStatus(
     colony,
     requiredRoles,
@@ -110,7 +111,7 @@ const NetworkContractUpgradeDialogForm = ({
           <LegacyPermissionWarning />
         </DialogSection>
       )}
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection>
           <PermissionRequiredInfo requiredRoles={requiredRoles} />
         </DialogSection>
@@ -129,7 +130,7 @@ const NetworkContractUpgradeDialogForm = ({
           disabled={disabledInput}
         />
       </DialogSection>
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <NoPermissionMessage requiredPermissions={requiredRoles} />
         </DialogSection>
@@ -139,7 +140,7 @@ const NetworkContractUpgradeDialogForm = ({
           <NotEnoughReputation />
         </DialogSection>
       )}
-      {!canCreateMotion && (
+      {!hasMotionCompatibleVersion && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <CannotCreateMotionMessage />
         </DialogSection>

--- a/src/components/common/Dialogs/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.tsx
+++ b/src/components/common/Dialogs/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.tsx
@@ -137,7 +137,7 @@ const NetworkContractUpgradeDialogForm = ({
       )}
       {canOnlyForceAction && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
-          <NotEnoughReputation />
+          <NotEnoughReputation includeForceCopy={userHasPermission} />
         </DialogSection>
       )}
       {!hasMotionCompatibleVersion && (

--- a/src/components/common/Dialogs/NetworkContractUpgradeDialog/helpers.ts
+++ b/src/components/common/Dialogs/NetworkContractUpgradeDialog/helpers.ts
@@ -31,11 +31,9 @@ export const useNetworkContractUpgradeDialogStatus = (
   const { colonyContractVersion } = useColonyContractVersion();
 
   const {
-    userHasPermission,
     disabledSubmit: defaultDisabledSubmit,
     disabledInput: defaultDisabledInput,
-    canCreateMotion,
-    canOnlyForceAction,
+    ...rest
   } = useActionDialogStatus(
     colony,
     requiredRoles,
@@ -60,12 +58,10 @@ export const useNetworkContractUpgradeDialogStatus = (
   //   ? data?.legacyNumberOfRecoveryRoles > 1
   //   : false;
   return {
-    userHasPermission,
+    ...rest,
     disabledInput: defaultDisabledInput || !canUpgradeVersion,
     disabledSubmit:
       defaultDisabledSubmit || hasLegacyRecoveryRole || !canUpgradeVersion,
-    canCreateMotion,
-    canOnlyForceAction,
     hasLegacyRecoveryRole,
     isLoadingLegacyRecoveryRole,
   };

--- a/src/components/common/Dialogs/PermissionManagementDialog/PermissionManagementForm.tsx
+++ b/src/components/common/Dialogs/PermissionManagementDialog/PermissionManagementForm.tsx
@@ -240,8 +240,8 @@ const PermissionManagementForm = ({
       {canOnlyForceAction && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <NotEnoughReputation
-            appearance={{ marginTop: 'negative' }}
             domainId={selectedDomainId}
+            includeForceCopy={userHasPermission}
           />
         </DialogSection>
       )}

--- a/src/components/common/Dialogs/PermissionManagementDialog/PermissionManagementForm.tsx
+++ b/src/components/common/Dialogs/PermissionManagementDialog/PermissionManagementForm.tsx
@@ -116,10 +116,11 @@ const PermissionManagementForm = ({
 
   const {
     userHasPermission,
-    canCreateMotion,
     disabledInput,
     disabledSubmit,
     canOnlyForceAction,
+    hasMotionCompatibleVersion,
+    showPermissionErrors,
   } = usePermissionManagementDialogStatus(
     colony,
     requiredRoles,
@@ -165,7 +166,7 @@ const PermissionManagementForm = ({
           selectedDomainId={selectedDomainId}
         />
       </DialogSection>
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection>
           <PermissionRequiredInfo requiredRoles={requiredRoles} />
         </DialogSection>
@@ -224,12 +225,12 @@ const PermissionManagementForm = ({
           dataTest="permissionAnnotation"
         />
       </DialogSection>
-      {!canCreateMotion && (
+      {!hasMotionCompatibleVersion && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <CannotCreateMotionMessage />
         </DialogSection>
       )}
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <NoPermissionMessage
             requiredPermissions={[ColonyRole.Architecture]}

--- a/src/components/common/Dialogs/PermissionManagementDialog/helpers.ts
+++ b/src/components/common/Dialogs/PermissionManagementDialog/helpers.ts
@@ -111,19 +111,14 @@ export const usePermissionManagementDialogStatus = (
   const { watch } = useFormContext();
   const { domainId, roles, user: selectedUser, motionDomainId } = watch();
 
-  const {
-    userHasPermission,
-    disabledSubmit: defaultDisabledSubmit,
-    disabledInput,
-    canCreateMotion,
-    canOnlyForceAction,
-  } = useActionDialogStatus(
-    colony,
-    requiredRoles,
-    [domainId],
-    enabledExtensionData,
-    motionDomainId,
-  );
+  const { disabledSubmit: defaultDisabledSubmit, ...rest } =
+    useActionDialogStatus(
+      colony,
+      requiredRoles,
+      [domainId],
+      enabledExtensionData,
+      motionDomainId,
+    );
 
   const userDirectAndInheritedRoles = getUserRolesForDomain(
     colony,
@@ -132,16 +127,13 @@ export const usePermissionManagementDialogStatus = (
   );
 
   return {
-    userHasPermission,
-    disabledInput,
+    ...rest,
     disabledSubmit:
       defaultDisabledSubmit ||
       isEqual(
         sortBy(roles),
         sortBy(userDirectAndInheritedRoles.map((role) => role.toString())),
       ),
-    canCreateMotion,
-    canOnlyForceAction,
   };
 };
 

--- a/src/components/common/Dialogs/TokenManagementDialog/TokenManagementDialogForm/TokenManagementDialogForm.tsx
+++ b/src/components/common/Dialogs/TokenManagementDialog/TokenManagementDialogForm/TokenManagementDialogForm.tsx
@@ -85,6 +85,7 @@ const TokenManagementDialogForm = ({
     disabledInput,
     disabledSubmit,
     canOnlyForceAction,
+    showPermissionErrors,
   } = useActionDialogStatus(
     colony,
     requiredRoles,
@@ -134,12 +135,11 @@ const TokenManagementDialogForm = ({
           }
         />
       </DialogSection>
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <PermissionRequiredInfo requiredRoles={requiredRoles} />
         </DialogSection>
       )}
-
       <DialogSection appearance={{ theme: 'sidePadding' }}>
         {allTokens.length > 0 ? (
           <div className={styles.tokenChoiceContainer}>
@@ -179,7 +179,7 @@ const TokenManagementDialogForm = ({
           />
         </div>
       </DialogSection>
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <NoPermissionMessage requiredPermissions={requiredRoles} />
         </DialogSection>

--- a/src/components/common/Dialogs/TokenManagementDialog/TokenManagementDialogForm/TokenManagementDialogForm.tsx
+++ b/src/components/common/Dialogs/TokenManagementDialog/TokenManagementDialogForm/TokenManagementDialogForm.tsx
@@ -185,8 +185,8 @@ const TokenManagementDialogForm = ({
         </DialogSection>
       )}
       {canOnlyForceAction && (
-        <DialogSection>
-          <NotEnoughReputation appearance={{ marginTop: 'negative' }} />
+        <DialogSection appearance={{ theme: 'sidePadding' }}>
+          <NotEnoughReputation includeForceCopy={userHasPermission} />
         </DialogSection>
       )}
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>

--- a/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
+++ b/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
@@ -130,7 +130,10 @@ const TransferFundsDialogForm = ({
       )}
       {canOnlyForceAction && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
-          <NotEnoughReputation appearance={{ marginTop: 'negative' }} />
+          <NotEnoughReputation
+            appearance={{ marginTop: 'negative' }}
+            includeForceCopy={userHasPermission}
+          />
         </DialogSection>
       )}
       {!hasMotionCompatibleVersion && (

--- a/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
+++ b/src/components/common/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
@@ -66,8 +66,9 @@ const TransferFundsDialogForm = ({
     userHasPermission,
     disabledInput,
     disabledSubmit,
-    canCreateMotion,
     canOnlyForceAction,
+    hasMotionCompatibleVersion,
+    showPermissionErrors,
     hasRoleInFromDomain,
   } = useTransferFundsDialogStatus(colony, requiredRoles, enabledExtensionData);
 
@@ -90,7 +91,7 @@ const TransferFundsDialogForm = ({
           isRootMotion
         />
       </DialogSection>
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <div className={styles.permissionsRequired}>
           <DialogSection>
             <PermissionRequiredInfo requiredRoles={requiredRoles} />
@@ -115,7 +116,7 @@ const TransferFundsDialogForm = ({
           dataTest="transferFundsAnnotation"
         />
       </DialogSection>
-      {!userHasPermission && (
+      {showPermissionErrors && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <NoPermissionMessage
             requiredPermissions={requiredRoles}
@@ -132,7 +133,7 @@ const TransferFundsDialogForm = ({
           <NotEnoughReputation appearance={{ marginTop: 'negative' }} />
         </DialogSection>
       )}
-      {!canCreateMotion && (
+      {!hasMotionCompatibleVersion && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <CannotCreateMotionMessage />
         </DialogSection>

--- a/src/components/common/Dialogs/TransferFundsDialog/helpers.ts
+++ b/src/components/common/Dialogs/TransferFundsDialog/helpers.ts
@@ -61,13 +61,7 @@ export const useTransferFundsDialogStatus = (
     wallet?.address ?? '',
     fromDomainId,
   ]);
-  const {
-    userHasPermission,
-    disabledSubmit,
-    disabledInput,
-    canCreateMotion,
-    canOnlyForceAction,
-  } = useActionDialogStatus(
+  const actionDialogStatus = useActionDialogStatus(
     colony,
     requiredRoles,
     [fromDomainId, toDomainId],
@@ -77,11 +71,7 @@ export const useTransferFundsDialogStatus = (
   const hasRoleInFromDomain = userHasRole(fromDomainRoles, ColonyRole.Funding);
 
   return {
-    userHasPermission,
-    disabledInput,
-    disabledSubmit,
-    canCreateMotion,
-    canOnlyForceAction,
+    ...actionDialogStatus,
     hasRoleInFromDomain,
   };
 };

--- a/src/components/common/Dialogs/UnlockTokenDialog/UnlockTokenForm.tsx
+++ b/src/components/common/Dialogs/UnlockTokenDialog/UnlockTokenForm.tsx
@@ -156,7 +156,7 @@ const UnlockTokenForm = ({
       )}
       {canOnlyForceAction && ( // && isNativeTokenLocked
         <DialogSection appearance={{ theme: 'sidePadding' }}>
-          <NotEnoughReputation />
+          <NotEnoughReputation includeForceCopy={userHasPermission} />
         </DialogSection>
       )}
       {!hasMotionCompatibleVersion && (

--- a/src/components/common/Dialogs/UnlockTokenDialog/UnlockTokenForm.tsx
+++ b/src/components/common/Dialogs/UnlockTokenDialog/UnlockTokenForm.tsx
@@ -78,8 +78,9 @@ const UnlockTokenForm = ({
     userHasPermission,
     disabledInput,
     disabledSubmit,
-    canCreateMotion,
     canOnlyForceAction,
+    hasMotionCompatibleVersion,
+    showPermissionErrors,
   } = useActionDialogStatus(
     colony,
     requiredRoles,
@@ -109,7 +110,7 @@ const UnlockTokenForm = ({
           isRootMotion
         />
       </DialogSection>
-      {!userHasPermission && ( // && isNativeTokenLocked
+      {showPermissionErrors && ( // && isNativeTokenLocked
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <div className={styles.wrapper}>
             <PermissionRequiredInfo requiredRoles={[ColonyRole.Root]} />
@@ -148,7 +149,7 @@ const UnlockTokenForm = ({
           </DialogSection>
         </>
       )}
-      {!userHasPermission && ( // && isNativeTokenLocked
+      {showPermissionErrors && ( // && isNativeTokenLocked
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <NoPermissionMessage requiredPermissions={requiredRoles} />
         </DialogSection>
@@ -158,7 +159,7 @@ const UnlockTokenForm = ({
           <NotEnoughReputation />
         </DialogSection>
       )}
-      {!canCreateMotion && (
+      {!hasMotionCompatibleVersion && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <CannotCreateMotionMessage />
         </DialogSection>

--- a/src/components/shared/DetailsWidget/DetailItem.css
+++ b/src/components/shared/DetailsWidget/DetailItem.css
@@ -35,6 +35,10 @@
   border-bottom: 1px solid color-mod(var(--grey-purple) alpha(15%));
 }
 
+.item:last-child {
+  border-bottom: none;
+}
+
 .tooltip {
   width: 220px;
 }

--- a/src/components/shared/UserInfoPopover/UserInfoPopover.css
+++ b/src/components/shared/UserInfoPopover/UserInfoPopover.css
@@ -20,6 +20,7 @@
 
 .section:last-of-type {
   padding-bottom: 0;
+  border-bottom: none;
 }
 
 .loadingSpinnerContainer {

--- a/src/hooks/useActionDialogStatus.ts
+++ b/src/hooks/useActionDialogStatus.ts
@@ -1,7 +1,7 @@
 import { ColonyRole } from '@colony/colony-js';
 import { useFormContext } from 'react-hook-form';
 
-import { useDialogActionPermissions } from '~hooks';
+import { useColonyHasReputation, useDialogActionPermissions } from '~hooks';
 import { Colony } from '~types';
 import { noMotionsVotingReputationVersion } from '~utils/colonyMotions';
 
@@ -23,19 +23,29 @@ const useActionDialogStatus = (
   const { isVotingReputationEnabled, votingReputationVersion } =
     enabledExtensionData;
 
+  const hasReputation = useColonyHasReputation(
+    colony.colonyAddress,
+    requiredRepDomain,
+  );
+
   const [userHasPermission, canOnlyForceAction] = useDialogActionPermissions(
     colony,
     isVotingReputationEnabled,
     requiredRoles,
     requiredRolesDomains,
-    requiredRepDomain,
+    hasReputation,
   );
-  const disabledInput =
-    !userHasPermission || canOnlyForceAction || isSubmitting;
-  const disabledSubmit = disabledInput || !isValid;
 
-  const canCreateMotion =
+  const canCreateMotion = isVotingReputationEnabled && hasReputation;
+  const hasMotionCompatibleVersion =
     votingReputationVersion !== noMotionsVotingReputationVersion || forceAction;
+
+  const disabledInput =
+    (!userHasPermission && !canCreateMotion) ||
+    canOnlyForceAction ||
+    isSubmitting;
+  const disabledSubmit = disabledInput || !isValid;
+  const showPermissionErrors = !userHasPermission && !isVotingReputationEnabled;
 
   return {
     userHasPermission,
@@ -43,6 +53,8 @@ const useActionDialogStatus = (
     disabledSubmit,
     canCreateMotion,
     canOnlyForceAction,
+    hasMotionCompatibleVersion,
+    showPermissionErrors,
   };
 };
 

--- a/src/hooks/useDialogActionPermissions.ts
+++ b/src/hooks/useDialogActionPermissions.ts
@@ -6,14 +6,12 @@ import { getUserRolesForDomain } from '~transformers';
 import { Colony } from '~types';
 import { userHasRole } from '~utils/checks';
 
-import useColonyHasReputation from './useColonyHasReputation';
-
 const useDialogActionPermissions = (
   colony: Colony,
   isVotingExtensionEnabled: boolean,
   requiredRoles: ColonyRole[],
   requiredRolesDomains: number[],
-  requiredRepDomain?: number,
+  hasReputation: boolean,
 ): [boolean, boolean] => {
   const { wallet } = useAppContext();
   const { watch } = useFormContext();
@@ -29,18 +27,10 @@ const useDialogActionPermissions = (
     return requiredRoles.every((role) => userHasRole(userDomainRoles, role));
   });
 
-  const hasReputation = useColonyHasReputation(
-    colony.colonyAddress,
-    requiredRepDomain,
-  );
-
   const onlyForceAction =
     isVotingExtensionEnabled && !hasReputation && !forceAction;
 
-  const userHasPermission =
-    hasRoles || (isVotingExtensionEnabled && hasReputation);
-
-  return [userHasPermission, onlyForceAction];
+  return [hasRoles, onlyForceAction];
 };
 
 export default useDialogActionPermissions;

--- a/src/redux/sagas/motions/rootMotion.ts
+++ b/src/redux/sagas/motions/rootMotion.ts
@@ -135,7 +135,7 @@ function* createRootMotionSaga({
 
     if (annotationMessage) {
       yield put(transactionPending(annotateRootMotion.id));
-      // TODO: handle uploading annotation msg to db in saga
+      // @TODO: handle uploading annotation msg to db in saga
       yield put(transactionAddParams(annotateRootMotion.id, [txHash, '']));
 
       yield put(transactionReady(annotateRootMotion.id));


### PR DESCRIPTION
- Added trimming to the domain name and description in the create/edit domain dialogs so the user can't submit a name or description with just spaces.
- Removed unnecessary border-bottom from user info popover's last section.
- Fixed limit in the objection slider inside the objection modal being ignored when you have a higher percentage set in the stake motion slider before opening the modal.
- Removed excessive top padding from the vote results widget used on the event feeds of the motion page.

**EDIT:**
- Updated `useActionDialogStatus` logic to cover the case in which we need to hide the ForceToggle when the user cannot force the action.
- Updated `NotEnoughReputation` message positioning and added missing copy change logic.
- Updated `DetailsWidget` positioning on the motion's page as in some cases there was unnecessary spacing.