### PR TITLE
Update permission management read only permission logic

### DIFF
--- a/src/components/common/Dialogs/PermissionManagementDialog/PermissionManagementForm.tsx
+++ b/src/components/common/Dialogs/PermissionManagementDialog/PermissionManagementForm.tsx
@@ -207,7 +207,10 @@ const PermissionManagementForm = ({
             return (
               <PermissionManagementCheckbox
                 key={role}
-                readOnly={(inheritedRole && !directRole) || !canRoleBeSet(role)}
+                readOnly={
+                  (inheritedRole && !directRole) ||
+                  (!canRoleBeSet(role) && showPermissionErrors)
+                }
                 disabled={disabledInput || !selectedUser}
                 role={role}
                 asterisk={inheritedRole}
@@ -231,9 +234,7 @@ const PermissionManagementForm = ({
       )}
       {showPermissionErrors && (
         <DialogSection>
-          <NoPermissionMessage
-            requiredPermissions={[ColonyRole.Architecture]}
-          />
+          <NoPermissionMessage requiredPermissions={requiredRoles} />
         </DialogSection>
       )}
       {canOnlyForceAction && (

--- a/src/components/common/Dialogs/PermissionManagementDialog/helpers.ts
+++ b/src/components/common/Dialogs/PermissionManagementDialog/helpers.ts
@@ -174,20 +174,16 @@ export const useCanRoleBeSet = (colony: Colony) => {
    */
   const canRoleBeSet = (role: ColonyRole) => {
     switch (role) {
-      case ColonyRole.Arbitration:
-        return canAssignRole;
-
       // Can only be set by root and in root domain (and only unset if other root accounts exist)
       case ColonyRole.Root:
       case ColonyRole.Recovery:
         return hasUltimateRoot;
 
+      // Can be set if the user has root OR has architecture
+      case ColonyRole.Arbitration:
+      case ColonyRole.Architecture:
       case ColonyRole.Administration:
       case ColonyRole.Funding:
-        return canAssignRole;
-
-      // Can be set if root domain and has root OR has architecture in parent
-      case ColonyRole.Architecture:
         return canAssignRole;
 
       default:


### PR DESCRIPTION
This is not a perfect solution. I think `canRoleBeSet` or the permission validation, and the UI in this dialog needs to be reworked to accommodate for the user actually needing `Root` or `Architecture` roles depending on the domain and permissions being modified. 

That would require more time and effort which is why I'm just uploading this fix, which should be enough to fix a user with no permissions not being able to create a motion.

![FireShot Capture 083 - Colony CDapp - localhost](https://github.com/JoinColony/colonyCDapp/assets/18473896/28f913d3-7df0-4ec4-93ee-8dd438ea3d15)

Resolves #696 
