### PR TITLE
Update staked tokens after staking a motion

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=be73ee58797d50807289a16ab0fa7d73207eb51d
+ENV BLOCK_INGESTOR_HASH=135b210012227b2439807ebbc0eb0d1ccf15dbc3
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=135b210012227b2439807ebbc0eb0d1ccf15dbc3
+ENV BLOCK_INGESTOR_HASH=4a5e31ccc95db55ec6f8d7b22b9ebe5de99689e6
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/useClaimWidgetConfig.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/useClaimWidgetConfig.tsx
@@ -12,6 +12,7 @@ import { DetailItemProps } from '~shared/DetailsWidget';
 import { getTransactionHashFromPathName } from '~utils/urls';
 import { ColonyMotion } from '~types';
 import { RefetchAction } from '~common/ColonyActions/ActionDetailsPage/useGetColonyAction';
+import { useUserTokenBalanceContext } from '~context';
 
 import { ClaimMotionStakesStyles } from './ClaimMotionStakes';
 
@@ -31,6 +32,8 @@ const useClaimWidgetConfig = (
 ) => {
   const { user } = useAppContext();
   const { colony } = useColonyContext();
+  const { pollTokenBalance } = useUserTokenBalanceContext();
+
   const location = useLocation();
   const [isClaimed, setIsClaimed] = useState(false);
 
@@ -101,6 +104,7 @@ const useClaimWidgetConfig = (
   const handleClaimSuccess = () => {
     setIsClaimed(true);
     startPollingAction(1000);
+    pollTokenBalance();
   };
 
   const claimPayload = {

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/useClaimWidgetConfig.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/useClaimWidgetConfig.tsx
@@ -32,7 +32,7 @@ const useClaimWidgetConfig = (
 ) => {
   const { user } = useAppContext();
   const { colony } = useColonyContext();
-  const { pollTokenBalance } = useUserTokenBalanceContext();
+  const { pollLockedTokenBalance } = useUserTokenBalanceContext();
 
   const location = useLocation();
   const [isClaimed, setIsClaimed] = useState(false);
@@ -104,7 +104,7 @@ const useClaimWidgetConfig = (
   const handleClaimSuccess = () => {
     setIsClaimed(true);
     startPollingAction(1000);
-    pollTokenBalance();
+    pollLockedTokenBalance();
   };
 
   const claimPayload = {

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/useObjectButton.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/useObjectButton.ts
@@ -13,7 +13,7 @@ import { SLIDER_AMOUNT_KEY } from '../StakingInput';
 const useObjectButton = () => {
   const { user } = useAppContext();
   const { colony } = useColonyContext();
-  const { pollTokenBalance } = useUserTokenBalanceContext();
+  const { pollLockedTokenBalance } = useUserTokenBalanceContext();
 
   const { getValues } = useFormContext();
   const openRaiseObjectionDialog = useDialog(RaiseObjectionDialog);
@@ -38,7 +38,7 @@ const useObjectButton = () => {
   const handleStakeSuccess = getHandleStakeSuccessFn(
     setIsRefetching,
     startPollingAction,
-    pollTokenBalance,
+    pollLockedTokenBalance,
   );
 
   const handleObjection = () =>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/useObjectButton.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/useObjectButton.ts
@@ -4,6 +4,7 @@ import { RaiseObjectionDialog } from '~common/Dialogs';
 import { useAppContext, useColonyContext } from '~hooks';
 import { useDialog } from '~shared/Dialog';
 import { MotionVote } from '~utils/colonyMotions';
+import { useUserTokenBalanceContext } from '~context';
 
 import { useStakingWidgetContext } from '../../StakingWidgetProvider';
 import { getHandleStakeSuccessFn, getStakingTransformFn } from '../helpers';
@@ -12,6 +13,8 @@ import { SLIDER_AMOUNT_KEY } from '../StakingInput';
 const useObjectButton = () => {
   const { user } = useAppContext();
   const { colony } = useColonyContext();
+  const { pollTokenBalance } = useUserTokenBalanceContext();
+
   const { getValues } = useFormContext();
   const openRaiseObjectionDialog = useDialog(RaiseObjectionDialog);
   const {
@@ -35,6 +38,7 @@ const useObjectButton = () => {
   const handleStakeSuccess = getHandleStakeSuccessFn(
     setIsRefetching,
     startPollingAction,
+    pollTokenBalance,
   );
 
   const handleObjection = () =>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/helpers.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/helpers.ts
@@ -36,12 +36,12 @@ export const getHandleStakeSuccessFn =
   (
     setIsRefetching: SetStateFn,
     startPollingMotion: (pollingInterval: number) => void,
-    pollTokenBalance: () => void,
+    pollLockedTokenBalance: () => void,
   ) =>
   (_, { reset }) => {
     reset();
     setIsRefetching(true);
     /* On stake success, initiate db polling so ui updates */
     startPollingMotion(1000);
-    pollTokenBalance();
+    pollLockedTokenBalance();
   };

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/helpers.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/helpers.ts
@@ -35,11 +35,13 @@ export const getStakingTransformFn = (
 export const getHandleStakeSuccessFn =
   (
     setIsRefetching: SetStateFn,
-    startPolling: (pollingInterval: number) => void,
+    startPollingMotion: (pollingInterval: number) => void,
+    pollTokenBalance: () => void,
   ) =>
   (_, { reset }) => {
     reset();
     setIsRefetching(true);
     /* On stake success, initiate db polling so ui updates */
-    startPolling(1000);
+    startPollingMotion(1000);
+    pollTokenBalance();
   };

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/useStakingInput.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/useStakingInput.ts
@@ -1,12 +1,15 @@
 import { useAppContext, useColonyContext } from '~hooks';
 
 import { MotionVote } from '~utils/colonyMotions';
+import { useUserTokenBalanceContext } from '~context';
 import { useStakingWidgetContext } from '../StakingWidgetProvider';
 import { getHandleStakeSuccessFn, getStakingTransformFn } from './helpers';
 
 export const useStakingInput = () => {
   const { user } = useAppContext();
   const { colony } = useColonyContext();
+  const { pollTokenBalance } = useUserTokenBalanceContext();
+
   const {
     isObjection,
     motionId,
@@ -30,6 +33,7 @@ export const useStakingInput = () => {
   const handleSuccess = getHandleStakeSuccessFn(
     setIsRefetching,
     startPollingAction,
+    pollTokenBalance,
   );
 
   return {

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/useStakingInput.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/useStakingInput.ts
@@ -8,7 +8,7 @@ import { getHandleStakeSuccessFn, getStakingTransformFn } from './helpers';
 export const useStakingInput = () => {
   const { user } = useAppContext();
   const { colony } = useColonyContext();
-  const { pollTokenBalance } = useUserTokenBalanceContext();
+  const { pollLockedTokenBalance } = useUserTokenBalanceContext();
 
   const {
     isObjection,
@@ -33,7 +33,7 @@ export const useStakingInput = () => {
   const handleSuccess = getHandleStakeSuccessFn(
     setIsRefetching,
     startPollingAction,
-    pollTokenBalance,
+    pollLockedTokenBalance,
   );
 
   return {

--- a/src/components/frame/AvatarDropdown/AvatarDropdown.tsx
+++ b/src/components/frame/AvatarDropdown/AvatarDropdown.tsx
@@ -16,7 +16,6 @@ interface Props {
   preventTransactions?: boolean;
   spinnerMsg: SimpleMessageValues;
   tokenBalanceData?: UserTokenBalanceData;
-  pollTokenBalance: () => void;
 }
 
 const displayName = 'frame.AvatarDropdown';
@@ -27,7 +26,6 @@ const AvatarDropdown = ({
   preventTransactions = false,
   spinnerMsg,
   tokenBalanceData,
-  pollTokenBalance,
 }: Props) => {
   const isMobile = useMobile();
   const { wallet, user } = useAppContext();
@@ -61,7 +59,6 @@ const AvatarDropdown = ({
             {...{
               spinnerMsg,
               tokenBalanceData,
-              pollTokenBalance,
             }}
           />
         )

--- a/src/components/frame/AvatarDropdown/AvatarDropdownPopoverMobile.tsx
+++ b/src/components/frame/AvatarDropdown/AvatarDropdownPopoverMobile.tsx
@@ -47,13 +47,11 @@ const MSG = defineMessages({
 interface Props {
   spinnerMsg: SimpleMessageValues;
   tokenBalanceData?: UserTokenBalanceData;
-  pollTokenBalance: () => void;
 }
 
 const AvatarDropdownPopoverMobile = ({
   spinnerMsg,
   tokenBalanceData,
-  pollTokenBalance,
 }: Props) => {
   const { colony } = useColonyContext();
   const { wallet } = useAppContext();
@@ -98,10 +96,7 @@ const AvatarDropdownPopoverMobile = ({
         <DropdownMenuItem>
           <div className={styles.buttonContainer}>
             {nativeToken && tokenBalanceData && (
-              <TokenActivationPopover
-                tokenBalanceData={tokenBalanceData}
-                pollTokenBalance={pollTokenBalance}
-              >
+              <TokenActivationPopover tokenBalanceData={tokenBalanceData}>
                 {({ toggle, ref }) => (
                   <Button
                     appearance={{

--- a/src/components/frame/RouteLayouts/UserNavigation/UserNavigation.tsx
+++ b/src/components/frame/RouteLayouts/UserNavigation/UserNavigation.tsx
@@ -13,7 +13,7 @@ import {
   useMobile,
   useCanInteractWithNetwork,
 } from '~hooks';
-import { useGetUserTokenBalanceQuery } from '~gql';
+import { useUserTokenBalanceContext } from '~context';
 
 import Wallet from './Wallet';
 
@@ -38,38 +38,17 @@ const MSG = defineMessages({
 const UserNavigation = () => {
   const { colony } = useColonyContext();
   const { wallet } = useAppContext();
+  const { tokenBalanceData } = useUserTokenBalanceContext();
   const { formatMessage } = useIntl();
   const isMobile = useMobile();
   const canInteractWithNetwork = useCanInteractWithNetwork();
 
-  const { colonyAddress, nativeToken } = colony || {};
+  const { colonyAddress } = colony || {};
 
   const { userReputation, totalReputation } = useUserReputation(
     colonyAddress,
     wallet?.address,
   );
-
-  const {
-    data: tokenBalanceQueryData,
-    startPolling,
-    stopPolling,
-  } = useGetUserTokenBalanceQuery({
-    variables: {
-      input: {
-        walletAddress: wallet?.address ?? '',
-        tokenAddress: nativeToken?.tokenAddress ?? '',
-        colonyAddress: colonyAddress ?? '',
-      },
-    },
-    skip: !wallet?.address || !nativeToken?.tokenAddress,
-  });
-
-  const startShortPollForUserTokenBalance = () => {
-    startPolling(1000);
-    setTimeout(stopPolling, 10_000);
-  };
-
-  const tokenBalanceData = tokenBalanceQueryData?.getUserTokenBalance;
 
   return (
     <div className={styles.main}>
@@ -102,7 +81,6 @@ const UserNavigation = () => {
           <UserTokenActivationButton
             nativeToken={colony.nativeToken}
             tokenBalanceData={tokenBalanceData}
-            pollTokenBalance={startShortPollForUserTokenBalance}
             dataTest="tokenActivationButton"
           />
         </div>
@@ -111,7 +89,6 @@ const UserNavigation = () => {
       <AvatarDropdown
         spinnerMsg={MSG.walletAutologin}
         tokenBalanceData={tokenBalanceData ?? undefined}
-        pollTokenBalance={startShortPollForUserTokenBalance}
       />
       <HamburgerDropdown />
     </div>

--- a/src/components/frame/TokenActivation/StakesTab/ClaimAllButton.tsx
+++ b/src/components/frame/TokenActivation/StakesTab/ClaimAllButton.tsx
@@ -20,7 +20,7 @@ const ClaimAllButton = ({
   colonyAddress,
 }: Props) => {
   const { startPolling, stopPolling } = useColonyContext();
-  const { pollTokenBalance } = useUserTokenBalanceContext();
+  const { pollLockedTokenBalance } = useUserTokenBalanceContext();
   const { setIsOpen } = useTokenActivationContext();
   return (
     <ActionButton
@@ -37,7 +37,7 @@ const ClaimAllButton = ({
         setIsOpen(false);
         startPolling(1000);
         setTimeout(stopPolling, 10_000);
-        pollTokenBalance();
+        pollLockedTokenBalance();
       }}
     />
   );

--- a/src/components/frame/TokenActivation/StakesTab/ClaimAllButton.tsx
+++ b/src/components/frame/TokenActivation/StakesTab/ClaimAllButton.tsx
@@ -4,6 +4,7 @@ import { ActionButton } from '~shared/Button';
 import { ActionTypes } from '~redux/actionTypes';
 import { Address, UnclaimedStakes } from '~types/index';
 import { useColonyContext, useTokenActivationContext } from '~hooks';
+import { useUserTokenBalanceContext } from '~context';
 
 const displayName = 'frame.TokenActivation.StakesTab.ClaimAllButton';
 
@@ -19,6 +20,7 @@ const ClaimAllButton = ({
   colonyAddress,
 }: Props) => {
   const { startPolling, stopPolling } = useColonyContext();
+  const { pollTokenBalance } = useUserTokenBalanceContext();
   const { setIsOpen } = useTokenActivationContext();
   return (
     <ActionButton
@@ -35,6 +37,7 @@ const ClaimAllButton = ({
         setIsOpen(false);
         startPolling(1000);
         setTimeout(stopPolling, 10_000);
+        pollTokenBalance();
       }}
     />
   );

--- a/src/components/frame/TokenActivation/TokenActivationContent/TokenActivationContent.tsx
+++ b/src/components/frame/TokenActivation/TokenActivationContent/TokenActivationContent.tsx
@@ -23,7 +23,7 @@ const MSG = defineMessages({
   },
 });
 
-const TokenActivationContent = ({ ...otherProps }: TokensTabProps) => {
+const TokenActivationContent = ({ tokenBalanceData }: TokensTabProps) => {
   const [tabIndex, setTabIndex] = useState<number>(0);
   const { colony } = useColonyContext();
   const { user } = useAppContext();
@@ -67,13 +67,10 @@ const TokenActivationContent = ({ ...otherProps }: TokensTabProps) => {
           </Tab>
         </TabList>
         <TabPanel className={styles.tabContainer}>
-          <TokensTab {...otherProps} />
+          <TokensTab tokenBalanceData={tokenBalanceData} />
         </TabPanel>
         <TabPanel className={styles.tabContainer}>
-          <StakesTab
-            {...otherProps}
-            currentUserClaims={currentUserClaims ?? []}
-          />
+          <StakesTab currentUserClaims={currentUserClaims ?? []} />
         </TabPanel>
       </Tabs>
     </div>

--- a/src/components/frame/TokenActivation/TokenActivationPopover.tsx
+++ b/src/components/frame/TokenActivation/TokenActivationPopover.tsx
@@ -15,7 +15,7 @@ interface Props extends TokensTabProps {
 
 const { verticalOffset } = styles;
 
-const TokenActivationPopover = ({ children, ...otherProps }: Props) => {
+const TokenActivationPopover = ({ children, tokenBalanceData }: Props) => {
   const { isOpen, setIsOpen } = useTokenActivationContext();
 
   /*
@@ -43,7 +43,9 @@ const TokenActivationPopover = ({ children, ...otherProps }: Props) => {
       isOpen={isOpen}
       setIsOpen={setIsOpen}
       onClose={() => setIsOpen(false)}
-      renderContent={() => <TokenActivationContent {...otherProps} />}
+      renderContent={() => (
+        <TokenActivationContent tokenBalanceData={tokenBalanceData} />
+      )}
       popperOptions={{
         modifiers: [
           {

--- a/src/components/frame/TokenActivation/TokensTab/ChangeTokenStateForm.tsx
+++ b/src/components/frame/TokenActivation/TokensTab/ChangeTokenStateForm.tsx
@@ -75,7 +75,7 @@ const ChangeTokenStateForm = ({
   hasLockedTokens,
 }: ChangeTokenStateFormProps) => {
   const { colony } = useColonyContext();
-  const { pollTokenBalance } = useUserTokenBalanceContext();
+  const { pollActiveTokenBalance } = useUserTokenBalanceContext();
 
   const [isActivate, setIsActive] = useState(true);
 
@@ -131,7 +131,7 @@ const ChangeTokenStateForm = ({
         validationSchema={validationSchema}
         transform={transform}
         onSuccess={(_, { reset }) => {
-          pollTokenBalance();
+          pollActiveTokenBalance();
           reset();
         }}
       >

--- a/src/components/frame/TokenActivation/TokensTab/ChangeTokenStateForm.tsx
+++ b/src/components/frame/TokenActivation/TokensTab/ChangeTokenStateForm.tsx
@@ -17,6 +17,7 @@ import { pipe, mapPayload } from '~utils/actions';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
 import { useColonyContext } from '~hooks';
 import { UserTokenBalanceData } from '~types';
+import { useUserTokenBalanceContext } from '~context';
 
 import styles from './TokensTab.css';
 
@@ -67,15 +68,14 @@ type FormValues = InferType<typeof validationSchema>;
 export interface ChangeTokenStateFormProps {
   tokenBalanceData: UserTokenBalanceData;
   hasLockedTokens: boolean;
-  pollTokenBalance: () => void;
 }
 
 const ChangeTokenStateForm = ({
   tokenBalanceData: { inactiveBalance, activeBalance, lockedBalance },
   hasLockedTokens,
-  pollTokenBalance,
 }: ChangeTokenStateFormProps) => {
   const { colony } = useColonyContext();
+  const { pollTokenBalance } = useUserTokenBalanceContext();
 
   const [isActivate, setIsActive] = useState(true);
 

--- a/src/components/frame/TokenActivation/TokensTab/TokensTab.tsx
+++ b/src/components/frame/TokenActivation/TokensTab/TokensTab.tsx
@@ -63,10 +63,9 @@ const MSG = defineMessages({
 
 export interface TokensTabProps {
   tokenBalanceData: UserTokenBalanceData;
-  pollTokenBalance: () => void;
 }
 
-const TokensTab = ({ tokenBalanceData, pollTokenBalance }: TokensTabProps) => {
+const TokensTab = ({ tokenBalanceData }: TokensTabProps) => {
   const { colony } = useColonyContext();
   const targetRef = useRef<HTMLParagraphElement>(null);
 
@@ -209,7 +208,6 @@ const TokensTab = ({ tokenBalanceData, pollTokenBalance }: TokensTabProps) => {
       <ChangeTokenStateForm
         tokenBalanceData={tokenBalanceData}
         hasLockedTokens={hasLockedTokens}
-        pollTokenBalance={pollTokenBalance}
       />
     </>
   );

--- a/src/components/frame/UserTokenActivationButton/UserTokenActivationButton.tsx
+++ b/src/components/frame/UserTokenActivationButton/UserTokenActivationButton.tsx
@@ -22,7 +22,6 @@ const MSG = defineMessages({
 interface Props {
   dataTest: string;
   tokenBalanceData: UserTokenBalanceData;
-  pollTokenBalance: () => void;
   nativeToken: Token;
 }
 
@@ -30,13 +29,9 @@ const UserTokenActivationButton = ({
   dataTest,
   nativeToken,
   tokenBalanceData,
-  pollTokenBalance,
 }: Props) => {
   return (
-    <TokenActivationPopover
-      tokenBalanceData={tokenBalanceData}
-      pollTokenBalance={pollTokenBalance}
-    >
+    <TokenActivationPopover tokenBalanceData={tokenBalanceData}>
       {({ isOpen, toggle, ref }) => (
         <button
           type="button"

--- a/src/context/ColonyContext.tsx
+++ b/src/context/ColonyContext.tsx
@@ -8,6 +8,7 @@ import { Colony } from '~types';
 import LoadingTemplate from '~frame/LoadingTemplate';
 import NotFoundRoute from '~routes/NotFoundRoute';
 import { useCanInteractWithColony } from '~hooks';
+import { UserTokenBalanceProvider } from './UserTokenBalanceContext';
 
 interface ColonyContextValue {
   colony?: Colony;
@@ -113,7 +114,7 @@ export const ColonyContextProvider = ({
 
   return (
     <ColonyContext.Provider value={colonyContext}>
-      {children}
+      <UserTokenBalanceProvider>{children}</UserTokenBalanceProvider>
     </ColonyContext.Provider>
   );
 };

--- a/src/context/UserTokenBalanceContext.tsx
+++ b/src/context/UserTokenBalanceContext.tsx
@@ -1,15 +1,19 @@
-import React, { ReactNode, createContext, useContext, useMemo } from 'react';
+import React, {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+} from 'react';
 import { GetUserTokenBalanceReturn, useGetUserTokenBalanceQuery } from '~gql';
 import { useAppContext, useColonyContext } from '~hooks';
 
 export const UserTokenBalanceContext = createContext<{
   tokenBalanceData: GetUserTokenBalanceReturn | null | undefined;
-  startPollingTokenBalance: (interval: number) => void;
-  stopPollingTokenBalance: () => void;
+  pollTokenBalance: () => void;
 }>({
   tokenBalanceData: null,
-  startPollingTokenBalance: () => {},
-  stopPollingTokenBalance: () => {},
+  pollTokenBalance: () => {},
 });
 
 export const UserTokenBalanceProvider = ({
@@ -38,13 +42,17 @@ export const UserTokenBalanceProvider = ({
 
   const tokenBalanceData = tokenBalanceQueryData?.getUserTokenBalance;
 
+  const pollTokenBalance = useCallback(() => {
+    startPolling(1000);
+    setTimeout(stopPolling, 10_000);
+  }, [startPolling, stopPolling]);
+
   const value = useMemo(
     () => ({
       tokenBalanceData,
-      startPollingTokenBalance: startPolling,
-      stopPollingTokenBalance: stopPolling,
+      pollTokenBalance,
     }),
-    [tokenBalanceData, startPolling, stopPolling],
+    [tokenBalanceData, pollTokenBalance],
   );
 
   return (

--- a/src/context/UserTokenBalanceContext.tsx
+++ b/src/context/UserTokenBalanceContext.tsx
@@ -1,0 +1,67 @@
+import React, { ReactNode, createContext, useContext, useMemo } from 'react';
+import { GetUserTokenBalanceReturn, useGetUserTokenBalanceQuery } from '~gql';
+import { useAppContext, useColonyContext } from '~hooks';
+
+export const UserTokenBalanceContext = createContext<{
+  tokenBalanceData: GetUserTokenBalanceReturn | null | undefined;
+  startPollingTokenBalance: (interval: number) => void;
+  stopPollingTokenBalance: () => void;
+}>({
+  tokenBalanceData: null,
+  startPollingTokenBalance: () => {},
+  stopPollingTokenBalance: () => {},
+});
+
+export const UserTokenBalanceProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const { wallet } = useAppContext();
+  const { colony } = useColonyContext();
+  const { colonyAddress, nativeToken } = colony || {};
+
+  const {
+    data: tokenBalanceQueryData,
+    startPolling,
+    stopPolling,
+  } = useGetUserTokenBalanceQuery({
+    variables: {
+      input: {
+        walletAddress: wallet?.address ?? '',
+        tokenAddress: nativeToken?.tokenAddress ?? '',
+        colonyAddress: colonyAddress ?? '',
+      },
+    },
+    skip: !wallet?.address || !nativeToken?.tokenAddress,
+  });
+
+  const tokenBalanceData = tokenBalanceQueryData?.getUserTokenBalance;
+
+  const value = useMemo(
+    () => ({
+      tokenBalanceData,
+      startPollingTokenBalance: startPolling,
+      stopPollingTokenBalance: stopPolling,
+    }),
+    [tokenBalanceData, startPolling, stopPolling],
+  );
+
+  return (
+    <UserTokenBalanceContext.Provider value={value}>
+      {children}
+    </UserTokenBalanceContext.Provider>
+  );
+};
+
+export const useUserTokenBalanceContext = () => {
+  const context = useContext(UserTokenBalanceContext);
+
+  if (!context) {
+    throw new Error(
+      'This hook must be used within the "UserTokenBalanceContext" provider',
+    );
+  }
+
+  return context;
+};

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -13,6 +13,11 @@ export { UserSettingsClass as UserSettings };
 export { AppContext, AppContextProvider } from './AppContext';
 export { ColonyManagerClass as ColonyManager };
 export { ColonyContext, ColonyContextProvider } from './ColonyContext';
+export {
+  UserTokenBalanceContext,
+  UserTokenBalanceProvider,
+  useUserTokenBalanceContext,
+} from './UserTokenBalanceContext';
 
 export enum ContextModule {
   Wallet = 'wallet',


### PR DESCRIPTION
## Description

This PR updates the Staked Tokens item in the Token Activation Popover after staking a motion, and also after claiming token rewards (via widget and via stakes tab in Token Activation Popover).

## To Test

We're testing two things. The first is that the "Staked" item in the Token Activation Popover correctly updates whenever we stake a motion, or claim our rewards (either via the widget, or via the Token Activation Popover).

This is fairly simple to test: ensure that the value updates after staking / claiming.

The second is that the Staking limit updates after staking. To test this, you need to activate enough tokens to stake but not enough to stake 100%. Then stake. Once the widget updates, the staking limit should have updated to reflect the fact that you have fewer active tokens now.


**New stuff** ✨

* moved `useGetUserTokenBalanceQuery` to new context provider
* add polling after staking and claiming tokens

**Changes** 🏗

* Removed prop drilling of token balance data

Resolves #675
