### PR TITLE
Fix reputation in motion msg

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/useVoteDetailsConfig.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/useVoteDetailsConfig.tsx
@@ -42,6 +42,7 @@ export const useVoteDetailsConfig = ({
     colony?.colonyAddress ?? '',
     user?.walletAddress ?? '',
     Number(nativeMotionDomainId),
+    rootHash,
   );
 
   const { data } = useGetVoterRewardsQuery({

--- a/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
+++ b/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
@@ -186,14 +186,14 @@ export const useMapMotionEventToExpectedFormat = (
   motionMessageData: MotionMessage,
   actionData: ColonyAction,
 ) => {
-  const { colonyAddress, fromDomain, motionData, pendingColonyMetadata } =
-    actionData;
+  const { colonyAddress, motionData, pendingColonyMetadata } = actionData;
+  const { nativeMotionDomainId } = motionData || {};
   const { colony } = useColonyContext();
 
   const initiatorUserReputation = useUserReputation(
     colonyAddress,
     motionMessageData.initiatorAddress,
-    fromDomain?.nativeId,
+    Number(nativeMotionDomainId),
     motionData?.rootHash,
   );
 


### PR DESCRIPTION
## Description

Currently, the reputation for the motion messages is using the reputation in the `fromDomain`, as opposed to the reputation in the `motionDomain`, which means that in the example below, it's showing that I have no rep, when I do. 

![rep-calc](https://github.com/JoinColony/colonyCDapp/assets/64402732/d3df480f-cc38-46aa-ace9-95ec2a66e730)

We are interested in displaying the rep in the `motionDomain` because that's what is used in the voting calculation. 

**Changes** 🏗

* Use the motion domain, not from domain, to calculate rep in the motion messages

