### PR TITLE
Ensure staking slider has correct max value

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/helpers.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/helpers.ts
@@ -8,6 +8,10 @@ export const getStakeFromSlider = (
   remainingToStake: string,
   userMinStake: string,
 ) => {
+  if (sliderAmount === 100) {
+    return BigNumber.from(remainingToStake);
+  }
+
   const exactStake = new Decimal(sliderAmount)
     .mul(BigNumber.from(remainingToStake).sub(userMinStake).toString())
     .div(100)


### PR DESCRIPTION
## Description

I noticed a bug (difficult to reproduce) in which the staking slider would only stake 99% of the remaining stake, even if I had enough tokens. 

This is a rounding error, and so I've updated the logic to capture the state in which a user wants to stake 100% of the remaining stake amount.

**Changes** 🏗

* Add case specifically if slider is at 100

