### PR TITLE
Fix user name in action message

### DIFF
--- a/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
+++ b/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
@@ -11,6 +11,9 @@ import {
   ColonyActionType,
   DomainMetadata,
   MotionMessage,
+  User,
+  ColonyExtension,
+  Token,
 } from '~types';
 import { useColonyContext, useUserReputation } from '~hooks';
 import { MotionVote } from '~utils/colonyMotions';
@@ -63,6 +66,60 @@ const getDomainNameFromChangelog = (
   return changelogItem.newName;
 };
 
+const getRecipient = (actionData: ColonyAction) => {
+  const { recipientUser, recipientColony, recipientExtension, recipientToken } =
+    actionData;
+
+  let recipient: User | Colony | ColonyExtension | Token | undefined;
+
+  if (recipientUser) {
+    recipient = recipientUser;
+  } else if (recipientColony) {
+    recipient = recipientColony;
+  } else if (recipientExtension) {
+    recipient = recipientExtension;
+  } else if (recipientToken) {
+    recipient = recipientToken;
+  }
+
+  return (
+    <span className={styles.userDecoration}>
+      {recipient ? (
+        <FriendlyName agent={recipient} autoShrinkAddress />
+      ) : (
+        <MaskedAddress address={actionData.recipientAddress || AddressZero} />
+      )}
+    </span>
+  );
+};
+
+const getInitiator = (actionData: ColonyAction) => {
+  const { initiatorUser, initiatorColony, initiatorExtension, initiatorToken } =
+    actionData;
+
+  let initiator: User | Colony | ColonyExtension | Token | undefined;
+
+  if (initiatorUser) {
+    initiator = initiatorUser;
+  } else if (initiatorColony) {
+    initiator = initiatorColony;
+  } else if (initiatorExtension) {
+    initiator = initiatorExtension;
+  } else if (initiatorToken) {
+    initiator = initiatorToken;
+  }
+
+  return (
+    <span className={styles.userDecoration}>
+      {initiator ? (
+        <FriendlyName agent={initiator} autoShrinkAddress />
+      ) : (
+        <MaskedAddress address={actionData.initiatorAddress || AddressZero} />
+      )}
+    </span>
+  );
+};
+
 export const mapColonyActionToExpectedFormat = (
   actionData: ColonyAction,
   colony?: Colony,
@@ -84,21 +141,8 @@ export const mapColonyActionToExpectedFormat = (
         actionData.transactionHash,
         actionData.fromDomain?.metadata || actionData.pendingDomainMetadata,
       ) ?? formatMessage({ id: 'unknownDomain' }),
-    initiator: (
-      <span className={styles.titleDecoration}>
-        {/* @TODO All all the other initiator types, and the fallback */}
-        <FriendlyName user={actionData.initiatorUser} autoShrinkAddress />
-      </span>
-    ),
-    recipient: (
-      <span className={styles.titleDecoration}>
-        {actionData.recipientUser ? (
-          <FriendlyName user={actionData.recipientUser} autoShrinkAddress />
-        ) : (
-          <MaskedAddress address={actionData.recipientAddress || AddressZero} />
-        )}
-      </span>
-    ),
+    initiator: getInitiator(actionData),
+    recipient: getRecipient(actionData),
     toDomain:
       actionData.toDomain?.metadata?.name ??
       formatMessage({ id: 'unknownDomain' }),
@@ -148,21 +192,8 @@ export const mapActionEventToExpectedFormat = (
     // clientOrExtensionType: (
     //   <span className={styles.highlight}>{event.emittedBy}</span>
     // ),
-    initiator: (
-      <span className={styles.userDecoration}>
-        {/* @TODO All all the other initiator types, and the fallback */}
-        <FriendlyName user={actionData.initiatorUser} autoShrinkAddress />
-      </span>
-    ),
-    recipient: (
-      <span className={styles.userDecoration}>
-        {actionData.recipientUser || actionData.recipientColony ? (
-          <FriendlyName user={actionData.recipientUser} autoShrinkAddress />
-        ) : (
-          <MaskedAddress address={actionData.recipientAddress || AddressZero} />
-        )}
-      </span>
-    ),
+    initiator: getInitiator(actionData),
+    recipient: getRecipient(actionData),
     isSmiteAction:
       actionData.type === ColonyActionType.EmitDomainReputationPenalty,
     tokenSymbol: actionData.token?.symbol,
@@ -240,7 +271,7 @@ export const useMapMotionEventToExpectedFormat = (
       <>
         <span className={styles.userDecoration}>
           <FriendlyName
-            user={motionMessageData.initiatorUser}
+            agent={motionMessageData.initiatorUser}
             autoShrinkAddress
           />
         </span>
@@ -256,7 +287,7 @@ export const useMapMotionEventToExpectedFormat = (
       <>
         <span className={styles.userDecoration}>
           <FriendlyName
-            user={motionMessageData.initiatorUser}
+            agent={motionMessageData.initiatorUser}
             autoShrinkAddress
           />
         </span>

--- a/src/components/shared/FriendlyName/FriendlyName.tsx
+++ b/src/components/shared/FriendlyName/FriendlyName.tsx
@@ -2,19 +2,18 @@ import React, { useRef, useEffect } from 'react';
 import { AddressZero } from '@ethersproject/constants';
 
 import MaskedAddress from '~shared/MaskedAddress';
-import { isEmpty } from '~utils/lodash';
 import { removeValueUnits } from '~utils/css';
 
-import { User } from '~types';
-import { useColonyContext } from '~hooks';
+import { Colony, ColonyExtension, Token, User } from '~types';
 
 import styles from './FriendlyName.css';
+import { getAddressFromAgent, getDisplayNameFromAgent } from './helpers';
 
 const displayName = 'FriendlyName';
 
-interface Props {
+export interface FriendlyNameProps {
   /**  The user object to display */
-  user?: User | null;
+  agent?: User | Colony | ColonyExtension | Token | null;
   /** Whether to show a masked address or a full one */
   maskedAddress?: boolean;
   /** Whether to apply the "shrink tech font by 1px" logic */
@@ -22,18 +21,12 @@ interface Props {
 }
 
 const FriendlyName = ({
-  user,
+  agent,
   maskedAddress = true,
   autoShrinkAddress = false,
-}: Props) => {
-  const { colony } = useColonyContext();
+}: FriendlyNameProps) => {
   const addressRef = useRef<HTMLElement>(null);
-  const colonyDisplayName = colony?.metadata?.displayName || colony?.name;
-  const colonyDisplayAddress =
-    colony?.colonyAddress !== AddressZero ? colony?.colonyAddress : '';
-  const walletAddress = user?.walletAddress;
-  const userDisplayName = user?.profile?.displayName || user?.name;
-  const userDisplayAddress = walletAddress !== AddressZero ? walletAddress : '';
+  const agentDisplayName = getDisplayNameFromAgent(agent);
 
   /*
    * We always make (for this component only), the address
@@ -49,16 +42,12 @@ const FriendlyName = ({
     }
   }, [addressRef, autoShrinkAddress]);
 
-  const isColony =
-    walletAddress === colony?.colonyAddress ||
-    (isEmpty(user) && !isEmpty(colony));
-
   return (
     <div className={styles.main}>
       <div className={styles.name}>
-        {userDisplayName || (isColony && colonyDisplayName) || (
+        {agentDisplayName || (
           <MaskedAddress
-            address={userDisplayAddress || colonyDisplayAddress || AddressZero}
+            address={getAddressFromAgent(agent) ?? AddressZero}
             full={!maskedAddress}
             ref={addressRef}
           />

--- a/src/components/shared/FriendlyName/helpers.ts
+++ b/src/components/shared/FriendlyName/helpers.ts
@@ -47,11 +47,11 @@ export const getDisplayNameFromAgent = (
 
     case 'ColonyExtension': {
       if (getExtensionHash(Extension.OneTxPayment) === agent.hash) {
-        return 'One Transaction Payment';
+        return 'One Transaction Payment Extension';
       }
 
       if (getExtensionHash(Extension.VotingReputation) === agent.hash) {
-        return 'Governance (Reputation Weighted)';
+        return 'Governance (Reputation Weighted) Extension';
       }
 
       return undefined;
@@ -62,7 +62,7 @@ export const getDisplayNameFromAgent = (
     }
 
     case 'User': {
-      return agent.name;
+      return agent.profile?.displayName || agent.name;
     }
 
     default: {

--- a/src/components/shared/FriendlyName/helpers.ts
+++ b/src/components/shared/FriendlyName/helpers.ts
@@ -1,0 +1,72 @@
+import { Extension, getExtensionHash } from '@colony/colony-js';
+import { FriendlyNameProps } from './FriendlyName';
+
+export const getAddressFromAgent = (
+  agent: FriendlyNameProps['agent'],
+): string | undefined => {
+  if (!agent) {
+    return undefined;
+  }
+
+  // eslint-disable-next-line no-underscore-dangle
+  switch (agent.__typename) {
+    case 'Colony': {
+      return agent.colonyAddress;
+    }
+
+    case 'ColonyExtension': {
+      return agent.address;
+    }
+
+    case 'Token': {
+      return agent.tokenAddress;
+    }
+
+    case 'User': {
+      return agent.walletAddress;
+    }
+
+    default: {
+      return undefined;
+    }
+  }
+};
+
+export const getDisplayNameFromAgent = (
+  agent: FriendlyNameProps['agent'],
+): string | undefined => {
+  if (!agent) {
+    return undefined;
+  }
+
+  // eslint-disable-next-line no-underscore-dangle
+  switch (agent.__typename) {
+    case 'Colony': {
+      return agent.metadata?.displayName || agent.name;
+    }
+
+    case 'ColonyExtension': {
+      if (getExtensionHash(Extension.OneTxPayment) === agent.hash) {
+        return 'One Transaction Payment';
+      }
+
+      if (getExtensionHash(Extension.VotingReputation) === agent.hash) {
+        return 'Governance (Reputation Weighted)';
+      }
+
+      return undefined;
+    }
+
+    case 'Token': {
+      return agent.name;
+    }
+
+    case 'User': {
+      return agent.name;
+    }
+
+    default: {
+      return undefined;
+    }
+  }
+};


### PR DESCRIPTION
## Description

Currently, the logic for generating recipient / initiator info in the action message doesn't properly account for the fact that it could be a Colony, Colony Extension or Token as well as a user. This is resulting in the following when paying a Colony:

It's incorrectly and inconsistently displaying the recipient
![payment](https://github.com/JoinColony/colonyCDapp/assets/64402732/8b619cfe-36b1-4cde-a019-33e3ca79edf4)

This PR fixes it. 

![bigbenafter](https://github.com/JoinColony/colonyCDapp/assets/64402732/d5d97128-65f2-498e-a029-698bfb5b1da2)

## Testing

Create an action such as paying another colony, and the correct data should be displayed in the message. 

**New stuff** ✨

*Add logic to detect the type of the initiator / recipient

