### PR TITLE
Update funds after claim

### DIFF
--- a/src/components/common/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.tsx
+++ b/src/components/common/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.tsx
@@ -41,7 +41,12 @@ const MSG = defineMessages({
 });
 
 const ColonyUnclaimedTransfers = () => {
-  const { colony, canInteractWithColony } = useColonyContext();
+  const {
+    colony,
+    canInteractWithColony,
+    startPolling: startPollingColony,
+    stopPolling: stopPollingColony,
+  } = useColonyContext();
   const claims = useColonyFundsClaims();
 
   const firstItem = claims[0];
@@ -58,6 +63,11 @@ const ColonyUnclaimedTransfers = () => {
    * Token of the first claim (to be displayed)
    */
   const token = firstItem?.token;
+
+  const handleClaimSuccess = () => {
+    startPollingColony(1_000);
+    setTimeout(stopPollingColony, 10_000);
+  };
 
   return claimsLength ? (
     <div className={styles.main}>
@@ -106,6 +116,7 @@ const ColonyUnclaimedTransfers = () => {
               text={MSG.claimButton}
               className={styles.button}
               actionType={ActionTypes.CLAIM_TOKEN}
+              onSuccess={handleClaimSuccess}
               transform={transform}
               disabled={!canInteractWithColony}
             />

--- a/src/components/common/UnclaimedTransfers/UnclaimedTransfersItem.tsx
+++ b/src/components/common/UnclaimedTransfers/UnclaimedTransfersItem.tsx
@@ -39,7 +39,12 @@ interface Props {
 }
 
 const UnclaimedTransfersItem = ({ claim }: Props) => {
-  const { colony, canInteractWithColony } = useColonyContext();
+  const {
+    colony,
+    canInteractWithColony,
+    startPolling: startPollingColony,
+    stopPolling: stopPollingColony,
+  } = useColonyContext();
   const [isClaimed, setIsClaimed] = useState(false);
 
   const token = claim?.token;
@@ -48,6 +53,12 @@ const UnclaimedTransfersItem = ({ claim }: Props) => {
     colonyAddress: colony?.colonyAddress,
     tokenAddress: token?.tokenAddress,
   });
+
+  const handleClaimSuccess = () => {
+    setIsClaimed(true);
+    startPollingColony(1_000);
+    setTimeout(stopPollingColony, 10_000);
+  };
 
   return (
     <li>
@@ -80,7 +91,7 @@ const UnclaimedTransfersItem = ({ claim }: Props) => {
             className={styles.button}
             actionType={ActionTypes.CLAIM_TOKEN}
             transform={transform}
-            onSuccess={() => setIsClaimed(true)}
+            onSuccess={handleClaimSuccess}
             disabled={!canInteractWithColony || isClaimed}
             dataTest="claimForColonyButton"
           />

--- a/src/context/ColonyContext.tsx
+++ b/src/context/ColonyContext.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useMemo, ReactNode, useState } from 'react';
+import React, {
+  createContext,
+  useMemo,
+  ReactNode,
+  useState,
+  useEffect,
+} from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { defineMessages } from 'react-intl';
 import { ObservableQuery } from '@apollo/client';
@@ -46,8 +52,18 @@ export const ColonyContextProvider = ({
   children: ReactNode;
 }) => {
   const { colonyName } = useParams<{ colonyName: string }>();
+  const [prevColonyName, setPrevColonyName] = useState<string>();
+
   const { state: locationState } = useLocation();
   const [isPolling, setIsPolling] = useState(!!colonyName);
+
+  /* Update polling state when routing between colonies */
+  useEffect(() => {
+    if (colonyName && colonyName !== prevColonyName) {
+      setPrevColonyName(colonyName);
+      setIsPolling(true);
+    }
+  }, [colonyName, prevColonyName]);
 
   const {
     data,

--- a/src/context/UserTokenBalanceContext.tsx
+++ b/src/context/UserTokenBalanceContext.tsx
@@ -40,6 +40,11 @@ export const UserTokenBalanceProvider = ({
 
   const tokenBalanceData = tokenBalanceQueryData?.getUserTokenBalance;
 
+  /*
+   * Custom polling functions ensure that they don't interfere with one another.
+   * If you used startPoll & stopPoll, a call to stopPoll would cancel all polling, so if you were polling
+   * more than one balance simultaneously, you'd not see the updates in the UI you'd be expecting.
+   */
   const pollActiveTokenBalance = useCallback(() => {
     let interval;
 


### PR DESCRIPTION
## Description

This PR updates the colony object after claiming an incoming funds item, meaning the ui will update automatically without need for a browser refresh.

## Testing
Transfer a colony some token so there's an incoming funds claim. Make the claim, either from the funding widget or the funds page. You should see the ui update automatically some seconds later.

**Changes** 🏗

* Poll colony object after claiming

