### PR TITLE
Consistent max colony name

### DIFF
--- a/src/components/common/CreateColonyWizard/StepColonyNameInputs.tsx
+++ b/src/components/common/CreateColonyWizard/StepColonyNameInputs.tsx
@@ -3,7 +3,7 @@ import { defineMessages } from 'react-intl';
 
 import QuestionMarkTooltip from '~shared/QuestionMarkTooltip';
 import { HookFormInput as Input } from '~shared/Fields';
-import { DEFAULT_NETWORK_INFO } from '~constants';
+import { DEFAULT_NETWORK_INFO, MAX_COLONY_DISPLAY_NAME } from '~constants';
 
 import styles from './StepColonyName.css';
 
@@ -54,6 +54,7 @@ const StepColonyNameInputs = ({
       data-test="claimColonyDisplayNameInput"
       label={MSG.colonyName}
       disabled={disabled}
+      maxLength={MAX_COLONY_DISPLAY_NAME}
     />
     <Input
       appearance={{ theme: 'fat' }}

--- a/src/components/common/CreateColonyWizard/validation.ts
+++ b/src/components/common/CreateColonyWizard/validation.ts
@@ -1,10 +1,6 @@
 import { string, object } from 'yup';
 
-import {
-  ADDRESS_ZERO,
-  DEFAULT_NETWORK_TOKEN,
-  MAX_COLONY_DISPLAY_NAME,
-} from '~constants';
+import { ADDRESS_ZERO, DEFAULT_NETWORK_TOKEN } from '~constants';
 import { GetFullColonyByNameDocument } from '~gql';
 import { intl } from '~utils/intl';
 import { createYupTestFromQuery } from '~utils/yup/tests';
@@ -48,7 +44,6 @@ const { formatMessage } = intl({
 export const colonyNameValidationSchema = object({
   displayName: string()
     .trim()
-    .max(MAX_COLONY_DISPLAY_NAME)
     .required(formatMessage({ id: 'error.colonyNameRequired' })),
   colonyName: string()
     .required(formatMessage({ id: 'error.colonyURLRequired' }))

--- a/src/components/common/CreateColonyWizard/validation.ts
+++ b/src/components/common/CreateColonyWizard/validation.ts
@@ -42,9 +42,10 @@ const { formatMessage } = intl({
 });
 
 export const colonyNameValidationSchema = object({
-  displayName: string().required(
-    formatMessage({ id: 'error.colonyNameRequired' }),
-  ),
+  displayName: string()
+    .trim()
+    .max(20)
+    .required(formatMessage({ id: 'error.colonyNameRequired' })),
   colonyName: string()
     .required(formatMessage({ id: 'error.colonyURLRequired' }))
     .test('isValidName', formatMessage({ id: 'error.colonyURL' }), isValidName)

--- a/src/components/common/CreateColonyWizard/validation.ts
+++ b/src/components/common/CreateColonyWizard/validation.ts
@@ -1,6 +1,10 @@
 import { string, object } from 'yup';
 
-import { ADDRESS_ZERO, DEFAULT_NETWORK_TOKEN } from '~constants';
+import {
+  ADDRESS_ZERO,
+  DEFAULT_NETWORK_TOKEN,
+  MAX_COLONY_DISPLAY_NAME,
+} from '~constants';
 import { GetFullColonyByNameDocument } from '~gql';
 import { intl } from '~utils/intl';
 import { createYupTestFromQuery } from '~utils/yup/tests';
@@ -44,7 +48,7 @@ const { formatMessage } = intl({
 export const colonyNameValidationSchema = object({
   displayName: string()
     .trim()
-    .max(20)
+    .max(MAX_COLONY_DISPLAY_NAME)
     .required(formatMessage({ id: 'error.colonyNameRequired' })),
   colonyName: string()
     .required(formatMessage({ id: 'error.colonyURLRequired' }))

--- a/src/components/common/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialogForm.tsx
+++ b/src/components/common/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialogForm.tsx
@@ -13,6 +13,7 @@ import { Annotations, HookFormInput as Input } from '~shared/Fields';
 import { DropzoneErrors } from '~shared/AvatarUploader/helpers';
 import { useActionDialogStatus } from '~hooks';
 import { SetStateFn } from '~types';
+import { MAX_COLONY_DISPLAY_NAME } from '~constants';
 
 import {
   CannotCreateMotionMessage,
@@ -123,7 +124,7 @@ const EditColonyDetailsDialogForm = ({
           name="colonyDisplayName"
           appearance={{ colorSchema: 'grey', theme: 'fat' }}
           disabled={disabledInput}
-          maxLength={20}
+          maxLength={MAX_COLONY_DISPLAY_NAME}
           value={colonyDisplayName}
         />
       </DialogSection>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -158,3 +158,5 @@ export const isDev = process.env.NETWORK === 'ganache';
 export const CDAPP_VERSION = version;
 
 export const STAKING_THRESHOLD = 10;
+
+export const MAX_COLONY_DISPLAY_NAME = 20;


### PR DESCRIPTION
## Description

This PR makes the colony (display) name max length consistent

![Screenshot from 2023-07-05 12-56-49](https://github.com/JoinColony/colonyCDapp/assets/32598350/ddfe2e47-d634-4893-82a6-c58fa21da9a0)

![image](https://github.com/JoinColony/colonyCDapp/assets/32598350/4e28f378-eda4-4b50-89b3-043fe59846af)


**New stuff** ✨

* A new constant has been created in `MAX_DISPLAY_NAME` 

**Changes** 🏗

* `MAX_DISPLAY_NAME` is now used in colony creation validation and colony editing input limiting

Resolves #711