### PR TITLE
Wire in whitelist

### DIFF
--- a/src/components/common/ColonyHome/ColonyMembersWidget/ColonyMembersWidget.tsx
+++ b/src/components/common/ColonyHome/ColonyMembersWidget/ColonyMembersWidget.tsx
@@ -44,7 +44,6 @@ const ColonyMembersWidget = ({
     },
     fetchPolicy: 'cache-and-network',
   });
-
   if (!colony) return null;
 
   const contributors = data?.getMembersForColony?.contributors;

--- a/src/components/common/ColonyMembers/ColonyMembers.tsx
+++ b/src/components/common/ColonyMembers/ColonyMembers.tsx
@@ -69,7 +69,7 @@ const ColonyMembers = () => {
           <TotalReputation selectedDomainId={selectedDomainId} />
           <MemberControls isRootOrAllDomains={isRootOrAllDomains} />
           <MembersFilter
-            handleFilterChange={handleFilterChange}
+            onFilterChange={handleFilterChange}
             isRootOrAllDomains={isRootOrAllDomains}
           />
         </aside>

--- a/src/components/common/ColonyMembers/ColonyMembers.tsx
+++ b/src/components/common/ColonyMembers/ColonyMembers.tsx
@@ -69,7 +69,7 @@ const ColonyMembers = () => {
           <TotalReputation selectedDomainId={selectedDomainId} />
           <MemberControls isRootOrAllDomains={isRootOrAllDomains} />
           <MembersFilter
-            onFilterChange={handleFilterChange}
+            handleFilterChange={handleFilterChange}
             isRootOrAllDomains={isRootOrAllDomains}
           />
         </aside>

--- a/src/components/common/ColonyMembers/MemberControls/MemberControls.tsx
+++ b/src/components/common/ColonyMembers/MemberControls/MemberControls.tsx
@@ -1,72 +1,86 @@
 import React from 'react';
-// import { defineMessages } from 'react-intl';
 import { Extension } from '@colony/colony-js';
+import { defineMessages } from 'react-intl';
 
 import InviteLinkButton from '~shared/Button/InviteLinkButton';
-// import Button from '~shared/Button';
-// import { useDialog } from '~shared/Dialog';
-// import PermissionManagementDialog from '~dialogs/PermissionManagementDialog';
-// import ManageWhitelistDialog from '~dialogs/ManageWhitelistDialog';
 import { isInstalledExtensionData } from '~utils/extensions';
-import { useColonyContext, useExtensionData } from '~hooks';
+import {
+  useAppContext,
+  useCanInteractWithNetwork,
+  useColonyContext,
+  useEnabledExtensions,
+  useExtensionData,
+} from '~hooks';
+
+import { canArchitect, hasRoot } from '~utils/checks';
+import { getAllUserRoles } from '~transformers';
+import Button from '~shared/Button/Button';
+import { useDialog } from '~shared/Dialog';
+import {
+  ManageWhitelistDialog,
+  PermissionManagementDialog,
+} from '~common/Dialogs';
 
 import styles from './MemberControls.css';
 
 const displayName = 'common.ColonyMembers.MemberControls';
 
-// const MSG = defineMessages({
-//   editPermissions: {
-//     id: `${displayName}.editPermissions`,
-//     defaultMessage: 'Edit permissions',
-//   },
-//   manageWhitelist: {
-//     id: `${displayName}.manageWhitelist`,
-//     defaultMessage: 'Manage address book',
-//   },
-// });
+const MSG = defineMessages({
+  editPermissions: {
+    id: `${displayName}.editPermissions`,
+    defaultMessage: 'Edit permissions',
+  },
+  manageWhitelist: {
+    id: `${displayName}.manageWhitelist`,
+    defaultMessage: 'Manage address book',
+  },
+});
 
 type Props = {
   isRootOrAllDomains: boolean;
 };
 
 const MemberControls = ({ isRootOrAllDomains }: Props) => {
-  const { colony } = useColonyContext();
-
-  // const openPermissionManagementDialog =  useDialog(PermissionManagementDialog);
-  // const handlePermissionManagementDialog = useCallback(() => {
-  //   openPermissionManagementDialog({
-  //     colony,
-  //   });
-  // }, []);
-
-  // const openToggleManageWhitelistDialog = useDialog(ManageWhitelistDialog);
-  // const handleToggleWhitelistDialog = useCallback(() => {
-  //   return openToggleManageWhitelistDialog({
-  //     colony,
-  //   });
-  // }, []);
-
+  const { colony, isSupportedColonyVersion } = useColonyContext();
+  const canInteractWithNetwork = useCanInteractWithNetwork();
+  const { user } = useAppContext();
+  const currentUserRoles = getAllUserRoles(colony, user?.walletAddress);
+  const enabledExtensionData = useEnabledExtensions();
   const { extensionData } = useExtensionData(Extension.OneTxPayment);
+
+  const canManangePermissions =
+    (user && canArchitect(currentUserRoles)) || hasRoot(currentUserRoles);
+  const canManageWhitelist = user && hasRoot(currentUserRoles);
+
+  const openPermissionManagementDialog = useDialog(PermissionManagementDialog);
+  const openToggleManageWhitelistDialog = useDialog(ManageWhitelistDialog);
+
+  if (!colony) {
+    return null;
+  }
+
+  const handlePermissionManagementDialog = () =>
+    openPermissionManagementDialog({
+      colony,
+      enabledExtensionData,
+    });
+
+  const handleToggleWhitelistDialog = () =>
+    openToggleManageWhitelistDialog({
+      colony,
+      enabledExtensionData,
+    });
+
   const mustUpgradeOneTx =
     extensionData && isInstalledExtensionData(extensionData)
       ? extensionData?.currentVersion < extensionData?.availableVersion
       : false;
 
-  // const currentUserRoles = useTransformer(getAllUserRoles, [
-  //   colony,
-  //   currentUserWalletAddress,
-  // ]);
-  // const canManagePermissions =
-  //   (hasRegisteredProfile && canArchitect(currentUserRoles)) ||
-  //   hasRoot(currentUserRoles);
-
-  // const canManageWhitelist = hasRegisteredProfile && hasRoot(currentUserRoles);
-
-  const controlsDisabled = mustUpgradeOneTx;
-  // !isSupportedColonyVersion ||
-  // !isNetworkAllowed ||
-  // !hasRegisteredProfile ||
-  // !isDeploymentFinished ||
+  const controlsDisabled =
+    mustUpgradeOneTx ||
+    !isSupportedColonyVersion ||
+    !canInteractWithNetwork ||
+    !user;
 
   return (
     <>
@@ -80,24 +94,24 @@ const MemberControls = ({ isRootOrAllDomains }: Props) => {
               />
             </li>
           )}
-          {/* {canMamangePermissions && (
-          <li>
-            <Button
-              appearance={{ theme: 'blue' }}
-              text={MSG.editPermissions}
-              onClick={handlePermissionManagementDialog}
-            />
-          </li>
-        )}
+          {canManangePermissions && (
+            <li>
+              <Button
+                appearance={{ theme: 'blue' }}
+                text={MSG.editPermissions}
+                onClick={handlePermissionManagementDialog}
+              />
+            </li>
+          )}
           {canManageWhitelist && (
-          <li>
-            <Button
-              appearance={{ theme: 'blue' }}
-              text={MSG.manageWhitelist}
-              onClick={handleToggleWhitelistDialog}
-            />
-          </li>
-        )} */}
+            <li>
+              <Button
+                appearance={{ theme: 'blue' }}
+                text={MSG.manageWhitelist}
+                onClick={handleToggleWhitelistDialog}
+              />
+            </li>
+          )}
         </ul>
       )}
     </>

--- a/src/components/common/ColonyMembers/MemberControls/MemberControls.tsx
+++ b/src/components/common/ColonyMembers/MemberControls/MemberControls.tsx
@@ -48,7 +48,7 @@ const MemberControls = ({ isRootOrAllDomains }: Props) => {
   const enabledExtensionData = useEnabledExtensions();
   const { extensionData } = useExtensionData(Extension.OneTxPayment);
 
-  const canManangePermissions =
+  const canManagePermissions =
     (user && canArchitect(currentUserRoles)) || hasRoot(currentUserRoles);
   const canManageWhitelist = user && hasRoot(currentUserRoles);
 
@@ -94,7 +94,7 @@ const MemberControls = ({ isRootOrAllDomains }: Props) => {
               />
             </li>
           )}
-          {canManangePermissions && (
+          {canManagePermissions && (
             <li>
               <Button
                 appearance={{ theme: 'blue' }}

--- a/src/components/common/ColonyMembers/MembersFilter/Filter.tsx
+++ b/src/components/common/ColonyMembers/MembersFilter/Filter.tsx
@@ -13,7 +13,7 @@ interface Props {
   name: string;
   options?: SelectOption[];
   label: string | MessageDescriptor;
-  handleFilterChange: (name, value) => void;
+  onFilterChange: (name, value) => void;
 }
 
 const Filter = ({
@@ -21,7 +21,7 @@ const Filter = ({
   name,
   options,
   label,
-  handleFilterChange,
+  onFilterChange,
 }: Props) => {
   const selectRef = useRef<HTMLDivElement>(null);
 
@@ -38,7 +38,7 @@ const Filter = ({
       onKeyUp={scrollIntoView}
     >
       <Select
-        onChange={(value) => handleFilterChange(name, value)}
+        onChange={(value) => onFilterChange(name, value)}
         appearance={appearance}
         name={name}
         options={options}

--- a/src/components/common/ColonyMembers/MembersFilter/MembersFilter.tsx
+++ b/src/components/common/ColonyMembers/MembersFilter/MembersFilter.tsx
@@ -36,7 +36,7 @@ export interface FormValues {
 }
 
 interface Props {
-  handleFilterChange: (name, value) => void;
+  onFilterChange: (name, value) => void;
   isRootOrAllDomains: boolean;
 }
 
@@ -47,7 +47,7 @@ const handleReset = (handleFilterChange, reset, defaultValues) => {
   reset();
 };
 
-const MembersFilter = ({ handleFilterChange, isRootOrAllDomains }: Props) => {
+const MembersFilter = ({ onFilterChange, isRootOrAllDomains }: Props) => {
   return (
     <>
       <hr className={styles.divider} />
@@ -70,7 +70,7 @@ const MembersFilter = ({ handleFilterChange, isRootOrAllDomains }: Props) => {
                     text={MSG.reset}
                     appearance={{ theme: 'blue' }}
                     onClick={() =>
-                      handleReset(handleFilterChange, reset, defaultValues)
+                      handleReset(onFilterChange, reset, defaultValues)
                     }
                   />
                 )}
@@ -86,7 +86,7 @@ const MembersFilter = ({ handleFilterChange, isRootOrAllDomains }: Props) => {
                         name={name}
                         options={options}
                         label={label}
-                        handleFilterChange={handleFilterChange}
+                        onFilterChange={onFilterChange}
                       />
                     )
                   );

--- a/src/components/common/ColonyMembers/MembersFilter/MembersFilter.tsx
+++ b/src/components/common/ColonyMembers/MembersFilter/MembersFilter.tsx
@@ -36,7 +36,7 @@ export interface FormValues {
 }
 
 interface Props {
-  onFilterChange: (name, value) => void;
+  handleFilterChange: (name, value) => void;
   isRootOrAllDomains: boolean;
 }
 
@@ -47,7 +47,7 @@ const handleReset = (handleFilterChange, reset, defaultValues) => {
   reset();
 };
 
-const MembersFilter = ({ onFilterChange, isRootOrAllDomains }: Props) => {
+const MembersFilter = ({ handleFilterChange, isRootOrAllDomains }: Props) => {
   return (
     <>
       <hr className={styles.divider} />
@@ -70,7 +70,7 @@ const MembersFilter = ({ onFilterChange, isRootOrAllDomains }: Props) => {
                     text={MSG.reset}
                     appearance={{ theme: 'blue' }}
                     onClick={() =>
-                      handleReset(onFilterChange, reset, defaultValues)
+                      handleReset(handleFilterChange, reset, defaultValues)
                     }
                   />
                 )}
@@ -86,7 +86,7 @@ const MembersFilter = ({ onFilterChange, isRootOrAllDomains }: Props) => {
                         name={name}
                         options={options}
                         label={label}
-                        handleFilterChange={onFilterChange}
+                        handleFilterChange={handleFilterChange}
                       />
                     )
                   );

--- a/src/components/common/ColonyMembers/MembersFilter/filtersConfig.ts
+++ b/src/components/common/ColonyMembers/MembersFilter/filtersConfig.ts
@@ -67,6 +67,12 @@ const memberTypes = [
   { label: MSG.watchers, value: MemberType.Watchers },
 ];
 
+const verificationTypes = [
+  { label: MSG.any, value: VerificationType.All },
+  { label: MSG.verified, value: VerificationType.Verified },
+  { label: MSG.unverified, value: VerificationType.Unverified },
+];
+
 export type filterItem = {
   appearance?: Appearance;
   name: string;
@@ -83,11 +89,11 @@ export const filterItems: filterItem[] = [
     label: MSG.memberType,
     isRootRequired: true,
   },
-  // {
-  //   appearance: { theme: 'grey' },
-  //   name: 'verificationType',
-  //   options: verificationTypes,
-  //   label: MSG.verificationType,
-  //   isRootRequired: false,
-  // },
+  {
+    appearance: { theme: 'grey' },
+    name: 'verificationType',
+    options: verificationTypes,
+    label: MSG.verificationType,
+    isRootRequired: false,
+  },
 ];

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/ManageReputationContainer.tsx
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/ManageReputationContainer.tsx
@@ -8,15 +8,12 @@ import { ActionTypes } from '~redux/index';
 import { pipe, withMeta, mapPayload } from '~utils/actions';
 import { getVerifiedUsers } from '~utils/verifiedUsers';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
-import { useSelectedUser } from '~hooks';
+import { useSelectedUser, useGetColonyMembers } from '~hooks';
 
 import DialogForm from '../ManageReputationDialogForm';
 import { AwardAndSmiteDialogProps } from '../types';
 
-import {
-  getManageReputationDialogPayload,
-  useGetColonyMembers,
-} from './helpers';
+import { getManageReputationDialogPayload } from './helpers';
 
 import {
   FormValues,

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/ManageReputationContainer.tsx
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/ManageReputationContainer.tsx
@@ -6,7 +6,7 @@ import Dialog from '~shared/Dialog';
 import { ActionForm } from '~shared/Fields';
 import { ActionTypes } from '~redux/index';
 import { pipe, withMeta, mapPayload } from '~utils/actions';
-// import { getVerifiedUsers } from '~utils/verifiedRecipients';
+import { getVerifiedUsers } from '~utils/verifiedUsers';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
 import { useSelectedUser } from '~hooks';
 
@@ -42,9 +42,10 @@ const ManageReputationContainer = ({
   const navigate = useNavigate();
   const allColonyMembers = useGetColonyMembers(colony.colonyAddress);
 
-  // const verifiedUsers = useMemo(() => {
-  //   return getVerifiedUsers(colony.whitelistedAddresses, colonyWatchers) || [];
-  // }, [colonyWatchers, colony]);
+  const verifiedUsers = getVerifiedUsers(
+    colony.metadata?.whitelistedAddresses ?? [],
+    allColonyMembers,
+  );
 
   const { isVotingReputationEnabled } = enabledExtensionData;
 
@@ -79,9 +80,11 @@ const ManageReputationContainer = ({
     withMeta({ navigate }),
   );
 
-  // const { isWhitelistActivated } = colony;
-  const selectedUser = useSelectedUser(allColonyMembers);
-  //   isWhitelistActivated ? verifiedUsers : colonyWatchers,
+  const { metadata } = colony;
+  const selectedUser = useSelectedUser(
+    metadata?.isWhitelistActivated ? verifiedUsers : allColonyMembers,
+  );
+
   return (
     <Dialog cancel={cancel}>
       <ActionForm<FormValues>
@@ -103,7 +106,7 @@ const ManageReputationContainer = ({
           nativeTokenDecimals={nativeTokenDecimals}
           back={() => callStep(prevStep)}
           users={
-            allColonyMembers // isWhitelistActivated ? verifiedUsers : colonyWatchers
+            metadata?.isWhitelistActivated ? verifiedUsers : allColonyMembers
           }
           updateSchemaUserReputation={
             isSmiteAction ? setSchemaUserReputation : undefined

--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/helpers.ts
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/helpers.ts
@@ -1,10 +1,8 @@
 import Decimal from 'decimal.js';
 import { BigNumber } from 'ethers';
 
-import { useGetMembersForColonyQuery } from '~gql';
-import { Address, Colony, Member, MemberUser } from '~types';
+import { Colony } from '~types';
 import { ManageReputationMotionPayload } from '~redux/sagas/motions/manageReputationMotion';
-import { notMaybe } from '~utils/arrays';
 
 import { FormValues } from './validation';
 
@@ -29,20 +27,4 @@ export const getManageReputationDialogPayload = (
     amount: BigNumber.from(reputationChangeAmount.toString()),
     isSmitingReputation: isSmiteAction,
   } as ManageReputationMotionPayload;
-};
-
-export const useGetColonyMembers = (colonyAddress?: Address | null) => {
-  const { data } = useGetMembersForColonyQuery({
-    skip: !colonyAddress,
-    variables: {
-      input: {
-        colonyAddress: colonyAddress ?? '',
-      },
-    },
-  });
-
-  const watchers = data?.getMembersForColony?.watchers ?? [];
-  const contributors = data?.getMembersForColony?.contributors ?? [];
-  const allMembers: Member[] = [...watchers, ...contributors];
-  return allMembers.map((member) => member.user).filter<MemberUser>(notMaybe);
 };

--- a/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
+++ b/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
@@ -7,16 +7,11 @@ import Dialog, { DialogProps, ActionDialogProps } from '~shared/Dialog';
 import { ActionForm } from '~shared/Fields';
 
 import { ActionTypes } from '~redux/index';
-// import {
-//   useColonyFromNameQuery,
-// } from '~data/index';
 import { pipe, withMeta, mapPayload } from '~utils/actions';
-// import { getVerifiedUsers } from '~utils/verifiedRecipients';
+import { getVerifiedUsers } from '~utils/verifiedUsers';
 import { WizardDialogType, useNetworkInverseFee } from '~hooks';
-import { useGetMembersForColonyQuery } from '~gql';
 
-import { extractUsersFromColonyMemberData } from '../helpers';
-
+import { useGetColonyMembers } from '../AwardAndSmiteDialogs/ManageReputationContainer/helpers';
 import DialogForm from './CreatePaymentDialogForm';
 import { getCreatePaymentDialogPayload } from './helpers';
 import getValidationSchema from './validation';
@@ -43,23 +38,7 @@ const CreatePaymentDialog = ({
   const [isForce, setIsForce] = useState(false);
   const navigate = useNavigate();
 
-  // @TODO: Could the below use the useGetColonyMembers hook?
-  const { data } = useGetMembersForColonyQuery({
-    skip: !colony.colonyAddress,
-    variables: {
-      input: {
-        colonyAddress: colony.colonyAddress,
-      },
-    },
-    fetchPolicy: 'cache-and-network',
-  });
-  const colonyContributors = extractUsersFromColonyMemberData(
-    data?.getMembersForColony?.contributors,
-  );
-  const colonyWatchers = extractUsersFromColonyMemberData(
-    data?.getMembersForColony?.watchers,
-  );
-  const colonyMembers = colonyContributors.concat(colonyWatchers);
+  const allColonyMembers = useGetColonyMembers(colony.colonyAddress);
 
   const { isVotingReputationEnabled } = enabledExtensionData;
   const { networkInverseFee } = useNetworkInverseFee();
@@ -71,32 +50,12 @@ const CreatePaymentDialog = ({
 
   const validationSchema = getValidationSchema(colony, networkInverseFee);
 
-  /*
-   * @NOTE This (extravagant) query retrieves the latest whitelist data.
-   * Whitelist data from colony prop can be stale.
-   *
-   * Add/remove to whitelist then navigating to payment dialog
-   * without closing the modal will cause the whitelist data in
-   * colony prop to be outdated.
-   */
-  // const { data: colonyData } = useColonyFromNameQuery({
-  //   variables: { name: colonyName, address: colonyAddress },
-  // });
-  // const isWhitelistActivated =
-  //   colonyData?.processedColony?.isWhitelistActivated;
+  const isWhitelistActivated = colony.metadata?.isWhitelistActivated;
 
-  // const verifiedUsers = useMemo(() => {
-  //   return getVerifiedUsers(colony.whitelistedAddresses, subscribedUsers) || [];
-  // }, [subscribedUsers, colony]);
-
-  // const showWarningForAddress = (walletAddress) => {
-  //   if (!walletAddress) return false;
-  //   return isWhitelistActivated
-  //     ? !colonyData?.processedColony?.whitelistedAddresses.some(
-  //         (el) => el.toLowerCase() === walletAddress.toLowerCase(),
-  //       )
-  //     : false;
-  // };
+  const verifiedUsers = getVerifiedUsers(
+    colony.metadata?.whitelistedAddresses ?? [],
+    allColonyMembers,
+  );
 
   const transform = pipe(
     mapPayload((payload) =>
@@ -125,11 +84,8 @@ const CreatePaymentDialog = ({
         <DialogForm
           back={() => callStep(prevStep)}
           verifiedUsers={
-            colonyMembers // isWhitelistActivated ? verifiedUsers : ...
+            isWhitelistActivated ? verifiedUsers : allColonyMembers
           }
-          // showWhitelistWarning={showWarningForAddress(
-          //   values?.recipient?.walletAddress,
-          // )}
           colony={colony}
           enabledExtensionData={enabledExtensionData}
           handleIsForceChange={setIsForce}

--- a/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
+++ b/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
@@ -9,9 +9,12 @@ import { ActionForm } from '~shared/Fields';
 import { ActionTypes } from '~redux/index';
 import { pipe, withMeta, mapPayload } from '~utils/actions';
 import { getVerifiedUsers } from '~utils/verifiedUsers';
-import { WizardDialogType, useNetworkInverseFee } from '~hooks';
+import {
+  WizardDialogType,
+  useNetworkInverseFee,
+  useGetColonyMembers,
+} from '~hooks';
 
-import { useGetColonyMembers } from '../AwardAndSmiteDialogs/ManageReputationContainer/helpers';
 import DialogForm from './CreatePaymentDialogForm';
 import { getCreatePaymentDialogPayload } from './helpers';
 import getValidationSchema from './validation';

--- a/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css
+++ b/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css
@@ -11,7 +11,7 @@
   margin-top: 20px;
   padding: 20px 15px;
   border-radius: var(--radius-normal);
-  background-color: rgba(var(--danger), 0.15);
+  background-color: color-mod(var(--danger) alpha(0.15));
 }
 
 .warningText {

--- a/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/components/common/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -65,7 +65,6 @@ const MSG = defineMessages({
 
 interface Props extends ActionDialogProps {
   verifiedUsers: MemberUser[];
-  // showWhitelistWarning: boolean;
   handleIsForceChange: SetStateFn;
   isForce: boolean;
 }
@@ -79,6 +78,10 @@ const supRenderAvatar = (item: ItemDataType<User>) => (
   <UserAvatar user={item} size="xs" />
 );
 
+const WarningLabel = (chunks) => (
+  <span className={styles.warningLabel}>{chunks}</span>
+);
+
 const CreatePaymentDialogForm = ({
   back,
   verifiedUsers,
@@ -86,8 +89,7 @@ const CreatePaymentDialogForm = ({
   enabledExtensionData,
   handleIsForceChange,
   isForce,
-}: // showWhitelistWarning,
-Props) => {
+}: Props) => {
   const { watch } = useFormContext();
   const { recipient, fromDomainId, forceAction } = watch();
 
@@ -111,6 +113,14 @@ Props) => {
       handleIsForceChange(forceAction);
     }
   }, [forceAction, isForce, handleIsForceChange]);
+
+  const showWarningForAddress = colony.metadata?.isWhitelistActivated
+    ? recipient &&
+      !(colony.metadata?.whitelistedAddresses ?? []).some(
+        (address) =>
+          address.toLowerCase() === recipient.walletAddress.toLowerCase(),
+      )
+    : false;
 
   return (
     <>
@@ -152,20 +162,16 @@ Props) => {
             renderAvatar={supRenderAvatar}
           />
         </div>
-        {/* {showWhitelistWarning && (
+        {showWarningForAddress && (
           <div className={styles.warningContainer}>
             <p className={styles.warningText}>
               <FormattedMessage
                 {...MSG.warningText}
-                values={{
-                  span: (chunks) => (
-                    <span className={styles.warningLabel}>{chunks}</span>
-                  ),
-                }}
+                values={{ span: WarningLabel }}
               />
             </p>
           </div>
-        )} */}
+        )}
         {recipient &&
           recipient.name &&
           isConfusing(recipient.name || recipient.profile?.displayName) && (

--- a/src/components/common/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
+++ b/src/components/common/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
@@ -13,13 +13,13 @@ import {
   mergeSchemas,
   validationSchemaFile,
   validationSchemaInput,
-} from '~utils/whitelistValidation';
+} from './whitelistValidation';
 
 import ManageWhitelistDialogForm from './ManageWhitelistDialogForm';
 import { getManageWhitelistDialogPayload, TABS } from './helpers';
 
-type Props = Required<DialogProps> &
-  WizardDialogType<object> &
+type Props = DialogProps &
+  Partial<WizardDialogType<object>> &
   ActionDialogProps & {
     userAddress?: string;
   };

--- a/src/components/common/Dialogs/ManageWhitelistDialog/ManageWhitelistDialogForm.tsx
+++ b/src/components/common/Dialogs/ManageWhitelistDialog/ManageWhitelistDialogForm.tsx
@@ -30,7 +30,7 @@ const MSG = defineMessages({
   },
   annotation: {
     id: `${displayName}.annotation`,
-    defaultMessage: 'Explain why you’re making these changes (optional)',
+    defaultMessage: "Explain why you're making these changes (optional)",
   },
   addAddress: {
     id: `${displayName}.addAddress`,
@@ -85,7 +85,11 @@ const ManageWhitelistDialogForm = ({
     formState: { errors, isDirty },
     reset: resetForm,
   } = useFormContext();
-  const isWhitelistActivated = watch('isWhitelistActivated');
+  const [isWhitelistActivated, whitelistAddress] = watch([
+    'isWhitelistActivated',
+    'whitelistAddress',
+  ]);
+
   const {
     userHasPermission,
     disabledSubmit,
@@ -180,7 +184,11 @@ const ManageWhitelistDialogForm = ({
         <DialogControls
           secondaryButtonText={backButtonText}
           onSecondaryButtonClick={back}
-          disabled={!isDirty || disabledSubmit}
+          disabled={
+            (!isDirty && !whitelistAddress) ||
+            (tabIndex === TABS.WHITELISTED && !whitelistedAddresses.length) ||
+            disabledSubmit
+          }
           dataTest="whitelistConfirmButton"
           submitButtonAppearance={{
             theme: tabIndex === TABS.ADD_ADDRESS ? 'primary' : 'pink',

--- a/src/components/common/Dialogs/ManageWhitelistDialog/ManageWhitelistDialogForm.tsx
+++ b/src/components/common/Dialogs/ManageWhitelistDialog/ManageWhitelistDialogForm.tsx
@@ -185,6 +185,7 @@ const ManageWhitelistDialogForm = ({
           secondaryButtonText={backButtonText}
           onSecondaryButtonClick={back}
           disabled={
+            /* disable the form if it isn't dirty, except for when there's an address already populated in the address field. */
             (!isDirty && !whitelistAddress) ||
             (tabIndex === TABS.WHITELISTED && !whitelistedAddresses.length) ||
             disabledSubmit

--- a/src/components/common/Dialogs/ManageWhitelistDialog/helpers.ts
+++ b/src/components/common/Dialogs/ManageWhitelistDialog/helpers.ts
@@ -1,6 +1,7 @@
 import { Action, ActionTypes } from '~redux';
 import { Address, Colony } from '~types';
 import { notNull } from '~utils/arrays';
+import { createAddress } from '~utils/web3';
 
 export enum TABS {
   ADD_ADDRESS = 0,
@@ -30,7 +31,12 @@ export const getManageWhitelistDialogPayload = (
   } else {
     verifiedAddresses =
       whitelistAddress !== undefined
-        ? [...new Set([...whitelistedAddresses, whitelistAddress])]
+        ? [
+            ...new Set([
+              ...whitelistedAddresses,
+              createAddress(whitelistAddress),
+            ]),
+          ]
         : [
             ...new Set([
               ...whitelistedAddresses,

--- a/src/components/common/Dialogs/ManageWhitelistDialog/whitelistValidation.ts
+++ b/src/components/common/Dialogs/ManageWhitelistDialog/whitelistValidation.ts
@@ -1,6 +1,6 @@
 import { defineMessages } from 'react-intl';
-import isEmpty from 'lodash/isEmpty';
 import { string, object, array, ObjectSchema } from 'yup';
+import { isEmpty } from '~utils/lodash';
 
 import { isAddress } from '~utils/web3';
 import { formatText } from '~utils/intl';

--- a/src/components/common/Members/Members.tsx
+++ b/src/components/common/Members/Members.tsx
@@ -103,12 +103,14 @@ const Members = ({
 
   const filteredContributors = filterMembers<Contributor>(
     data?.getMembersForColony?.contributors || [],
+    colony?.metadata?.whitelistedAddresses ?? [],
     searchValue,
     filters,
   );
 
   const filteredWatchers = filterMembers<Watcher>(
     data?.getMembersForColony?.watchers || [],
+    colony?.metadata?.whitelistedAddresses ?? [],
     searchValue,
     filters,
   );

--- a/src/components/common/Members/MembersList/Actions/MemberActionsPopover.tsx
+++ b/src/components/common/Members/MembersList/Actions/MemberActionsPopover.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { defineMessages } from 'react-intl';
+import { FormattedMessage, defineMessages } from 'react-intl';
 
 import { getBlockscoutUserURL } from '~constants';
 import DropdownMenu, {
@@ -10,6 +10,10 @@ import Button from '~shared/Button';
 import ExternalLink from '~shared/ExternalLink';
 
 import styles from './MemberActionsPopover.css';
+import { isUserVerified } from '~utils/verifiedUsers';
+import { useDialog } from '~shared/Dialog';
+import { ManageWhitelistDialog } from '~common/Dialogs';
+import { useColonyContext, useEnabledExtensions } from '~hooks';
 
 const displayName = 'MembersList.Actions.MemberActionsPopover';
 
@@ -17,6 +21,10 @@ const MSG = defineMessages({
   viewOnBlockscout: {
     id: `${displayName}.viewOnBlockscout`,
     defaultMessage: 'View on Blockscout',
+  },
+  addToAddressBook: {
+    id: `${displayName}.addToAddressBook`,
+    defaultMessage: `Add to address book`,
   },
 });
 
@@ -26,6 +34,28 @@ interface Props {
 }
 
 const MemberActionsPopover = ({ closePopover, userAddress }: Props) => {
+  const { colony } = useColonyContext();
+
+  const isWhitelisted = isUserVerified(
+    userAddress,
+    colony?.metadata?.whitelistedAddresses ?? [],
+  );
+  const enabledExtensionData = useEnabledExtensions();
+
+  const openManageWhitelistDialog = useDialog(ManageWhitelistDialog);
+
+  if (!colony) {
+    return null;
+  }
+
+  const handleManageWhitelist = () => {
+    openManageWhitelistDialog({
+      userAddress,
+      colony,
+      enabledExtensionData,
+    });
+  };
+
   return (
     <DropdownMenu onClick={closePopover}>
       <DropdownMenuSection>
@@ -38,6 +68,18 @@ const MemberActionsPopover = ({ closePopover, userAddress }: Props) => {
             />
           </Button>
         </DropdownMenuItem>
+        {!isWhitelisted && (
+          <DropdownMenuItem>
+            <Button
+              appearance={{ theme: 'no-style' }}
+              onClick={handleManageWhitelist}
+            >
+              <div className={styles.actionButton}>
+                <FormattedMessage {...MSG.addToAddressBook} />
+              </div>
+            </Button>
+          </DropdownMenuItem>
+        )}
       </DropdownMenuSection>
     </DropdownMenu>
   );

--- a/src/components/common/Members/MembersList/MembersListItem.tsx
+++ b/src/components/common/Members/MembersList/MembersListItem.tsx
@@ -8,6 +8,7 @@ import { Contributor, Member, MemberUser } from '~types';
 import { getMainClasses } from '~utils/css';
 import { useColonyContext, useMobile } from '~hooks';
 import { DEFAULT_TOKEN_DECIMALS } from '~constants';
+import { isUserVerified } from '~utils/verifiedUsers';
 
 import MemberActions from './Actions';
 import MemberInfo from './MemberInfo';
@@ -40,8 +41,10 @@ const MembersListItem = ({
   );
 
   const isMobile = useMobile();
-  // Temp hardcoded values until the features are implemented
-  const isWhitelisted = false;
+  const isWhitelisted = isUserVerified(
+    walletAddress,
+    colony?.metadata?.whitelistedAddresses ?? [],
+  );
 
   return (
     <ListGroupItem>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -59,6 +59,7 @@ export { default as useNetworkInverseFee } from './useNetworkInverseFee';
 export { default as useUserByAddress } from './useUserByAddress';
 export { default as useUserByName } from './useUserByName';
 export { default as useUserByNameOrAddress } from './useUserByNameOrAddress';
+export { default as useGetColonyMembers } from './useGetColonyMembers';
 
 /* Used in cases where we need to memoize the transformed output of any data.
  * Transform function has to be pure, obviously

--- a/src/hooks/useGetColonyMembers.ts
+++ b/src/hooks/useGetColonyMembers.ts
@@ -1,0 +1,21 @@
+import { useGetMembersForColonyQuery } from '~gql';
+import { Address, Member, MemberUser } from '~types';
+import { notMaybe } from '~utils/arrays';
+
+const useGetColonyMembers = (colonyAddress?: Address | null) => {
+  const { data } = useGetMembersForColonyQuery({
+    skip: !colonyAddress,
+    variables: {
+      input: {
+        colonyAddress: colonyAddress ?? '',
+      },
+    },
+  });
+
+  const watchers = data?.getMembersForColony?.watchers ?? [];
+  const contributors = data?.getMembersForColony?.contributors ?? [];
+  const allMembers: Member[] = [...watchers, ...contributors];
+  return allMembers.map((member) => member.user).filter<MemberUser>(notMaybe);
+};
+
+export default useGetColonyMembers;

--- a/src/redux/sagas/colony/colonyCreate.ts
+++ b/src/redux/sagas/colony/colonyCreate.ts
@@ -347,7 +347,7 @@ function* colonyCreate({
           input: {
             id: colonyAddress,
             displayName,
-            isWhitelistActivated: true,
+            isWhitelistActivated: false,
           },
         },
       });

--- a/src/utils/verifiedUsers.ts
+++ b/src/utils/verifiedUsers.ts
@@ -1,0 +1,14 @@
+import { Address, MemberUser } from '~types';
+
+export const getVerifiedUsers = (
+  verifiedAddresses: Address[],
+  colonyMembers: MemberUser[],
+) => {
+  const verified = new Set(verifiedAddresses);
+  return colonyMembers.filter((member) => verified.has(member.walletAddress));
+};
+
+export const isUserVerified = (
+  userAddress: Address,
+  whitelistedAddresses: Address[],
+) => whitelistedAddresses.some((address) => address === userAddress);


### PR DESCRIPTION
## Description

This PR wires in the whitelist functionality. It also adds some missing features from the members page, namely, the address book / permissions controls, and the verified filter.

Verified filter:

![whitelist](https://github.com/JoinColony/colonyCDapp/assets/64402732/19ccf08a-3532-4e3b-b944-e80e3663641c)

Whitelist activated, users filtered out if not verified:

![whitelistactivated](https://github.com/JoinColony/colonyCDapp/assets/64402732/dacc4209-e2e0-4099-8e02-bf4e98968906)

Whitelist activated, warning if trying to pay an address not on it:

![whitelist warnign](https://github.com/JoinColony/colonyCDapp/assets/64402732/a5a4caa4-3fb7-46f8-afb3-17bae2da428d)

Add to address book:
![addressBook](https://github.com/JoinColony/colonyCDapp/assets/64402732/7e09e717-4412-4ed9-9132-974413e08d2b)


**Changes** 🏗

* Wire in whitelist with create payment and manage reputation dialogs
* Wire in members controls items (whitelist and permissions)
* Add verified filter

## Testing

Dialogs:
- Payment: 
  - warning should appear if you try and pay someone who's not verified when the whitelist is activated
  - The user picker should also filter out non verified users when the whitelist is activated
 - Manage reputation
   - User picker should filter out non verified users when the whitelist is activated
- Manage addresses:
  - You should not be able to add the same address twice (e.g. one lower case version and one normal)
  - The Address Book tab should show all your verified users. If you switch the whitelist off, it should disable the UserPicker filtering in the other dialogs (i.e. you see all watchers, not just verified ones).

Members page:
- If your wallet has the root permission, you should be able to edit permissions and manage the address book from the MembersControls.
- The verified filter should work with all filter permutations
- You should see a blue tick next to a verified member in the members list
- Clicking "Add to address book" in the 3 dots menu who pre-populate the address field with the user's address

The intention is that all the unwired verified recipients logic is now wired, so let me know if you notice that I've missed anything.


Resolves https://github.com/JoinColony/colonyCDapp/issues/561

