### PR TITLE
Fix postinstall script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "colony-cdapp",
       "version": "5.0.0-alpha.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@apollo/client": "^3.6.9",
         "@colony/colony-js": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "amplify": "amplify",
     "DEPRECATED:webpack:prod": "NODE_OPTIONS=\"--max-old-space-size=4096\" NODE_ENV=production webpack-cli --config webpack.prod.js",
     "voyager": "ts-node temp-voyager/voyager",
-    "codegen": "node codegen"
+    "codegen": "node codegen",
+    "postinstall": "./scripts/lambda-functions-dependencies.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/lambda-functions-dependencies.sh
+++ b/scripts/lambda-functions-dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 pwd=$(pwd)
 

--- a/scripts/lambda-functions-dependencies.sh
+++ b/scripts/lambda-functions-dependencies.sh
@@ -1,15 +1,21 @@
 #!/usr/bin/env bash
 
 pwd=$(pwd)
+directory="amplify/backend/function"
 
-for d in amplify/backend/function/*/ ; do
-    [ -L "${d%/}" ] && continue
-    fnName=$(echo ${d} | cut -c 26- | rev | cut -c 2- | rev)
-    cd "${pwd}/${d}src"
-    # Skip if the folder doesn't contain package.json
-    # Otherwise npm will look for the root package.json and cause an infinite loop
-    !([ -f "package.json" ]) && continue
-    echo "Installing dependencies for Lambda Function \"${fnName}\""
-    npm i
-    echo
-done
+if [ -d "$directory" ]; then
+    for d in amplify/backend/function/*/ ; do
+        [ -L "${d%/}" ] && continue
+        fnName=$(echo "${d}" | cut -c 26- | rev | cut -c 2- | rev)
+        # Check if src directory exists
+        if [ -d "${pwd}/${d}src" ]; then
+            cd "${pwd}/${d}src" || exit
+            # Skip if the folder doesn't contain package.json
+            # Otherwise npm will look for the root package.json and cause an infinite loop
+            ! [ -f "package.json" ] && continue
+            echo "Installing dependencies for Lambda Function \"${fnName}\""
+            npm i
+            echo
+        fi
+    done
+fi


### PR DESCRIPTION
# Fix postinstall script

-------

## Description

This PR fixes the postinstall script and adds it back in so that new developers can seamlessly get started 

**Changes** ✨

* `lambda-functions-dependencies.sh` has been refactored to short circuit to stop it from breaking QA (the new bash script is courtesy of @willm30 )
* `lambda-functions-dependencies.sh`'s method to find the bash interpreter has been changed in order to improve portability (IE it doesn't work on some distros)