### PR TITLE
Use constant for annotation limit

### DIFF
--- a/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/validation.ts
+++ b/src/components/common/Dialogs/AwardAndSmiteDialogs/ManageReputationContainer/validation.ts
@@ -1,5 +1,7 @@
 import { InferType, boolean, number, object, string } from 'yup';
 
+import { MAX_ANNOTATION_LENGTH } from '~constants';
+
 const amountValidation = number().required().moreThan(0);
 
 export const defaultValidationSchema = object()
@@ -9,7 +11,7 @@ export const defaultValidationSchema = object()
       walletAddress: string().address().required(),
     }),
     amount: amountValidation,
-    annotation: string().max(4000),
+    annotation: string().max(MAX_ANNOTATION_LENGTH),
     forceAction: boolean().defined(),
     motionDomainId: number().defined(),
   })

--- a/src/components/common/Dialogs/CreateDomainDialog/CreateDomainDialog.tsx
+++ b/src/components/common/Dialogs/CreateDomainDialog/CreateDomainDialog.tsx
@@ -4,6 +4,7 @@ import { Id } from '@colony/colony-js';
 import { string, object, boolean, InferType, number } from 'yup';
 import { defineMessages } from 'react-intl';
 
+import { MAX_ANNOTATION_LENGTH } from '~constants';
 import Dialog, { DialogProps, ActionDialogProps } from '~shared/Dialog';
 import { ActionHookForm as Form } from '~shared/Fields';
 
@@ -37,7 +38,7 @@ const validationSchema = object()
       .required(() => MSG.requiredFieldError),
     domainColor: string().notRequired(),
     domainPurpose: string().trim().max(90).notRequired(),
-    annotationMessage: string().max(4000).notRequired(),
+    annotationMessage: string().max(MAX_ANNOTATION_LENGTH).notRequired(),
     motionDomainId: number().defined(),
   })
   .defined();

--- a/src/components/common/Dialogs/CreatePaymentDialog/validation.ts
+++ b/src/components/common/Dialogs/CreatePaymentDialog/validation.ts
@@ -1,6 +1,7 @@
 import { string, object, number, boolean } from 'yup';
 import { defineMessages } from 'react-intl';
 
+import { MAX_ANNOTATION_LENGTH } from '~constants';
 import { toFinite } from '~utils/lodash';
 import { Colony } from '~types';
 import { getHasEnoughBalanceTestFn } from '~utils/yup/tests';
@@ -45,7 +46,7 @@ const getValidationSchema = (
           getHasEnoughBalanceTestFn(colony, networkInverseFee),
         ),
       tokenAddress: string().address().required(),
-      annotation: string().max(4000).defined(),
+      annotation: string().max(MAX_ANNOTATION_LENGTH).defined(),
       forceAction: boolean().defined(),
       motionDomainId: number().defined(),
     })

--- a/src/components/common/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialog.tsx
+++ b/src/components/common/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialog.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { string, object, boolean, InferType } from 'yup';
 import { defineMessages } from 'react-intl';
 
+import { MAX_ANNOTATION_LENGTH } from '~constants';
 import Dialog, { DialogProps, ActionDialogProps } from '~shared/Dialog';
 import { ActionHookForm as Form } from '~shared/Fields';
 
@@ -34,7 +35,7 @@ const validationSchema = object()
     colonyDisplayName: string()
       .trim()
       .required(() => MSG.requiredFieldError),
-    annotationMessage: string().max(4000).defined(),
+    annotationMessage: string().max(MAX_ANNOTATION_LENGTH).defined(),
   })
   .defined();
 

--- a/src/components/common/Dialogs/EditDomainDialog/EditDomainDialog.tsx
+++ b/src/components/common/Dialogs/EditDomainDialog/EditDomainDialog.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { string, object, number, boolean, InferType } from 'yup';
 import { defineMessages } from 'react-intl';
 
+import { MAX_ANNOTATION_LENGTH } from '~constants';
 import Dialog, { DialogProps, ActionDialogProps } from '~shared/Dialog';
 import { ActionHookForm as Form } from '~shared/Fields';
 
@@ -43,7 +44,7 @@ const validationSchema = object()
     domainId: number().required(),
     domainColor: string().defined(),
     domainPurpose: string().trim().max(90),
-    annotationMessage: string().max(4000),
+    annotationMessage: string().max(MAX_ANNOTATION_LENGTH),
     motionDomainId: number(),
   })
   .defined();

--- a/src/components/common/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
+++ b/src/components/common/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { string, object, array, boolean, InferType } from 'yup';
 import { useNavigate } from 'react-router-dom';
 
+import { MAX_ANNOTATION_LENGTH } from '~constants';
 import Dialog, { ActionDialogProps, DialogProps } from '~shared/Dialog';
 import { ActionHookForm as Form } from '~shared/Fields';
 
@@ -26,7 +27,7 @@ type Props = Required<DialogProps> &
 const displayName = 'common.ManageWhitelistDialog';
 
 const validationSchema = object({
-  annotation: string().max(4000).defined(),
+  annotation: string().max(MAX_ANNOTATION_LENGTH).defined(),
   isWhitelistActivated: boolean().defined(),
 }).defined();
 

--- a/src/components/common/Dialogs/MintTokenDialog/MintTokenDialog.tsx
+++ b/src/components/common/Dialogs/MintTokenDialog/MintTokenDialog.tsx
@@ -3,6 +3,7 @@ import { defineMessages } from 'react-intl';
 import { string, object, bool, InferType, number } from 'yup';
 import { useNavigate } from 'react-router-dom';
 
+import { MAX_ANNOTATION_LENGTH } from '~constants';
 import Dialog, { DialogProps, ActionDialogProps } from '~shared/Dialog';
 import { ActionHookForm as Form } from '~shared/Fields';
 import { ActionTypes } from '~redux';
@@ -33,7 +34,7 @@ type Props = DialogProps &
 const validationSchema = object()
   .shape({
     forceAction: bool().defined(),
-    annotation: string().max(4000).defined(),
+    annotation: string().max(MAX_ANNOTATION_LENGTH).defined(),
     mintAmount: number()
       .required(() => MSG.errorAmountRequired)
       .transform((value) => toFinite(value))

--- a/src/components/common/Dialogs/NetworkContractUpgradeDialog/NetworkContractUpgradeDialog.tsx
+++ b/src/components/common/Dialogs/NetworkContractUpgradeDialog/NetworkContractUpgradeDialog.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { string, object, boolean, InferType } from 'yup';
 import { useNavigate } from 'react-router-dom';
 
+import { MAX_ANNOTATION_LENGTH } from '~constants';
 import { pipe, withMeta, mapPayload } from '~utils/actions';
 import Dialog, { DialogProps, ActionDialogProps } from '~shared/Dialog';
 import { ActionHookForm as Form } from '~shared/Fields';
@@ -21,7 +22,7 @@ const displayName = 'common.NetworkContractUpgradeDialog';
 const validationSchema = object()
   .shape({
     forceAction: boolean().defined(),
-    annotation: string().max(4000).defined(),
+    annotation: string().max(MAX_ANNOTATION_LENGTH).defined(),
   })
   .defined();
 

--- a/src/components/common/Dialogs/PermissionManagementDialog/PermissionManagementDialog.tsx
+++ b/src/components/common/Dialogs/PermissionManagementDialog/PermissionManagementDialog.tsx
@@ -3,6 +3,7 @@ import { Id } from '@colony/colony-js';
 import { useNavigate } from 'react-router-dom';
 import { string, object, array, number, boolean, InferType } from 'yup';
 
+import { MAX_ANNOTATION_LENGTH } from '~constants';
 import {
   mergePayload,
   withKey,
@@ -34,7 +35,7 @@ const validationSchema = object()
       })
       .defined(),
     roles: array().ensure().of(string()).defined(),
-    annotation: string().max(4000).defined(),
+    annotation: string().max(MAX_ANNOTATION_LENGTH).defined(),
     forceAction: boolean(),
     motionDomainId: number(),
   })

--- a/src/components/common/Dialogs/RaiseObjectionDialog/ObjectionAnnotation.tsx
+++ b/src/components/common/Dialogs/RaiseObjectionDialog/ObjectionAnnotation.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
 
+import { MAX_ANNOTATION_LENGTH } from '~constants';
 import { DialogSection } from '~shared/Dialog';
 import { Annotations } from '~shared/Fields';
 
@@ -22,7 +23,7 @@ const ObjectionAnnotation = ({ disabled }: ObjectionAnnotationProps) => (
     <Annotations
       label={MSG.annotation}
       name="annotation"
-      maxLength={4000}
+      maxLength={MAX_ANNOTATION_LENGTH}
       disabled={disabled}
     />
   </DialogSection>

--- a/src/components/common/Dialogs/RecoveryModeDialog/RecoveryModeDialog.tsx
+++ b/src/components/common/Dialogs/RecoveryModeDialog/RecoveryModeDialog.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { object, string, InferType } from 'yup';
 import { useNavigate } from 'react-router-dom';
 
+import { MAX_ANNOTATION_LENGTH } from '~constants';
 import Dialog, { ActionDialogProps, DialogProps } from '~shared/Dialog';
 import { ActionHookForm as Form } from '~shared/Fields';
 
@@ -20,7 +21,7 @@ const displayName = 'common.RecoveryModeDialog';
 
 const validationSchema = object()
   .shape({
-    annotation: string().max(4000).defined(),
+    annotation: string().max(MAX_ANNOTATION_LENGTH).defined(),
   })
   .defined();
 

--- a/src/components/common/Dialogs/TokenManagementDialog/validation.ts
+++ b/src/components/common/Dialogs/TokenManagementDialog/validation.ts
@@ -1,9 +1,11 @@
 import { defineMessages } from 'react-intl';
 import { InferType, array, boolean, object, string } from 'yup';
+
 import { Colony, Token } from '~types';
 import { notNull } from '~utils/arrays';
 import { formatText } from '~utils/intl';
 import { createAddress, isAddress } from '~utils/web3';
+import { MAX_ANNOTATION_LENGTH } from '~constants';
 
 const displayName = 'common.TokenManagementDialog';
 
@@ -70,7 +72,7 @@ export const getValidationSchema = (colony: Colony) =>
     selectedTokenAddresses: array()
       .of(string().address().defined())
       .notRequired(),
-    annotationMessage: string().max(4000).notRequired(),
+    annotationMessage: string().max(MAX_ANNOTATION_LENGTH).notRequired(),
   }).defined();
 
 export type FormValues = InferType<ReturnType<typeof getValidationSchema>>;

--- a/src/components/common/Dialogs/TransferFundsDialog/validation.ts
+++ b/src/components/common/Dialogs/TransferFundsDialog/validation.ts
@@ -1,6 +1,7 @@
 import { defineMessages } from 'react-intl';
 import { boolean, number, object, string } from 'yup';
 
+import { MAX_ANNOTATION_LENGTH } from '~constants';
 import { Colony } from '~types';
 import { toFinite } from '~utils/lodash';
 import { getHasEnoughBalanceTestFn } from '~utils/yup/tests';
@@ -42,7 +43,7 @@ export const getValidationSchema = (colony: Colony) => {
           getHasEnoughBalanceTestFn(colony),
         ),
       tokenAddress: string().address().required(),
-      annotation: string().max(4000).defined(),
+      annotation: string().max(MAX_ANNOTATION_LENGTH).defined(),
     })
     .defined();
 };

--- a/src/components/common/Dialogs/UnlockTokenDialog/UnlockTokenDialog.tsx
+++ b/src/components/common/Dialogs/UnlockTokenDialog/UnlockTokenDialog.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { string, object, boolean, InferType } from 'yup';
 
+import { MAX_ANNOTATION_LENGTH } from '~constants';
 import Dialog, { ActionDialogProps, DialogProps } from '~shared/Dialog';
 import { ActionHookForm as Form } from '~shared/Fields';
 import { ActionTypes } from '~redux/index';
@@ -20,7 +21,7 @@ const displayName = 'common.UnlockTokenDialog';
 const validationSchema = object()
   .shape({
     forceAction: boolean().defined(),
-    annotationMessage: string().max(4000).defined(),
+    annotationMessage: string().max(MAX_ANNOTATION_LENGTH).defined(),
   })
   .defined();
 

--- a/src/components/shared/Fields/Annotations/Annotations.tsx
+++ b/src/components/shared/Fields/Annotations/Annotations.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { MAX_ANNOTATION_LENGTH } from '~constants';
+
 import {
   HookFormTextArea as Textarea,
   HookFormTextareaComponentProps as TextareaComponentProps,
@@ -9,7 +11,7 @@ import styles from './Annotations.css';
 
 const Annotations = ({
   appearance = { colorSchema: 'grey', resizable: 'vertical' },
-  maxLength = 4000,
+  maxLength = MAX_ANNOTATION_LENGTH,
   ...props
 }: TextareaComponentProps) => {
   const textAreaProps: TextareaComponentProps = {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -160,3 +160,5 @@ export const CDAPP_VERSION = version;
 export const STAKING_THRESHOLD = 10;
 
 export const MAX_COLONY_DISPLAY_NAME = 20;
+
+export const MAX_ANNOTATION_LENGTH = 4000;


### PR DESCRIPTION
## Description

- This PR uses a new constant in place of all the hard coded 4000 character limits

**New stuff** ✨

* A `MAX_ANNOTATION_LENGTH` constant was added to `constants/index.ts`

Resolves #355