### PR TITLE
Port "Linked Assets" section

### DIFF
--- a/src/components/common/ColonyHome/ColonyHomeLayout.tsx
+++ b/src/components/common/ColonyHome/ColonyHomeLayout.tsx
@@ -15,6 +15,7 @@ import ColonyUpgrade from './ColonyUpgrade';
 import OneTxPaymentUpgrade from './OneTxPaymentUpgrade';
 // import ExtensionUpgrade from './ExtensionUpgrade';
 import ColonyHomeInfo from './ColonyHomeInfo';
+import ColonySafes from './ColonySafes';
 
 import styles from './ColonyHomeLayout.css';
 
@@ -77,6 +78,7 @@ const ColonyHomeLayout = ({
             <ColonyDomainDescription currentDomainId={filteredDomainId} />
             <ColonyUnclaimedTransfers />
             <ColonyFundingWidget currentDomainId={filteredDomainId} />
+            <ColonySafes colony={colony} />
             <ColonyMembersWidget currentDomainId={filteredDomainId} />
             <ColonyExtensions />
           </aside>

--- a/src/components/common/ColonyHome/ColonySafes/ColonySafes.css
+++ b/src/components/common/ColonyHome/ColonySafes/ColonySafes.css
@@ -1,0 +1,31 @@
+.main {
+  margin-top: 16px;
+}
+
+.main > h4 {
+  font-size: var(--size-smallish);
+  color: var(--dark);
+  letter-spacing: var(--spacing-medium);
+}
+
+.safeItem {
+  margin-bottom: 3px;
+}
+
+.safeItem:last-child {
+  margin-bottom: 0;
+}
+
+.safeItemButton {
+  padding: 0;
+  border: none;
+  background-color: transparent;
+  font-size: var(--size-normal);
+  line-height: 18px;
+  color: var(--dark);
+  cursor: pointer;
+}
+
+.safeItemToggledButton {
+  color: var(--dark-blue);
+}

--- a/src/components/common/ColonyHome/ColonySafes/ColonySafes.css.d.ts
+++ b/src/components/common/ColonyHome/ColonySafes/ColonySafes.css.d.ts
@@ -1,0 +1,15 @@
+declare namespace ColonySafesCssNamespace {
+  export interface IColonySafesCss {
+    main: string;
+    safeItem: string;
+    safeItemButton: string;
+    safeItemToggledButton: string;
+  }
+}
+
+declare const ColonySafesCssModule: ColonySafesCssNamespace.IColonySafesCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: ColonySafesCssNamespace.IColonySafesCss;
+};
+
+export = ColonySafesCssModule;

--- a/src/components/common/ColonyHome/ColonySafes/ColonySafes.tsx
+++ b/src/components/common/ColonyHome/ColonySafes/ColonySafes.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import classnames from 'classnames';
+
+import { isEmpty } from '~utils/lodash';
+import SafeInfoPopover from '~shared/SafeInfoPopover';
+import Heading from '~shared/Heading';
+import { Colony } from '~types';
+// import { useDialog } from '~shared/Dialog';
+// import ControlSafeDialog from '~dashboard/Dialogs/ControlSafeDialog/ControlSafeDialog';
+
+import styles from './ColonySafes.css';
+
+const displayName = 'common.ColonyHome.ColonySafes';
+
+const MSG = defineMessages({
+  title: {
+    id: `${displayName}.title`,
+    defaultMessage: 'Linked assets',
+  },
+});
+
+interface Props {
+  colony: Colony;
+}
+
+const ColonySafes = ({ colony: { metadata } }: Props) => {
+  // const openControlSafeDialog = useDialog(ControlSafeDialog);
+  // const handleOpenControlSafeDialog = (safe: Safe) =>
+  //   openControlSafeDialog({ preselectedSafe: safe, colony });
+
+  if (isEmpty(metadata?.safes)) {
+    return null;
+  }
+
+  return (
+    <div className={styles.main}>
+      <Heading appearance={{ size: 'normal', weight: 'bold' }}>
+        <FormattedMessage {...MSG.title} />
+      </Heading>
+      <ul>
+        {metadata?.safes?.map((safe) => (
+          <li
+            key={`${safe.chainId}-${safe.address}`}
+            className={styles.safeItem}
+          >
+            <SafeInfoPopover
+              safe={safe}
+              // openDialog={handleOpenControlSafeDialog}
+              popperOptions={{
+                modifiers: [
+                  {
+                    name: 'offset',
+                    options: {
+                      offset: [55, 10],
+                    },
+                  },
+                ],
+              }}
+            >
+              {({ id, isOpen, toggle, ref }) => (
+                <button
+                  className={classnames(styles.safeItemButton, {
+                    [styles.safeItemToggledButton]: isOpen,
+                  })}
+                  onClick={toggle}
+                  aria-describedby={isOpen ? id : undefined}
+                  ref={ref}
+                  type="button"
+                >
+                  {safe.name}
+                </button>
+              )}
+            </SafeInfoPopover>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+ColonySafes.displayName = displayName;
+
+export default ColonySafes;

--- a/src/components/common/ColonyHome/ColonySafes/index.ts
+++ b/src/components/common/ColonyHome/ColonySafes/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ColonySafes';

--- a/src/components/shared/SafeInfoPopover/SafeInfo/SafeInfo.css
+++ b/src/components/shared/SafeInfoPopover/SafeInfo/SafeInfo.css
@@ -1,0 +1,41 @@
+.container {
+  composes: flexContainerRow flexAlignCenter from '~styles/layout.css';
+  display: flex;
+}
+
+.textContainer {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  flex-direction: column;
+  margin-left: 15px;
+  width: 100%;
+  overflow: hidden;
+}
+
+.safeLogo {
+  height: 30px;
+}
+
+.safeLogo svg {
+  height: 30px;
+  width: 30px;
+}
+
+.userName {
+  composes: inlineEllipsis from '~styles/text.css';
+  margin-bottom: 2px;
+  width: 100%;
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
+  color: var(--pink);
+}
+
+.address span {
+  font-size: var(--size-small);
+  color: var(--grey-purple);
+}
+
+.address button {
+  height: auto;
+}

--- a/src/components/shared/SafeInfoPopover/SafeInfo/SafeInfo.css.d.ts
+++ b/src/components/shared/SafeInfoPopover/SafeInfo/SafeInfo.css.d.ts
@@ -1,0 +1,16 @@
+declare namespace SafeInfoCssNamespace {
+  export interface ISafeInfoCss {
+    address: string;
+    container: string;
+    safeLogo: string;
+    textContainer: string;
+    userName: string;
+  }
+}
+
+declare const SafeInfoCssModule: SafeInfoCssNamespace.ISafeInfoCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: SafeInfoCssNamespace.ISafeInfoCss;
+};
+
+export = SafeInfoCssModule;

--- a/src/components/shared/SafeInfoPopover/SafeInfo/SafeInfo.tsx
+++ b/src/components/shared/SafeInfoPopover/SafeInfo/SafeInfo.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { Safe } from '~types';
+
+import CopyableAddress from '~shared/CopyableAddress';
+import Heading from '~shared/Heading';
+import Icon from '~shared/Icon';
+
+import styles from './SafeInfo.css';
+
+interface Props {
+  safe: Safe;
+}
+
+const displayName = 'SafeInfoPopover.SafeInfo';
+
+const SafeInfo = ({ safe }: Props) => {
+  return (
+    <div className={styles.container}>
+      <Icon className={styles.safeLogo} name="safe-logo" />
+      <div className={styles.textContainer}>
+        <Heading
+          appearance={{ margin: 'none', size: 'normal' }}
+          text={safe.name}
+          className={styles.userName}
+        />
+        <div className={styles.address}>
+          <CopyableAddress full>{safe.address}</CopyableAddress>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+SafeInfo.displayName = displayName;
+
+export default SafeInfo;

--- a/src/components/shared/SafeInfoPopover/SafeInfo/index.ts
+++ b/src/components/shared/SafeInfoPopover/SafeInfo/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SafeInfo';

--- a/src/components/shared/SafeInfoPopover/SafeInfoPopover.css
+++ b/src/components/shared/SafeInfoPopover/SafeInfoPopover.css
@@ -1,0 +1,37 @@
+@value query700 from '~styles/queries.css';
+
+.main {
+  padding: 20px 0 15px 0;
+  width: 455px;
+  text-align: left;
+  letter-spacing: normal;
+  cursor: auto;
+}
+
+.section {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 15px 25px 0 25px;
+}
+
+.section:first-of-type {
+  padding-top: 0;
+  padding-bottom: 20px;
+  border-bottom: 1px solid color-mod(var(--grey-purple) alpha(15%));
+}
+
+.section:last-of-type {
+  padding-bottom: 0;
+}
+
+.safeLink {
+  color: var(--dark-blue);
+}
+
+@media screen and query700 {
+  .main {
+    padding-left: 15px;
+    max-width: calc(100vw - 28px);
+  }
+}

--- a/src/components/shared/SafeInfoPopover/SafeInfoPopover.css.d.ts
+++ b/src/components/shared/SafeInfoPopover/SafeInfoPopover.css.d.ts
@@ -1,0 +1,21 @@
+declare namespace SafeInfoPopoverCssNamespace {
+  export interface ISafeInfoPopoverCss {
+    main: string;
+    mappings: string;
+    names: string;
+    query700: string;
+    safeLink: string;
+    section: string;
+    sourceRoot: string;
+    sources: string;
+    sourcesContent: string;
+    version: string;
+  }
+}
+
+declare const SafeInfoPopoverCssModule: SafeInfoPopoverCssNamespace.ISafeInfoPopoverCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: SafeInfoPopoverCssNamespace.ISafeInfoPopoverCss;
+};
+
+export = SafeInfoPopoverCssModule;

--- a/src/components/shared/SafeInfoPopover/SafeInfoPopover.tsx
+++ b/src/components/shared/SafeInfoPopover/SafeInfoPopover.tsx
@@ -1,0 +1,82 @@
+import React, { ReactElement } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { PopperOptions } from 'react-popper-tooltip';
+
+import { Safe } from '~types';
+import ExternalLink from '~shared/ExternalLink';
+import { getSafeLink } from '~constants/externalUrls';
+// import { DialogType } from '~shared/Dialog';
+import { ETHEREUM_NETWORK, SUPPORTED_SAFE_NETWORKS } from '~constants';
+import Button from '~shared/Button';
+import Popover, { PopoverChildFn } from '~shared/Popover';
+
+import SafeInfo from './SafeInfo';
+
+import styles from './SafeInfoPopover.css';
+
+interface Props {
+  safe: Safe;
+  // openControlSafeDialog: (safe: Safe) => DialogType<any>;
+  children: ReactElement | PopoverChildFn;
+  popperOptions?: PopperOptions;
+}
+
+const displayName = 'SafeInfoPopover';
+
+const MSG = defineMessages({
+  buttonText: {
+    id: `${displayName}.buttonText`,
+    defaultMessage: 'Control the Safe',
+  },
+  linkText: {
+    id: `${displayName}.linkText`,
+    defaultMessage: 'Go to the Safe',
+  },
+});
+
+const SafeInfoPopover = ({
+  safe,
+  // openControlSafeDialog,
+  children,
+  popperOptions,
+}: Props) => {
+  const selectedChain = SUPPORTED_SAFE_NETWORKS.find(
+    (network) => network.chainId === Number(safe.chainId),
+  );
+  const safeLink = getSafeLink(
+    selectedChain?.shortName.toLowerCase() ||
+      ETHEREUM_NETWORK.shortName.toLowerCase(),
+    safe.address,
+  );
+
+  return (
+    <Popover
+      renderContent={
+        <div className={styles.main}>
+          <div className={styles.section}>
+            <SafeInfo safe={safe} />
+          </div>
+          <div className={styles.section}>
+            <Button
+              appearance={{ theme: 'blue', size: 'small' }}
+              text={MSG.buttonText}
+              // onClick={() => {
+              //   openControlSafeDialog(safe);
+              // }}
+            />
+            <ExternalLink href={safeLink} className={styles.safeLink}>
+              <FormattedMessage {...MSG.linkText} />
+            </ExternalLink>
+          </div>
+        </div>
+      }
+      popperOptions={popperOptions}
+    >
+      {children}
+    </Popover>
+  );
+};
+
+SafeInfoPopover.displayName = displayName;
+
+export default SafeInfoPopover;

--- a/src/components/shared/SafeInfoPopover/index.ts
+++ b/src/components/shared/SafeInfoPopover/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SafeInfoPopover';


### PR DESCRIPTION
When you add a safe, a new "Linked assets" section should appear in the sidebar:

![FireShot Capture 123 - Colony CDapp - localhost](https://github.com/JoinColony/colonyCDapp/assets/18473896/11ade954-3cda-4c3c-88fd-7e07a442ee92)

if you click on the name, a popover should appear with 2 buttons on the bottom ("Control safe" should not work yet as that dialog doesn't exist in this branch yet).

Resolves #734 
