### PR TITLE
Bump colony version to v12

### DIFF
--- a/docker/colony-cdapp-dev-env-network
+++ b/docker/colony-cdapp-dev-env-network
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV NETWORK_HASH=0b78037610a96c0f27b1d78122b467a6c413afae
+ENV NETWORK_HASH=618722ed9ae30900ab717e36621c57289c363042
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/common/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/components/common/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -122,11 +122,8 @@ const ControlSafeForm = ({
   const isSupportedColonyVersion = version >= 12;
 
   /* invert this only for testing! */
-  const disabledInputs = !(
-    !userHasPermission ||
-    isSubmitting ||
-    !isSupportedColonyVersion
-  );
+  const disabledInputs =
+    !userHasPermission || isSubmitting || !isSupportedColonyVersion;
 
   const renderTransactionSection = () => {
     switch (transactionType) {


### PR DESCRIPTION
This PR bumps the commit of `colonyNetwork` to support v12. This version is required to allow meta transactions for Control Safe.

To test this PR, we just need to make sure nothing broke and that the warning in the Control Safe dialog disappeared :)