### PR TITLE
Fix: Wallet switching to Metamask when page refreshed

### DIFF
--- a/src/redux/sagas/setupWalletContext.ts
+++ b/src/redux/sagas/setupWalletContext.ts
@@ -34,7 +34,11 @@ const setupWalletContext = async () => {
      * If the wallet we've pulled from context does not have the same address as the selected account
      * in Metamask, it's because the user just switched their account in metamask.
      */
-    if (selectedMetamaskAddress && wallet.address !== selectedMetamaskAddress) {
+    if (
+      selectedMetamaskAddress &&
+      wallet.address !== selectedMetamaskAddress &&
+      wallet.label === ONBOARD_METAMASK_WALLET_LABEL
+    ) {
       disconnectWallet(wallet.label); // disconnect previous wallet
 
       // replace it in local storage with the wallet the user switched to


### PR DESCRIPTION
## Description

This PR fixes a bug where the wallet would always switch to Metamask when page is refreshed, even when the dev wallet is connected.

## Testing

Connect any of the dev wallets and refresh the page. You should see the connected wallet staying the same, instead of switching to Metamask.
