### PR TITLE
Hide move funds from actions list (expenditures)

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -2520,6 +2520,10 @@ type Expenditure @model {
   status: ExpenditureStatus!
   slots: [ExpenditureSlot!]!
   nativeFundingPotId: Int!
+    @index(
+      name: "byNativeFundingPotId"
+      queryField: "getExpendituresByNativeFundingPotId"
+    )
   metadata: ExpenditureMetadata @hasOne(fields: ["id"])
   balances: [ExpenditureBalance!]
     @function(name: "fetchExpenditureBalances-${env}")

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=2ed291790b66cfea92493f261f8af14ac9d59c3d
+ENV BLOCK_INGESTOR_HASH=911645adb6f9b8f62f4cc93df3bdbdb02b470fd7
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -3645,6 +3645,7 @@ export type Query = {
   getExpenditure?: Maybe<Expenditure>;
   getExpenditureMetadata?: Maybe<ExpenditureMetadata>;
   getExpendituresByColony?: Maybe<ModelExpenditureConnection>;
+  getExpendituresByNativeFundingPotId?: Maybe<ModelExpenditureConnection>;
   getExtensionByColonyAndHash?: Maybe<ModelColonyExtensionConnection>;
   getExtensionsByHash?: Maybe<ModelColonyExtensionConnection>;
   getIngestorStats?: Maybe<IngestorStats>;
@@ -3904,6 +3905,16 @@ export type QueryGetExpendituresByColonyArgs = {
   createdAt?: InputMaybe<ModelStringKeyConditionInput>;
   filter?: InputMaybe<ModelExpenditureFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
+  nextToken?: InputMaybe<Scalars['String']>;
+  sortDirection?: InputMaybe<ModelSortDirection>;
+};
+
+
+/** Root query type */
+export type QueryGetExpendituresByNativeFundingPotIdArgs = {
+  filter?: InputMaybe<ModelExpenditureFilterInput>;
+  limit?: InputMaybe<Scalars['Int']>;
+  nativeFundingPotId: Scalars['Int'];
   nextToken?: InputMaybe<Scalars['String']>;
   sortDirection?: InputMaybe<ModelSortDirection>;
 };


### PR DESCRIPTION
## Description

This PR makes the nativeFundingPotId an index on the Expenditure model, so we can easily see if an expenditure exists in the db with a given nativeFundingPotId.

Test with: https://github.com/JoinColony/block-ingestor/pull/115

Resolves #914