### PR TITLE
Wire expenditure funding

### DIFF
--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureAdvanceButton/ExpenditureAdvanceButton.tsx
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureAdvanceButton/ExpenditureAdvanceButton.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { Id } from '@colony/colony-js';
+import { BigNumber } from 'ethers';
+
+import { ExpenditureStatus } from '~gql';
+import { ActionTypes } from '~redux';
+import { ActionButton } from '~shared/Button';
+import { Colony, Expenditure } from '~types';
+
+interface ExpenditureAdvanceButtonProps {
+  expenditure: Expenditure;
+  colony: Colony;
+}
+
+const isExpenditureFunded = (expenditure: Expenditure) => {
+  return (
+    expenditure.balances?.every((balance) =>
+      BigNumber.from(balance.amount).gte(balance.requiredAmount),
+    ) ?? false
+  );
+};
+
+const getExpenditurePayoutsTotal = (expenditure: Expenditure) => {
+  return expenditure.slots.reduce((total, slot) => {
+    return total.add(
+      slot.payouts?.reduce(
+        (slotTotal, payout) => slotTotal.add(payout.amount),
+        BigNumber.from(0),
+      ) ?? 0,
+    );
+  }, BigNumber.from(0));
+};
+
+const ExpenditureAdvanceButton = ({
+  expenditure,
+  colony,
+}: ExpenditureAdvanceButtonProps) => {
+  if (expenditure.status === ExpenditureStatus.Draft) {
+    return (
+      <ActionButton
+        actionType={ActionTypes.EXPENDITURE_LOCK}
+        values={{
+          colonyAddress: colony.colonyAddress,
+          nativeExpenditureId: expenditure.nativeId,
+        }}
+      >
+        Lock expenditure
+      </ActionButton>
+    );
+  }
+
+  if (
+    expenditure.status === ExpenditureStatus.Locked &&
+    !isExpenditureFunded(expenditure)
+  ) {
+    return (
+      <ActionButton
+        actionType={ActionTypes.EXPENDITURE_FUND}
+        values={{
+          colonyAddress: colony.colonyAddress,
+          fromDomainFundingPotId:
+            expenditure.metadata?.nativeDomainId ?? Id.RootDomain,
+          expenditureFundingPotId: expenditure.nativeFundingPotId,
+          // @TODO: Refactor to support multiple token addresses
+          amount: getExpenditurePayoutsTotal(expenditure),
+          tokenAddress: expenditure.slots[0].payouts?.[0]?.tokenAddress,
+        }}
+      >
+        Fund expenditure
+      </ActionButton>
+    );
+  }
+
+  if (
+    expenditure.status === ExpenditureStatus.Locked &&
+    isExpenditureFunded(expenditure)
+  ) {
+    return (
+      <ActionButton
+        actionType={ActionTypes.EXPENDITURE_FINALIZE}
+        values={{
+          colonyAddress: colony.colonyAddress,
+          nativeExpenditureId: expenditure.nativeId,
+        }}
+      >
+        Finalize expenditure
+      </ActionButton>
+    );
+  }
+  return null;
+};
+
+export default ExpenditureAdvanceButton;

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureAdvanceButton/ExpenditureAdvanceButton.tsx
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureAdvanceButton/ExpenditureAdvanceButton.tsx
@@ -6,19 +6,12 @@ import { ExpenditureStatus } from '~gql';
 import { ActionTypes } from '~redux';
 import { ActionButton } from '~shared/Button';
 import { Colony, Expenditure } from '~types';
+import { isExpenditureFunded } from '~utils/expenditures';
 
 interface ExpenditureAdvanceButtonProps {
   expenditure: Expenditure;
   colony: Colony;
 }
-
-const isExpenditureFunded = (expenditure: Expenditure) => {
-  return (
-    expenditure.balances?.every((balance) =>
-      BigNumber.from(balance.amount).gte(balance.requiredAmount),
-    ) ?? false
-  );
-};
 
 const getExpenditurePayoutsTotal = (expenditure: Expenditure) => {
   return expenditure.slots.reduce((total, slot) => {

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureAdvanceButton/ExpenditureAdvanceButton.tsx
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureAdvanceButton/ExpenditureAdvanceButton.tsx
@@ -1,28 +1,17 @@
 import React from 'react';
 import { Id } from '@colony/colony-js';
-import { BigNumber } from 'ethers';
 
 import { ExpenditureStatus } from '~gql';
 import { ActionTypes } from '~redux';
 import { ActionButton } from '~shared/Button';
 import { Colony, Expenditure } from '~types';
 import { isExpenditureFunded } from '~utils/expenditures';
+import { findDomainByNativeId } from '~utils/domains';
 
 interface ExpenditureAdvanceButtonProps {
   expenditure: Expenditure;
   colony: Colony;
 }
-
-const getExpenditurePayoutsTotal = (expenditure: Expenditure) => {
-  return expenditure.slots.reduce((total, slot) => {
-    return total.add(
-      slot.payouts?.reduce(
-        (slotTotal, payout) => slotTotal.add(payout.amount),
-        BigNumber.from(0),
-      ) ?? 0,
-    );
-  }, BigNumber.from(0));
-};
 
 const ExpenditureAdvanceButton = ({
   expenditure,
@@ -52,11 +41,11 @@ const ExpenditureAdvanceButton = ({
         values={{
           colonyAddress: colony.colonyAddress,
           fromDomainFundingPotId:
-            expenditure.metadata?.nativeDomainId ?? Id.RootDomain,
-          expenditureFundingPotId: expenditure.nativeFundingPotId,
-          // @TODO: Refactor to support multiple token addresses
-          amount: getExpenditurePayoutsTotal(expenditure),
-          tokenAddress: expenditure.slots[0].payouts?.[0]?.tokenAddress,
+            findDomainByNativeId(
+              expenditure.metadata?.nativeDomainId ?? Id.RootDomain,
+              colony,
+            )?.nativeFundingPotId ?? Id.RootPot,
+          expenditure,
         }}
       >
         Fund expenditure
@@ -80,6 +69,7 @@ const ExpenditureAdvanceButton = ({
       </ActionButton>
     );
   }
+
   return null;
 };
 

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureAdvanceButton/index.ts
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureAdvanceButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ExpenditureAdvanceButton';

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureBalances/ExpenditureBalances.module.css
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureBalances/ExpenditureBalances.module.css
@@ -1,0 +1,10 @@
+.balances {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.balance {
+  display: flex;
+  gap: 10px;
+}

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureBalances/ExpenditureBalances.module.css.d.ts
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureBalances/ExpenditureBalances.module.css.d.ts
@@ -1,0 +1,13 @@
+declare namespace ExpenditureBalancesModuleCssNamespace {
+  export interface IExpenditureBalancesModuleCss {
+    balance: string;
+    balances: string;
+  }
+}
+
+declare const ExpenditureBalancesModuleCssModule: ExpenditureBalancesModuleCssNamespace.IExpenditureBalancesModuleCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: ExpenditureBalancesModuleCssNamespace.IExpenditureBalancesModuleCss;
+};
+
+export = ExpenditureBalancesModuleCssModule;

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureBalances/ExpenditureBalances.tsx
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureBalances/ExpenditureBalances.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { weiToEth } from '@web3-onboard/common';
+
+import { Expenditure } from '~types';
+
+import styles from './ExpenditureBalances.module.css';
+import MaskedAddress from '~shared/MaskedAddress/MaskedAddress';
+
+interface ExpenditureBalancesProps {
+  expenditure: Expenditure;
+}
+
+const ExpenditureBalances = ({ expenditure }: ExpenditureBalancesProps) => {
+  return (
+    <div>
+      <div>Balances</div>
+      <div className={styles.balances}>
+        {expenditure.balances?.map((balance) => (
+          <div key={balance.tokenAddress} className={styles.balance}>
+            <div>
+              <div>Token address</div>
+              <MaskedAddress address={balance.tokenAddress} />
+            </div>
+            <div>
+              <div>Balance</div>
+              <div>
+                {weiToEth(balance.amount)}/{weiToEth(balance.requiredAmount)}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ExpenditureBalances;

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureBalances/ExpenditureBalances.tsx
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureBalances/ExpenditureBalances.tsx
@@ -5,6 +5,7 @@ import { Expenditure } from '~types';
 
 import styles from './ExpenditureBalances.module.css';
 import MaskedAddress from '~shared/MaskedAddress/MaskedAddress';
+import { isExpenditureFunded } from '~utils/expenditures';
 
 interface ExpenditureBalancesProps {
   expenditure: Expenditure;
@@ -29,6 +30,9 @@ const ExpenditureBalances = ({ expenditure }: ExpenditureBalancesProps) => {
             </div>
           </div>
         ))}
+      </div>
+      <div>
+        Is fully funded: {isExpenditureFunded(expenditure) ? 'Yes' : 'No'}
       </div>
     </div>
   );

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureBalances/index.ts
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureBalances/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ExpenditureBalances';

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.module.css
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.module.css
@@ -1,6 +1,7 @@
 .details {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: 20px;
 }
 

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.module.css
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.module.css
@@ -1,3 +1,9 @@
+.details {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
 .recipients {
   display: flex;
   flex-direction: column;

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.module.css.d.ts
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.module.css.d.ts
@@ -1,5 +1,6 @@
 declare namespace ExpenditureDetailsPageModuleCssNamespace {
   export interface IExpenditureDetailsPageModuleCss {
+    details: string;
     recipient: string;
     recipients: string;
   }

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.tsx
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.tsx
@@ -21,7 +21,7 @@ const ExpenditureDetailsPage = () => {
 
   const { colony } = useColonyContext();
 
-  const { data } = useGetExpenditureQuery({
+  const { data, loading } = useGetExpenditureQuery({
     variables: {
       expenditureId: getExpenditureDatabaseId(
         colony?.colonyAddress ?? '',
@@ -31,7 +31,15 @@ const ExpenditureDetailsPage = () => {
     skip: !expenditureId,
   });
 
-  if (!colony || !data) {
+  if (!colony) {
+    return null;
+  }
+
+  if (loading) {
+    return <div>Loading expenditure...</div>;
+  }
+
+  if (!data) {
     return null;
   }
 

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.tsx
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.tsx
@@ -56,57 +56,63 @@ const ExpenditureDetailsPage = () => {
   return (
     <div>
       <Heading3>Expenditure {expenditure.id}</Heading3>
-      <div>Status: {expenditure.status}</div>
-      <div>Team: {expenditureDomain?.metadata?.name ?? 'Unknown team'}</div>
-      <ExpenditureBalances expenditure={expenditure} />
 
-      <ul className={styles.recipients}>
-        {expenditure.slots.map((slot) => (
-          <li key={slot.id} className={styles.recipient}>
-            <div>
-              <div>Slot ID</div>
-              <div>{slot.id}</div>
-            </div>
+      <div className={styles.details}>
+        <div>Status: {expenditure.status}</div>
+        <div>Team: {expenditureDomain?.metadata?.name ?? 'Unknown team'}</div>
+        <ExpenditureBalances expenditure={expenditure} />
 
-            <div>
-              <div>Recipient address</div>
-              <MaskedAddress address={slot.recipientAddress ?? ''} />
-            </div>
-
-            <div>
-              <div>Token address</div>
-              {slot.payouts?.map((payout) => (
-                <MaskedAddress
-                  key={payout.tokenAddress}
-                  address={payout.tokenAddress}
-                />
-              ))}
-            </div>
-
-            <div>
-              <div>Amount</div>
-              {slot.payouts?.map((payout) => (
-                <div key={payout.tokenAddress}>
-                  <Numeral
-                    value={payout.amount}
-                    decimals={colony.nativeToken.decimals}
-                    suffix={colony.nativeToken.symbol}
-                  />
+        <div>
+          <div>Slots</div>
+          <ul className={styles.recipients}>
+            {expenditure.slots.map((slot) => (
+              <li key={slot.id} className={styles.recipient}>
+                <div>
+                  <div>Slot ID</div>
+                  <div>{slot.id}</div>
                 </div>
-              ))}
-            </div>
 
-            <div>
-              <div>Claim delay</div>
-              <div>
-                {slot.claimDelay ? `${slot.claimDelay} seconds` : 'None'}
-              </div>
-            </div>
-          </li>
-        ))}
-      </ul>
+                <div>
+                  <div>Recipient address</div>
+                  <MaskedAddress address={slot.recipientAddress ?? ''} />
+                </div>
 
-      <ExpenditureAdvanceButton expenditure={expenditure} colony={colony} />
+                <div>
+                  <div>Token address</div>
+                  {slot.payouts?.map((payout) => (
+                    <MaskedAddress
+                      key={payout.tokenAddress}
+                      address={payout.tokenAddress}
+                    />
+                  ))}
+                </div>
+
+                <div>
+                  <div>Amount</div>
+                  {slot.payouts?.map((payout) => (
+                    <div key={payout.tokenAddress}>
+                      <Numeral
+                        value={payout.amount}
+                        decimals={colony.nativeToken.decimals}
+                        suffix={colony.nativeToken.symbol}
+                      />
+                    </div>
+                  ))}
+                </div>
+
+                <div>
+                  <div>Claim delay</div>
+                  <div>
+                    {slot.claimDelay ? `${slot.claimDelay} seconds` : 'None'}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <ExpenditureAdvanceButton expenditure={expenditure} colony={colony} />
+      </div>
     </div>
   );
 };

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.tsx
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.tsx
@@ -17,6 +17,7 @@ import Numeral from '~shared/Numeral';
 import { findDomainByNativeId } from '~utils/domains';
 
 import styles from './ExpenditureDetailsPage.module.css';
+import ExpenditureBalances from './ExpenditureBalances/ExpenditureBalances';
 
 const getExpenditurePayoutsTotal = (expenditure: Expenditure) => {
   return expenditure.slots.reduce((total, slot) => {
@@ -63,22 +64,20 @@ const ExpenditureDetailsPage = () => {
       <Heading3>Expenditure {expenditure.id}</Heading3>
       <div>Status: {expenditure.status}</div>
       <div>Team: {expenditureDomain?.metadata?.name ?? 'Unknown team'}</div>
-      <div>
-        Balance:{' '}
-        <ActionButton
-          actionType={ActionTypes.EXPENDITURE_FUND}
-          values={{
-            colonyAddress: colony.colonyAddress,
-            expenditureFundingPotId: expenditure.nativeFundingPotId,
-            fromDomainFundingPotId:
-              expenditureDomain?.nativeFundingPotId ?? Id.RootPot,
-            amount: getExpenditurePayoutsTotal(expenditure).toString(),
-            tokenAddress: colony.nativeToken.tokenAddress,
-          }}
-        >
-          Fund expenditure
-        </ActionButton>
-      </div>
+      <ExpenditureBalances expenditure={expenditure} />
+      <ActionButton
+        actionType={ActionTypes.EXPENDITURE_FUND}
+        values={{
+          colonyAddress: colony.colonyAddress,
+          expenditureFundingPotId: expenditure.nativeFundingPotId,
+          fromDomainFundingPotId:
+            expenditureDomain?.nativeFundingPotId ?? Id.RootPot,
+          amount: getExpenditurePayoutsTotal(expenditure).toString(),
+          tokenAddress: colony.nativeToken.tokenAddress,
+        }}
+      >
+        Fund expenditure
+      </ActionButton>
 
       <ul className={styles.recipients}>
         {expenditure.slots.map((slot) => (

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.tsx
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.tsx
@@ -1,34 +1,20 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import { Id } from '@colony/colony-js';
-import { BigNumber } from 'ethers';
 
-import { ExpenditureStatus, useGetExpenditureQuery } from '~gql';
+import { useGetExpenditureQuery } from '~gql';
 import { useColonyContext } from '~hooks';
-import { ActionTypes } from '~redux';
 import NotFoundRoute from '~routes/NotFoundRoute';
-import { ActionButton } from '~shared/Button';
 import { Heading3 } from '~shared/Heading';
 import { getExpenditureDatabaseId } from '~utils/databaseId';
 import MaskedAddress from '~shared/MaskedAddress';
-import { Expenditure } from '~types';
 
 import Numeral from '~shared/Numeral';
 import { findDomainByNativeId } from '~utils/domains';
 
 import styles from './ExpenditureDetailsPage.module.css';
 import ExpenditureBalances from './ExpenditureBalances/ExpenditureBalances';
-
-const getExpenditurePayoutsTotal = (expenditure: Expenditure) => {
-  return expenditure.slots.reduce((total, slot) => {
-    return total.add(
-      slot.payouts?.reduce(
-        (slotTotal, payout) => slotTotal.add(payout.amount),
-        BigNumber.from(0),
-      ) ?? 0,
-    );
-  }, BigNumber.from(0));
-};
+import ExpenditureAdvanceButton from './ExpenditureAdvanceButton';
 
 const ExpenditureDetailsPage = () => {
   const { expenditureId } = useParams();
@@ -65,19 +51,6 @@ const ExpenditureDetailsPage = () => {
       <div>Status: {expenditure.status}</div>
       <div>Team: {expenditureDomain?.metadata?.name ?? 'Unknown team'}</div>
       <ExpenditureBalances expenditure={expenditure} />
-      <ActionButton
-        actionType={ActionTypes.EXPENDITURE_FUND}
-        values={{
-          colonyAddress: colony.colonyAddress,
-          expenditureFundingPotId: expenditure.nativeFundingPotId,
-          fromDomainFundingPotId:
-            expenditureDomain?.nativeFundingPotId ?? Id.RootPot,
-          amount: getExpenditurePayoutsTotal(expenditure).toString(),
-          tokenAddress: colony.nativeToken.tokenAddress,
-        }}
-      >
-        Fund expenditure
-      </ActionButton>
 
       <ul className={styles.recipients}>
         {expenditure.slots.map((slot) => (
@@ -125,29 +98,7 @@ const ExpenditureDetailsPage = () => {
         ))}
       </ul>
 
-      {expenditure.status === ExpenditureStatus.Draft && (
-        <ActionButton
-          actionType={ActionTypes.EXPENDITURE_LOCK}
-          values={{
-            colonyAddress: colony.colonyAddress,
-            nativeExpenditureId: expenditure.nativeId,
-          }}
-        >
-          Lock expenditure
-        </ActionButton>
-      )}
-
-      {expenditure.status === ExpenditureStatus.Locked && (
-        <ActionButton
-          actionType={ActionTypes.EXPENDITURE_FINALIZE}
-          values={{
-            colonyAddress: colony.colonyAddress,
-            nativeExpenditureId: expenditure.nativeId,
-          }}
-        >
-          Finalize expenditure
-        </ActionButton>
-      )}
+      <ExpenditureAdvanceButton expenditure={expenditure} colony={colony} />
     </div>
   );
 };

--- a/src/components/common/Expenditures/ExpendituresPage/ExpendituresPage.tsx
+++ b/src/components/common/Expenditures/ExpendituresPage/ExpendituresPage.tsx
@@ -13,7 +13,7 @@ import styles from './ExpendituresPage.module.css';
 const ExpendituresPage = () => {
   const { colony } = useColonyContext();
 
-  const { data } = useGetColonyExpendituresQuery({
+  const { data, loading } = useGetColonyExpendituresQuery({
     variables: {
       colonyAddress: colony?.colonyAddress ?? '',
     },
@@ -27,6 +27,7 @@ const ExpendituresPage = () => {
   return (
     <div className={styles.pageWrapper}>
       <ul>
+        {loading && <div>Loading expenditures...</div>}
         {data?.getColony?.expenditures?.items
           .filter(notNull)
           .map((expenditure) => (

--- a/src/graphql/fragments/expenditures.graphql
+++ b/src/graphql/fragments/expenditures.graphql
@@ -17,4 +17,9 @@ fragment Expenditure on Expenditure {
   metadata {
     nativeDomainId
   }
+  balances {
+    tokenAddress
+    amount
+    requiredAmount
+  }
 }

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -5356,7 +5356,7 @@ export type DomainFragment = { __typename?: 'Domain', id: string, nativeId: numb
 
 export type DomainMetadataFragment = { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null };
 
-export type ExpenditureFragment = { __typename?: 'Expenditure', id: string, nativeId: number, ownerAddress: string, status: ExpenditureStatus, nativeFundingPotId: number, slots: Array<{ __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string }> | null }>, metadata?: { __typename?: 'ExpenditureMetadata', nativeDomainId: number } | null };
+export type ExpenditureFragment = { __typename?: 'Expenditure', id: string, nativeId: number, ownerAddress: string, status: ExpenditureStatus, nativeFundingPotId: number, slots: Array<{ __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string }> | null }>, metadata?: { __typename?: 'ExpenditureMetadata', nativeDomainId: number } | null, balances?: Array<{ __typename?: 'ExpenditureBalance', tokenAddress: string, amount: string, requiredAmount: string }> | null };
 
 export type ExtensionFragment = { __typename?: 'ColonyExtension', hash: string, installedBy: string, installedAt: any, isDeprecated: boolean, isDeleted: boolean, isInitialized: boolean, address: string, colonyAddress: string, currentVersion: number, params?: { __typename?: 'ExtensionParams', votingReputation?: { __typename?: 'VotingReputationParams', maxVoteFraction: string } | null } | null };
 
@@ -5554,14 +5554,14 @@ export type GetColonyExpendituresQueryVariables = Exact<{
 }>;
 
 
-export type GetColonyExpendituresQuery = { __typename?: 'Query', getColony?: { __typename?: 'Colony', id: string, expenditures?: { __typename?: 'ModelExpenditureConnection', items: Array<{ __typename?: 'Expenditure', id: string, nativeId: number, ownerAddress: string, status: ExpenditureStatus, nativeFundingPotId: number, slots: Array<{ __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string }> | null }>, metadata?: { __typename?: 'ExpenditureMetadata', nativeDomainId: number } | null } | null> } | null } | null };
+export type GetColonyExpendituresQuery = { __typename?: 'Query', getColony?: { __typename?: 'Colony', id: string, expenditures?: { __typename?: 'ModelExpenditureConnection', items: Array<{ __typename?: 'Expenditure', id: string, nativeId: number, ownerAddress: string, status: ExpenditureStatus, nativeFundingPotId: number, slots: Array<{ __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string }> | null }>, metadata?: { __typename?: 'ExpenditureMetadata', nativeDomainId: number } | null, balances?: Array<{ __typename?: 'ExpenditureBalance', tokenAddress: string, amount: string, requiredAmount: string }> | null } | null> } | null } | null };
 
 export type GetExpenditureQueryVariables = Exact<{
   expenditureId: Scalars['ID'];
 }>;
 
 
-export type GetExpenditureQuery = { __typename?: 'Query', getExpenditure?: { __typename?: 'Expenditure', id: string, nativeId: number, ownerAddress: string, status: ExpenditureStatus, nativeFundingPotId: number, slots: Array<{ __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string }> | null }>, metadata?: { __typename?: 'ExpenditureMetadata', nativeDomainId: number } | null } | null };
+export type GetExpenditureQuery = { __typename?: 'Query', getExpenditure?: { __typename?: 'Expenditure', id: string, nativeId: number, ownerAddress: string, status: ExpenditureStatus, nativeFundingPotId: number, slots: Array<{ __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string }> | null }>, metadata?: { __typename?: 'ExpenditureMetadata', nativeDomainId: number } | null, balances?: Array<{ __typename?: 'ExpenditureBalance', tokenAddress: string, amount: string, requiredAmount: string }> | null } | null };
 
 export type GetMotionStateQueryVariables = Exact<{
   input: GetMotionStateInput;
@@ -6188,6 +6188,11 @@ export const ExpenditureFragmentDoc = gql`
   nativeFundingPotId
   metadata {
     nativeDomainId
+  }
+  balances {
+    tokenAddress
+    amount
+    requiredAmount
   }
 }
     `;

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -5554,7 +5554,7 @@ export type GetColonyExpendituresQueryVariables = Exact<{
 }>;
 
 
-export type GetColonyExpendituresQuery = { __typename?: 'Query', getColony?: { __typename?: 'Colony', id: string, expenditures?: { __typename?: 'ModelExpenditureConnection', items: Array<{ __typename?: 'Expenditure', id: string, nativeId: number, ownerAddress: string, status: ExpenditureStatus, nativeFundingPotId: number, slots: Array<{ __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string }> | null }>, metadata?: { __typename?: 'ExpenditureMetadata', nativeDomainId: number } | null, balances?: Array<{ __typename?: 'ExpenditureBalance', tokenAddress: string, amount: string, requiredAmount: string }> | null } | null> } | null } | null };
+export type GetColonyExpendituresQuery = { __typename?: 'Query', getColony?: { __typename?: 'Colony', id: string, expenditures?: { __typename?: 'ModelExpenditureConnection', items: Array<{ __typename?: 'Expenditure', id: string, nativeId: number } | null> } | null } | null };
 
 export type GetExpenditureQueryVariables = Exact<{
   expenditureId: Scalars['ID'];
@@ -7094,12 +7094,13 @@ export const GetColonyExpendituresDocument = gql`
     id
     expenditures {
       items {
-        ...Expenditure
+        id
+        nativeId
       }
     }
   }
 }
-    ${ExpenditureFragmentDoc}`;
+    `;
 
 /**
  * __useGetColonyExpendituresQuery__

--- a/src/graphql/queries/expenditures.graphql
+++ b/src/graphql/queries/expenditures.graphql
@@ -3,7 +3,8 @@ query GetColonyExpenditures($colonyAddress: ID!) {
     id
     expenditures {
       items {
-        ...Expenditure
+        id
+        nativeId
       }
     }
   }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -258,6 +258,8 @@
   "transaction.ColonyClient.setExpenditurePayouts.description": "Set Expenditure Payouts",
   "transaction.ColonyClient.lockExpenditure.title": "Lock Expenditure",
   "transaction.ColonyClient.lockExpenditure.description": "Lock Expenditure",
+  "transaction.ColonyClient.finalizeExpenditure.title": "Finalize Expenditure",
+  "transaction.ColonyClient.finalizeExpenditure.description": "Finalize Expenditure",
 
   "metatransaction.debug.description": "DEBUG: context: {context} methodName: {methodName}",
   "metatransaction.group.deposit.title": "Activate tokens",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -260,6 +260,8 @@
   "transaction.ColonyClient.lockExpenditure.description": "Lock Expenditure",
   "transaction.ColonyClient.finalizeExpenditure.title": "Finalize Expenditure",
   "transaction.ColonyClient.finalizeExpenditure.description": "Finalize Expenditure",
+  "transaction.group.fundExpenditure.title": "Fund Expenditure",
+  "transaction.group.fundExpenditure.description": "Fund Expenditure",
 
   "metatransaction.debug.description": "DEBUG: context: {context} methodName: {methodName}",
   "metatransaction.group.deposit.title": "Activate tokens",

--- a/src/redux/sagas/expenditures/fundExpenditure.ts
+++ b/src/redux/sagas/expenditures/fundExpenditure.ts
@@ -1,38 +1,82 @@
 import { ClientType } from '@colony/colony-js';
-import { call, fork, put, takeEvery } from 'redux-saga/effects';
+import { all, fork, put, takeEvery } from 'redux-saga/effects';
+import { BigNumber } from 'ethers';
 
 import { Action, ActionTypes, AllActions } from '~redux';
+import {
+  transactionAddParams,
+  transactionPending,
+  transactionReady,
+} from '~redux/actionCreators';
 
-import { createTransaction, getTxChannel } from '../transactions';
+import { createTransaction, createTransactionChannels } from '../transactions';
 import { putError, takeFrom } from '../utils';
 
 function* fundExpenditure({
-  payload: {
-    colonyAddress,
-    fromDomainFundingPotId,
-    expenditureFundingPotId,
-    amount,
-    tokenAddress,
-  },
+  payload: { colonyAddress, expenditure, fromDomainFundingPotId },
   meta,
 }: Action<ActionTypes.EXPENDITURE_FUND>) {
-  const txChannel = yield call(getTxChannel, meta.id);
+  const { nativeFundingPotId: expenditureFundingPotId } = expenditure;
+
+  const batchKey = 'fundExpenditure';
+
+  // Create a map between token addresses and the total amount of the payouts for each token
+  // We will call one moveFunds method for each token address instead of each payout to save gas
+  const balancesByTokenAddresses = new Map<string, BigNumber>();
+  expenditure.slots.forEach((slot) => {
+    slot.payouts?.forEach((payout) => {
+      const currentBalance =
+        balancesByTokenAddresses.get(payout.tokenAddress) ?? '0';
+      balancesByTokenAddresses.set(
+        payout.tokenAddress,
+        BigNumber.from(payout.amount).add(currentBalance),
+      );
+    });
+  });
+
+  // Create channel for each token, using its address as channel id
+  const channels = yield createTransactionChannels(meta.id, [
+    ...balancesByTokenAddresses.keys(),
+  ]);
 
   try {
-    yield fork(createTransaction, meta.id, {
-      context: ClientType.ColonyClient,
-      methodName:
-        'moveFundsBetweenPotsWithProofs(uint256,uint256,uint256,address)',
-      identifier: colonyAddress,
-      params: [
-        fromDomainFundingPotId,
-        expenditureFundingPotId,
-        amount,
-        tokenAddress,
-      ],
-    });
+    yield all(
+      [...balancesByTokenAddresses.keys()].map((tokenAddress, index) =>
+        fork(createTransaction, channels[tokenAddress].id, {
+          context: ClientType.ColonyClient,
+          methodName:
+            'moveFundsBetweenPotsWithProofs(uint256,uint256,uint256,address)',
+          identifier: colonyAddress,
+          group: {
+            key: batchKey,
+            id: meta.id,
+            index,
+          },
+          ready: false,
+        }),
+      ),
+    );
 
-    yield takeFrom(txChannel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield all(
+      [...balancesByTokenAddresses.entries()]
+        .map(([tokenAddress, amount]) => [
+          put(transactionPending(channels[tokenAddress].id)),
+          put(
+            transactionAddParams(channels[tokenAddress].id, [
+              fromDomainFundingPotId,
+              expenditureFundingPotId,
+              amount,
+              tokenAddress,
+            ]),
+          ),
+          put(transactionReady(channels[tokenAddress].id)),
+          takeFrom(
+            channels[tokenAddress].channel,
+            ActionTypes.TRANSACTION_SUCCEEDED,
+          ),
+        ])
+        .flat(),
+    );
 
     yield put<AllActions>({
       type: ActionTypes.EXPENDITURE_FUND_SUCCESS,
@@ -43,7 +87,9 @@ function* fundExpenditure({
     return yield putError(ActionTypes.EXPENDITURE_FUND_ERROR, error, meta);
   }
 
-  txChannel.close();
+  [...balancesByTokenAddresses.keys()].forEach((tokenAddress) =>
+    channels[tokenAddress].channel.close(),
+  );
 
   return null;
 }

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -1,5 +1,5 @@
 import { ActionTypes } from '~redux/actionTypes';
-import { Address, Colony } from '~types';
+import { Address, Colony, Expenditure } from '~types';
 import { ExpenditureSlotFieldValue } from '~common/Expenditures/ExpenditureForm';
 
 import { UniqueActionType, ErrorActionType, MetaWithNavigate } from './index';
@@ -43,9 +43,7 @@ export type ExpendituresActionTypes =
       {
         colonyAddress: Address;
         fromDomainFundingPotId: number;
-        expenditureFundingPotId: number;
-        amount: string;
-        tokenAddress: Address;
+        expenditure: Expenditure;
       },
       object
     >

--- a/src/utils/expenditures.ts
+++ b/src/utils/expenditures.ts
@@ -1,0 +1,12 @@
+import { BigNumber } from 'ethers';
+
+import { Expenditure } from '~types';
+
+// Returns true if there's enough balance in the expenditure's funding pot to cover all payouts of all tokens
+export const isExpenditureFunded = (expenditure: Expenditure) => {
+  return (
+    expenditure.balances?.every((balance) =>
+      BigNumber.from(balance.amount).gte(balance.requiredAmount),
+    ) ?? false
+  );
+};


### PR DESCRIPTION
## Description

This PR wires expenditure funding functionality with the information received from the expenditure's `balances` field. The balances are displayed on the expenditure details page and now, the UI will only ask for an expenditure to be funded if it's locked and not fully funded:
![image](https://github.com/JoinColony/colonyCDapp/assets/112586815/2649846d-ded8-416d-bbf6-2275784b8fd3)

Contributes to #897 
