### PR TITLE
Setting expenditure claim delay

### DIFF
--- a/src/components/common/Expenditures/ExpenditureForm/ExpenditureForm.module.css
+++ b/src/components/common/Expenditures/ExpenditureForm/ExpenditureForm.module.css
@@ -1,7 +1,7 @@
 .field {
   display: grid;
   align-items: center;
-  grid-template-columns: auto repeat(3, 1fr);
+  grid-template-columns: auto repeat(4, 1fr);
   column-gap: 10px;
 }
 

--- a/src/components/common/Expenditures/ExpenditureForm/ExpenditureFormFields.tsx
+++ b/src/components/common/Expenditures/ExpenditureForm/ExpenditureFormFields.tsx
@@ -45,7 +45,7 @@ const ExpenditureFormFields = ({
             <Input name={`payouts.${index}.amount`} label="Amount" />
             <div>{colony.nativeToken.symbol}</div>
           </div>
-          <Input name={`slots.${index}.claimDelay`} label="Claim delay" />
+          <Input name={`payouts.${index}.claimDelay`} label="Claim delay" />
         </div>
       ))}
 

--- a/src/components/common/Expenditures/ExpenditureForm/ExpenditureFormFields.tsx
+++ b/src/components/common/Expenditures/ExpenditureForm/ExpenditureFormFields.tsx
@@ -45,6 +45,7 @@ const ExpenditureFormFields = ({
             <Input name={`payouts.${index}.amount`} label="Amount" />
             <div>{colony.nativeToken.symbol}</div>
           </div>
+          <Input name={`slots.${index}.claimDelay`} label="Claim delay" />
         </div>
       ))}
 

--- a/src/components/common/Expenditures/ExpenditureForm/helpers.ts
+++ b/src/components/common/Expenditures/ExpenditureForm/helpers.ts
@@ -12,6 +12,7 @@ export const getInitialPayoutFieldValue = (
   recipientAddress: '',
   tokenAddress,
   amount: '0',
+  claimDelay: 0,
 });
 
 export const getExpenditurePayoutsFieldValue = (
@@ -26,6 +27,7 @@ export const getExpenditurePayoutsFieldValue = (
           recipientAddress: slot.recipientAddress ?? '',
           tokenAddress: payout.tokenAddress,
           amount: weiToEth(payout.amount),
+          claimDelay: slot.claimDelay ?? 0,
         })) ?? [];
 
     return [...payouts, ...slotPayouts];

--- a/src/components/common/Expenditures/ExpenditureForm/types.ts
+++ b/src/components/common/Expenditures/ExpenditureForm/types.ts
@@ -3,4 +3,5 @@ export interface ExpenditurePayoutFieldValue {
   recipientAddress: string;
   tokenAddress: string;
   amount: string;
+  claimDelay: number;
 }

--- a/src/redux/sagas/expenditures/editExpenditure.ts
+++ b/src/redux/sagas/expenditures/editExpenditure.ts
@@ -46,6 +46,7 @@ function* editExpenditure({
           recipientAddress: payout.recipientAddress,
           tokenAddress: slotPayout.tokenAddress,
           amount: '0',
+          claimDelay: payout.claimDelay,
         })) ?? []),
     );
   });
@@ -59,6 +60,7 @@ function* editExpenditure({
         recipientAddress: slot.recipientAddress ?? '',
         tokenAddress: payout.tokenAddress,
         amount: '0',
+        claimDelay: slot.claimDelay ?? 0,
       });
     });
   });

--- a/src/redux/sagas/utils/expenditures.ts
+++ b/src/redux/sagas/utils/expenditures.ts
@@ -45,9 +45,9 @@ export const getSetExpenditureValuesFunctionParams = (
     // skill ids
     [],
     // slot ids for claim delays
-    [],
+    payouts.map((payout) => payout.slotId ?? 0),
     // claim delays
-    [],
+    payouts.map((payout) => payout.claimDelay),
     // slot ids for payout modifiers
     [],
     // payout modifiers


### PR DESCRIPTION
## Description

This PR modifies the expenditure form to allow setting claim delay both while creating and updating an expenditure.

## Testing
Creating an expenditure: Try setting claim delay for one or more recipients when creating an expenditure. You should see the correct delays displayed next to slots on the expenditure details page.

Editing an expenditure: On the expenditure details page, while an expenditure is in Draft status, modify some of the claim delays. After refreshing the page, you should see the updated values.

Note there's no validation of the form inputs at the moment, so entering anything that's not a number will break things.

Resolves #927 
