### PR TITLE
Installing and initializing Staked Expenditure extension

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -2009,6 +2009,10 @@ type VotingReputationParams {
   escalationPeriod: String!
 }
 
+type StakedExpenditureParams {
+  stakeFraction: String!
+}
+
 """
 Map of parameters that extensions are initialised with
 """
@@ -2017,6 +2021,10 @@ type ExtensionParams {
   Initialization parameters for the `VotingReputation` extension
   """
   votingReputation: VotingReputationParams
+  """
+  Initialization parameters for the `StakedExpenditure` extension
+  """
+  stakedExpenditure: StakedExpenditureParams
 }
 
 """

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=cb6d7ec631360fe9106b11ff4f3cc3dc8e3044f9
+ENV BLOCK_INGESTOR_HASH=0ed5279a3db32d6ce80164ba0a5744fdcb4ae3d6
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/constants/extensions.ts
+++ b/src/constants/extensions.ts
@@ -139,12 +139,12 @@ const stakedExpenditureMessages = {
     id: `${stakedExpenditureName}.descriptionLong`,
     defaultMessage: 'Staked Expenditure extension.',
   },
-  stakedExpenditureTotalStakeFractionTitle: {
-    id: `${stakedExpenditureName}.param.totalStakeFraction.title`,
+  stakedExpenditureStakeFractionTitle: {
+    id: `${stakedExpenditureName}.param.stakeFraction.title`,
     defaultMessage: 'Required Stake',
   },
-  stakedExpenditureTotalStakeFractionDescription: {
-    id: `${stakedExpenditureName}.param.totalStakeFraction.description`,
+  stakedExpenditureStakeFractionDescription: {
+    id: `${stakedExpenditureName}.param.stakeFraction.description`,
     defaultMessage: `What percentage of the team's reputation, in token terms, should need to stake to create an expenditure?\n\n<span>e.g. if a team has 100 reputation points between them, and the Required Stake is 5%, then 5 tokens would need to be staked to create an expenditure.</span>`,
   },
 };
@@ -329,15 +329,15 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
     createdAt: 1692048380000,
     initializationParams: [
       {
-        paramName: 'totalStakeFraction',
+        paramName: 'stakeFraction',
         validation: number()
           .transform((value) => toFinite(value))
           .positive(() => MSG.positiveError)
           .required(() => MSG.requiredError)
           .max(100, () => MSG.lessThan100Error),
         defaultValue: 1,
-        title: MSG.stakedExpenditureTotalStakeFractionTitle,
-        description: MSG.stakedExpenditureTotalStakeFractionDescription,
+        title: MSG.stakedExpenditureStakeFractionTitle,
+        description: MSG.stakedExpenditureStakeFractionDescription,
         type: ExtensionParamType.Input,
         complementaryLabel: 'percent',
         formattingOptions: {

--- a/src/constants/extensions.ts
+++ b/src/constants/extensions.ts
@@ -6,7 +6,8 @@ import { toFinite } from '~utils/lodash';
 import { ExtensionConfig, ExtensionParamType } from '~types';
 
 const oneTransactionPaymentName = 'extensions.OneTxPayment';
-const votingReputationName = 'extensions.votingReputation';
+const votingReputationName = 'extensions.VotingReputation';
+const stakedExpenditureName = 'extensions.StakedExpenditure';
 
 const oneTransactionPaymentMessages = {
   oneTxPaymentName: {
@@ -122,9 +123,25 @@ const votingReputationMessages = {
   },
 };
 
+const stakedExpenditureMessages = {
+  stakedExpenditureName: {
+    id: `${stakedExpenditureName}.name`,
+    defaultMessage: 'Staked Expenditure',
+  },
+  stakedExpenditureDescriptionShort: {
+    id: `${stakedExpenditureName}.description`,
+    defaultMessage: 'Staked Expenditure extension.',
+  },
+  stakedExpenditureDescriptionLong: {
+    id: `${stakedExpenditureName}.descriptionLong`,
+    defaultMessage: 'Staked Expenditure extension.',
+  },
+};
+
 const MSG = defineMessages({
   ...oneTransactionPaymentMessages,
   ...votingReputationMessages,
+  ...stakedExpenditureMessages,
 });
 
 export const supportedExtensionsConfig: ExtensionConfig[] = [
@@ -134,8 +151,7 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
     descriptionShort: MSG.oneTxPaymentDescriptionShort,
     descriptionLong: MSG.oneTxPaymentDescriptionLong,
     neededColonyPermissions: [ColonyRole.Administration, ColonyRole.Funding],
-    // @NOTE: This is for testing only, should be set to false afterwards
-    uninstallable: true,
+    uninstallable: false,
     createdAt: 1557698400000,
   },
   {
@@ -290,5 +306,14 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
     ],
     uninstallable: true,
     createdAt: 1603915271852,
+  },
+  {
+    extensionId: Extension.StakedExpenditure,
+    name: MSG.stakedExpenditureName,
+    descriptionShort: MSG.stakedExpenditureDescriptionShort,
+    descriptionLong: MSG.stakedExpenditureDescriptionLong,
+    neededColonyPermissions: [ColonyRole.Administration, ColonyRole.Funding],
+    uninstallable: true,
+    createdAt: 1692048380000,
   },
 ];

--- a/src/constants/extensions.ts
+++ b/src/constants/extensions.ts
@@ -9,6 +9,29 @@ const oneTransactionPaymentName = 'extensions.OneTxPayment';
 const votingReputationName = 'extensions.VotingReputation';
 const stakedExpenditureName = 'extensions.StakedExpenditure';
 
+const validationMessages = {
+  requiredError: {
+    id: 'extensions.param.validation.requiredError',
+    defaultMessage: 'Please enter a value.',
+  },
+  lessThan50Error: {
+    id: 'extensions.param.validation.lessThan50Error',
+    defaultMessage: 'Please enter a percentage less than or equal to 50%.',
+  },
+  lessThan100Error: {
+    id: 'extensions.param.validation.lessThan100Error',
+    defaultMessage: 'Please enter a percentage less than or equal to 100%.',
+  },
+  lessThan1YearError: {
+    id: 'extensions.param.validation.lessThan50Error',
+    defaultMessage: 'Please enter hours less than or equal to 1 year.',
+  },
+  positiveError: {
+    id: 'extensions.param.validation.positiveError',
+    defaultMessage: 'Please enter a positive number',
+  },
+};
+
 const oneTransactionPaymentMessages = {
   oneTxPaymentName: {
     id: `${oneTransactionPaymentName}.name`,
@@ -101,26 +124,6 @@ const votingReputationMessages = {
     id: `${votingReputationName}.param.escalationPeriod.description`,
     defaultMessage: `How long do you wish to allow for members to escalate a dispute to a higher team?\n\n<span>e.g. If the escalation phase is 72 hours, once the outcome of a vote is known, if the loser feels the outcome was for any reason incorrect, then they will have 72 hours in which to escalate the dispute to a higher team in the colony by increasing the stake to meet the required stake of that higher team.</span>`,
   },
-  votingReputationRequiredError: {
-    id: `${votingReputationName}.param.validation.requiredError`,
-    defaultMessage: 'Please enter a value.',
-  },
-  votingReputationLessThan50Error: {
-    id: `${votingReputationName}.param.validation.lessThan50Error`,
-    defaultMessage: 'Please enter a percentage less than or equal to 50%.',
-  },
-  votingReputationLessThan100Error: {
-    id: `${votingReputationName}.param.validation.lessThan100Error`,
-    defaultMessage: 'Please enter a percentage less than or equal to 100%.',
-  },
-  votingReputationLessThan1YearError: {
-    id: `${votingReputationName}.param.validation.lessThan50Error`,
-    defaultMessage: 'Please enter hours less than or equal to 1 year.',
-  },
-  votingReputationPositiveError: {
-    id: `${votingReputationName}.param.validation.positiveError`,
-    defaultMessage: 'Please enter a positive number',
-  },
 };
 
 const stakedExpenditureMessages = {
@@ -136,9 +139,18 @@ const stakedExpenditureMessages = {
     id: `${stakedExpenditureName}.descriptionLong`,
     defaultMessage: 'Staked Expenditure extension.',
   },
+  stakedExpenditureTotalStakeFractionTitle: {
+    id: `${stakedExpenditureName}.param.totalStakeFraction.title`,
+    defaultMessage: 'Required Stake',
+  },
+  stakedExpenditureTotalStakeFractionDescription: {
+    id: `${stakedExpenditureName}.param.totalStakeFraction.description`,
+    defaultMessage: `What percentage of the team's reputation, in token terms, should need to stake to create an expenditure?\n\n<span>e.g. if a team has 100 reputation points between them, and the Required Stake is 5%, then 5 tokens would need to be staked to create an expenditure.</span>`,
+  },
 };
 
 const MSG = defineMessages({
+  ...validationMessages,
   ...oneTransactionPaymentMessages,
   ...votingReputationMessages,
   ...stakedExpenditureMessages,
@@ -171,9 +183,9 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
         paramName: 'totalStakeFraction',
         validation: number()
           .transform((value) => toFinite(value))
-          .positive(() => MSG.votingReputationPositiveError)
-          .required(() => MSG.votingReputationRequiredError)
-          .max(50, () => MSG.votingReputationLessThan50Error),
+          .positive(() => MSG.positiveError)
+          .required(() => MSG.requiredError)
+          .max(50, () => MSG.lessThan50Error),
         defaultValue: 1,
         title: MSG.votingReputationTotalStakeFractionTitle,
         description: MSG.votingReputationTotalStakeFractionDescription,
@@ -188,9 +200,9 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
         paramName: 'voterRewardFraction',
         validation: number()
           .transform((value) => toFinite(value))
-          .positive(() => MSG.votingReputationPositiveError)
-          .required(() => MSG.votingReputationRequiredError)
-          .max(50, () => MSG.votingReputationLessThan50Error),
+          .positive(() => MSG.positiveError)
+          .required(() => MSG.requiredError)
+          .max(50, () => MSG.lessThan50Error),
         defaultValue: 20,
         title: MSG.votingReputationVoterRewardFractionTitle,
         description: MSG.votingReputationVoterRewardFractionDescription,
@@ -205,9 +217,9 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
         paramName: 'userMinStakeFraction',
         validation: number()
           .transform((value) => toFinite(value))
-          .positive(() => MSG.votingReputationPositiveError)
-          .required(() => MSG.votingReputationRequiredError)
-          .max(100, () => MSG.votingReputationLessThan100Error),
+          .positive(() => MSG.positiveError)
+          .required(() => MSG.requiredError)
+          .max(100, () => MSG.lessThan100Error),
         defaultValue: 1,
         title: MSG.votingReputationUserMinStakeFractionTitle,
         description: MSG.votingReputationUserMinStakeFractionDescription,
@@ -222,9 +234,9 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
         paramName: 'maxVoteFraction',
         validation: number()
           .transform((value) => toFinite(value))
-          .positive(() => MSG.votingReputationPositiveError)
-          .required(() => MSG.votingReputationRequiredError)
-          .max(100, () => MSG.votingReputationLessThan100Error),
+          .positive(() => MSG.positiveError)
+          .required(() => MSG.requiredError)
+          .max(100, () => MSG.lessThan100Error),
         defaultValue: 70,
         title: MSG.votingReputationMaxVoteFractionTitle,
         description: MSG.votingReputationMaxVoteFractionDescription,
@@ -239,9 +251,9 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
         paramName: 'stakePeriod',
         validation: number()
           .transform((value) => toFinite(value))
-          .positive(() => MSG.votingReputationPositiveError)
-          .required(() => MSG.votingReputationRequiredError)
-          .max(8760, () => MSG.votingReputationLessThan1YearError),
+          .positive(() => MSG.positiveError)
+          .required(() => MSG.requiredError)
+          .max(8760, () => MSG.lessThan1YearError),
         defaultValue: 72, // 3 days in hours
         title: MSG.votingReputationStakePeriodTitle,
         description: MSG.votingReputationStakePeriodDescription,
@@ -256,9 +268,9 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
         paramName: 'submitPeriod',
         validation: number()
           .transform((value) => toFinite(value))
-          .positive(() => MSG.votingReputationPositiveError)
-          .required(() => MSG.votingReputationRequiredError)
-          .max(8760, () => MSG.votingReputationLessThan1YearError),
+          .positive(() => MSG.positiveError)
+          .required(() => MSG.requiredError)
+          .max(8760, () => MSG.lessThan1YearError),
         defaultValue: 72, // 3 days in hours
         title: MSG.votingReputationSubmitPeriodTitle,
         description: MSG.votingReputationSubmitPeriodDescription,
@@ -273,9 +285,9 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
         paramName: 'revealPeriod',
         validation: number()
           .transform((value) => toFinite(value))
-          .positive(() => MSG.votingReputationPositiveError)
-          .required(() => MSG.votingReputationRequiredError)
-          .max(8760, () => MSG.votingReputationLessThan1YearError),
+          .positive(() => MSG.positiveError)
+          .required(() => MSG.requiredError)
+          .max(8760, () => MSG.lessThan1YearError),
         defaultValue: 72, // 3 days in hours
         title: MSG.votingReputationRevealPeriodTitle,
         description: MSG.votingReputationRevealPeriodDescription,
@@ -290,9 +302,9 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
         paramName: 'escalationPeriod',
         validation: number()
           .transform((value) => toFinite(value))
-          .positive(() => MSG.votingReputationPositiveError)
-          .required(() => MSG.votingReputationRequiredError)
-          .max(8760, () => MSG.votingReputationLessThan1YearError),
+          .positive(() => MSG.positiveError)
+          .required(() => MSG.requiredError)
+          .max(8760, () => MSG.lessThan1YearError),
         defaultValue: 72, // 3 days in hours
         title: MSG.votingReputationEscalationPeriodTitle,
         description: MSG.votingReputationEscalationPeriodDescription,
@@ -315,5 +327,24 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
     neededColonyPermissions: [ColonyRole.Administration, ColonyRole.Funding],
     uninstallable: true,
     createdAt: 1692048380000,
+    initializationParams: [
+      {
+        paramName: 'totalStakeFraction',
+        validation: number()
+          .transform((value) => toFinite(value))
+          .positive(() => MSG.positiveError)
+          .required(() => MSG.requiredError)
+          .max(100, () => MSG.lessThan100Error),
+        defaultValue: 1,
+        title: MSG.stakedExpenditureTotalStakeFractionTitle,
+        description: MSG.stakedExpenditureTotalStakeFractionDescription,
+        type: ExtensionParamType.Input,
+        complementaryLabel: 'percent',
+        formattingOptions: {
+          numeral: true,
+          numeralPositiveOnly: true,
+        },
+      },
+    ],
   },
 ];

--- a/src/context/ColonyManager.ts
+++ b/src/context/ColonyManager.ts
@@ -180,6 +180,14 @@ export default class ColonyManager {
           throw new Error('Need colony identifier to get the WhitelistClient');
         return this.getColonyExtensionClient(identifier, Extension.Whitelist);
       }
+      case ClientType.StakedExpenditureClient: {
+        if (!identifier)
+          throw new Error('Need colony identifier to get the WhitelistClient');
+        return this.getColonyExtensionClient(
+          identifier,
+          Extension.StakedExpenditure,
+        );
+      }
       default: {
         throw new Error('A valid contract client type has to be specified');
       }

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -1421,11 +1421,14 @@ export enum ExpenditureStatus {
 /** Map of parameters that extensions are initialised with */
 export type ExtensionParams = {
   __typename?: 'ExtensionParams';
+  /** Initialization parameters for the `StakedExpenditure` extension */
+  stakedExpenditure?: Maybe<StakedExpenditureParams>;
   /** Initialization parameters for the `VotingReputation` extension */
   votingReputation?: Maybe<VotingReputationParams>;
 };
 
 export type ExtensionParamsInput = {
+  stakedExpenditure?: InputMaybe<StakedExpenditureParamsInput>;
   votingReputation?: InputMaybe<VotingReputationParamsInput>;
 };
 
@@ -4316,6 +4319,15 @@ export enum SortingMethod {
   /** Sort members by having more permissions */
   ByMorePermissions = 'BY_MORE_PERMISSIONS'
 }
+
+export type StakedExpenditureParams = {
+  __typename?: 'StakedExpenditureParams';
+  stakeFraction: Scalars['String'];
+};
+
+export type StakedExpenditureParamsInput = {
+  stakeFraction: Scalars['String'];
+};
 
 /** Staker rewards of a user for a motion */
 export type StakerRewards = {

--- a/src/hooks/useEnabledExtensions.tsx
+++ b/src/hooks/useEnabledExtensions.tsx
@@ -7,6 +7,7 @@ export interface EnabledExtensionData {
   isOneTxPaymentEnabled: boolean;
   isVotingReputationEnabled: boolean;
   votingReputationVersion: number | undefined;
+  isStakedExpenditureEnabled: boolean;
 }
 
 const useEnabledExtensions = (): EnabledExtensionData => {
@@ -18,12 +19,16 @@ const useEnabledExtensions = (): EnabledExtensionData => {
   const votingReputationExtension = installedExtensionsData.find(
     (extension) => extension.extensionId === Extension.VotingReputation,
   );
+  const stakedExpenditureExtension = installedExtensionsData.find(
+    (extension) => extension.extensionId === Extension.StakedExpenditure,
+  );
 
   return {
     loading,
     isOneTxPaymentEnabled: !!oneTxPaymentExtension?.isEnabled,
     isVotingReputationEnabled: !!votingReputationExtension?.isEnabled,
     votingReputationVersion: votingReputationExtension?.currentVersion,
+    isStakedExpenditureEnabled: !!stakedExpenditureExtension?.isEnabled,
   };
 };
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -188,6 +188,7 @@
   "transaction.group.unistallExtensions.title": "Uninstall Colony Extension",
   "transaction.group.unistallExtensions.description": "Uninstall Colony Extension",
   "transaction.VotingReputationClient.initialise.title": "Initialize Voting Reputation Extension",
+  "transaction.StakedExpenditureClient.initialise.title": "Initialize Staked Expenditure Extension",
   "transaction.ColonyClient.uninstallExtension.title": "Uninstall Colony Extension",
   "transaction.ColonyClient.uninstallExtension.description": "Uninstall Colony Extension",
   "transaction.ColonyClient.deprecateExtension.title": "Deprecate Colony Extension",


### PR DESCRIPTION
## Description

This PR adds support for the Staked Expenditure extension. You should be able to install and initialize this extension in your colony.

It should accept a simple param, Stake Fraction, that should be stored in the DB after initialization.

## Testing

Usual extension interactions should be tested. You can verify the params have been stored in the DB by running the following query:

```gql
query ListExtensions {
  listColonyExtensions {
    items {
      id
      params {
        stakedExpenditure {
          stakeFraction
        }
      }
    }
  }
}
```

Resolves #898 
