### PR TITLE
Re-implement expenditure domains

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -2524,6 +2524,7 @@ type Expenditure @model {
       name: "byNativeFundingPotId"
       queryField: "getExpendituresByNativeFundingPotId"
     )
+  nativeDomainId: Int!
   metadata: ExpenditureMetadata @hasOne(fields: ["id"])
   balances: [ExpenditureBalance!]
     @function(name: "fetchExpenditureBalances-${env}")
@@ -2545,7 +2546,7 @@ type ExpenditurePayout {
 
 type ExpenditureMetadata @model {
   id: ID! # Self-managed, formatted as colonyId_nativeExpenditureId
-  nativeDomainId: Int!
+  fundFromDomainNativeId: Int!
 }
 
 type ExpenditureBalance {

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=fa2670ce246406d991ae1a89a64636e9390a3bc0
+ENV BLOCK_INGESTOR_HASH=f4a8b4ea57d777a11d0575f10a97b033bf47738b
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureAdvanceButton/ExpenditureAdvanceButton.tsx
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureAdvanceButton/ExpenditureAdvanceButton.tsx
@@ -42,7 +42,7 @@ const ExpenditureAdvanceButton = ({
           colonyAddress: colony.colonyAddress,
           fromDomainFundingPotId:
             findDomainByNativeId(
-              expenditure.metadata?.nativeDomainId ?? Id.RootDomain,
+              expenditure.metadata?.fundFromDomainNativeId ?? Id.RootDomain,
               colony,
             )?.nativeFundingPotId ?? Id.RootPot,
           expenditure,

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.tsx
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.tsx
@@ -48,7 +48,12 @@ const ExpenditureDetailsPage = () => {
   }
 
   const expenditureDomain = findDomainByNativeId(
-    expenditure.metadata?.nativeDomainId ?? Id.RootDomain,
+    expenditure.nativeDomainId,
+    colony,
+  );
+
+  const fundFromDomain = findDomainByNativeId(
+    expenditure.metadata?.fundFromDomainNativeId ?? Id.RootDomain,
     colony,
   );
 
@@ -58,7 +63,10 @@ const ExpenditureDetailsPage = () => {
 
       <div className={styles.details}>
         <div>Status: {expenditure.status}</div>
-        <div>Team: {expenditureDomain?.metadata?.name ?? 'Unknown team'}</div>
+        <div>
+          Created in: {expenditureDomain?.metadata?.name ?? 'Unknown team'}
+        </div>
+        <div>Fund from: {fundFromDomain?.metadata?.name ?? 'Unknown team'}</div>
         <ExpenditureBalances expenditure={expenditure} />
         <ExpenditurePayouts expenditure={expenditure} colony={colony} />
         <ExpenditureAdvanceButton expenditure={expenditure} colony={colony} />

--- a/src/components/common/Expenditures/ExpenditureForm/ExpenditureForm.tsx
+++ b/src/components/common/Expenditures/ExpenditureForm/ExpenditureForm.tsx
@@ -44,8 +44,9 @@ const ExpenditureForm = ({
     mapPayload((payload: ExpenditureFormValues) => ({
       colony,
       payouts: payload.payouts,
-      // @TODO: This should come from the form values
+      // @TODO: These should come from the form values
       domainId: Id.RootDomain,
+      fundFromDomainId: Id.RootDomain,
     })),
     withMeta({ navigate }),
   );

--- a/src/graphql/fragments/expenditures.graphql
+++ b/src/graphql/fragments/expenditures.graphql
@@ -7,8 +7,9 @@ fragment Expenditure on Expenditure {
     ...ExpenditureSlot
   }
   nativeFundingPotId
+  nativeDomainId
   metadata {
-    nativeDomainId
+    fundFromDomainNativeId
   }
   balances {
     tokenAddress

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -986,6 +986,7 @@ export type CreateExpenditureInput = {
   colonyId: Scalars['ID'];
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
   id?: InputMaybe<Scalars['ID']>;
+  nativeDomainId: Scalars['Int'];
   nativeFundingPotId: Scalars['Int'];
   nativeId: Scalars['Int'];
   ownerAddress: Scalars['ID'];
@@ -994,8 +995,8 @@ export type CreateExpenditureInput = {
 };
 
 export type CreateExpenditureMetadataInput = {
+  fundFromDomainNativeId: Scalars['Int'];
   id?: InputMaybe<Scalars['ID']>;
-  nativeDomainId: Scalars['Int'];
 };
 
 export type CreateIngestorStatsInput = {
@@ -1350,6 +1351,7 @@ export type Expenditure = {
   createdAt: Scalars['AWSDateTime'];
   id: Scalars['ID'];
   metadata?: Maybe<ExpenditureMetadata>;
+  nativeDomainId: Scalars['Int'];
   nativeFundingPotId: Scalars['Int'];
   nativeId: Scalars['Int'];
   ownerAddress: Scalars['ID'];
@@ -1374,8 +1376,8 @@ export type ExpenditureBalanceInput = {
 export type ExpenditureMetadata = {
   __typename?: 'ExpenditureMetadata';
   createdAt: Scalars['AWSDateTime'];
+  fundFromDomainNativeId: Scalars['Int'];
   id: Scalars['ID'];
-  nativeDomainId: Scalars['Int'];
   updatedAt: Scalars['AWSDateTime'];
 };
 
@@ -2109,6 +2111,7 @@ export type ModelExpenditureConditionInput = {
   and?: InputMaybe<Array<InputMaybe<ModelExpenditureConditionInput>>>;
   colonyId?: InputMaybe<ModelIdInput>;
   createdAt?: InputMaybe<ModelStringInput>;
+  nativeDomainId?: InputMaybe<ModelIntInput>;
   nativeFundingPotId?: InputMaybe<ModelIntInput>;
   nativeId?: InputMaybe<ModelIntInput>;
   not?: InputMaybe<ModelExpenditureConditionInput>;
@@ -2128,6 +2131,7 @@ export type ModelExpenditureFilterInput = {
   colonyId?: InputMaybe<ModelIdInput>;
   createdAt?: InputMaybe<ModelStringInput>;
   id?: InputMaybe<ModelIdInput>;
+  nativeDomainId?: InputMaybe<ModelIntInput>;
   nativeFundingPotId?: InputMaybe<ModelIntInput>;
   nativeId?: InputMaybe<ModelIntInput>;
   not?: InputMaybe<ModelExpenditureFilterInput>;
@@ -2138,7 +2142,7 @@ export type ModelExpenditureFilterInput = {
 
 export type ModelExpenditureMetadataConditionInput = {
   and?: InputMaybe<Array<InputMaybe<ModelExpenditureMetadataConditionInput>>>;
-  nativeDomainId?: InputMaybe<ModelIntInput>;
+  fundFromDomainNativeId?: InputMaybe<ModelIntInput>;
   not?: InputMaybe<ModelExpenditureMetadataConditionInput>;
   or?: InputMaybe<Array<InputMaybe<ModelExpenditureMetadataConditionInput>>>;
 };
@@ -2151,8 +2155,8 @@ export type ModelExpenditureMetadataConnection = {
 
 export type ModelExpenditureMetadataFilterInput = {
   and?: InputMaybe<Array<InputMaybe<ModelExpenditureMetadataFilterInput>>>;
+  fundFromDomainNativeId?: InputMaybe<ModelIntInput>;
   id?: InputMaybe<ModelIdInput>;
-  nativeDomainId?: InputMaybe<ModelIntInput>;
   not?: InputMaybe<ModelExpenditureMetadataFilterInput>;
   or?: InputMaybe<Array<InputMaybe<ModelExpenditureMetadataFilterInput>>>;
 };
@@ -2533,6 +2537,7 @@ export type ModelSubscriptionExpenditureFilterInput = {
   colonyId?: InputMaybe<ModelSubscriptionIdInput>;
   createdAt?: InputMaybe<ModelSubscriptionStringInput>;
   id?: InputMaybe<ModelSubscriptionIdInput>;
+  nativeDomainId?: InputMaybe<ModelSubscriptionIntInput>;
   nativeFundingPotId?: InputMaybe<ModelSubscriptionIntInput>;
   nativeId?: InputMaybe<ModelSubscriptionIntInput>;
   or?: InputMaybe<Array<InputMaybe<ModelSubscriptionExpenditureFilterInput>>>;
@@ -2542,8 +2547,8 @@ export type ModelSubscriptionExpenditureFilterInput = {
 
 export type ModelSubscriptionExpenditureMetadataFilterInput = {
   and?: InputMaybe<Array<InputMaybe<ModelSubscriptionExpenditureMetadataFilterInput>>>;
+  fundFromDomainNativeId?: InputMaybe<ModelSubscriptionIntInput>;
   id?: InputMaybe<ModelSubscriptionIdInput>;
-  nativeDomainId?: InputMaybe<ModelSubscriptionIntInput>;
   or?: InputMaybe<Array<InputMaybe<ModelSubscriptionExpenditureMetadataFilterInput>>>;
 };
 
@@ -5024,6 +5029,7 @@ export type UpdateExpenditureInput = {
   colonyId?: InputMaybe<Scalars['ID']>;
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
   id: Scalars['ID'];
+  nativeDomainId?: InputMaybe<Scalars['Int']>;
   nativeFundingPotId?: InputMaybe<Scalars['Int']>;
   nativeId?: InputMaybe<Scalars['Int']>;
   ownerAddress?: InputMaybe<Scalars['ID']>;
@@ -5032,8 +5038,8 @@ export type UpdateExpenditureInput = {
 };
 
 export type UpdateExpenditureMetadataInput = {
+  fundFromDomainNativeId?: InputMaybe<Scalars['Int']>;
   id: Scalars['ID'];
-  nativeDomainId?: InputMaybe<Scalars['Int']>;
 };
 
 /**
@@ -5356,7 +5362,7 @@ export type DomainFragment = { __typename?: 'Domain', id: string, nativeId: numb
 
 export type DomainMetadataFragment = { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null };
 
-export type ExpenditureFragment = { __typename?: 'Expenditure', id: string, nativeId: number, ownerAddress: string, status: ExpenditureStatus, nativeFundingPotId: number, slots: Array<{ __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string }> | null }>, metadata?: { __typename?: 'ExpenditureMetadata', nativeDomainId: number } | null, balances?: Array<{ __typename?: 'ExpenditureBalance', tokenAddress: string, amount: string, requiredAmount: string }> | null };
+export type ExpenditureFragment = { __typename?: 'Expenditure', id: string, nativeId: number, ownerAddress: string, status: ExpenditureStatus, nativeFundingPotId: number, nativeDomainId: number, slots: Array<{ __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string }> | null }>, metadata?: { __typename?: 'ExpenditureMetadata', fundFromDomainNativeId: number } | null, balances?: Array<{ __typename?: 'ExpenditureBalance', tokenAddress: string, amount: string, requiredAmount: string }> | null };
 
 export type ExpenditureSlotFragment = { __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string }> | null };
 
@@ -5563,7 +5569,7 @@ export type GetExpenditureQueryVariables = Exact<{
 }>;
 
 
-export type GetExpenditureQuery = { __typename?: 'Query', getExpenditure?: { __typename?: 'Expenditure', id: string, nativeId: number, ownerAddress: string, status: ExpenditureStatus, nativeFundingPotId: number, slots: Array<{ __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string }> | null }>, metadata?: { __typename?: 'ExpenditureMetadata', nativeDomainId: number } | null, balances?: Array<{ __typename?: 'ExpenditureBalance', tokenAddress: string, amount: string, requiredAmount: string }> | null } | null };
+export type GetExpenditureQuery = { __typename?: 'Query', getExpenditure?: { __typename?: 'Expenditure', id: string, nativeId: number, ownerAddress: string, status: ExpenditureStatus, nativeFundingPotId: number, nativeDomainId: number, slots: Array<{ __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string }> | null }>, metadata?: { __typename?: 'ExpenditureMetadata', fundFromDomainNativeId: number } | null, balances?: Array<{ __typename?: 'ExpenditureBalance', tokenAddress: string, amount: string, requiredAmount: string }> | null } | null };
 
 export type GetMotionStateQueryVariables = Exact<{
   input: GetMotionStateInput;
@@ -6193,8 +6199,9 @@ export const ExpenditureFragmentDoc = gql`
     ...ExpenditureSlot
   }
   nativeFundingPotId
+  nativeDomainId
   metadata {
-    nativeDomainId
+    fundFromDomainNativeId
   }
   balances {
     tokenAddress

--- a/src/redux/sagas/colony/colonyCreate.ts
+++ b/src/redux/sagas/colony/colonyCreate.ts
@@ -32,7 +32,7 @@ import {
   GetTokenFromEverywhereQueryVariables,
 } from '~gql';
 import { ColonyManager, ContextModule, getContext } from '~context';
-import { DEFAULT_TOKEN_DECIMALS, isDev } from '~constants';
+import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { ActionTypes, Action, AllActions } from '~redux/index';
 import { createAddress } from '~utils/web3';
 import { toNumber } from '~utils/numbers';
@@ -135,9 +135,6 @@ function* colonyCreate({
         context: ClientType.NetworkClient,
         methodName: 'createColony(address,uint256,string,string)',
         ready: false,
-        title: isDev
-          ? { id: 'transaction.group.createColony.titleWithHold' }
-          : undefined,
       });
     }
 
@@ -443,22 +440,6 @@ function* colonyCreate({
         .filter(Boolean)
         .map(({ id }) => put(transactionAddIdentifier(id, tokenAddress))),
     );
-
-    /*
-     * @NOTE Wait for the block ingestor to pick up the new colony
-     *
-     * This is not ideal, but it's only needed for the local dev environment since
-     * the transactions fire at such a rapid rate, that the block ingestor can't
-     * keep up, so it won't set up the required event listeners, by the time the
-     * actual events from the new colony get emmited
-     *
-     * This isn't a issue in production, since transactions get mined at a more
-     * leasurely pace.
-     */
-    if (isDev) {
-      // eslint-disable-next-line no-promise-executor-return
-      yield new Promise((resolve) => setTimeout(resolve, 3000));
-    }
 
     if (deployTokenAuthority) {
       /*

--- a/src/redux/sagas/expenditures/createExpenditure.ts
+++ b/src/redux/sagas/expenditures/createExpenditure.ts
@@ -36,6 +36,7 @@ function* createExpenditure({
     colony: { name: colonyName, colonyAddress },
     payouts,
     domainId,
+    fundFromDomainId,
   },
 }: Action<ActionTypes.EXPENDITURE_CREATE>) {
   const colonyManager: ColonyManager = yield getColonyManager();
@@ -66,7 +67,12 @@ function* createExpenditure({
       context: ClientType.ColonyClient,
       methodName: 'makeExpenditure',
       identifier: colonyAddress,
-      params: [1, BigNumber.from(2).pow(256).sub(1), 1],
+      params: [
+        // @TODO: Get the permissions domain id using colony-js's getPermissionProofs
+        1,
+        BigNumber.from(2).pow(256).sub(1),
+        domainId,
+      ],
       group: {
         key: batchKey,
         id: meta.id,
@@ -117,7 +123,7 @@ function* createExpenditure({
       variables: {
         input: {
           id: getExpenditureDatabaseId(colonyAddress, toNumber(expenditureId)),
-          nativeDomainId: domainId,
+          fundFromDomainNativeId: fundFromDomainId,
         },
       },
     });

--- a/src/redux/sagas/extensions/extensionEnable.ts
+++ b/src/redux/sagas/extensions/extensionEnable.ts
@@ -1,7 +1,6 @@
 import { all, call, put, takeEvery } from 'redux-saga/effects';
 import { ClientType, Id } from '@colony/colony-js';
 
-import { isDev } from '~constants';
 import { intArrayToBytes32 } from '~utils/web3';
 
 import { ActionTypes } from '../../actionTypes';
@@ -66,30 +65,20 @@ function* extensionEnable({
 
       const batchKey = 'enableExtensions';
 
-      const effects = Object.keys(transactionChannels).map((channelName) =>
-        createGroupTransaction(
-          transactionChannels[channelName],
-          batchKey,
-          meta,
-          {
-            identifier: colonyAddress,
-            methodName: channelName,
-            ...channels[channelName],
-          },
+      yield all(
+        Object.keys(transactionChannels).map((channelName) =>
+          createGroupTransaction(
+            transactionChannels[channelName],
+            batchKey,
+            meta,
+            {
+              identifier: colonyAddress,
+              methodName: channelName,
+              ...channels[channelName],
+            },
+          ),
         ),
       );
-
-      /* Delay action creation in development, else block ingestor doesn't detect all on-chain events */
-      if (isDev) {
-        for (const effect of effects) {
-          yield effect;
-          yield new Promise((res) => {
-            setTimeout(res, 3_000);
-          });
-        }
-      } else {
-        yield all(effects);
-      }
 
       yield all(
         Object.keys(transactionChannels).map((id) =>

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -10,7 +10,10 @@ export type ExpendituresActionTypes =
       {
         colony: Colony;
         payouts: ExpenditurePayoutFieldValue[];
+        // id of the domain to create the expenditure in
         domainId: number;
+        // id of the domain to fund the expenditure from
+        fundFromDomainId: number;
       },
       MetaWithNavigate<object>
     >


### PR DESCRIPTION
## Description

This PR implements the refactoring of expenditure domains as described in #955. 

**New stuff** ✨

* `nativeDomainId` field on the Expenditure model

**Changes** 🏗

* ExpenditureMetadata's `nativeDomainId` renamed to `fundFromDomainNativeId`

**Deletions** ⚰️

* Deleted the dev only delays (aka waiting for block-ingestor) since they're not needed anymore 

## Testing

There should be no changes in functionality, so it's sufficient to only test if creating expenditures still works.

Resolves #955 
