### PR TITLE
Ensure errors propagate to ui from extension sagas

### DIFF
--- a/src/components/shared/Button/ActionButton.tsx
+++ b/src/components/shared/Button/ActionButton.tsx
@@ -55,15 +55,13 @@ const ActionButton = ({
         typeof values == 'function' ? await values() : values;
       result = await asyncFunction(asyncFuncValues);
       if (isMountedRef.current) setLoading(false);
+      if (typeof onSuccess == 'function') onSuccess(result);
     } catch (err) {
       setLoading(false);
 
       /**
        * @todo : display error somewhere
        */
-      return;
-    } finally {
-      if (typeof onSuccess == 'function') onSuccess(result);
     }
   };
 

--- a/src/redux/sagas/extensions/extensionDeprecate.ts
+++ b/src/redux/sagas/extensions/extensionDeprecate.ts
@@ -27,13 +27,15 @@ function* extensionDeprecate({
 
     yield takeFrom(txChannel, ActionTypes.TRANSACTION_CREATED);
 
-    yield put<AllActions>({
-      type: ActionTypes.EXTENSION_DEPRECATE_SUCCESS,
-      payload: {},
-      meta,
-    });
+    const result = yield waitForTxResult(txChannel);
 
-    yield waitForTxResult(txChannel);
+    if (result.type === ActionTypes.TRANSACTION_SUCCEEDED) {
+      yield put<AllActions>({
+        type: ActionTypes.EXTENSION_DEPRECATE_SUCCESS,
+        payload: {},
+        meta,
+      });
+    }
   } catch (error) {
     return yield putError(ActionTypes.EXTENSION_DEPRECATE_ERROR, error, meta);
   }

--- a/src/redux/sagas/extensions/extensionEnable.ts
+++ b/src/redux/sagas/extensions/extensionEnable.ts
@@ -5,8 +5,12 @@ import { isDev } from '~constants';
 import { intArrayToBytes32 } from '~utils/web3';
 
 import { ActionTypes } from '../../actionTypes';
-import { Action } from '../../types/actions';
-import { createGroupTransaction, getTxChannel } from '../transactions';
+import { Action, AllActions } from '../../types/actions';
+import {
+  createGroupTransaction,
+  getTxChannel,
+  waitForTxResult,
+} from '../transactions';
 import {
   Channel,
   modifyParams,
@@ -100,20 +104,21 @@ function* extensionEnable({
         ),
       );
 
-      yield takeFrom(initialise.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+      const result = yield waitForTxResult(initialise.channel);
 
       if (setUserRolesWithProofs) {
-        yield takeFrom(
-          setUserRolesWithProofs.channel,
-          ActionTypes.TRANSACTION_SUCCEEDED,
-        );
+        yield waitForTxResult(setUserRolesWithProofs.channel);
+        // assume if this doesn't error, the transaction has succeeded.
+        // @TODO: Handle state in which it gets cancelled
       }
 
-      yield put({
-        type: ActionTypes.EXTENSION_ENABLE_SUCCESS,
-        payload: {},
-        meta,
-      });
+      if (result.type === ActionTypes.TRANSACTION_SUCCEEDED) {
+        yield put<AllActions>({
+          type: ActionTypes.EXTENSION_ENABLE_SUCCESS,
+          payload: {},
+          meta,
+        });
+      }
     }
   } catch (error) {
     return yield putError(ActionTypes.EXTENSION_ENABLE_ERROR, error, meta);

--- a/src/redux/sagas/extensions/extensionInstall.ts
+++ b/src/redux/sagas/extensions/extensionInstall.ts
@@ -29,13 +29,15 @@ export function* extensionInstall({
 
     yield takeFrom(txChannel, ActionTypes.TRANSACTION_CREATED);
 
-    yield put<AllActions>({
-      type: ActionTypes.EXTENSION_INSTALL_SUCCESS,
-      payload: {},
-      meta,
-    });
+    const result = yield waitForTxResult(txChannel);
 
-    yield waitForTxResult(txChannel);
+    if (result.type === ActionTypes.TRANSACTION_SUCCEEDED) {
+      yield put<AllActions>({
+        type: ActionTypes.EXTENSION_INSTALL_SUCCESS,
+        payload: {},
+        meta,
+      });
+    }
   } catch (error) {
     return yield putError(ActionTypes.EXTENSION_INSTALL_ERROR, error, meta);
   }

--- a/src/redux/sagas/extensions/extensionUninstall.ts
+++ b/src/redux/sagas/extensions/extensionUninstall.ts
@@ -26,13 +26,14 @@ export function* extensionUninstall({
 
     yield takeFrom(txChannel, ActionTypes.TRANSACTION_CREATED);
 
-    yield put<AllActions>({
-      type: ActionTypes.EXTENSION_UNINSTALL_SUCCESS,
-      payload: {},
-      meta,
-    });
-
-    yield waitForTxResult(txChannel);
+    const result = yield waitForTxResult(txChannel);
+    if (result.type === ActionTypes.TRANSACTION_SUCCEEDED) {
+      yield put<AllActions>({
+        type: ActionTypes.EXTENSION_UNINSTALL_SUCCESS,
+        payload: {},
+        meta,
+      });
+    }
   } catch (error) {
     return yield putError(ActionTypes.EXTENSION_UNINSTALL_ERROR, error, meta);
   }

--- a/src/redux/sagas/extensions/extensionUpgrade.ts
+++ b/src/redux/sagas/extensions/extensionUpgrade.ts
@@ -25,14 +25,14 @@ function* extensionUpgrade({
     });
 
     yield takeFrom(txChannel, ActionTypes.TRANSACTION_CREATED);
-
-    yield put<AllActions>({
-      type: ActionTypes.EXTENSION_UPGRADE_SUCCESS,
-      payload: {},
-      meta,
-    });
-
-    yield waitForTxResult(txChannel);
+    const result = yield waitForTxResult(txChannel);
+    if (result.type === ActionTypes.TRANSACTION_SUCCEEDED) {
+      yield put<AllActions>({
+        type: ActionTypes.EXTENSION_UPGRADE_SUCCESS,
+        payload: {},
+        meta,
+      });
+    }
   } catch (error) {
     return yield putError(ActionTypes.EXTENSION_UPGRADE_ERROR, error, meta);
   }


### PR DESCRIPTION
## Description

This PR tweaks the extension sagas logic so that errors correctly propagate to the UI. 

**Changes** 🏗

* Listen for the success / error tx action, before resolving the saga as successful

Contributes to #1018 

