### PR TITLE
Include various fixes to Safe Control

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=c4ca9f818e9f40f9e34798dec36b58251c44f433
+ENV BLOCK_INGESTOR_HASH=ba7a551bda1097fcb6620b6a33c84659122c60ba
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=ba7a551bda1097fcb6620b6a33c84659122c60ba
+ENV BLOCK_INGESTOR_HASH=feb7a8e53d1887ff9192ba00c01c77dc47f65f0f
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/common/ColonyActions/ActionDetailsPage/ActionDetailsPageFeed/ActionDetailsPageFeed.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/ActionDetailsPageFeed/ActionDetailsPageFeed.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { ColonyAction } from '~types';
-import { parseSafeTransactionEventType } from '~utils/safes';
+import { parseSafeTransactionType } from '~utils/safes';
 
 import { ACTIONS_EVENTS } from '../staticMaps';
 
@@ -14,22 +14,10 @@ interface ActionsPageFeedProps {
   actionData: ColonyAction;
 }
 
-// only safe events for now
-const arbitraryTransactionEventParser = (actionData: ColonyAction) => {
-  const safeType = parseSafeTransactionEventType(actionData);
-
-  if (safeType) {
-    return safeType;
-  }
-
-  return undefined;
-};
-
 const ActionDetailsPageFeed = ({ actionData }: ActionsPageFeedProps) => {
   const events =
     JSON.parse(actionData.individualEvents as string) ||
-    ACTIONS_EVENTS[actionData.type] ||
-    arbitraryTransactionEventParser(actionData);
+    ACTIONS_EVENTS[parseSafeTransactionType(actionData) || actionData.type];
 
   return (
     <>

--- a/src/components/common/ColonyActions/ActionDetailsPage/staticMaps.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/staticMaps.ts
@@ -1,6 +1,11 @@
 import { ColonyRole } from '@colony/colony-js';
 
-import { ColonyActionType, ColonyAndExtensionsEvents } from '~types';
+import {
+  AnyActionType,
+  ColonyActionType,
+  ColonyAndExtensionsEvents,
+  ExtendedColonyActionType,
+} from '~types';
 
 export enum TransactionStatuses {
   Failed = 'failed',
@@ -66,16 +71,8 @@ const MOTION_EVENTS = [
   ColonyAndExtensionsEvents.MotionRewardClaimed,
 ];
 
-const SAFE_EVENTS = [
-  ColonyAndExtensionsEvents.SafeTransferFunds,
-  ColonyAndExtensionsEvents.SafeRawTransaction,
-  ColonyAndExtensionsEvents.SafeTransferNft,
-  ColonyAndExtensionsEvents.SafeContractInteraction,
-  ColonyAndExtensionsEvents.SafeMultipleTransactions,
-];
-
 type ActionsEventsMap = Partial<{
-  [key in ColonyActionType]: ColonyAndExtensionsEvents[];
+  [key in AnyActionType]: ColonyAndExtensionsEvents[];
 }>;
 
 export const ACTIONS_EVENTS: ActionsEventsMap = {
@@ -102,7 +99,6 @@ export const ACTIONS_EVENTS: ActionsEventsMap = {
   [ColonyActionType.EmitDomainReputationReward]: [
     ColonyAndExtensionsEvents.ArbitraryReputationUpdate,
   ],
-  [ColonyActionType.MakeArbitraryTransaction]: SAFE_EVENTS,
   [ColonyActionType.UnlockTokenMotion]: MOTION_EVENTS,
   [ColonyActionType.MintTokensMotion]: MOTION_EVENTS,
   [ColonyActionType.CreateDomainMotion]: MOTION_EVENTS,
@@ -115,4 +111,25 @@ export const ACTIONS_EVENTS: ActionsEventsMap = {
   [ColonyActionType.EmitDomainReputationPenaltyMotion]: MOTION_EVENTS,
   [ColonyActionType.EmitDomainReputationRewardMotion]: MOTION_EVENTS,
   [ColonyActionType.MakeArbitraryTransactionsMotion]: MOTION_EVENTS,
+  // @NOTE: Extended colony action events
+  [ExtendedColonyActionType.SafeTransferFunds]: [
+    ColonyAndExtensionsEvents.SafeTransferFunds,
+  ],
+  [ExtendedColonyActionType.SafeRawTransaction]: [
+    ColonyAndExtensionsEvents.SafeRawTransaction,
+  ],
+  [ExtendedColonyActionType.SafeTransferNft]: [
+    ColonyAndExtensionsEvents.SafeTransferNft,
+  ],
+  [ExtendedColonyActionType.SafeContractInteraction]: [
+    ColonyAndExtensionsEvents.SafeContractInteraction,
+  ],
+  [ExtendedColonyActionType.SafeMultipleTransactions]: [
+    ColonyAndExtensionsEvents.SafeMultipleTransactions,
+  ],
+  [ExtendedColonyActionType.SafeTransferFundsMotion]: MOTION_EVENTS,
+  [ExtendedColonyActionType.SafeRawTransactionMotion]: MOTION_EVENTS,
+  [ExtendedColonyActionType.SafeTransferNftMotion]: MOTION_EVENTS,
+  [ExtendedColonyActionType.SafeContractInteractionMotion]: MOTION_EVENTS,
+  [ExtendedColonyActionType.SafeMultipleTransactionsMotion]: MOTION_EVENTS,
 };

--- a/src/components/common/ColonyActions/ActionDetailsPage/staticMaps.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/staticMaps.ts
@@ -46,6 +46,11 @@ export const EVENT_ROLES_MAP: EventRolesMap = {
     ColonyRole.Root,
     ColonyRole.Arbitration,
   ],
+  [ColonyAndExtensionsEvents.SafeContractInteraction]: [ColonyRole.Root],
+  [ColonyAndExtensionsEvents.SafeMultipleTransactions]: [ColonyRole.Root],
+  [ColonyAndExtensionsEvents.SafeRawTransaction]: [ColonyRole.Root],
+  [ColonyAndExtensionsEvents.SafeTransferFunds]: [ColonyRole.Root],
+  [ColonyAndExtensionsEvents.SafeTransferNft]: [ColonyRole.Root],
   [ColonyAndExtensionsEvents.Generic]: [],
 };
 

--- a/src/components/common/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/components/common/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -352,6 +352,7 @@ const ControlSafeForm = ({
                 placeholder={MSG.safePickerPlaceholder}
                 filter={filterUserSelection}
                 disabled={disabledSectionInputs}
+                excludeFilterValue
               />
             </div>
           </DialogSection>

--- a/src/components/common/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/components/common/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -125,6 +125,7 @@ const ControlSafeForm = ({
     setValue,
     trigger,
     control,
+    resetField,
   } = useFormContext();
 
   const selectedSafe: SelectedPickerItem = watch('safe');
@@ -387,6 +388,12 @@ const ControlSafeForm = ({
                       name={`transactions[${index}].transactionType`}
                       onChange={(type) => {
                         removeSelectedContractMethod(index);
+                        resetField(`transactions.${index}`, {
+                          defaultValue: {
+                            ...defaultTransaction,
+                            transactionType: type,
+                          },
+                        });
                         handleTransactionTypeChange(type as string, index);
                       }}
                       appearance={{ theme: 'grey', width: 'fluid' }}

--- a/src/components/common/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/components/common/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { ColonyRole } from '@colony/colony-js';
@@ -158,40 +158,38 @@ const ControlSafeForm = ({
     trigger();
   };
 
-  const handleSelectedContractMethods = useCallback(
-    (contractMethods: UpdatedMethods, transactionIndex: number) => {
-      const functionParamTypes: FunctionParamType[] =
-        contractMethods[transactionIndex]?.inputs?.map((input) => ({
-          name: input.name || '',
-          type: input.type || '',
-        })) || [];
+  const handleSelectedContractMethods = (
+    contractMethods: UpdatedMethods,
+    transactionIndex: number,
+  ) => {
+    const functionParamTypes: FunctionParamType[] | undefined = contractMethods[
+      transactionIndex
+    ]?.inputs?.map((input) => ({
+      name: input.name || '',
+      type: input.type || '',
+    }));
 
-      setSelectedContractMethods(contractMethods);
-      setValue(
-        `transactions.${transactionIndex}.functionParamTypes`,
-        functionParamTypes,
-      );
-    },
-    [setValue, setSelectedContractMethods],
-  );
+    setSelectedContractMethods(contractMethods);
+    setValue(
+      `transactions.${transactionIndex}.functionParamTypes`,
+      functionParamTypes,
+    );
+  };
 
-  const removeSelectedContractMethod = useCallback(
-    (transactionIndex: number) => {
-      const updatedSelectedContractMethods = omit(
-        selectedContractMethods,
+  const removeSelectedContractMethod = (transactionIndex: number) => {
+    const updatedSelectedContractMethods = omit(
+      selectedContractMethods,
+      transactionIndex,
+    );
+
+    if (!isEqual(updatedSelectedContractMethods, selectedContractMethods)) {
+      handleSelectedContractMethods(
+        updatedSelectedContractMethods,
         transactionIndex,
       );
-
-      if (!isEqual(updatedSelectedContractMethods, selectedContractMethods)) {
-        handleSelectedContractMethods(
-          updatedSelectedContractMethods,
-          transactionIndex,
-        );
-        setValue(`transactions.${transactionIndex}.contractFunction`, '');
-      }
-    },
-    [selectedContractMethods, handleSelectedContractMethods, setValue],
-  );
+      setValue(`transactions.${transactionIndex}.contractFunction`, '');
+    }
+  };
 
   const disabledSectionInputs =
     !isSupportedColonyVersion || (!userHasPermission && canOnlyForceAction);
@@ -370,6 +368,7 @@ const ControlSafeForm = ({
                   transactionIndex={index}
                   transactionTabStatus={transactionTabStatus}
                   handleTransactionTabStatus={setTransactionTabStatus}
+                  selectedContractMethods={selectedContractMethods}
                   handleSelectedContractMethods={handleSelectedContractMethods}
                   removeTab={removeTab}
                 />

--- a/src/components/common/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/components/common/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -369,7 +369,7 @@ const ControlSafeForm = ({
                   transactionTabStatus={transactionTabStatus}
                   handleTransactionTabStatus={setTransactionTabStatus}
                   selectedContractMethods={selectedContractMethods}
-                  handleSelectedContractMethods={handleSelectedContractMethods}
+                  handleSelectedContractMethods={setSelectedContractMethods}
                   removeTab={removeTab}
                 />
               )}

--- a/src/components/common/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/components/common/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -115,7 +115,7 @@ const ControlSafeForm = ({
   handleIsForceChange,
   isForce,
 }: ControlSafeProps) => {
-  const [prevSafeAddress, setPrevSafeAddress] = useState<string>('');
+  const [prevSafeChainId, setPrevSafeChainId] = useState<number | undefined>();
   const [transactionTabStatus, setTransactionTabStatus] = useState([true]);
   const savedTokenState = useState({});
 
@@ -227,6 +227,8 @@ const ControlSafeForm = ({
             selectedContractMethods={selectedContractMethods}
             handleSelectedContractMethods={handleSelectedContractMethods}
             removeSelectedContractMethod={removeSelectedContractMethod}
+            prevSafeChainId={prevSafeChainId}
+            handlePrevSafeChainIdChange={setPrevSafeChainId}
           />
         );
       case SafeTransactionType.TransferNft:
@@ -239,14 +241,6 @@ const ControlSafeForm = ({
         );
       default:
         return null;
-    }
-  };
-
-  const handleSafeChange = (newSafe: SelectedPickerItem) => {
-    const safeAddress = newSafe?.walletAddress;
-
-    if (safeAddress !== prevSafeAddress) {
-      setPrevSafeAddress(safeAddress);
     }
   };
 
@@ -358,7 +352,6 @@ const ControlSafeForm = ({
                 placeholder={MSG.safePickerPlaceholder}
                 filter={filterUserSelection}
                 disabled={disabledSectionInputs}
-                onSelected={handleSafeChange}
               />
             </div>
           </DialogSection>

--- a/src/components/common/Dialogs/ControlSafeDialog/TransactionHeader/TransactionHeader.tsx
+++ b/src/components/common/Dialogs/ControlSafeDialog/TransactionHeader/TransactionHeader.tsx
@@ -37,7 +37,7 @@ interface Props {
   transactionTabStatus: boolean[];
   handleTransactionTabStatus: React.Dispatch<React.SetStateAction<boolean[]>>;
   removeTab: UseFieldArrayRemove;
-  selectedContractMethods?: UpdatedMethods;
+  selectedContractMethods: UpdatedMethods | undefined;
   handleSelectedContractMethods: (
     selectedContractMethods: UpdatedMethods,
     index: number,
@@ -49,7 +49,7 @@ const TransactionHeader = ({
   transactionTabStatus,
   handleTransactionTabStatus,
   removeTab,
-  selectedContractMethods = {},
+  selectedContractMethods,
   handleSelectedContractMethods,
 }: Props) => {
   const { watch, trigger } = useFormContext();
@@ -57,9 +57,7 @@ const TransactionHeader = ({
 
   const { formatMessage } = useIntl();
 
-  const handleTabRemoval = (contractMethods: UpdatedMethods) => {
-    removeTab(transactionIndex);
-
+  const handleTabRemoval = (contractMethods: UpdatedMethods | undefined) => {
     const shiftedContractMethods = contractMethods
       ? Object.keys(contractMethods).reduce((acc, contractMethodIndex) => {
           if (transactionIndex < Number(contractMethodIndex)) {
@@ -80,6 +78,7 @@ const TransactionHeader = ({
     const newTransactionTabStatus = [...transactionTabStatus];
     newTransactionTabStatus.splice(transactionIndex, 1);
     handleTransactionTabStatus(newTransactionTabStatus);
+    removeTab(transactionIndex);
     trigger();
   };
 
@@ -94,7 +93,7 @@ const TransactionHeader = ({
     transactionTypeValue: FormSafeTransaction['transactionType'],
   ) => {
     if (transactionTypeValue) {
-      formatMessage(SafeTransactionMSG[transactionTypeValue]);
+      return formatMessage(SafeTransactionMSG[transactionTypeValue]);
     }
 
     return null;
@@ -116,7 +115,7 @@ const TransactionHeader = ({
         textValues={{
           transactionNumber: transactionIndex + 1,
           transactionType: getTransactionTypeLabel(
-            transactions[transactionIndex]?.transactionType,
+            transactions[transactionIndex].transactionType,
           ),
         }}
       />

--- a/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection/ContractInteractionSection.css
+++ b/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection/ContractInteractionSection.css
@@ -1,0 +1,43 @@
+.contractFunctionSelectorContainer label {
+  color: var(--dark);
+}
+
+.singleUserPickerContainer div[class*='inputContainer'] {
+  column-gap: 10px;
+}
+
+.abiContainer {
+  position: relative;
+}
+
+.fetchFailedErrorContainer {
+  margin-top: 19px;
+}
+
+/* @NOTE: Ensures noUsefulMethods error sits in between
+ * text area and  AddNewItem button */
+.noUsefulMethods > section {
+  padding: 1px 20px 20px;
+}
+
+/*
+ * @NOTE: I can't think of any other way of overriding the theme styles
+ * right now without adding another theme or prop just to change the color
+ */
+.inputParamContainer label span,
+.inputParamContainer input::placeholder {
+  color: var(--grey-purple) !important;
+}
+
+.inputParamContainer p {
+  margin-bottom: 10px;
+}
+
+.attributionMessage {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  font-size: var(--size-tiny);
+  line-height: 18px;
+  color: var(--dark);
+}

--- a/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection/ContractInteractionSection.css.d.ts
+++ b/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection/ContractInteractionSection.css.d.ts
@@ -1,0 +1,18 @@
+declare namespace ContractInteractionSectionCssNamespace {
+  export interface IContractInteractionSectionCss {
+    abiContainer: string;
+    attributionMessage: string;
+    contractFunctionSelectorContainer: string;
+    fetchFailedErrorContainer: string;
+    inputParamContainer: string;
+    noUsefulMethods: string;
+    singleUserPickerContainer: string;
+  }
+}
+
+declare const ContractInteractionSectionCssModule: ContractInteractionSectionCssNamespace.IContractInteractionSectionCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: ContractInteractionSectionCssNamespace.IContractInteractionSectionCss;
+};
+
+export = ContractInteractionSectionCssModule;

--- a/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection/ContractInteractionSection.tsx
+++ b/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection/ContractInteractionSection.tsx
@@ -9,7 +9,6 @@ import { useFormContext } from 'react-hook-form';
 
 import { isAddress } from '~utils/web3';
 import {
-  HookFormInput as Input,
   HookFormSelect as Select,
   SelectOption,
   HookFormTextArea as Textarea,
@@ -31,17 +30,19 @@ import { Message } from '~types';
 import { isMessageDescriptor } from '~utils/intl';
 import { BINANCE_NETWORK } from '~constants';
 
-import { invalidSafeError } from '..';
+import { invalidSafeError } from '../..';
 import {
   ABIResponse,
   FormSafeTransaction,
   TransactionSectionProps,
   UpdatedMethods,
-} from '../types';
+} from '../../types';
 
-import { ErrorMessage as Error, Loading, AvatarXS } from './shared';
+import { ErrorMessage as Error, Loading, AvatarXS } from '../shared';
 
-import styles from './TransactionTypesSection.css';
+import defaultStyles from '../TransactionTypesSection.css';
+import styles from './ContractInteractionSection.css';
+import MethodParamInput from './MethodParamInput';
 
 const displayName = `common.ControlSafeDialog.ControlSafeForm.ContractInteractionSection`;
 
@@ -316,7 +317,7 @@ const ContractInteractionSection = ({
   return (
     <>
       <DialogSection>
-        <div className={styles.singleUserPickerContainer}>
+        <div className={defaultStyles.singleUserPickerContainer}>
           <SingleUserPicker
             data={[]}
             label={MSG.contractLabel}
@@ -409,27 +410,12 @@ const ContractInteractionSection = ({
               key={`${input.name}-${input.type}`}
               appearance={{ theme: 'sidePadding' }}
             >
-              <div className={styles.inputParamContainer}>
-                <Input
-                  label={`${input.name} (${input.type})`}
-                  // eslint-disable-next-line max-len
-                  name={`transactions.${transactionIndex}.${input.name}-${selectedContractMethods[transactionIndex]?.name}`}
-                  appearance={{ colorSchema: 'grey', theme: 'fat' }}
-                  disabled={disabledInput}
-                  placeholder={`${input.name} (${input.type})`}
-                  formattingOptions={
-                    input?.type?.includes('int') &&
-                    input.type.substring(input.type.length - 2) !== '[]'
-                      ? {
-                          numeral: true,
-                          numeralPositiveOnly:
-                            input.type.substring(0, 4) === 'uint',
-                          numeralDecimalScale: 0,
-                        }
-                      : undefined
-                  }
-                />
-              </div>
+              <MethodParamInput
+                disabledInput={disabledInput}
+                param={input}
+                transactionIndex={transactionIndex}
+                selectedContractMethods={selectedContractMethods}
+              />
             </DialogSection>
           ))}
         </>

--- a/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection/MethodParamInput.tsx
+++ b/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection/MethodParamInput.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { JsonFragment } from '@ethersproject/abi';
+
+import { HookFormInput as Input } from '~shared/Fields';
+
+import { UpdatedMethods } from '../../types';
+
+import styles from './ContractInteractionSection.css';
+
+const displayName = `common.ControlSafeDialog.ControlSafeForm.ContractInteractionSection.MethodParamInput`;
+
+interface Props {
+  disabledInput: boolean;
+  transactionIndex: number;
+  selectedContractMethods: UpdatedMethods;
+  param: JsonFragment;
+}
+
+const MethodParamInput = ({
+  disabledInput,
+  transactionIndex,
+  selectedContractMethods = {},
+  param,
+}: Props) => (
+  <div className={styles.inputParamContainer}>
+    <Input
+      label={`${param.name} (${param.type})`}
+      // eslint-disable-next-line max-len
+      name={`transactions.${transactionIndex}.${param.name}-${selectedContractMethods[transactionIndex]?.name}`}
+      appearance={{ colorSchema: 'grey', theme: 'fat' }}
+      disabled={disabledInput}
+      placeholder={`${param.name} (${param.type})`}
+    />
+  </div>
+);
+
+MethodParamInput.displayName = displayName;
+
+export default MethodParamInput;

--- a/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection/index.ts
+++ b/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ContractInteractionSection';

--- a/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/RawTransactionSection.tsx
+++ b/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/RawTransactionSection.tsx
@@ -49,11 +49,6 @@ const RawTransactionSection = ({
         labelValues={{
           span: labelValues,
         }}
-        formattingOptions={{
-          numeral: true,
-          numeralPositiveOnly: true,
-          numeralDecimalScale: 0,
-        }}
       />
     </DialogSection>
     <DialogSection appearance={{ theme: 'sidePadding' }}>

--- a/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
+++ b/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
@@ -13,30 +13,12 @@
   padding-left: 0;
 }
 
-.singleUserPickerContainer label,
-.contractFunctionSelectorContainer label {
+.singleUserPickerContainer label {
   color: var(--dark);
-}
-
-.singleUserPickerContainer div[class*='inputContainer'] {
-  column-gap: 10px;
 }
 
 .labelDescription {
   color: var(--grey-purple);
-}
-
-/*
-  I can't think of any other way of overriding the theme styles
-  right now without adding another theme or prop just to change the color
-*/
-.inputParamContainer label span,
-.inputParamContainer input::placeholder {
-  color: var(--grey-purple) !important;
-}
-
-.inputParamContainer p {
-  margin-bottom: 10px;
 }
 
 .spinner {
@@ -49,12 +31,6 @@
   justify-content: center;
   text-align: center;
   color: var(--pink);
-}
-
-/* Ensures noUsefulMethods error sits in between
- * text area and  AddNewItem button */
-.noUsefulMethods > section {
-  padding: 1px 20px 20px;
 }
 
 .warningContainer {
@@ -77,21 +53,4 @@
   height: 18px;
   min-width: 18px;
   fill: var(--golden);
-}
-
-.abiContainer {
-  position: relative;
-}
-
-.attributionMessage {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  font-size: var(--size-tiny);
-  line-height: 18px;
-  color: var(--dark);
-}
-
-.fetchFailedErrorContainer {
-  margin-top: 19px;
 }

--- a/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css.d.ts
+++ b/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css.d.ts
@@ -1,13 +1,7 @@
 declare namespace TransactionTypesSectionCssNamespace {
   export interface ITransactionTypesSectionCss {
-    abiContainer: string;
-    attributionMessage: string;
-    contractFunctionSelectorContainer: string;
     error: string;
-    fetchFailedErrorContainer: string;
-    inputParamContainer: string;
     labelDescription: string;
-    noUsefulMethods: string;
     singleUserPickerContainer: string;
     spinner: string;
     warningContainer: string;

--- a/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferNFTSection/TransferNFTSection.tsx
+++ b/src/components/common/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferNFTSection/TransferNFTSection.tsx
@@ -146,6 +146,7 @@ const TransferNFTSection = ({
             label={MSG.selectNFT}
             name={`transactions.${transactionIndex}.nft`}
             filter={filterUserSelection}
+            excludeFilterValue
             renderAvatar={AvatarXS}
             data={availableNFTs || []}
             disabled={disabledInput}

--- a/src/components/common/Dialogs/ControlSafeDialog/validation.ts
+++ b/src/components/common/Dialogs/ControlSafeDialog/validation.ts
@@ -193,7 +193,8 @@ export const getValidationSchema = (
               then: number()
                 .typeError(() => MSG.notPositiveIntegerError)
                 .required(() => MSG.requiredFieldError)
-                .positive(() => MSG.notPositiveIntegerError),
+                .min(0, () => MSG.notPositiveIntegerError)
+                .integer(() => MSG.notPositiveIntegerError),
               otherwise: number().nullable(),
             })
             .nullable(),

--- a/src/components/common/Dialogs/ControlSafeDialog/validation.ts
+++ b/src/components/common/Dialogs/ControlSafeDialog/validation.ts
@@ -35,9 +35,9 @@ const MSG = defineMessages({
     id: `${displayName}.notHexError`,
     defaultMessage: 'Value must be a valid hex string',
   },
-  notIntegerError: {
-    id: `${displayName}.notIntegerError`,
-    defaultMessage: 'Amount must be an integer',
+  notPositiveIntegerError: {
+    id: `${displayName}.notPositiveIntegerError`,
+    defaultMessage: 'Amount must be a positive integer',
   },
   invalidArrayError: {
     id: `${displayName}.invalidArrayError`,
@@ -191,9 +191,9 @@ export const getValidationSchema = (
             .when('transactionType', {
               is: SafeTransactionType.RawTransaction,
               then: number()
-                .transform((value) => (Number.isNaN(value) ? null : value))
+                .typeError(() => MSG.notPositiveIntegerError)
                 .required(() => MSG.requiredFieldError)
-                .integer(() => MSG.notIntegerError),
+                .positive(() => MSG.notPositiveIntegerError),
               otherwise: number().nullable(),
             })
             .nullable(),

--- a/src/components/shared/OmniPicker/withOmniPicker.ts
+++ b/src/components/shared/OmniPicker/withOmniPicker.ts
@@ -19,7 +19,12 @@ const defaultProps = {
 
 export interface Props extends Partial<DefaultProps> {
   data: ((arg0: any) => any) | any[];
-  filter: (data: any, filterStr: string) => OmniPickerData[];
+  filter: (
+    data: any,
+    filterStr: string,
+    excludeFilterValue?: boolean,
+  ) => OmniPickerData[];
+  excludeFilterValue?: boolean;
 }
 
 type DefaultProps = Readonly<typeof defaultProps>;
@@ -62,10 +67,10 @@ const getClass = (WrappedComponent) => {
     };
 
     getFilteredData = () => {
-      const { data, filter, ...props } = this.props;
+      const { data, filter, excludeFilterValue, ...props } = this.props;
       const { filterValue } = this.state;
       const result = typeof data === 'function' ? data(props) : data;
-      return filter(result, filterValue);
+      return filter(result, filterValue, excludeFilterValue);
     };
 
     open = () => {

--- a/src/components/shared/SingleUserPicker/utils.ts
+++ b/src/components/shared/SingleUserPicker/utils.ts
@@ -18,7 +18,7 @@ export const filterUserSelection = (
 
   const filteredUsers = data.filter(
     (user) =>
-      user?.name.toLowerCase().includes(filterValue.toLowerCase()) ||
+      user?.name?.toLowerCase().includes(filterValue.toLowerCase()) ||
       user?.walletAddress.toLowerCase().includes(filterValue.toLowerCase()) ||
       user?.profile?.displayName
         ?.toLowerCase()

--- a/src/components/shared/SingleUserPicker/utils.ts
+++ b/src/components/shared/SingleUserPicker/utils.ts
@@ -11,6 +11,7 @@ export type OmniPickerUser = User & OmniPickerData;
 export const filterUserSelection = (
   data: OmniPickerUser[],
   filterValue: string | undefined,
+  excludeFilterValue?: boolean,
 ) => {
   if (!filterValue) {
     return data;
@@ -32,6 +33,10 @@ export const filterUserSelection = (
     },
     walletAddress: filterValue,
   };
+
+  if (excludeFilterValue) {
+    return filteredUsers;
+  }
 
   return [customUser].concat(filteredUsers);
 };


### PR DESCRIPTION
- Fixed removal of tabs in the Control Safe dialog. They weren't being deleted properly and that caused a bunch of other weird behaviours.

- Fixed safe balance validation of the Transfer Funds transaction type. The validation wasn't taking into account the safe's balance at all.

- Fixed numeral inputs in the Contract Interaction transaction type not being updated properly after a re-render caused by a bug of Cleave.js. To reproduce in the feature branch or any other branch besides this one, add a contract interaction section in the second or more position in the dialog that has a`UINT` or `INT` param input filled and remove the transaction tab that comes before the contract interaction one, and try to change the number input value. 

- Fixed the CDapp crashing when a custom wallet address is selected in the NFT picker.

- Fixed permission icons missing in the action page for safe transaction events.

- Added `excludeFilterValue` to `SingleUserPicker` to filter out the value from the selection in the NFT picker.

- Updated raw amount validation to fix it not updating correctly after a re-render (Like what happened with the numeral inputs of the contract interaction section.)

- Fixed errors being persistent when you change transaction types, therefore, not allowing you to continue with the flow if you had errors before changing transaction type.

- Improved contract interaction `useEffects` performance, before the `useEffects` where hitting the API to get the contract's ABI too often, exceeding the limits.

Resolves #[1013](https://github.com/JoinColony/colonyCDapp/issues/1013)
