### PR TITLE
Cache expenditure payout claimed status

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -2566,6 +2566,7 @@ type ExpenditureSlot {
 type ExpenditurePayout {
   tokenAddress: ID!
   amount: String!
+  isClaimed: Boolean!
 }
 
 type ExpenditureMetadata @model {

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=025cfb30a03d0be2be41bcf60de991afceefaaa9
+ENV BLOCK_INGESTOR_HASH=12dfd775411ec12b911ed63cea4acfe5b0fcfeb4
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureClaimButton/ExpenditureClaimButton.tsx
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureClaimButton/ExpenditureClaimButton.tsx
@@ -32,6 +32,13 @@ const ExpenditureClaimButton = ({
 
   let nextClaimableAt: number | null = null;
   const claimableSlots = expenditure.slots.filter((slot) => {
+    const hasClaimablePayouts = !!slot.payouts?.some(
+      (payout) => !payout.isClaimed,
+    );
+    if (!hasClaimablePayouts) {
+      return false;
+    }
+
     const claimableFrom = new Date(
       ((expenditure.finalizedAt ?? 0) + (slot.claimDelay ?? 0)) * 1000,
     ).getTime();
@@ -69,7 +76,8 @@ const ExpenditureClaimButton = ({
           actionType={ActionTypes.EXPENDITURE_CLAIM}
           values={{
             colonyAddress: colony.colonyAddress,
-            expenditure,
+            expenditureId: expenditure.nativeId,
+            claimableSlots,
           }}
         >
           Claim funds

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditurePayouts/ExpenditurePayouts.tsx
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditurePayouts/ExpenditurePayouts.tsx
@@ -93,6 +93,11 @@ const ExpenditurePayouts = ({
                       {slot.claimDelay ? `${slot.claimDelay} seconds` : 'None'}
                     </div>
                   </div>
+
+                  <div>
+                    <div>Claimed</div>
+                    <div>{payout.isClaimed ? 'Yes' : 'No'}</div>
+                  </div>
                 </li>
               )),
           )}

--- a/src/graphql/fragments/expenditures.graphql
+++ b/src/graphql/fragments/expenditures.graphql
@@ -34,4 +34,5 @@ fragment ExpenditureSlot on ExpenditureSlot {
 fragment ExpenditurePayout on ExpenditurePayout {
   tokenAddress
   amount
+  isClaimed
 }

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -1390,11 +1390,13 @@ export type ExpenditureMetadata = {
 export type ExpenditurePayout = {
   __typename?: 'ExpenditurePayout';
   amount: Scalars['String'];
+  isClaimed: Scalars['Boolean'];
   tokenAddress: Scalars['ID'];
 };
 
 export type ExpenditurePayoutInput = {
   amount: Scalars['String'];
+  isClaimed: Scalars['Boolean'];
   tokenAddress: Scalars['ID'];
 };
 
@@ -5405,11 +5407,11 @@ export type DomainFragment = { __typename?: 'Domain', id: string, nativeId: numb
 
 export type DomainMetadataFragment = { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null };
 
-export type ExpenditureFragment = { __typename?: 'Expenditure', id: string, nativeId: number, ownerAddress: string, status: ExpenditureStatus, nativeFundingPotId: number, nativeDomainId: number, finalizedAt?: number | null, hasReclaimedStake?: boolean | null, slots: Array<{ __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string }> | null }>, metadata?: { __typename?: 'ExpenditureMetadata', fundFromDomainNativeId: number, type: ExpenditureType } | null, balances?: Array<{ __typename?: 'ExpenditureBalance', tokenAddress: string, amount: string, requiredAmount: string }> | null };
+export type ExpenditureFragment = { __typename?: 'Expenditure', id: string, nativeId: number, ownerAddress: string, status: ExpenditureStatus, nativeFundingPotId: number, nativeDomainId: number, finalizedAt?: number | null, hasReclaimedStake?: boolean | null, slots: Array<{ __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string, isClaimed: boolean }> | null }>, metadata?: { __typename?: 'ExpenditureMetadata', fundFromDomainNativeId: number, type: ExpenditureType } | null, balances?: Array<{ __typename?: 'ExpenditureBalance', tokenAddress: string, amount: string, requiredAmount: string }> | null };
 
-export type ExpenditureSlotFragment = { __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string }> | null };
+export type ExpenditureSlotFragment = { __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string, isClaimed: boolean }> | null };
 
-export type ExpenditurePayoutFragment = { __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string };
+export type ExpenditurePayoutFragment = { __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string, isClaimed: boolean };
 
 export type ExtensionFragment = { __typename?: 'ColonyExtension', hash: string, installedBy: string, installedAt: number, isDeprecated: boolean, isDeleted: boolean, isInitialized: boolean, address: string, colonyAddress: string, currentVersion: number, params?: { __typename?: 'ExtensionParams', votingReputation?: { __typename?: 'VotingReputationParams', maxVoteFraction: string } | null, stakedExpenditure?: { __typename?: 'StakedExpenditureParams', stakeFraction: string } | null } | null };
 
@@ -5614,7 +5616,7 @@ export type GetExpenditureQueryVariables = Exact<{
 }>;
 
 
-export type GetExpenditureQuery = { __typename?: 'Query', getExpenditure?: { __typename?: 'Expenditure', id: string, nativeId: number, ownerAddress: string, status: ExpenditureStatus, nativeFundingPotId: number, nativeDomainId: number, finalizedAt?: number | null, hasReclaimedStake?: boolean | null, slots: Array<{ __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string }> | null }>, metadata?: { __typename?: 'ExpenditureMetadata', fundFromDomainNativeId: number, type: ExpenditureType } | null, balances?: Array<{ __typename?: 'ExpenditureBalance', tokenAddress: string, amount: string, requiredAmount: string }> | null } | null };
+export type GetExpenditureQuery = { __typename?: 'Query', getExpenditure?: { __typename?: 'Expenditure', id: string, nativeId: number, ownerAddress: string, status: ExpenditureStatus, nativeFundingPotId: number, nativeDomainId: number, finalizedAt?: number | null, hasReclaimedStake?: boolean | null, slots: Array<{ __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string, isClaimed: boolean }> | null }>, metadata?: { __typename?: 'ExpenditureMetadata', fundFromDomainNativeId: number, type: ExpenditureType } | null, balances?: Array<{ __typename?: 'ExpenditureBalance', tokenAddress: string, amount: string, requiredAmount: string }> | null } | null };
 
 export type GetMotionStateQueryVariables = Exact<{
   input: GetMotionStateInput;
@@ -6230,6 +6232,7 @@ export const ExpenditurePayoutFragmentDoc = gql`
     fragment ExpenditurePayout on ExpenditurePayout {
   tokenAddress
   amount
+  isClaimed
 }
     `;
 export const ExpenditureSlotFragmentDoc = gql`

--- a/src/redux/sagas/expenditures/claimExpenditure.ts
+++ b/src/redux/sagas/expenditures/claimExpenditure.ts
@@ -21,12 +21,12 @@ const getPayoutChannelId = (payout: PayoutWithSlotId) =>
 
 function* claimExpenditure({
   meta,
-  payload: { colonyAddress, expenditure },
+  payload: { colonyAddress, expenditureId, claimableSlots },
 }: Action<ActionTypes.EXPENDITURE_CLAIM>) {
   const txChannel = yield call(getTxChannel, meta.id);
   const batchKey = 'claimExpenditure';
 
-  const payoutsWithSlotIds = expenditure.slots.flatMap(
+  const payoutsWithSlotIds = claimableSlots.flatMap(
     (slot) =>
       slot.payouts
         ?.filter((payout) => payout.amount !== '0')
@@ -49,7 +49,7 @@ function* claimExpenditure({
           context: ClientType.ColonyClient,
           methodName: 'claimExpenditurePayout',
           identifier: colonyAddress,
-          params: [expenditure.nativeId, payout.slotId, payout.tokenAddress],
+          params: [expenditureId, payout.slotId, payout.tokenAddress],
           group: {
             key: batchKey,
             id: meta.id,

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -1,5 +1,5 @@
 import { ActionTypes } from '~redux/actionTypes';
-import { Address, Colony, Domain, Expenditure } from '~types';
+import { Address, Colony, Domain, Expenditure, ExpenditureSlot } from '~types';
 import { ExpenditurePayoutFieldValue } from '~common/Expenditures/ExpenditureForm';
 
 import { UniqueActionType, ErrorActionType, MetaWithNavigate } from './index';
@@ -77,7 +77,8 @@ export type ExpendituresActionTypes =
       ActionTypes.EXPENDITURE_CLAIM,
       {
         colonyAddress: Address;
-        expenditure: Expenditure;
+        expenditureId: number;
+        claimableSlots: ExpenditureSlot[];
       },
       object
     >


### PR DESCRIPTION
## Description

This PR brings in the necessary changes to store expenditure payout claimed status in the DB.

## Testing

- Create an expenditure with 2 slots, one with no claim delay, the other with an arbitrary claim delay.
- Progress the expenditure to finalization. Both slots should have claimed status of "No".
- Click on the claim button. If the second slot claim delay is far enough in the future, only the first slot would be claimed. 
- See that the claimed status changed to "Yes". You should also be unable to claim the same slot again.

Resolves #982 
