### PR TITLE
Improve upgrade banner dismissal

### DIFF
--- a/src/components/common/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
+++ b/src/components/common/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
@@ -39,7 +39,13 @@ const MSG = defineMessages({
 
 const ColonyUpgrade = () => {
   const { colony } = useColonyContext();
-  const { colonyContractVersion } = useColonyContractVersion();
+  const { colonyContractVersion, loadingColonyContractVersion } =
+    useColonyContractVersion();
+
+  const hasAlreadyDismissedAlert = !!localStorage.getItem(
+    `upgradeTo${colonyContractVersion}BannerDismissed`,
+  );
+
   const openUpgradeColonyDialog = useDialog(NetworkContractUpgradeDialog);
   const { user, wallet } = useAppContext();
   const enabledExtensionData = useEnabledExtensions();
@@ -49,6 +55,13 @@ const ColonyUpgrade = () => {
       colony,
       enabledExtensionData,
     });
+
+  const handleAlertDismissed = () => {
+    localStorage.setItem(
+      `upgradeTo${colonyContractVersion}BannerDismissed`,
+      'true',
+    );
+  };
 
   const allUserRoles = useTransformer(getAllUserRoles, [
     colony,
@@ -86,7 +99,11 @@ const ColonyUpgrade = () => {
     );
   }
 
-  if (canUpgrade) {
+  if (
+    canUpgrade &&
+    !hasAlreadyDismissedAlert &&
+    !loadingColonyContractVersion
+  ) {
     return (
       <div className={styles.upgradeBannerContainer}>
         <Alert
@@ -95,6 +112,7 @@ const ColonyUpgrade = () => {
             margin: 'none',
             borderRadius: 'none',
           }}
+          onAlertDismissed={handleAlertDismissed}
         >
           {(handleDismissed) => (
             <>


### PR DESCRIPTION
Added improvements to one of the upgraded colony version banners.

A long time ago, Juliana correctly pointed out that the upgrade colony version banner comes back after a refresh even if you dismiss it, which is bad UX. This PR should remedy that.

To test the banner, just invert the `canUpgrade` in line 103 of `ColonyUpgrade`, click the `Dismiss` button, and reload the page to check if the banner reappears.

Resolves #372 
