### PR TITLE
Remove unnecessary memoization from routes

### DIFF
--- a/src/components/common/ColonyHome/ColonyHome.tsx
+++ b/src/components/common/ColonyHome/ColonyHome.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import {
   Outlet,
   Route,
@@ -10,20 +10,19 @@ import ColonyActions from '~common/ColonyActions';
 // import ColonyEvents from '~dashboard/ColonyEvents';
 
 import ColonyDecisions from '~common/ColonyDecisions';
-
+import { ColonyHomeProvider } from '~context/ColonyHomeContext';
 import {
   COLONY_DECISIONS_ROUTE,
   COLONY_EVENTS_ROUTE,
   COLONY_EXTENSIONS_ROUTE,
   COLONY_EXTENSION_DETAILS_ROUTE,
-} from '~routes/index';
-import NotFoundRoute from '~routes/NotFoundRoute';
+  NotFoundRoute,
+} from '~routes';
 import ColonyExtensions from '~common/ColonyExtensions';
 import ExtensionDetails from '~common/Extensions/ExtensionDetails';
 import { useColonyContext } from '~hooks';
 
 import ColonyHomeLayout from './ColonyHomeLayout';
-import { ColonyHomeProvider } from '~context/ColonyHomeContext';
 
 const displayName = 'common.ColonyHome';
 
@@ -37,57 +36,54 @@ const ColonyHome = () => {
     Number(queryDomainIdFilter),
   );
 
-  const memoizedSwitch = useMemo(() => {
-    if (colony) {
-      return (
-        <RoutesSwitch>
-          <Route
-            path={COLONY_EVENTS_ROUTE}
-            element={
+  if (colony) {
+    return (
+      <RoutesSwitch>
+        <Route
+          path={COLONY_EVENTS_ROUTE}
+          element={
+            <ColonyHomeLayout
+              filteredDomainId={domainIdFilter}
+              onDomainChange={setDomainIdFilter}
+            >
+              {/* <ColonyEvents colony={colony} ethDomainId={filteredDomainId} /> */}
+              <div>Events (Transactions Log)</div>
+            </ColonyHomeLayout>
+          }
+        />
+        <Route
+          element={
+            <ColonyHomeProvider>
               <ColonyHomeLayout
                 filteredDomainId={domainIdFilter}
                 onDomainChange={setDomainIdFilter}
               >
-                {/* <ColonyEvents colony={colony} ethDomainId={filteredDomainId} /> */}
-                <div>Events (Transactions Log)</div>
+                <Outlet />
               </ColonyHomeLayout>
-            }
+            </ColonyHomeProvider>
+          }
+        >
+          <Route path="/" element={<ColonyActions />} />
+          <Route
+            path={COLONY_EXTENSIONS_ROUTE}
+            element={<ColonyExtensions />}
           />
           <Route
-            element={
-              <ColonyHomeProvider>
-                <ColonyHomeLayout
-                  filteredDomainId={domainIdFilter}
-                  onDomainChange={setDomainIdFilter}
-                >
-                  <Outlet />
-                </ColonyHomeLayout>
-              </ColonyHomeProvider>
-            }
-          >
-            <Route path="/" element={<ColonyActions />} />
-            <Route
-              path={COLONY_EXTENSIONS_ROUTE}
-              element={<ColonyExtensions />}
-            />
-            <Route
-              path={COLONY_EXTENSION_DETAILS_ROUTE}
-              element={<ExtensionDetails />}
-            />
-            <Route
-              path={COLONY_DECISIONS_ROUTE}
-              element={<ColonyDecisions domainId={domainIdFilter} />}
-            />
-          </Route>
+            path={COLONY_EXTENSION_DETAILS_ROUTE}
+            element={<ExtensionDetails />}
+          />
+          <Route
+            path={COLONY_DECISIONS_ROUTE}
+            element={<ColonyDecisions domainId={domainIdFilter} />}
+          />
+        </Route>
 
-          <Route path="*" element={<NotFoundRoute />} />
-        </RoutesSwitch>
-      );
-    }
-    return null;
-  }, [colony, domainIdFilter]);
+        <Route path="*" element={<NotFoundRoute />} />
+      </RoutesSwitch>
+    );
+  }
 
-  return memoizedSwitch;
+  return null;
 };
 
 ColonyHome.displayName = displayName;

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import {
   Route,
   Routes as RoutesSwitch,
@@ -14,6 +14,10 @@ import ColonyMembers from '~common/ColonyMembers';
 import FourOFour from '~frame/FourOFour';
 import UserProfile from '~common/UserProfile';
 import UserProfileEdit from '~common/UserProfileEdit';
+import { ColonyContextProvider } from '~context/ColonyContext';
+import CreateColonyWizard from '~common/CreateColonyWizard';
+import DecisionPreview from '~common/ColonyDecisions/DecisionPreview';
+import ActionDetailsPage from '~common/ColonyActions/ActionDetailsPage';
 import {
   // NavBar, Plain, SimpleNav,
   Default,
@@ -27,7 +31,7 @@ import LandingPage from '~frame/LandingPage';
 // import { ClaimTokensPage, UnwrapTokensPage } from '~dashboard/Vesting';
 
 // import appLoadingContext from '~context/appLoadingState';
-import { useAppContext, useMobile } from '~hooks';
+import { useAppContext, useMobile, useTitle } from '~hooks';
 
 import {
   COLONY_FUNDING_ROUTE,
@@ -48,12 +52,6 @@ import {
   // CLAIM_TOKEN_ROUTE,
 } from './routeConstants';
 import NotFoundRoute from './NotFoundRoute';
-import { ColonyContextProvider } from '~context/ColonyContext';
-import CreateColonyWizard from '~common/CreateColonyWizard';
-import DecisionPreview from '~common/ColonyDecisions/DecisionPreview';
-import ActionDetailsPage from '~common/ColonyActions/ActionDetailsPage';
-
-import useTitle from '~hooks/useTitle';
 
 const displayName = 'routes.Routes';
 
@@ -69,210 +67,185 @@ const MSG = defineMessages({
 });
 
 const Routes = () => {
-  const { user, wallet } = useAppContext();
+  const { user } = useAppContext(); // wallet
   const isMobile = useMobile();
   // const isAppLoading = appLoadingContext.getIsLoading();
-
-  // disabling rules to silence eslint warnings
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const isConnected = wallet?.address;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const didClaimProfile = user?.name;
+  // const isConnected = wallet?.address;
+  // const didClaimProfile = user?.name;
 
   useTitle();
-
-  /**
-   * @NOTE Memoized Switch
-   *
-   * We need to memoize the entire route switch to prevent re-renders at not
-   * so oportune times.
-   *
-   * The `balance` value, accessible through (no longer isLoggedInUser), even if we don't
-   * use it here directly, will cause a re-render of the `<Routes />` component
-   * every time it changes (using the subscription).
-   *
-   * To prevent this, we memoize the whole routes logic, to only render it again
-   * when the user connects a new wallet.
-   *
-   * This was particularly problematic when creating a new colony, and after
-   * the first TX, the balance would change and as a result everything would
-   * re-render, reseting the wizard.
-   */
-  const MemoizedSwitch = useMemo(
-    () => (
-      <RoutesSwitch>
-        <Route path="/" element={<Navigate to={LANDING_PAGE_ROUTE} />} />
-        <Route path={NOT_FOUND_ROUTE} element={<FourOFour />} />
-        <Route
-          path={LANDING_PAGE_ROUTE}
-          element={
-            <Default routeProps={{ hasBackLink: false }}>
-              <LandingPage />
-            </Default>
-          }
-        />
-        <Route
-          element={
-            <ColonyContextProvider>
-              <Default
-                routeProps={{
-                  backText: ColonyBackText,
-                  backRoute: ({ colonyName }) => `/colony/${colonyName}`,
-                  hasSubscribedColonies: false,
-                }}
-              >
-                <Outlet />
-              </Default>
-            </ColonyContextProvider>
-          }
-        >
-          <Route path={COLONY_FUNDING_ROUTE} element={<ColonyFunding />} />
-          {[COLONY_MEMBERS_ROUTE, COLONY_MEMBERS_WITH_DOMAIN_ROUTE].map(
-            (path) => (
-              <Route key={path} path={path} element={<ColonyMembers />} />
-            ),
-          )}
-        </Route>
-        <Route
-          path={COLONY_DECISIONS_PREVIEW_ROUTE}
-          element={
-            <ColonyContextProvider>
-              <NavBar>
-                <DecisionPreview />
-              </NavBar>
-            </ColonyContextProvider>
-          }
-        />
-        <Route
-          path={COLONY_HOME_ROUTE}
-          element={
-            <ColonyContextProvider>
-              <Default routeProps={{ hasBackLink: false }}>
-                <ColonyHome />
-              </Default>
-            </ColonyContextProvider>
-          }
-        />
-        {[ACTIONS_PAGE_ROUTE, DECISIONS_PAGE_ROUTE].map((path) => (
-          <Route
-            path={path}
-            element={
-              <ColonyContextProvider>
-                <NavBar
-                  routeProps={{
-                    backRoute: ({ colonyName }) =>
-                      `/colony/${colonyName}${
-                        path === DECISIONS_PAGE_ROUTE ? '/decisions' : ''
-                      }`,
-                  }}
-                >
-                  <ActionDetailsPage />
-                </NavBar>
-              </ColonyContextProvider>
-            }
-            key={path}
-          />
-        ))}
-        <Route path={CREATE_COLONY_ROUTE} element={<CreateColonyWizard />} />
-        <Route path={CREATE_USER_ROUTE} element={<CreateUserWizard />} />
-        <Route
-          path={USER_ROUTE}
-          element={
-            <UserLayout routeProps={{ hasBackLink: false }}>
-              <UserProfile />
-            </UserLayout>
-          }
-        />
-        <Route
-          path={USER_EDIT_ROUTE}
-          element={
-            <Default
-              routeProps={{
-                hasBackLink: true,
-                hasSubscribedColonies: isMobile,
-                backText: MSG.userProfileEditBack,
-                backRoute: `/user/${user?.name}`,
-              }}
-            >
-              <UserProfileEdit />
-            </Default>
-          }
-        />
-        {/* <WalletRequiredRoute
-          isConnected={isConnected}
-          didClaimProfile={didClaimProfile}
-          path={CREATE_USER_ROUTE}
-          component={CreateUserWizard}
-          layout={Plain}
-        />
-        <WalletRequiredRoute
-          isConnected={isConnected}
-          didClaimProfile={didClaimProfile}
-          path={CREATE_COLONY_ROUTE}
-          component={CreateColonyWizard}
-          layout={Plain}
-        />
-
-        <AlwaysAccesibleRoute
-          path={USER_ROUTE}
-          component={UserProfile}
-          layout={SimpleNav}
-          routeProps={{
-            hasBackLink: false,
-          }}
-        />
-        <AlwaysAccesibleRoute
-          path={USER_EDIT_ROUTE}
-          component={UserProfileEdit}
-          layout={Default}
-          routeProps={{
-            hasSubscribedColonies: false,
-            backText: MSG.userProfileEditBack,
-            backRoute: `/user/${username}`,
-          }}
-        />
-        <AlwaysAccesibleRoute
-          exact
-          path={ACTIONS_PAGE_ROUTE}
-          component={ActionsPage}
-          layout={NavBar}
-          routeProps={({ colonyName }) => ({
-            backText: '',
-            backRoute: `/colony/${colonyName}`,
-          })}
-        />
-        <AlwaysAccesibleRoute
-          path={UNWRAP_TOKEN_ROUTE}
-          component={UnwrapTokensPage}
-          layout={NavBar}
-          routeProps={({ colonyName }) => ({
-            backText: ColonyBackText,
-            backRoute: `/colony/${colonyName}`,
-          })}
-        />
-        <AlwaysAccesibleRoute
-          path={CLAIM_TOKEN_ROUTE}
-          component={ClaimTokensPage}
-          layout={NavBar}
-          routeProps={({ colonyName }) => ({
-            backText: ColonyBackText,
-            backRoute: `/colony/${colonyName}`,
-          })}
-        />
-
-        {/*
-         * Redirect anything else that's not found to the 404 route
-         */}
-        <Route path="*" element={<NotFoundRoute />} />
-      </RoutesSwitch>
-    ),
-    [user, isMobile],
-  );
 
   // if (isAppLoading) {
   //   return <LoadingTemplate loadingText={MSG.loadingAppMessage} />;
   // }
-  return MemoizedSwitch;
+
+  return (
+    <RoutesSwitch>
+      <Route path="/" element={<Navigate to={LANDING_PAGE_ROUTE} />} />
+      <Route path={NOT_FOUND_ROUTE} element={<FourOFour />} />
+      <Route
+        path={LANDING_PAGE_ROUTE}
+        element={
+          <Default routeProps={{ hasBackLink: false }}>
+            <LandingPage />
+          </Default>
+        }
+      />
+      <Route
+        element={
+          <ColonyContextProvider>
+            <Default
+              routeProps={{
+                backText: ColonyBackText,
+                backRoute: ({ colonyName }) => `/colony/${colonyName}`,
+                hasSubscribedColonies: false,
+              }}
+            >
+              <Outlet />
+            </Default>
+          </ColonyContextProvider>
+        }
+      >
+        <Route path={COLONY_FUNDING_ROUTE} element={<ColonyFunding />} />
+        {[COLONY_MEMBERS_ROUTE, COLONY_MEMBERS_WITH_DOMAIN_ROUTE].map(
+          (path) => (
+            <Route key={path} path={path} element={<ColonyMembers />} />
+          ),
+        )}
+      </Route>
+      <Route
+        path={COLONY_DECISIONS_PREVIEW_ROUTE}
+        element={
+          <ColonyContextProvider>
+            <NavBar>
+              <DecisionPreview />
+            </NavBar>
+          </ColonyContextProvider>
+        }
+      />
+      <Route
+        path={COLONY_HOME_ROUTE}
+        element={
+          <ColonyContextProvider>
+            <Default routeProps={{ hasBackLink: false }}>
+              <ColonyHome />
+            </Default>
+          </ColonyContextProvider>
+        }
+      />
+      {[ACTIONS_PAGE_ROUTE, DECISIONS_PAGE_ROUTE].map((path) => (
+        <Route
+          path={path}
+          element={
+            <ColonyContextProvider>
+              <NavBar
+                routeProps={{
+                  backRoute: ({ colonyName }) =>
+                    `/colony/${colonyName}${
+                      path === DECISIONS_PAGE_ROUTE ? '/decisions' : ''
+                    }`,
+                }}
+              >
+                <ActionDetailsPage />
+              </NavBar>
+            </ColonyContextProvider>
+          }
+          key={path}
+        />
+      ))}
+      <Route path={CREATE_COLONY_ROUTE} element={<CreateColonyWizard />} />
+      <Route path={CREATE_USER_ROUTE} element={<CreateUserWizard />} />
+      <Route
+        path={USER_ROUTE}
+        element={
+          <UserLayout routeProps={{ hasBackLink: false }}>
+            <UserProfile />
+          </UserLayout>
+        }
+      />
+      <Route
+        path={USER_EDIT_ROUTE}
+        element={
+          <Default
+            routeProps={{
+              hasBackLink: true,
+              hasSubscribedColonies: isMobile,
+              backText: MSG.userProfileEditBack,
+              backRoute: `/user/${user?.name}`,
+            }}
+          >
+            <UserProfileEdit />
+          </Default>
+        }
+      />
+      {/* <WalletRequiredRoute
+        isConnected={isConnected}
+        didClaimProfile={didClaimProfile}
+        path={CREATE_USER_ROUTE}
+        component={CreateUserWizard}
+        layout={Plain}
+      />
+      <WalletRequiredRoute
+        isConnected={isConnected}
+        didClaimProfile={didClaimProfile}
+        path={CREATE_COLONY_ROUTE}
+        component={CreateColonyWizard}
+        layout={Plain}
+      />
+
+      <AlwaysAccesibleRoute
+        path={USER_ROUTE}
+        component={UserProfile}
+        layout={SimpleNav}
+        routeProps={{
+          hasBackLink: false,
+        }}
+      />
+      <AlwaysAccesibleRoute
+        path={USER_EDIT_ROUTE}
+        component={UserProfileEdit}
+        layout={Default}
+        routeProps={{
+          hasSubscribedColonies: false,
+          backText: MSG.userProfileEditBack,
+          backRoute: `/user/${username}`,
+        }}
+      />
+      <AlwaysAccesibleRoute
+        exact
+        path={ACTIONS_PAGE_ROUTE}
+        component={ActionsPage}
+        layout={NavBar}
+        routeProps={({ colonyName }) => ({
+          backText: '',
+          backRoute: `/colony/${colonyName}`,
+        })}
+      />
+      <AlwaysAccesibleRoute
+        path={UNWRAP_TOKEN_ROUTE}
+        component={UnwrapTokensPage}
+        layout={NavBar}
+        routeProps={({ colonyName }) => ({
+          backText: ColonyBackText,
+          backRoute: `/colony/${colonyName}`,
+        })}
+      />
+      <AlwaysAccesibleRoute
+        path={CLAIM_TOKEN_ROUTE}
+        component={ClaimTokensPage}
+        layout={NavBar}
+        routeProps={({ colonyName }) => ({
+          backText: ColonyBackText,
+          backRoute: `/colony/${colonyName}`,
+        })}
+      />
+
+      {/*
+       * Redirect anything else that's not found to the 404 route
+       */}
+      <Route path="*" element={<NotFoundRoute />} />
+    </RoutesSwitch>
+  );
 };
 
 Routes.displayName = displayName;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,3 +3,5 @@ import Routes from './Routes';
 export * from './routeConstants';
 
 export default Routes;
+
+export { default as NotFoundRoute } from './NotFoundRoute';


### PR DESCRIPTION
Self-explanatory PR, this memoization was needed in the Dapp and that's no longer the case in the CDapp. I've tested by creating several colonies, doing some actions, and enabling extensions and I didn't notice any extra re-render or weird behaviors.

Resolves #175 
