### PR TITLE
Fix/1098 refactor expenditure sagas

### DIFF
--- a/src/redux/sagas/expenditures/cancelStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/cancelStakedExpenditure.ts
@@ -4,7 +4,11 @@ import { ClientType, ColonyRole, getPermissionProofs } from '@colony/colony-js';
 import { Action, ActionTypes, AllActions } from '~redux';
 import { ColonyManager } from '~context';
 
-import { createTransaction, getTxChannel } from '../transactions';
+import {
+  createTransaction,
+  getTxChannel,
+  waitForTxResult,
+} from '../transactions';
 import { getColonyManager, putError } from '../utils';
 
 function* cancelStakedExpenditure({
@@ -54,11 +58,15 @@ function* cancelStakedExpenditure({
       ],
     });
 
-    yield put<AllActions>({
-      type: ActionTypes.STAKED_EXPENDITURE_CANCEL_SUCCESS,
-      payload: {},
-      meta,
-    });
+    const { type } = yield waitForTxResult(txChannel);
+
+    if (type === ActionTypes.TRANSACTION_SUCCEEDED) {
+      yield put<AllActions>({
+        type: ActionTypes.STAKED_EXPENDITURE_CANCEL_SUCCESS,
+        payload: {},
+        meta,
+      });
+    }
   } catch (error) {
     return yield putError(
       ActionTypes.STAKED_EXPENDITURE_CANCEL_ERROR,

--- a/src/redux/sagas/expenditures/editExpenditure.ts
+++ b/src/redux/sagas/expenditures/editExpenditure.ts
@@ -6,7 +6,11 @@ import { Action, ActionTypes, AllActions } from '~redux';
 import { ExpenditurePayoutFieldValue } from '~common/Expenditures/ExpenditureForm';
 
 import { putError, getSetExpenditureValuesFunctionParams } from '../utils';
-import { createTransaction, getTxChannel } from '../transactions';
+import {
+  createTransaction,
+  getTxChannel,
+  waitForTxResult,
+} from '../transactions';
 
 function* editExpenditure({
   payload: { colonyAddress, expenditure, payouts },
@@ -76,11 +80,15 @@ function* editExpenditure({
       ),
     });
 
-    yield put<AllActions>({
-      type: ActionTypes.EXPENDITURE_EDIT_SUCCESS,
-      payload: {},
-      meta,
-    });
+    const { type } = yield waitForTxResult(txChannel);
+
+    if (type === ActionTypes.TRANSACTION_SUCCEEDED) {
+      yield put<AllActions>({
+        type: ActionTypes.EXPENDITURE_EDIT_SUCCESS,
+        payload: {},
+        meta,
+      });
+    }
   } catch (error) {
     return yield putError(ActionTypes.EXPENDITURE_EDIT_ERROR, error, meta);
   }

--- a/src/redux/sagas/expenditures/lockExpenditure.ts
+++ b/src/redux/sagas/expenditures/lockExpenditure.ts
@@ -3,8 +3,12 @@ import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
 import { Action, ActionTypes, AllActions } from '~redux';
 
-import { createTransaction, getTxChannel } from '../transactions';
-import { putError, takeFrom } from '../utils';
+import {
+  createTransaction,
+  getTxChannel,
+  waitForTxResult,
+} from '../transactions';
+import { putError } from '../utils';
 
 function* lockExpenditure({
   payload: { colonyAddress, nativeExpenditureId },
@@ -20,13 +24,15 @@ function* lockExpenditure({
       params: [nativeExpenditureId],
     });
 
-    yield takeFrom(txChannel, ActionTypes.TRANSACTION_SUCCEEDED);
+    const { type } = yield waitForTxResult(txChannel);
 
-    yield put<AllActions>({
-      type: ActionTypes.EXPENDITURE_LOCK_SUCCESS,
-      payload: {},
-      meta,
-    });
+    if (type === ActionTypes.TRANSACTION_SUCCEEDED) {
+      yield put<AllActions>({
+        type: ActionTypes.EXPENDITURE_LOCK_SUCCESS,
+        payload: {},
+        meta,
+      });
+    }
   } catch (error) {
     return yield putError(ActionTypes.EXPENDITURE_LOCK_ERROR, error, meta);
   }

--- a/src/redux/sagas/extensions/extensionEnable.ts
+++ b/src/redux/sagas/extensions/extensionEnable.ts
@@ -10,6 +10,7 @@ import {
   ChannelDefinition,
   createTransaction,
   createTransactionChannels,
+  waitForTxResult,
 } from '../transactions';
 import {
   modifyParams,
@@ -85,15 +86,17 @@ function* extensionEnable({
     }
 
     if (needsInitialisation) {
+      yield takeFrom(initialise.channel, ActionTypes.TRANSACTION_CREATED);
       yield put(transactionPending(initialise.id));
       yield put(transactionReady(initialise.id));
-      yield takeFrom(initialise.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+      yield waitForTxResult(initialise.channel);
     }
 
     if (needsSettingRoles) {
+      yield takeFrom(setUserRoles.channel, ActionTypes.TRANSACTION_CREATED);
       yield put(transactionPending(setUserRoles.id));
       yield put(transactionReady(setUserRoles.id));
-      yield takeFrom(setUserRoles.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+      yield waitForTxResult(setUserRoles.channel);
     }
 
     yield put({


### PR DESCRIPTION
## Description

This PR lightly refactors the expenditure sagas to ensure that a) they propagate errors correctly to the ui and b) they wait for txs to be created before changing their status.


Resolves  #1098
