### PR TITLE
Fix: `caches` undefined

### DIFF
--- a/lib/pinata/PinataCache.ts
+++ b/lib/pinata/PinataCache.ts
@@ -9,7 +9,7 @@ class PinataCache {
 
   async init(): Promise<Cache> {
     if (!this.cache) {
-      this.cache = await caches.open(PINATA_CACHE_STORE);
+      this.cache = await caches?.open(PINATA_CACHE_STORE);
     }
     return this.cache;
   }

--- a/lib/pinata/PinataCache.ts
+++ b/lib/pinata/PinataCache.ts
@@ -9,7 +9,7 @@ class PinataCache {
 
   async init(): Promise<Cache> {
     if (!this.cache) {
-      this.cache = await caches?.open(PINATA_CACHE_STORE);
+      this.cache = await window.caches?.open(PINATA_CACHE_STORE);
     }
     return this.cache;
   }

--- a/lib/pinata/PinataCache.ts
+++ b/lib/pinata/PinataCache.ts
@@ -72,7 +72,11 @@ class PinataCache {
          * upload the IPFS blob ourself, in which case, we'll have to request it from
          * the Gateway
          */
-        await this.cache?.add(new Request(HASH_URL));
+        if (!this.cache) {
+          throw new Error('Cache has not been initialized successfully');
+        }
+
+        await this.cache.add(new Request(HASH_URL));
       } else {
         /*
          * @NOTE If we have a network response, that means that we've uploaded to IPFS


### PR DESCRIPTION
## Description

This pr checks `caches` for `undefined` in the event the app is being run in an insecure context.

This resolves an error when building for production.
