### PR TITLE
Add notifications web worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,8 @@
     "webpack": "^5.74.0",
     "webpack-bundle-analyzer": "^4.6.1",
     "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "^4.11.1"
+    "webpack-dev-server": "^4.11.1",
+    "workbox-webpack-plugin": "^7.0.0"
   },
   "dependencies": {
     "@apollo/client": "^3.6.9",

--- a/package.json
+++ b/package.json
@@ -201,6 +201,7 @@
     "embla-carousel-react": "^8.0.0-rc11",
     "eth-ens-namehash-ms": "^2.2.0",
     "ethers": "^5.6.8",
+    "firebase": "^10.4.0",
     "format-number": "^3.0.0",
     "framer-motion": "^10.12.4",
     "graphql": "^16.6.0",

--- a/src/workers/firebase-messaging-sw.ts
+++ b/src/workers/firebase-messaging-sw.ts
@@ -1,0 +1,34 @@
+/* eslint-disable no-restricted-globals */
+
+import { initializeApp } from 'firebase/app';
+import { getMessaging, onBackgroundMessage } from 'firebase/messaging/sw';
+
+const firebaseConfig = process.env.FIREBASE_CONFIG
+  ? JSON.parse(process.env.FIREBASE_CONFIG)
+  : {};
+
+// Initialize the Firebase app in the service worker by passing in
+// your app's Firebase config object.
+// https://firebase.google.com/docs/web/setup#config-object
+initializeApp(firebaseConfig);
+
+// Retrieve an instance of Firebase Messaging so that it can handle background
+// messages.
+const messaging = getMessaging();
+onBackgroundMessage(messaging, (payload) => {
+  console.warn(
+    '[firebase-messaging-sw.js] Received background message ',
+    payload,
+  );
+  // Customize notification here
+  const notificationTitle = payload?.notification?.title;
+  const notificationOptions = {
+    body: payload?.notification?.body,
+    icon: 'favicon.png',
+  };
+
+  // @ts-ignore
+  self.registration.showNotification(notificationTitle, notificationOptions);
+});
+
+// workbox.precaching.precacheAndRoute(self.__WB_MANIFEST);

--- a/src/workers/firebase-messaging-sw.ts
+++ b/src/workers/firebase-messaging-sw.ts
@@ -24,11 +24,6 @@ initializeApp(firebaseConfig);
 // messages.
 const messaging = getMessaging();
 onBackgroundMessage(messaging, (payload) => {
-  console.warn(
-    '[firebase-messaging-sw.js] Received background message ',
-    payload,
-  );
-
   // Customize notification here
   const notificationTitle = payload?.data?.title || 'Colony Notification';
   const notificationOptions = {

--- a/src/workers/firebase-messaging-sw.ts
+++ b/src/workers/firebase-messaging-sw.ts
@@ -1,10 +1,10 @@
 /// <reference lib="WebWorker" />
 
-// export empty type because of tsc --isolatedModules flag
 import { initializeApp } from 'firebase/app';
 import { getMessaging, onBackgroundMessage } from 'firebase/messaging/sw';
 import { precacheAndRoute } from 'workbox-precaching';
 
+// export empty type because of tsc --isolatedModules flag
 export type {};
 declare const self: ServiceWorkerGlobalScope;
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -39,7 +39,7 @@
     "downlevelIteration": true,
     "esModuleInterop": true,
     "jsx": "react",
-    "lib": ["dom", "es2019"],
+    "lib": ["dom", "es2019", "webworker"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmit": true,

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -6,6 +6,7 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
+const { InjectManifest } = require('workbox-webpack-plugin');
 
 const mode = process.env.NODE_ENV || 'development';
 
@@ -179,6 +180,11 @@ const config = {
     new webpack.ProvidePlugin({
       process: 'process/browser',
       Buffer: ['buffer', 'Buffer'],
+    }),
+    new InjectManifest({
+      swSrc: './src/workers/firebase-messaging-sw.ts',
+      swDest: 'firebase-messaging-sw.js',
+      exclude: [/./],
     }),
   ],
   /*

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -6,6 +6,22 @@ const ReactRefreshTypeScript = require('react-refresh-typescript');
 
 const webpackBaseConfig = require('./webpack.base').config;
 
+// Work around to enable web workers in dev mode
+// https://github.com/GoogleChrome/workbox/issues/1790#issuecomment-1241356293
+const workboxPluginInstance = webpackBaseConfig.plugins.find(
+  (plugin) => plugin.constructor.name === 'InjectManifest',
+);
+if (workboxPluginInstance) {
+  Object.defineProperty(workboxPluginInstance, 'alreadyCalled', {
+    get() {
+      return false;
+    },
+    set() {
+      // Do nothing; prevents the internals from setting it to true
+    },
+  });
+}
+
 module.exports = () => ({
   ...webpackBaseConfig,
   /*


### PR DESCRIPTION
## Description

This PR adds the firebase notification messaging web worker to the project

https://firebase.google.com/docs/cloud-messaging/js/receive

It is built using [workbox](https://developer.chrome.com/docs/workbox/) by Chrome team as I could not get any other method of building it to work. 

Currently it is setup to get the data from the firebase message and create a notification using it.

To test go to the `useNotifications` PR and send a notification while the app is in the background. A notification with the colony logo should appear.

**New stuff** ✨

- A workers folder in `src` where we can but any future web workers
- The firebase web worker 

Resolves #1138
