### PR TITLE
Add notifications to schema

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -1020,7 +1020,7 @@ type NotificationSettings {
   Device registration tokens for push notifications
   If this is null or the array is empty the user is not subscribed to push notifications
   """
-  notificationTokens: [String]
+  notificationTokens: [String!]
   """
   Indicates whether the user wants to be emailed
   """
@@ -1082,7 +1082,7 @@ type Notification @model {
   The links connected to what is signified in the text
   The order matches what is in the string
   """
-  links: [String]
+  links: [String!]
 }
 
 """

--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -1011,6 +1011,30 @@ type Profile @model {
   """
   notificationSettings: NotificationSettings
 }
+
+"""
+An object holding the personal notification settings of a user
+"""
+type NotificationSettings {
+  """
+  Device registration tokens for push notifications
+  If this is null or the array is empty the user is not subscribed to push notifications
+  """
+  notificationTokens: [String]
+  """
+  Indicates whether the user wants to be emailed
+  """
+  enableEmail: Boolean
+  """
+  Indicates whether the user wants to be notified on mentions
+  """
+  enableMention: Boolean
+  """
+  Indicates whether the user wants to be notified on assignments
+  """
+  enableAssign: Boolean
+}
+
 """
 Notifications that a user may receive from a Colony
 """

--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -1045,7 +1045,7 @@ type Notification @model {
   userId: ID!
     @index(
       name: "byUser"
-      queryField: "notificationsByDate"
+      queryField: "getNotificationsByDate"
       sortKeyFields: ["createdAt"]
     )
   """

--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -1011,6 +1011,54 @@ type Profile @model {
   """
   notificationSettings: NotificationSettings
 }
+"""
+Notifications that a user may receive from a Colony
+"""
+type Notification @model {
+  """
+  User ID the Notification was sent to
+  """
+  userId: ID!
+    @index(
+      name: "byUser"
+      queryField: "notificationsByDate"
+      sortKeyFields: ["createdAt"]
+    )
+  """
+  The user object the notification was sent to
+  """
+  user: User! @hasOne(fields: ["userId"])
+  """
+  Colony ID associated with the Notification
+  """
+  colonyId: ID!
+  """
+  The colony the notification was sent from
+  """
+  colony: Colony! @hasOne(fields: ["colonyId"])
+  """
+  Timestamp when the notification was sent
+  """
+  createdAt: AWSDateTime!
+  """
+  Flag indicating whether the notification has been read by the user
+  """
+  read: Boolean!
+  """
+  The default title for a notification is the Colony Display name
+  This enables setting a different title and takes precedence if set
+  """
+  title: String
+  """
+  The text of the notification with indications which string portions are links
+  eg. 'This signifies a {link}'
+  """
+  text: String!
+  """
+  The links connected to what is signified in the text
+  The order matches what is in the string
+  """
+  links: [String]
 }
 
 """

--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -1051,7 +1051,7 @@ type Notification @model {
   """
   The user object the notification was sent to
   """
-  user: User! @hasOne(fields: ["userId"])
+  user: Profile! @hasOne(fields: ["userId"])
   """
   Colony ID associated with the Notification
   """

--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -998,11 +998,19 @@ type Profile @model {
   Metadata associated with the user's profile
   """
   meta: ProfileMetadata
-
   """
   The user associated with this profile
   """
   user: User! @belongsTo(fields: ["id"])
+  """
+  List of a user's notifications
+  """
+  notifications: [Notification] @hasMany
+  """
+  Notification settings
+  """
+  notificationSettings: NotificationSettings
+}
 }
 
 """

--- a/src/graphql/fragments/user.graphql
+++ b/src/graphql/fragments/user.graphql
@@ -63,3 +63,18 @@ fragment Watcher on Watcher {
     ...MemberUser
   }
 }
+
+fragment Notification on Notification {
+  colony {
+    id
+    name
+    metadata {
+      displayName
+    }
+  }
+  createdAt
+  read
+  title
+  text
+  links
+}

--- a/src/graphql/queries/user.graphql
+++ b/src/graphql/queries/user.graphql
@@ -51,3 +51,15 @@ query GetUsers($filter: ModelUserFilterInput) {
     }
   }
 }
+
+query GetUserNotifications($id: ID!, $colonyId: ID) {
+  notificationsByDate(
+    userId: $id
+    filter: { colonyId: { eq: $colonyId } }
+    sortDirection: ASC
+  ) {
+    items {
+      ...Notification
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the notification types and models to the amplify schema including the notification settings.

These models will undoubtably change as the feature develops but this PR gives a solid baseline to work from.

Resolves #1124
