### PR TITLE
fix: changed sidebar height on mobile

### DIFF
--- a/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
@@ -114,7 +114,7 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
           fixed
           top-0
           right-0
-          bottom-0
+          h-screen
           w-full
           bg-base-white
           rounded-bl-lg
@@ -160,7 +160,7 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
         {children}
       </div>
       <div
-        className={clsx('flex w-full h-[calc(100%-4.625rem)] md:h-full', {
+        className={clsx('flex w-full flex-grow overflow-hidden', {
           'flex-col-reverse md:flex-row': transactionId,
         })}
       >

--- a/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
@@ -160,7 +160,7 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
         {children}
       </div>
       <div
-        className={clsx('flex w-full h-full', {
+        className={clsx('flex w-full h-[calc(100%-4.625rem)] md:h-full', {
           'flex-col-reverse md:flex-row': transactionId,
         })}
       >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,6 +18,9 @@ module.exports = {
       '4xl': ['2.375rem', 1.2],
     },
     extend: {
+      height: {
+        screen: ['100vh /* fallback for Opera, IE and etc. */', '100dvh'],
+      },
       colors: {
         gray: {
           25: 'var(--color-gray-25)',


### PR DESCRIPTION
Subtracting header height from content, to always take full screen height.

https://tw.auroracreation.com/app/tasks/15602047

![image](https://github.com/JoinColony/colonyCDapp/assets/76940796/1ff0f931-a74d-4b59-9113-abd54302a714)
