### PR TITLE
Change active installs to use db 

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -2574,7 +2574,7 @@ type ExtensionParams {
 }
 
 """
-Represents a single extension installed on a Colony
+Represents a single extension installation in a Colony
 """
 type ColonyExtension @model {
   """
@@ -3383,4 +3383,16 @@ type Safe {
   address: String!
   chainId: Int!
   moduleContractAddress: String!
+}
+
+type ExtensionInstallationsCount @model {
+  """
+  The model id. It's the chain id the of the colony the extension belongs to
+  """
+  id: ID!
+  oneTxPayment: Int!
+  stakedExpenditure: Int!
+  stagedExpenditure: Int!
+  streamingPayments: Int!
+  reputationWeighted: Int!
 }

--- a/amplify/backend/backend-config.json
+++ b/amplify/backend/backend-config.json
@@ -181,11 +181,6 @@
       "providerPlugin": "awscloudformation",
       "service": "Lambda"
     },
-    "getTotalMemberCount": {
-      "build": true,
-      "providerPlugin": "awscloudformation",
-      "service": "Lambda"
-    },
     "getSafeTransactionStatus": {
       "build": true,
       "dependsOn": [
@@ -197,6 +192,11 @@
           "resourceName": "colonycdappSSMAccess"
         }
       ],
+      "providerPlugin": "awscloudformation",
+      "service": "Lambda"
+    },
+    "getTotalMemberCount": {
+      "build": true,
       "providerPlugin": "awscloudformation",
       "service": "Lambda"
     },
@@ -242,7 +242,7 @@
       "providerPlugin": "awscloudformation",
       "service": "Lambda"
     },
-    "updateContributorsWithReputation": {
+    "setCurrentVersion": {
       "build": true,
       "dependsOn": [
         {
@@ -256,7 +256,7 @@
       "providerPlugin": "awscloudformation",
       "service": "Lambda"
     },
-    "setCurrentVersion": {
+    "updateContributorsWithReputation": {
       "build": true,
       "dependsOn": [
         {

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=00f046bcd3413a07ccaa959042527685ae6de9fa
+ENV BLOCK_INGESTOR_HASH=36c2b5f63d32e8e690cd74049e0cb7067eb36bc4
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/frame/Extensions/pages/partials/ActiveInstalls.tsx
+++ b/src/components/frame/Extensions/pages/partials/ActiveInstalls.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-import { MAX_INSTALLED_NUMBER } from '~constants';
+import { EXTENSIONS_COUNT_THRESHOLD } from '~constants';
 import { ActiveInstallsProps } from './types';
 import ExtensionStatusBadge from '~v5/common/Pills/ExtensionStatusBadge';
 import { formatText } from '~utils/intl';
@@ -10,7 +10,7 @@ const displayName = 'frame.Extensions.pages.partials.ActiveInstalls';
 const ActiveInstalls: FC<ActiveInstallsProps> = ({ activeInstalls }) => {
   return (
     <div className="sm:hidden md:block">
-      {activeInstalls < MAX_INSTALLED_NUMBER ? (
+      {activeInstalls < EXTENSIONS_COUNT_THRESHOLD ? (
         <ExtensionStatusBadge
           mode="new"
           text={formatText({ id: 'status.new' })}

--- a/src/components/frame/Extensions/pages/partials/ActiveInstalls.tsx
+++ b/src/components/frame/Extensions/pages/partials/ActiveInstalls.tsx
@@ -1,35 +1,25 @@
 import React, { FC } from 'react';
-import { useIntl } from 'react-intl';
 
 import { MAX_INSTALLED_NUMBER } from '~constants';
 import { ActiveInstallsProps } from './types';
 import ExtensionStatusBadge from '~v5/common/Pills/ExtensionStatusBadge';
-import { SpinnerLoader } from '~shared/Preloaders';
 import { formatText } from '~utils/intl';
 
 const displayName = 'frame.Extensions.pages.partials.ActiveInstalls';
 
 const ActiveInstalls: FC<ActiveInstallsProps> = ({ activeInstalls }) => {
-  const { formatMessage } = useIntl();
-
   return (
     <div className="sm:hidden md:block">
-      {activeInstalls ? (
-        <>
-          {activeInstalls < MAX_INSTALLED_NUMBER ? (
-            <ExtensionStatusBadge
-              mode="new"
-              text={formatText({ id: 'status.new' })}
-            />
-          ) : (
-            <p className="text-gray-400 text-sm text-right">
-              {activeInstalls.toLocaleString('en-US')}{' '}
-              {formatMessage({ id: 'active.installs' })}
-            </p>
-          )}
-        </>
+      {activeInstalls < MAX_INSTALLED_NUMBER ? (
+        <ExtensionStatusBadge
+          mode="new"
+          text={formatText({ id: 'status.new' })}
+        />
       ) : (
-        <SpinnerLoader />
+        <p className="text-gray-400 text-sm text-right">
+          {activeInstalls.toLocaleString('en-US')}{' '}
+          {formatText({ id: 'active.installs' })}
+        </p>
       )}
     </div>
   );

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -200,7 +200,7 @@ export const isDev = process.env.NETWORK === 'ganache';
 
 export const CDAPP_VERSION = version;
 
-export const MAX_INSTALLED_NUMBER = 39;
+export const EXTENSIONS_COUNT_THRESHOLD = 39;
 
 export const STAKING_THRESHOLD = 10;
 

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -548,7 +548,7 @@ export type ColonyDecision = {
   walletAddress: Scalars['String'];
 };
 
-/** Represents a single extension installed on a Colony */
+/** Represents a single extension installation in a Colony */
 export type ColonyExtension = {
   __typename?: 'ColonyExtension';
   /** The Colony that the extension belongs to */
@@ -1285,6 +1285,15 @@ export type CreateExpenditureMetadataInput = {
   stakeAmount?: InputMaybe<Scalars['String']>;
 };
 
+export type CreateExtensionInstallationsCountInput = {
+  id?: InputMaybe<Scalars['ID']>;
+  oneTxPayment: Scalars['Int'];
+  reputationWeighted: Scalars['Int'];
+  stagedExpenditure: Scalars['Int'];
+  stakedExpenditure: Scalars['Int'];
+  streamingPayments: Scalars['Int'];
+};
+
 export type CreateIngestorStatsInput = {
   id?: InputMaybe<Scalars['ID']>;
   value: Scalars['String'];
@@ -1559,6 +1568,10 @@ export type DeleteExpenditureInput = {
 };
 
 export type DeleteExpenditureMetadataInput = {
+  id: Scalars['ID'];
+};
+
+export type DeleteExtensionInstallationsCountInput = {
   id: Scalars['ID'];
 };
 
@@ -1890,6 +1903,19 @@ export enum ExpenditureType {
   PaymentBuilder = 'PAYMENT_BUILDER',
   Staged = 'STAGED'
 }
+
+export type ExtensionInstallationsCount = {
+  __typename?: 'ExtensionInstallationsCount';
+  createdAt: Scalars['AWSDateTime'];
+  /** The model id. It's the chain id the of the colony the extension belongs to */
+  id: Scalars['ID'];
+  oneTxPayment: Scalars['Int'];
+  reputationWeighted: Scalars['Int'];
+  stagedExpenditure: Scalars['Int'];
+  stakedExpenditure: Scalars['Int'];
+  streamingPayments: Scalars['Int'];
+  updatedAt: Scalars['AWSDateTime'];
+};
 
 /** Map of parameters that extensions are initialised with */
 export type ExtensionParams = {
@@ -2885,6 +2911,35 @@ export type ModelExpenditureTypeInput = {
   ne?: InputMaybe<ExpenditureType>;
 };
 
+export type ModelExtensionInstallationsCountConditionInput = {
+  and?: InputMaybe<Array<InputMaybe<ModelExtensionInstallationsCountConditionInput>>>;
+  not?: InputMaybe<ModelExtensionInstallationsCountConditionInput>;
+  oneTxPayment?: InputMaybe<ModelIntInput>;
+  or?: InputMaybe<Array<InputMaybe<ModelExtensionInstallationsCountConditionInput>>>;
+  reputationWeighted?: InputMaybe<ModelIntInput>;
+  stagedExpenditure?: InputMaybe<ModelIntInput>;
+  stakedExpenditure?: InputMaybe<ModelIntInput>;
+  streamingPayments?: InputMaybe<ModelIntInput>;
+};
+
+export type ModelExtensionInstallationsCountConnection = {
+  __typename?: 'ModelExtensionInstallationsCountConnection';
+  items: Array<Maybe<ExtensionInstallationsCount>>;
+  nextToken?: Maybe<Scalars['String']>;
+};
+
+export type ModelExtensionInstallationsCountFilterInput = {
+  and?: InputMaybe<Array<InputMaybe<ModelExtensionInstallationsCountFilterInput>>>;
+  id?: InputMaybe<ModelIdInput>;
+  not?: InputMaybe<ModelExtensionInstallationsCountFilterInput>;
+  oneTxPayment?: InputMaybe<ModelIntInput>;
+  or?: InputMaybe<Array<InputMaybe<ModelExtensionInstallationsCountFilterInput>>>;
+  reputationWeighted?: InputMaybe<ModelIntInput>;
+  stagedExpenditure?: InputMaybe<ModelIntInput>;
+  stakedExpenditure?: InputMaybe<ModelIntInput>;
+  streamingPayments?: InputMaybe<ModelIntInput>;
+};
+
 export type ModelFloatInput = {
   attributeExists?: InputMaybe<Scalars['Boolean']>;
   attributeType?: InputMaybe<ModelAttributeTypes>;
@@ -3525,6 +3580,17 @@ export type ModelSubscriptionExpenditureMetadataFilterInput = {
   stakeAmount?: InputMaybe<ModelSubscriptionStringInput>;
 };
 
+export type ModelSubscriptionExtensionInstallationsCountFilterInput = {
+  and?: InputMaybe<Array<InputMaybe<ModelSubscriptionExtensionInstallationsCountFilterInput>>>;
+  id?: InputMaybe<ModelSubscriptionIdInput>;
+  oneTxPayment?: InputMaybe<ModelSubscriptionIntInput>;
+  or?: InputMaybe<Array<InputMaybe<ModelSubscriptionExtensionInstallationsCountFilterInput>>>;
+  reputationWeighted?: InputMaybe<ModelSubscriptionIntInput>;
+  stagedExpenditure?: InputMaybe<ModelSubscriptionIntInput>;
+  stakedExpenditure?: InputMaybe<ModelSubscriptionIntInput>;
+  streamingPayments?: InputMaybe<ModelSubscriptionIntInput>;
+};
+
 export type ModelSubscriptionFloatInput = {
   between?: InputMaybe<Array<InputMaybe<Scalars['Float']>>>;
   eq?: InputMaybe<Scalars['Float']>;
@@ -4042,6 +4108,7 @@ export type Mutation = {
   createDomainMetadata?: Maybe<DomainMetadata>;
   createExpenditure?: Maybe<Expenditure>;
   createExpenditureMetadata?: Maybe<ExpenditureMetadata>;
+  createExtensionInstallationsCount?: Maybe<ExtensionInstallationsCount>;
   createIngestorStats?: Maybe<IngestorStats>;
   createMotionMessage?: Maybe<MotionMessage>;
   createPrivateBetaInviteCode?: Maybe<PrivateBetaInviteCode>;
@@ -4081,6 +4148,7 @@ export type Mutation = {
   deleteDomainMetadata?: Maybe<DomainMetadata>;
   deleteExpenditure?: Maybe<Expenditure>;
   deleteExpenditureMetadata?: Maybe<ExpenditureMetadata>;
+  deleteExtensionInstallationsCount?: Maybe<ExtensionInstallationsCount>;
   deleteIngestorStats?: Maybe<IngestorStats>;
   deleteMotionMessage?: Maybe<MotionMessage>;
   deletePrivateBetaInviteCode?: Maybe<PrivateBetaInviteCode>;
@@ -4120,6 +4188,7 @@ export type Mutation = {
   updateDomainMetadata?: Maybe<DomainMetadata>;
   updateExpenditure?: Maybe<Expenditure>;
   updateExpenditureMetadata?: Maybe<ExpenditureMetadata>;
+  updateExtensionInstallationsCount?: Maybe<ExtensionInstallationsCount>;
   updateIngestorStats?: Maybe<IngestorStats>;
   updateMotionMessage?: Maybe<MotionMessage>;
   updatePrivateBetaInviteCode?: Maybe<PrivateBetaInviteCode>;
@@ -4281,6 +4350,13 @@ export type MutationCreateExpenditureArgs = {
 export type MutationCreateExpenditureMetadataArgs = {
   condition?: InputMaybe<ModelExpenditureMetadataConditionInput>;
   input: CreateExpenditureMetadataInput;
+};
+
+
+/** Root mutation type */
+export type MutationCreateExtensionInstallationsCountArgs = {
+  condition?: InputMaybe<ModelExtensionInstallationsCountConditionInput>;
+  input: CreateExtensionInstallationsCountInput;
 };
 
 
@@ -4542,6 +4618,13 @@ export type MutationDeleteExpenditureMetadataArgs = {
 
 
 /** Root mutation type */
+export type MutationDeleteExtensionInstallationsCountArgs = {
+  condition?: InputMaybe<ModelExtensionInstallationsCountConditionInput>;
+  input: DeleteExtensionInstallationsCountInput;
+};
+
+
+/** Root mutation type */
 export type MutationDeleteIngestorStatsArgs = {
   condition?: InputMaybe<ModelIngestorStatsConditionInput>;
   input: DeleteIngestorStatsInput;
@@ -4795,6 +4878,13 @@ export type MutationUpdateExpenditureArgs = {
 export type MutationUpdateExpenditureMetadataArgs = {
   condition?: InputMaybe<ModelExpenditureMetadataConditionInput>;
   input: UpdateExpenditureMetadataInput;
+};
+
+
+/** Root mutation type */
+export type MutationUpdateExtensionInstallationsCountArgs = {
+  condition?: InputMaybe<ModelExtensionInstallationsCountConditionInput>;
+  input: UpdateExtensionInstallationsCountInput;
 };
 
 
@@ -5139,6 +5229,7 @@ export type Query = {
   getExpendituresByColony?: Maybe<ModelExpenditureConnection>;
   getExpendituresByNativeFundingPotIdAndColony?: Maybe<ModelExpenditureConnection>;
   getExtensionByColonyAndHash?: Maybe<ModelColonyExtensionConnection>;
+  getExtensionInstallationsCount?: Maybe<ExtensionInstallationsCount>;
   getExtensionsByHash?: Maybe<ModelColonyExtensionConnection>;
   getIngestorStats?: Maybe<IngestorStats>;
   /** Fetch the list of members for a specific Colony */
@@ -5206,6 +5297,7 @@ export type Query = {
   listDomains?: Maybe<ModelDomainConnection>;
   listExpenditureMetadata?: Maybe<ModelExpenditureMetadataConnection>;
   listExpenditures?: Maybe<ModelExpenditureConnection>;
+  listExtensionInstallationsCounts?: Maybe<ModelExtensionInstallationsCountConnection>;
   listIngestorStats?: Maybe<ModelIngestorStatsConnection>;
   listMotionMessages?: Maybe<ModelMotionMessageConnection>;
   listPrivateBetaInviteCodes?: Maybe<ModelPrivateBetaInviteCodeConnection>;
@@ -5515,6 +5607,12 @@ export type QueryGetExtensionByColonyAndHashArgs = {
   limit?: InputMaybe<Scalars['Int']>;
   nextToken?: InputMaybe<Scalars['String']>;
   sortDirection?: InputMaybe<ModelSortDirection>;
+};
+
+
+/** Root query type */
+export type QueryGetExtensionInstallationsCountArgs = {
+  id: Scalars['ID'];
 };
 
 
@@ -5977,6 +6075,14 @@ export type QueryListExpendituresArgs = {
 
 
 /** Root query type */
+export type QueryListExtensionInstallationsCountsArgs = {
+  filter?: InputMaybe<ModelExtensionInstallationsCountFilterInput>;
+  limit?: InputMaybe<Scalars['Int']>;
+  nextToken?: InputMaybe<Scalars['String']>;
+};
+
+
+/** Root query type */
 export type QueryListIngestorStatsArgs = {
   filter?: InputMaybe<ModelIngestorStatsFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -6289,6 +6395,7 @@ export type Subscription = {
   onCreateDomainMetadata?: Maybe<DomainMetadata>;
   onCreateExpenditure?: Maybe<Expenditure>;
   onCreateExpenditureMetadata?: Maybe<ExpenditureMetadata>;
+  onCreateExtensionInstallationsCount?: Maybe<ExtensionInstallationsCount>;
   onCreateIngestorStats?: Maybe<IngestorStats>;
   onCreateMotionMessage?: Maybe<MotionMessage>;
   onCreatePrivateBetaInviteCode?: Maybe<PrivateBetaInviteCode>;
@@ -6324,6 +6431,7 @@ export type Subscription = {
   onDeleteDomainMetadata?: Maybe<DomainMetadata>;
   onDeleteExpenditure?: Maybe<Expenditure>;
   onDeleteExpenditureMetadata?: Maybe<ExpenditureMetadata>;
+  onDeleteExtensionInstallationsCount?: Maybe<ExtensionInstallationsCount>;
   onDeleteIngestorStats?: Maybe<IngestorStats>;
   onDeleteMotionMessage?: Maybe<MotionMessage>;
   onDeletePrivateBetaInviteCode?: Maybe<PrivateBetaInviteCode>;
@@ -6359,6 +6467,7 @@ export type Subscription = {
   onUpdateDomainMetadata?: Maybe<DomainMetadata>;
   onUpdateExpenditure?: Maybe<Expenditure>;
   onUpdateExpenditureMetadata?: Maybe<ExpenditureMetadata>;
+  onUpdateExtensionInstallationsCount?: Maybe<ExtensionInstallationsCount>;
   onUpdateIngestorStats?: Maybe<IngestorStats>;
   onUpdateMotionMessage?: Maybe<MotionMessage>;
   onUpdatePrivateBetaInviteCode?: Maybe<PrivateBetaInviteCode>;
@@ -6478,6 +6587,11 @@ export type SubscriptionOnCreateExpenditureArgs = {
 
 export type SubscriptionOnCreateExpenditureMetadataArgs = {
   filter?: InputMaybe<ModelSubscriptionExpenditureMetadataFilterInput>;
+};
+
+
+export type SubscriptionOnCreateExtensionInstallationsCountArgs = {
+  filter?: InputMaybe<ModelSubscriptionExtensionInstallationsCountFilterInput>;
 };
 
 
@@ -6656,6 +6770,11 @@ export type SubscriptionOnDeleteExpenditureMetadataArgs = {
 };
 
 
+export type SubscriptionOnDeleteExtensionInstallationsCountArgs = {
+  filter?: InputMaybe<ModelSubscriptionExtensionInstallationsCountFilterInput>;
+};
+
+
 export type SubscriptionOnDeleteIngestorStatsArgs = {
   filter?: InputMaybe<ModelSubscriptionIngestorStatsFilterInput>;
 };
@@ -6828,6 +6947,11 @@ export type SubscriptionOnUpdateExpenditureArgs = {
 
 export type SubscriptionOnUpdateExpenditureMetadataArgs = {
   filter?: InputMaybe<ModelSubscriptionExpenditureMetadataFilterInput>;
+};
+
+
+export type SubscriptionOnUpdateExtensionInstallationsCountArgs = {
+  filter?: InputMaybe<ModelSubscriptionExtensionInstallationsCountFilterInput>;
 };
 
 
@@ -7375,6 +7499,15 @@ export type UpdateExtensionByColonyAndHashInput = {
   isInitialized?: InputMaybe<Scalars['Boolean']>;
   /** The version of the extension */
   version?: InputMaybe<Scalars['Int']>;
+};
+
+export type UpdateExtensionInstallationsCountInput = {
+  id: Scalars['ID'];
+  oneTxPayment?: InputMaybe<Scalars['Int']>;
+  reputationWeighted?: InputMaybe<Scalars['Int']>;
+  stagedExpenditure?: InputMaybe<Scalars['Int']>;
+  stakedExpenditure?: InputMaybe<Scalars['Int']>;
+  streamingPayments?: InputMaybe<Scalars['Int']>;
 };
 
 export type UpdateIngestorStatsInput = {
@@ -8140,6 +8273,13 @@ export type GetColonyExtensionsByColonyAddressQueryVariables = Exact<{
 
 
 export type GetColonyExtensionsByColonyAddressQuery = { __typename?: 'Query', getExtensionByColonyAndHash?: { __typename?: 'ModelColonyExtensionConnection', items: Array<{ __typename?: 'ColonyExtension', id: string } | null> } | null };
+
+export type GetExtensionInstallationsCountQueryVariables = Exact<{
+  id: Scalars['ID'];
+}>;
+
+
+export type GetExtensionInstallationsCountQuery = { __typename?: 'Query', getExtensionInstallationsCount?: { __typename?: 'ExtensionInstallationsCount', oneTxPayment: number, stakedExpenditure: number, stagedExpenditure: number, streamingPayments: number, reputationWeighted: number } | null };
 
 export type GetMotionStateQueryVariables = Exact<{
   input: GetMotionStateInput;
@@ -10770,6 +10910,45 @@ export function useGetColonyExtensionsByColonyAddressLazyQuery(baseOptions?: Apo
 export type GetColonyExtensionsByColonyAddressQueryHookResult = ReturnType<typeof useGetColonyExtensionsByColonyAddressQuery>;
 export type GetColonyExtensionsByColonyAddressLazyQueryHookResult = ReturnType<typeof useGetColonyExtensionsByColonyAddressLazyQuery>;
 export type GetColonyExtensionsByColonyAddressQueryResult = Apollo.QueryResult<GetColonyExtensionsByColonyAddressQuery, GetColonyExtensionsByColonyAddressQueryVariables>;
+export const GetExtensionInstallationsCountDocument = gql`
+    query GetExtensionInstallationsCount($id: ID!) {
+  getExtensionInstallationsCount(id: $id) {
+    oneTxPayment
+    stakedExpenditure
+    stagedExpenditure
+    streamingPayments
+    reputationWeighted
+  }
+}
+    `;
+
+/**
+ * __useGetExtensionInstallationsCountQuery__
+ *
+ * To run a query within a React component, call `useGetExtensionInstallationsCountQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetExtensionInstallationsCountQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetExtensionInstallationsCountQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useGetExtensionInstallationsCountQuery(baseOptions: Apollo.QueryHookOptions<GetExtensionInstallationsCountQuery, GetExtensionInstallationsCountQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetExtensionInstallationsCountQuery, GetExtensionInstallationsCountQueryVariables>(GetExtensionInstallationsCountDocument, options);
+      }
+export function useGetExtensionInstallationsCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetExtensionInstallationsCountQuery, GetExtensionInstallationsCountQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetExtensionInstallationsCountQuery, GetExtensionInstallationsCountQueryVariables>(GetExtensionInstallationsCountDocument, options);
+        }
+export type GetExtensionInstallationsCountQueryHookResult = ReturnType<typeof useGetExtensionInstallationsCountQuery>;
+export type GetExtensionInstallationsCountLazyQueryHookResult = ReturnType<typeof useGetExtensionInstallationsCountLazyQuery>;
+export type GetExtensionInstallationsCountQueryResult = Apollo.QueryResult<GetExtensionInstallationsCountQuery, GetExtensionInstallationsCountQueryVariables>;
 export const GetMotionStateDocument = gql`
     query GetMotionState($input: GetMotionStateInput!) {
   getMotionState(input: $input)

--- a/src/graphql/queries/extensions.graphql
+++ b/src/graphql/queries/extensions.graphql
@@ -5,3 +5,13 @@ query GetColonyExtensionsByColonyAddress($colonyAddress: ID!) {
     }
   }
 }
+
+query GetExtensionInstallationsCount($id: ID!) {
+  getExtensionInstallationsCount(id: $id) {
+    oneTxPayment
+    stakedExpenditure
+    stagedExpenditure
+    streamingPayments
+    reputationWeighted
+  }
+}

--- a/src/hooks/useActiveInstalls.ts
+++ b/src/hooks/useActiveInstalls.ts
@@ -1,16 +1,32 @@
 import { Extension } from '@colony/colony-js';
-import useFetchActiveInstallsExtension from './useFetchActiveInstallsExtension';
+import { useGetExtensionInstallationsCountQuery } from '~gql';
+import useColonyContext from './useColonyContext';
 
 const useActiveInstalls = (extensionId: string) => {
-  const { oneTxPaymentData, votingReputationData } =
-    useFetchActiveInstallsExtension();
+  const { colony } = useColonyContext();
 
-  const activeInstalls =
-    extensionId === Extension.OneTxPayment
-      ? oneTxPaymentData
-      : votingReputationData;
+  const { data } = useGetExtensionInstallationsCountQuery({
+    variables: { id: colony?.chainMetadata.chainId.toString() ?? '' },
+    skip: !colony,
+  });
 
-  return Number(activeInstalls);
+  const {
+    oneTxPayment,
+    reputationWeighted,
+    stagedExpenditure,
+    stakedExpenditure,
+    streamingPayments,
+  } = data?.getExtensionInstallationsCount ?? {};
+
+  const extensionIdDBKeyMap = {
+    [Extension.OneTxPayment]: oneTxPayment,
+    [Extension.VotingReputation]: reputationWeighted,
+    [Extension.StakedExpenditure]: stakedExpenditure,
+    [Extension.StagedExpenditure]: stagedExpenditure,
+    [Extension.StreamingPayments]: streamingPayments,
+  };
+
+  return extensionIdDBKeyMap[extensionId] ?? 0;
 };
 
 export default useActiveInstalls;


### PR DESCRIPTION
## Description

This PR enables the storing of global extension installation information in the db, so users can see how many times an extension has been installed on the chain.

**New stuff** ✨

* Add `ExtensionInstallationsCount` to schema

Block ingestor: https://github.com/JoinColony/block-ingestor/pull/141

Resolves #1134
