### PR TITLE
Streaming payment details UI

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -805,7 +805,7 @@ enum ColonyActionType {
   """
   CANCEL_STAKED_EXPENDITURE_MOTION
   """
-  An action related to the creation of a motion to start a streaming payment. 
+  An action related to the creation of a motion to start a streaming payment.
   """
   CREATE_STREAMING_PAYMENT_MOTION
 }
@@ -1412,6 +1412,8 @@ type Colony @model {
   reputation: String
 
   expenditures: [Expenditure] @hasMany(indexName: "byColony", fields: ["id"])
+  streamingPayments: [StreamingPayment]
+    @hasMany(indexName: "byColony", fields: ["id"])
   expendituresGlobalClaimDelay: Int
 }
 
@@ -2652,7 +2654,8 @@ type ColonyAction @model {
   """
   The type of action performed
   """
-  type: ColonyActionType! @index(name: "byType", queryField: "getColonyActionsByType")
+  type: ColonyActionType!
+    @index(name: "byType", queryField: "getColonyActionsByType")
   """
   The block number where the action was recorded
   """
@@ -3210,6 +3213,19 @@ type ExpenditureStage {
 
 type StreamingPayment @model {
   id: ID! # Self-managed, formatted as colonyId_nativeId
+  """
+  Colony ID (address) to which the streaming payment belongs
+  """
+  colonyId: ID!
+    @index(
+      name: "byColony"
+      queryField: "getStreamingPaymentsByColony"
+      sortKeyFields: ["createdAt"]
+    )
+  """
+  The Colony to which the streaming payment belongs
+  """
+  colony: Colony! @belongsTo(fields: ["colonyId"])
   nativeId: Int!
   createdAt: AWSDateTime!
   recipientAddress: String!

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=392da336899d6aef79f590fd790a5fd84d15f299
+ENV BLOCK_INGESTOR_HASH=8ebe23196c06a36625434bc3ef85da6fc8d0a6e9
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.tsx
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.tsx
@@ -112,10 +112,6 @@ const ExpenditureDetailsPage = () => {
     return <div>Loading expenditure...</div>;
   }
 
-  if (!data) {
-    return null;
-  }
-
   if (!expenditure) {
     return (
       <div>

--- a/src/components/common/Expenditures/ExpenditureForm/CreateExpenditure/AdvancedPaymentForm.tsx
+++ b/src/components/common/Expenditures/ExpenditureForm/CreateExpenditure/AdvancedPaymentForm.tsx
@@ -9,6 +9,7 @@ import { findDomainByNativeId } from '~utils/domains';
 import { CreateExpenditurePayload } from '~redux/sagas/expenditures/createExpenditure';
 import Button from '~shared/Button';
 import StakeExpenditureDialog from '~common/Expenditures/StakedExpenditure/StakeExpenditureDialog';
+import { TEMP_convertEthToWei } from '~utils/expenditures';
 
 import CreateExpenditureForm from './CreateExpenditureForm';
 import { AdvancedPaymentFormFields } from '../ExpenditureFormFields';
@@ -38,7 +39,10 @@ const AdvancedPaymentForm = () => {
         colony,
         createdInDomain: findDomainByNativeId(payload.createInDomainId, colony),
         fundFromDomainId: payload.fundFromDomainId,
-        payouts: payload.payouts,
+        payouts: payload.payouts.map((payout) => ({
+          ...payout,
+          amount: TEMP_convertEthToWei(payout.amount).toString(),
+        })),
       } as CreateExpenditurePayload;
     }),
     withMeta({ navigate }),

--- a/src/components/common/Expenditures/ExpenditureForm/CreateExpenditure/StreamingPaymentForm.tsx
+++ b/src/components/common/Expenditures/ExpenditureForm/CreateExpenditure/StreamingPaymentForm.tsx
@@ -16,6 +16,7 @@ import {
 } from '~gql';
 import ForceToggle from '~shared/Dialog/DialogHeading/ForceToggle';
 import { notNull } from '~utils/arrays';
+import { TEMP_convertEthToWei } from '~utils/expenditures';
 
 import { StreamingPaymentFormValues } from '../types';
 import { StreamingPaymentFormFields } from '../ExpenditureFormFields';
@@ -51,7 +52,8 @@ const StreamingPaymentForm = () => {
           ),
           recipientAddress: payload.recipientAddress,
           tokenAddress: payload.tokenAddress,
-          amount: payload.amount,
+          // @TODO: This should get the token decimals of the selected token
+          amount: TEMP_convertEthToWei(payload.amount).toString(),
           startTime: getTimestampFromCleaveDateAndTime(
             payload.startDate,
             payload.startTime,
@@ -65,7 +67,9 @@ const StreamingPaymentForm = () => {
               : undefined,
           interval: payload.interval,
           endCondition: payload.endCondition,
-          limitAmount: payload.limitAmount,
+          limitAmount: payload.limitAmount
+            ? TEMP_convertEthToWei(payload.limitAmount).toString()
+            : undefined,
         } as CreateStreamingPaymentPayload),
     ),
   );

--- a/src/components/common/Expenditures/ExpenditureForm/CreateExpenditure/StreamingPaymentForm.tsx
+++ b/src/components/common/Expenditures/ExpenditureForm/CreateExpenditure/StreamingPaymentForm.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import { Id } from '@colony/colony-js';
 import { format, addMonths } from 'date-fns';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import { ActionTypes } from '~redux';
 import { useColonyContext, useEnabledExtensions } from '~hooks';
 import Button from '~shared/Button';
-import { mapPayload, pipe } from '~utils/actions';
+import { mapPayload, pipe, withMeta } from '~utils/actions';
 import { CreateStreamingPaymentPayload } from '~redux/sagas/expenditures/createStreamingPayment';
 import { findDomainByNativeId } from '~utils/domains';
 import {
@@ -21,12 +21,12 @@ import { TEMP_convertEthToWei } from '~utils/expenditures';
 import { StreamingPaymentFormValues } from '../types';
 import { StreamingPaymentFormFields } from '../ExpenditureFormFields';
 import { getTimestampFromCleaveDateAndTime } from '../helpers';
-
 import CreateExpenditureForm from './CreateExpenditureForm';
 
 import styles from '../ExpenditureForm.module.css';
 
 const StreamingPaymentForm = () => {
+  const navigate = useNavigate();
   const { colony } = useColonyContext();
   const [isForce, setIsForce] = useState(false);
   const { data, loading } = useGetMotionsByActionTypeQuery({
@@ -45,7 +45,7 @@ const StreamingPaymentForm = () => {
     mapPayload(
       (payload: StreamingPaymentFormValues) =>
         ({
-          colonyAddress: colony.colonyAddress,
+          colony,
           createdInDomain: findDomainByNativeId(
             payload.createInDomainId,
             colony,
@@ -72,6 +72,7 @@ const StreamingPaymentForm = () => {
             : undefined,
         } as CreateStreamingPaymentPayload),
     ),
+    withMeta({ navigate }),
   );
 
   const nowDate = new Date();

--- a/src/components/common/Expenditures/ExpenditureForm/EditExpenditure/EditExpenditureForm.tsx
+++ b/src/components/common/Expenditures/ExpenditureForm/EditExpenditure/EditExpenditureForm.tsx
@@ -5,6 +5,7 @@ import { Colony, Expenditure } from '~types';
 import { ActionTypes } from '~redux';
 import { mapPayload, pipe, withMeta } from '~utils/actions';
 import Button from '~shared/Button';
+import { TEMP_convertEthToWei } from '~utils/expenditures';
 
 import { AdvancedPaymentFormFields } from '../ExpenditureFormFields';
 import {
@@ -32,7 +33,10 @@ const EditExpenditureForm = ({
     mapPayload((payload: AdvancedPaymentFormValues) => ({
       colonyAddress: colony.colonyAddress,
       expenditure,
-      payouts: payload.payouts,
+      payouts: payload.payouts.map((payout) => ({
+        ...payout,
+        amount: TEMP_convertEthToWei(payout.amount).toString(),
+      })),
     })),
     withMeta({}),
   );

--- a/src/components/common/Expenditures/ExpenditureForm/helpers.ts
+++ b/src/components/common/Expenditures/ExpenditureForm/helpers.ts
@@ -2,6 +2,7 @@ import { weiToEth } from '@web3-onboard/common';
 import { BigNumber } from 'ethers';
 
 import { Expenditure } from '~types';
+import { TEMP_convertEthToWei } from '~utils/expenditures';
 
 import {
   ExpenditurePayoutFieldValue,
@@ -44,7 +45,7 @@ export const getStagedExpenditurePayouts = (
   payload.stages.map((stage) => ({
     recipientAddress: payload.recipientAddress ?? '',
     tokenAddress: stage.tokenAddress,
-    amount: stage.amount,
+    amount: TEMP_convertEthToWei(stage.amount).toString(),
     claimDelay: 0,
   }));
 

--- a/src/components/common/Expenditures/Expenditures.tsx
+++ b/src/components/common/Expenditures/Expenditures.tsx
@@ -3,12 +3,17 @@ import { Route, Routes } from 'react-router-dom';
 
 import ExpendituresPage from './ExpendituresPage';
 import ExpenditureDetailsPage from './ExpenditureDetailsPage';
+import StreamingPaymentDetailsPage from './StreamingPaymentDetailsPage';
 
 const Expenditures = () => {
   return (
     <Routes>
       <Route path="/" element={<ExpendituresPage />} />
       <Route path="/:expenditureId" element={<ExpenditureDetailsPage />} />
+      <Route
+        path="/streaming/:streamingPaymentId"
+        element={<StreamingPaymentDetailsPage />}
+      />
     </Routes>
   );
 };

--- a/src/components/common/Expenditures/ExpendituresPage/ExpendituresList.tsx
+++ b/src/components/common/Expenditures/ExpendituresPage/ExpendituresList.tsx
@@ -45,7 +45,7 @@ const ExpendituresList = ({ colony }: ExpendituresListProps) => {
           .map((streamingPayment) => (
             <li key={streamingPayment.id}>
               <Link
-                to={`/colony/${colony.name}/expenditures/${streamingPayment.nativeId}`}
+                to={`/colony/${colony.name}/expenditures/streaming/${streamingPayment.nativeId}`}
               >
                 Streaming Payment ID: {streamingPayment.nativeId}
               </Link>

--- a/src/components/common/Expenditures/ExpendituresPage/ExpendituresList.tsx
+++ b/src/components/common/Expenditures/ExpendituresPage/ExpendituresList.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import { useGetColonyExpendituresQuery } from '~gql';
+import { Heading4 } from '~shared/Heading';
+import Link from '~shared/Link';
+import { Colony } from '~types';
+import { notNull } from '~utils/arrays';
+
+import styles from './ExpendituresPage.module.css';
+
+interface ExpendituresListProps {
+  colony: Colony;
+}
+
+const ExpendituresList = ({ colony }: ExpendituresListProps) => {
+  const { data, loading } = useGetColonyExpendituresQuery({
+    variables: {
+      colonyAddress: colony?.colonyAddress ?? '',
+    },
+    skip: !colony,
+  });
+
+  return (
+    <div className={styles.listWrapper}>
+      {loading && <div>Loading expenditures...</div>}
+      <Heading4 appearance={{ margin: 'none' }}>Expenditures</Heading4>
+      <ul>
+        {data?.getColony?.expenditures?.items
+          .filter(notNull)
+          .map((expenditure) => (
+            <li key={expenditure.id}>
+              <Link
+                to={`/colony/${colony.name}/expenditures/${expenditure.nativeId}`}
+              >
+                Expenditure ID: {expenditure.nativeId}
+              </Link>
+            </li>
+          ))}
+      </ul>
+
+      <Heading4 appearance={{ margin: 'none' }}>Streaming Payments</Heading4>
+      <ul>
+        {data?.getColony?.streamingPayments?.items
+          .filter(notNull)
+          .map((streamingPayment) => (
+            <li key={streamingPayment.id}>
+              <Link
+                to={`/colony/${colony.name}/expenditures/${streamingPayment.nativeId}`}
+              >
+                Streaming Payment ID: {streamingPayment.nativeId}
+              </Link>
+            </li>
+          ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ExpendituresList;

--- a/src/components/common/Expenditures/ExpendituresPage/ExpendituresPage.module.css
+++ b/src/components/common/Expenditures/ExpendituresPage/ExpendituresPage.module.css
@@ -4,3 +4,9 @@
   padding-top: 20px;
   gap: 20px;
 }
+
+.listWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}

--- a/src/components/common/Expenditures/ExpendituresPage/ExpendituresPage.module.css.d.ts
+++ b/src/components/common/Expenditures/ExpendituresPage/ExpendituresPage.module.css.d.ts
@@ -1,5 +1,6 @@
 declare namespace ExpendituresPageModuleCssNamespace {
   export interface IExpendituresPageModuleCss {
+    listWrapper: string;
     pageWrapper: string;
   }
 }

--- a/src/components/common/Expenditures/ExpendituresPage/ExpendituresPage.tsx
+++ b/src/components/common/Expenditures/ExpendituresPage/ExpendituresPage.tsx
@@ -1,25 +1,15 @@
 import React from 'react';
 
 import { Heading3 } from '~shared/Heading';
-import { useGetColonyExpendituresQuery } from '~gql';
 import { useColonyContext } from '~hooks';
-import { notNull } from '~utils/arrays';
-import Link from '~shared/Link';
 
-// import { CreateExpenditureForm } from '../ExpenditureForm';
 import CreateExpenditure from '../ExpenditureForm/CreateExpenditure';
+import ExpendituresList from './ExpendituresList';
 
 import styles from './ExpendituresPage.module.css';
 
 const ExpendituresPage = () => {
   const { colony } = useColonyContext();
-
-  const { data, loading } = useGetColonyExpendituresQuery({
-    variables: {
-      colonyAddress: colony?.colonyAddress ?? '',
-    },
-    skip: !colony,
-  });
 
   if (!colony) {
     return null;
@@ -27,20 +17,7 @@ const ExpendituresPage = () => {
 
   return (
     <div className={styles.pageWrapper}>
-      <ul>
-        {loading && <div>Loading expenditures...</div>}
-        {data?.getColony?.expenditures?.items
-          .filter(notNull)
-          .map((expenditure) => (
-            <li key={expenditure.id}>
-              <Link
-                to={`/colony/${colony.name}/expenditures/${expenditure.nativeId}`}
-              >
-                Expenditure ID: {expenditure.nativeId}
-              </Link>
-            </li>
-          ))}
-      </ul>
+      <ExpendituresList colony={colony} />
 
       <div>
         <Heading3>Create new expenditure</Heading3>

--- a/src/components/common/Expenditures/StakedExpenditure/CancelStakedExpenditureButton/CancelStakedExpenditureDialog/CancelStakedExpenditureDialog.tsx
+++ b/src/components/common/Expenditures/StakedExpenditure/CancelStakedExpenditureButton/CancelStakedExpenditureDialog/CancelStakedExpenditureDialog.tsx
@@ -1,8 +1,8 @@
 import { Extension, Id } from '@colony/colony-js';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 
+import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { useExtensionData } from '~hooks';
 import { ActionTypes } from '~redux';
 import Button from '~shared/Button';

--- a/src/components/common/Expenditures/StreamingPaymentDetailsPage/StreamingPaymentDetailsPage.module.css
+++ b/src/components/common/Expenditures/StreamingPaymentDetailsPage/StreamingPaymentDetailsPage.module.css
@@ -1,0 +1,6 @@
+.details {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 20px;
+}

--- a/src/components/common/Expenditures/StreamingPaymentDetailsPage/StreamingPaymentDetailsPage.module.css
+++ b/src/components/common/Expenditures/StreamingPaymentDetailsPage/StreamingPaymentDetailsPage.module.css
@@ -4,3 +4,12 @@
   align-items: flex-start;
   gap: 20px;
 }
+
+.payoutsContainer {
+  margin-top: 20px;
+}
+
+.payout {
+  display: flex;
+  gap: 10px;
+}

--- a/src/components/common/Expenditures/StreamingPaymentDetailsPage/StreamingPaymentDetailsPage.tsx
+++ b/src/components/common/Expenditures/StreamingPaymentDetailsPage/StreamingPaymentDetailsPage.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { useGetStreamingPaymentQuery } from '~gql';
+import { useColonyContext } from '~hooks';
+import { Heading3 } from '~shared/Heading';
+import { getExpenditureDatabaseId } from '~utils/databaseId';
+import { findDomainByNativeId } from '~utils/domains';
+
+const StreamingPaymentDetailsPage = () => {
+  const { streamingPaymentId } = useParams();
+
+  const { colony } = useColonyContext();
+  const { colonyAddress = '' } = colony || {};
+
+  const { data, loading } = useGetStreamingPaymentQuery({
+    variables: {
+      streamingPaymentId: getExpenditureDatabaseId(
+        colonyAddress,
+        Number(streamingPaymentId),
+      ),
+    },
+    skip: !streamingPaymentId,
+  });
+  const streamingPayment = data?.getStreamingPayment;
+
+  if (!colony) {
+    return null;
+  }
+
+  if (loading) {
+    return <div>Loading expenditure...</div>;
+  }
+
+  if (!streamingPayment) {
+    return (
+      <div>
+        This streaming payment does not exist in the database but a page refresh
+        might help.
+      </div>
+    );
+  }
+
+  const streamingPaymentDomain = findDomainByNativeId(
+    streamingPayment.nativeDomainId,
+    colony,
+  );
+
+  return (
+    <div>
+      <Heading3>Streaming payment {streamingPayment.id}</Heading3>
+
+      <div>
+        <div>Recipient address: {streamingPayment.recipientAddress}</div>
+        <div>
+          Created in: {streamingPaymentDomain?.metadata?.name ?? 'Unknown team'}
+        </div>
+        <div>
+          Start time:{' '}
+          {new Date(streamingPayment.startTime * 1000).toISOString()}
+        </div>
+        <div>
+          End time: {new Date(streamingPayment.endTime * 1000).toISOString()}
+        </div>
+        <div>Interval: {streamingPayment.interval}</div>
+        <div>Metadata: {JSON.stringify(streamingPayment.metadata)}</div>
+      </div>
+    </div>
+  );
+};
+
+export default StreamingPaymentDetailsPage;

--- a/src/components/common/Expenditures/StreamingPaymentDetailsPage/StreamingPaymentDetailsPage.tsx
+++ b/src/components/common/Expenditures/StreamingPaymentDetailsPage/StreamingPaymentDetailsPage.tsx
@@ -1,3 +1,4 @@
+import { weiToEth } from '@web3-onboard/common';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -6,6 +7,8 @@ import { useColonyContext } from '~hooks';
 import { Heading3 } from '~shared/Heading';
 import { getExpenditureDatabaseId } from '~utils/databaseId';
 import { findDomainByNativeId } from '~utils/domains';
+
+import styles from './StreamingPaymentDetailsPage.module.css';
 
 const StreamingPaymentDetailsPage = () => {
   const { streamingPaymentId } = useParams();
@@ -50,11 +53,19 @@ const StreamingPaymentDetailsPage = () => {
     <div>
       <Heading3>Streaming payment {streamingPayment.id}</Heading3>
 
-      <div>
+      <div className={styles.details}>
         <div>Recipient address: {streamingPayment.recipientAddress}</div>
         <div>
           Created in: {streamingPaymentDomain?.metadata?.name ?? 'Unknown team'}
         </div>
+        <div>
+          End condition: {streamingPayment.metadata?.endCondition ?? 'Unknown'}
+        </div>
+        {streamingPayment.metadata?.limitAmount && (
+          <div>
+            Limit amount: {weiToEth(streamingPayment.metadata?.limitAmount)}
+          </div>
+        )}
         <div>
           Start time:{' '}
           {new Date(streamingPayment.startTime * 1000).toISOString()}
@@ -62,8 +73,7 @@ const StreamingPaymentDetailsPage = () => {
         <div>
           End time: {new Date(streamingPayment.endTime * 1000).toISOString()}
         </div>
-        <div>Interval: {streamingPayment.interval}</div>
-        <div>Metadata: {JSON.stringify(streamingPayment.metadata)}</div>
+        <div>Interval: {streamingPayment.interval}s</div>
       </div>
     </div>
   );

--- a/src/components/common/Expenditures/StreamingPaymentDetailsPage/StreamingPaymentDetailsPage.tsx
+++ b/src/components/common/Expenditures/StreamingPaymentDetailsPage/StreamingPaymentDetailsPage.tsx
@@ -8,6 +8,8 @@ import { Heading3 } from '~shared/Heading';
 import { getExpenditureDatabaseId } from '~utils/databaseId';
 import { findDomainByNativeId } from '~utils/domains';
 
+import StreamingPaymentPayouts from './StreamingPaymentPayouts';
+
 import styles from './StreamingPaymentDetailsPage.module.css';
 
 const StreamingPaymentDetailsPage = () => {
@@ -75,6 +77,8 @@ const StreamingPaymentDetailsPage = () => {
         </div>
         <div>Interval: {streamingPayment.interval}s</div>
       </div>
+
+      <StreamingPaymentPayouts streamingPayment={streamingPayment} />
     </div>
   );
 };

--- a/src/components/common/Expenditures/StreamingPaymentDetailsPage/StreamingPaymentPayouts/StreamingPaymentPayouts.tsx
+++ b/src/components/common/Expenditures/StreamingPaymentDetailsPage/StreamingPaymentPayouts/StreamingPaymentPayouts.tsx
@@ -1,0 +1,39 @@
+import { weiToEth } from '@web3-onboard/common';
+import React from 'react';
+
+import MaskedAddress from '~shared/MaskedAddress';
+import { StreamingPayment } from '~types';
+
+import styles from '../StreamingPaymentDetailsPage.module.css';
+
+interface StreamingPaymentPayoutsProps {
+  streamingPayment: StreamingPayment;
+}
+
+const StreamingPaymentPayouts = ({
+  streamingPayment,
+}: StreamingPaymentPayoutsProps) => {
+  return (
+    <div className={styles.payoutsContainer}>
+      <div>Payouts</div>
+      <ul>
+        {streamingPayment.payouts?.map((payout) => (
+          <li key={payout.tokenAddress} className={styles.payout}>
+            <div>
+              <div>Token address</div>
+              <div>
+                <MaskedAddress address={payout.tokenAddress} />
+              </div>
+            </div>
+            <div>
+              <div>Amount</div>
+              <div>{weiToEth(payout.amount)}</div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default StreamingPaymentPayouts;

--- a/src/components/common/Expenditures/StreamingPaymentDetailsPage/StreamingPaymentPayouts/index.ts
+++ b/src/components/common/Expenditures/StreamingPaymentDetailsPage/StreamingPaymentPayouts/index.ts
@@ -1,0 +1,1 @@
+export { default } from './StreamingPaymentPayouts';

--- a/src/components/common/Expenditures/StreamingPaymentDetailsPage/index.ts
+++ b/src/components/common/Expenditures/StreamingPaymentDetailsPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './StreamingPaymentDetailsPage';

--- a/src/graphql/fragments/expenditures.graphql
+++ b/src/graphql/fragments/expenditures.graphql
@@ -54,6 +54,22 @@ fragment ExpenditureStage on ExpenditureStage {
   isReleased
 }
 
+fragment StreamingPayment on StreamingPayment {
+  id
+  nativeId
+  recipientAddress
+  nativeDomainId
+  startTime
+  endTime
+  interval
+  payouts {
+    ...ExpenditurePayout
+  }
+  metadata {
+    ...StreamingPaymentMetadata
+  }
+}
+
 fragment StreamingPaymentMetadata on StreamingPaymentMetadata {
   endCondition
   limitAmount

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -7267,6 +7267,8 @@ export type ExpenditurePayoutFragment = { __typename?: 'ExpenditurePayout', toke
 
 export type ExpenditureStageFragment = { __typename?: 'ExpenditureStage', slotId: number, name: string, isReleased: boolean };
 
+export type StreamingPaymentFragment = { __typename?: 'StreamingPayment', id: string, nativeId: number, recipientAddress: string, nativeDomainId: number, startTime: number, endTime: number, interval: string, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string, isClaimed: boolean }> | null, metadata?: { __typename?: 'StreamingPaymentMetadata', endCondition: StreamingPaymentEndCondition, limitAmount?: string | null } | null };
+
 export type StreamingPaymentMetadataFragment = { __typename?: 'StreamingPaymentMetadata', endCondition: StreamingPaymentEndCondition, limitAmount?: string | null };
 
 export type ExtensionFragment = { __typename?: 'ColonyExtension', hash: string, installedBy: string, installedAt: number, isDeprecated: boolean, isDeleted: boolean, isInitialized: boolean, address: string, colonyAddress: string, currentVersion: number, params?: { __typename?: 'ExtensionParams', votingReputation?: { __typename?: 'VotingReputationParams', maxVoteFraction: string, totalStakeFraction: string, voterRewardFraction: string, userMinStakeFraction: string, stakePeriod: string, submitPeriod: string, revealPeriod: string, escalationPeriod: string } | null, stakedExpenditure?: { __typename?: 'StakedExpenditureParams', stakeFraction: string } | null } | null };
@@ -7580,6 +7582,13 @@ export type GetExpenditureQueryVariables = Exact<{
 
 
 export type GetExpenditureQuery = { __typename?: 'Query', getExpenditure?: { __typename?: 'Expenditure', id: string, nativeId: number, ownerAddress: string, status: ExpenditureStatus, nativeFundingPotId: number, nativeDomainId: number, finalizedAt?: number | null, hasReclaimedStake?: boolean | null, type: ExpenditureType, isStaked: boolean, isStakeForfeited?: boolean | null, slots: Array<{ __typename?: 'ExpenditureSlot', id: number, recipientAddress?: string | null, claimDelay?: number | null, payoutModifier?: number | null, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string, isClaimed: boolean }> | null }>, metadata?: { __typename?: 'ExpenditureMetadata', fundFromDomainNativeId: number, stakeAmount?: string | null, stages?: Array<{ __typename?: 'ExpenditureStage', slotId: number, name: string, isReleased: boolean }> | null } | null, balances?: Array<{ __typename?: 'ExpenditureBalance', tokenAddress: string, amount: string, requiredAmount: string }> | null, motions?: { __typename?: 'ModelColonyMotionConnection', items: Array<{ __typename?: 'ColonyMotion', remainingStakes: Array<string>, userMinStake: string, requiredStake: string, rootHash: string, nativeMotionDomainId: string, isFinalized: boolean, skillRep: string, repSubmitted: string, hasObjection: boolean, isDecision: boolean, gasEstimate: string, transactionHash: string, databaseMotionId: string, motionId: string, motionStakes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } }, usersStakes: Array<{ __typename?: 'UserStakes', address: string, stakes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } } }>, motionDomain: { __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, nativeSkillId: number, reputation?: string | null, reputationPercentage?: string | null, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null }, stakerRewards: Array<{ __typename?: 'StakerRewards', address: string, isClaimed: boolean, rewards: { __typename?: 'MotionStakeValues', yay: string, nay: string } }>, voterRecord: Array<{ __typename?: 'VoterRecord', address: string, voteCount: string, vote?: number | null }>, revealedVotes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } }, motionStateHistory: { __typename?: 'MotionStateHistory', hasVoted: boolean, hasPassed: boolean, hasFailed: boolean, hasFailedNotFinalizable: boolean, inRevealPhase: boolean }, messages?: { __typename?: 'ModelMotionMessageConnection', items: Array<{ __typename?: 'MotionMessage', initiatorAddress: string, name: string, messageKey: string, vote?: string | null, amount?: string | null, initiatorUser?: { __typename?: 'User', walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, displayNameChanged?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null, meta?: { __typename?: 'ProfileMetadata', emailPermissions: Array<string>, metatransactionsEnabled?: boolean | null, decentralizedModeEnabled?: boolean | null, customRpc?: string | null } | null } | null, watchlist?: { __typename?: 'ModelWatchedColoniesConnection', items: Array<{ __typename?: 'WatchedColonies', id: string, createdAt: string, colony: { __typename?: 'Colony', name: string, colonyAddress: string, chainMetadata: { __typename?: 'ChainMetadata', chainId: number }, metadata?: { __typename?: 'ColonyMetadata', displayName: string, avatar?: string | null, description?: string | null, thumbnail?: string | null, isWhitelistActivated?: boolean | null, whitelistedAddresses?: Array<string> | null, externalLinks?: Array<{ __typename?: 'ExternalLink', name: ExternalLinks, link: string }> | null, changelog?: Array<{ __typename?: 'ColonyMetadataChangelog', transactionHash: string, newDisplayName: string, oldDisplayName: string, hasAvatarChanged: boolean, hasWhitelistChanged: boolean, haveTokensChanged: boolean, hasDescriptionChanged?: boolean | null, haveExternalLinksChanged?: boolean | null }> | null } | null } } | null> } | null } | null } | null> } | null, objectionAnnotation?: { __typename?: 'Annotation', createdAt: string, message: string } | null, action?: { __typename?: 'ColonyAction', type: ColonyActionType } | null } | null> } | null } | null };
+
+export type GetStreamingPaymentQueryVariables = Exact<{
+  streamingPaymentId: Scalars['ID'];
+}>;
+
+
+export type GetStreamingPaymentQuery = { __typename?: 'Query', getStreamingPayment?: { __typename?: 'StreamingPayment', id: string, nativeId: number, recipientAddress: string, nativeDomainId: number, startTime: number, endTime: number, interval: string, payouts?: Array<{ __typename?: 'ExpenditurePayout', tokenAddress: string, amount: string, isClaimed: boolean }> | null, metadata?: { __typename?: 'StreamingPaymentMetadata', endCondition: StreamingPaymentEndCondition, limitAmount?: string | null } | null } | null };
 
 export type GetColonyExtensionsByColonyAddressQueryVariables = Exact<{
   colonyAddress: Scalars['ID'];
@@ -8429,6 +8438,24 @@ export const ExpenditureFragmentDoc = gql`
     ${ExpenditureSlotFragmentDoc}
 ${ExpenditureStageFragmentDoc}
 ${ColonyMotionFragmentDoc}`;
+export const StreamingPaymentFragmentDoc = gql`
+    fragment StreamingPayment on StreamingPayment {
+  id
+  nativeId
+  recipientAddress
+  nativeDomainId
+  startTime
+  endTime
+  interval
+  payouts {
+    ...ExpenditurePayout
+  }
+  metadata {
+    ...StreamingPaymentMetadata
+  }
+}
+    ${ExpenditurePayoutFragmentDoc}
+${StreamingPaymentMetadataFragmentDoc}`;
 export const UserTokenBalanceDataFragmentDoc = gql`
     fragment UserTokenBalanceData on GetUserTokenBalanceReturn {
   balance
@@ -9936,6 +9963,41 @@ export function useGetExpenditureLazyQuery(baseOptions?: Apollo.LazyQueryHookOpt
 export type GetExpenditureQueryHookResult = ReturnType<typeof useGetExpenditureQuery>;
 export type GetExpenditureLazyQueryHookResult = ReturnType<typeof useGetExpenditureLazyQuery>;
 export type GetExpenditureQueryResult = Apollo.QueryResult<GetExpenditureQuery, GetExpenditureQueryVariables>;
+export const GetStreamingPaymentDocument = gql`
+    query GetStreamingPayment($streamingPaymentId: ID!) {
+  getStreamingPayment(id: $streamingPaymentId) {
+    ...StreamingPayment
+  }
+}
+    ${StreamingPaymentFragmentDoc}`;
+
+/**
+ * __useGetStreamingPaymentQuery__
+ *
+ * To run a query within a React component, call `useGetStreamingPaymentQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetStreamingPaymentQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetStreamingPaymentQuery({
+ *   variables: {
+ *      streamingPaymentId: // value for 'streamingPaymentId'
+ *   },
+ * });
+ */
+export function useGetStreamingPaymentQuery(baseOptions: Apollo.QueryHookOptions<GetStreamingPaymentQuery, GetStreamingPaymentQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetStreamingPaymentQuery, GetStreamingPaymentQueryVariables>(GetStreamingPaymentDocument, options);
+      }
+export function useGetStreamingPaymentLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetStreamingPaymentQuery, GetStreamingPaymentQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetStreamingPaymentQuery, GetStreamingPaymentQueryVariables>(GetStreamingPaymentDocument, options);
+        }
+export type GetStreamingPaymentQueryHookResult = ReturnType<typeof useGetStreamingPaymentQuery>;
+export type GetStreamingPaymentLazyQueryHookResult = ReturnType<typeof useGetStreamingPaymentLazyQuery>;
+export type GetStreamingPaymentQueryResult = Apollo.QueryResult<GetStreamingPaymentQuery, GetStreamingPaymentQueryVariables>;
 export const GetColonyExtensionsByColonyAddressDocument = gql`
     query GetColonyExtensionsByColonyAddress($colonyAddress: ID!) {
   getExtensionByColonyAndHash(colonyId: $colonyAddress) {

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -138,6 +138,7 @@ export type Colony = {
   roles?: Maybe<ModelColonyRoleConnection>;
   /** Status information for the Colony */
   status?: Maybe<ColonyStatus>;
+  streamingPayments?: Maybe<ModelStreamingPaymentConnection>;
   tokens?: Maybe<ModelColonyTokensConnection>;
   /** Type of the Colony (Regular or Metacolony) */
   type?: Maybe<ColonyType>;
@@ -199,6 +200,16 @@ export type ColonyFundsClaimsArgs = {
 /** Represents a Colony within the Colony Network */
 export type ColonyRolesArgs = {
   filter?: InputMaybe<ModelColonyRoleFilterInput>;
+  limit?: InputMaybe<Scalars['Int']>;
+  nextToken?: InputMaybe<Scalars['String']>;
+  sortDirection?: InputMaybe<ModelSortDirection>;
+};
+
+
+/** Represents a Colony within the Colony Network */
+export type ColonyStreamingPaymentsArgs = {
+  createdAt?: InputMaybe<ModelStringKeyConditionInput>;
+  filter?: InputMaybe<ModelStreamingPaymentFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
   nextToken?: InputMaybe<Scalars['String']>;
   sortDirection?: InputMaybe<ModelSortDirection>;
@@ -362,7 +373,7 @@ export enum ColonyActionType {
   CreateDomain = 'CREATE_DOMAIN',
   /** An action related to creating a domain within a Colony via a motion */
   CreateDomainMotion = 'CREATE_DOMAIN_MOTION',
-  /** An action related to the creation of a motion to start a streaming payment.  */
+  /** An action related to the creation of a motion to start a streaming payment. */
   CreateStreamingPaymentMotion = 'CREATE_STREAMING_PAYMENT_MOTION',
   /** An action related to editing a domain's details */
   EditDomain = 'EDIT_DOMAIN',
@@ -1290,6 +1301,7 @@ export type CreateReputationMiningCycleMetadataInput = {
 };
 
 export type CreateStreamingPaymentInput = {
+  colonyId: Scalars['ID'];
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
   endTime: Scalars['AWSTimestamp'];
   id?: InputMaybe<Scalars['ID']>;
@@ -2990,6 +3002,7 @@ export enum ModelSortDirection {
 
 export type ModelStreamingPaymentConditionInput = {
   and?: InputMaybe<Array<InputMaybe<ModelStreamingPaymentConditionInput>>>;
+  colonyId?: InputMaybe<ModelIdInput>;
   createdAt?: InputMaybe<ModelStringInput>;
   endTime?: InputMaybe<ModelIntInput>;
   interval?: InputMaybe<ModelStringInput>;
@@ -3014,6 +3027,7 @@ export type ModelStreamingPaymentEndConditionInput = {
 
 export type ModelStreamingPaymentFilterInput = {
   and?: InputMaybe<Array<InputMaybe<ModelStreamingPaymentFilterInput>>>;
+  colonyId?: InputMaybe<ModelIdInput>;
   createdAt?: InputMaybe<ModelStringInput>;
   endTime?: InputMaybe<ModelIntInput>;
   id?: InputMaybe<ModelIdInput>;
@@ -3433,6 +3447,7 @@ export type ModelSubscriptionReputationMiningCycleMetadataFilterInput = {
 
 export type ModelSubscriptionStreamingPaymentFilterInput = {
   and?: InputMaybe<Array<InputMaybe<ModelSubscriptionStreamingPaymentFilterInput>>>;
+  colonyId?: InputMaybe<ModelSubscriptionIdInput>;
   createdAt?: InputMaybe<ModelSubscriptionStringInput>;
   endTime?: InputMaybe<ModelSubscriptionIntInput>;
   id?: InputMaybe<ModelSubscriptionIdInput>;
@@ -4829,6 +4844,7 @@ export type Query = {
   getRoleByTargetAddressAndColony?: Maybe<ModelColonyRoleConnection>;
   getStreamingPayment?: Maybe<StreamingPayment>;
   getStreamingPaymentMetadata?: Maybe<StreamingPaymentMetadata>;
+  getStreamingPaymentsByColony?: Maybe<ModelStreamingPaymentConnection>;
   getToken?: Maybe<Token>;
   getTokenByAddress?: Maybe<ModelTokenConnection>;
   /** Fetch a token's information. Tries to get the data from the DB first, if that fails, resolves to get data from chain */
@@ -5333,6 +5349,17 @@ export type QueryGetStreamingPaymentMetadataArgs = {
 
 
 /** Root query type */
+export type QueryGetStreamingPaymentsByColonyArgs = {
+  colonyId: Scalars['ID'];
+  createdAt?: InputMaybe<ModelStringKeyConditionInput>;
+  filter?: InputMaybe<ModelStreamingPaymentFilterInput>;
+  limit?: InputMaybe<Scalars['Int']>;
+  nextToken?: InputMaybe<Scalars['String']>;
+  sortDirection?: InputMaybe<ModelSortDirection>;
+};
+
+
+/** Root query type */
 export type QueryGetTokenArgs = {
   id: Scalars['ID'];
 };
@@ -5775,6 +5802,10 @@ export type StakerRewardsInput = {
 
 export type StreamingPayment = {
   __typename?: 'StreamingPayment';
+  /** The Colony to which the streaming payment belongs */
+  colony: Colony;
+  /** Colony ID (address) to which the streaming payment belongs */
+  colonyId: Scalars['ID'];
   createdAt: Scalars['AWSDateTime'];
   endTime: Scalars['AWSTimestamp'];
   id: Scalars['ID'];
@@ -6892,6 +6923,7 @@ export type UpdateReputationMiningCycleMetadataInput = {
 };
 
 export type UpdateStreamingPaymentInput = {
+  colonyId?: InputMaybe<Scalars['ID']>;
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
   endTime?: InputMaybe<Scalars['AWSTimestamp']>;
   id: Scalars['ID'];
@@ -7540,7 +7572,7 @@ export type GetColonyExpendituresQueryVariables = Exact<{
 }>;
 
 
-export type GetColonyExpendituresQuery = { __typename?: 'Query', getColony?: { __typename?: 'Colony', id: string, expenditures?: { __typename?: 'ModelExpenditureConnection', items: Array<{ __typename?: 'Expenditure', id: string, nativeId: number } | null> } | null } | null };
+export type GetColonyExpendituresQuery = { __typename?: 'Query', getColony?: { __typename?: 'Colony', id: string, expenditures?: { __typename?: 'ModelExpenditureConnection', items: Array<{ __typename?: 'Expenditure', id: string, nativeId: number } | null> } | null, streamingPayments?: { __typename?: 'ModelStreamingPaymentConnection', items: Array<{ __typename?: 'StreamingPayment', id: string, nativeId: number } | null> } | null } | null };
 
 export type GetExpenditureQueryVariables = Exact<{
   expenditureId: Scalars['ID'];
@@ -9827,6 +9859,12 @@ export const GetColonyExpendituresDocument = gql`
   getColony(id: $colonyAddress) {
     id
     expenditures {
+      items {
+        id
+        nativeId
+      }
+    }
+    streamingPayments {
       items {
         id
         nativeId

--- a/src/graphql/queries/expenditures.graphql
+++ b/src/graphql/queries/expenditures.graphql
@@ -7,6 +7,12 @@ query GetColonyExpenditures($colonyAddress: ID!) {
         nativeId
       }
     }
+    streamingPayments {
+      items {
+        id
+        nativeId
+      }
+    }
   }
 }
 

--- a/src/graphql/queries/expenditures.graphql
+++ b/src/graphql/queries/expenditures.graphql
@@ -21,3 +21,9 @@ query GetExpenditure($expenditureId: ID!) {
     ...Expenditure
   }
 }
+
+query GetStreamingPayment($streamingPaymentId: ID!) {
+  getStreamingPayment(id: $streamingPaymentId) {
+    ...StreamingPayment
+  }
+}

--- a/src/redux/sagas/expenditures/createStreamingPayment.ts
+++ b/src/redux/sagas/expenditures/createStreamingPayment.ts
@@ -37,7 +37,7 @@ const TIMESTAMP_IN_FUTURE = 2_000_000_000;
 
 function* createStreamingPayment({
   payload: {
-    colonyAddress,
+    colony: { colonyAddress, name: colonyName },
     createdInDomain,
     recipientAddress,
     tokenAddress,
@@ -49,7 +49,7 @@ function* createStreamingPayment({
     limitAmount,
   },
   meta,
-  meta: { setTxHash },
+  meta: { setTxHash, navigate },
 }: Action<ActionTypes.STREAMING_PAYMENT_CREATE>) {
   const apolloClient = getContext(ContextModule.ApolloClient);
 
@@ -132,11 +132,17 @@ function* createStreamingPayment({
       },
     });
 
-    window.history.replaceState(
-      {},
-      '',
-      `${window.location.origin}${window.location.pathname}?tx=${txHash}`,
-    );
+    if (navigate) {
+      navigate?.(
+        `/colony/${colonyName}/expenditures/streaming/${streamingPaymentId}`,
+      );
+    } else {
+      window.history.replaceState(
+        {},
+        '',
+        `${window.location.origin}${window.location.pathname}?tx=${txHash}`,
+      );
+    }
   } catch (error) {
     return yield putError(
       ActionTypes.STREAMING_PAYMENT_CREATE_ERROR,

--- a/src/redux/sagas/utils/expenditures.ts
+++ b/src/redux/sagas/utils/expenditures.ts
@@ -4,7 +4,6 @@ import {
   ExpenditurePayoutFieldValue,
   ExpenditureStageFieldValue,
 } from '~common/Expenditures/ExpenditureForm';
-import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { Expenditure, MethodParams } from '~types';
 import { ContextModule, getContext } from '~context';
 import {
@@ -70,12 +69,7 @@ export const getSetExpenditureValuesFunctionParams = (
     ),
     // 2-dimensional array mapping token addresses to amounts
     [...payoutsByTokenAddresses.values()].map((payoutsByTokenAddress) =>
-      payoutsByTokenAddress.map((payout) =>
-        BigNumber.from(payout.amount).mul(
-          // @TODO: This should get the token decimals of the selected token
-          BigNumber.from(10).pow(DEFAULT_TOKEN_DECIMALS),
-        ),
-      ),
+      payoutsByTokenAddress.map((payout) => payout.amount),
     ),
   ];
 };

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -171,7 +171,7 @@ export type ExpendituresActionTypes =
   | UniqueActionType<
       ActionTypes.STREAMING_PAYMENT_CREATE,
       {
-        colonyAddress: Address;
+        colony: Colony;
         createdInDomain: Domain;
         recipientAddress: Address;
         tokenAddress: Address;

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -36,6 +36,7 @@ import {
   ExpenditureFragment,
   ExpenditureSlotFragment,
   ExpenditurePayoutFragment,
+  StreamingPaymentFragment,
 } from '~gql';
 
 export type AnnotationType = AnnotationFragment;
@@ -133,3 +134,5 @@ export type Expenditure = ExpenditureFragment;
 export type ExpenditureSlot = ExpenditureSlotFragment;
 
 export type ExpenditurePayout = ExpenditurePayoutFragment;
+
+export type StreamingPayment = StreamingPaymentFragment;

--- a/src/utils/expenditures.ts
+++ b/src/utils/expenditures.ts
@@ -1,6 +1,7 @@
-import { BigNumber, BigNumberish } from 'ethers';
-import { DEFAULT_TOKEN_DECIMALS } from '~constants';
+import Decimal from 'decimal.js';
+import { BigNumber } from 'ethers';
 
+import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { Expenditure } from '~types';
 
 // Returns true if there's enough balance in the expenditure's funding pot to cover all payouts of all tokens
@@ -16,5 +17,5 @@ export const isExpenditureFunded = (expenditure: Expenditure) => {
  * Emphasising this is a temporary solution to convert ETH amount to WEI
  * using the default token decimals. The new UI should use the selected token decimals
  */
-export const TEMP_convertEthToWei = (amount: BigNumberish) =>
-  BigNumber.from(amount).mul(BigNumber.from(10).pow(DEFAULT_TOKEN_DECIMALS));
+export const TEMP_convertEthToWei = (amount: string) =>
+  new Decimal(amount).mul(10 ** DEFAULT_TOKEN_DECIMALS).toString();

--- a/src/utils/expenditures.ts
+++ b/src/utils/expenditures.ts
@@ -1,4 +1,5 @@
-import { BigNumber } from 'ethers';
+import { BigNumber, BigNumberish } from 'ethers';
+import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 
 import { Expenditure } from '~types';
 
@@ -10,3 +11,10 @@ export const isExpenditureFunded = (expenditure: Expenditure) => {
     ) ?? false
   );
 };
+
+/**
+ * Emphasising this is a temporary solution to convert ETH amount to WEI
+ * using the default token decimals. The new UI should use the selected token decimals
+ */
+export const TEMP_convertEthToWei = (amount: BigNumberish) =>
+  BigNumber.from(amount).mul(BigNumber.from(10).pow(DEFAULT_TOKEN_DECIMALS));


### PR DESCRIPTION
## Description

This PR adds a streaming payment details page which shows all the data we store in the DB:
<img width="724" alt="image" src="https://github.com/JoinColony/colonyCDapp/assets/112586815/e62602e3-73aa-4025-941c-91cf07e6f7b6">

You should get redirected to the streaming payment details page after creating a streaming payment.

Resolves #1106 
