### PR TITLE
Hot fix for broken QA env

### DIFF
--- a/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
+++ b/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
@@ -74,19 +74,6 @@
             "Timeout": 25
           }
         },
-        "LambdaUrl": {
-            "Type": "AWS::Lambda::Url",
-            "DependsOn": "LambdaFunction",
-            "Properties": {
-                "AuthType": "NONE",
-                "TargetFunctionArn": {
-                    "Fn::GetAtt": [
-                        "LambdaFunction",
-                        "Arn"
-                    ]
-                }
-            }
-        },
         "LambdaExecutionRole": {
             "Type": "AWS::IAM::Role",
             "Properties": {


### PR DESCRIPTION
QA is broken because we are trying to provision a lambda url via cloudformation but the aws amplify user doesnt have this permission. 

The commit that adds this is reverted until this permission is added
