### PR TITLE
Hot fix for the inability to create colony

### DIFF
--- a/src/components/v5/common/AvatarUploader/hooks.tsx
+++ b/src/components/v5/common/AvatarUploader/hooks.tsx
@@ -2,7 +2,6 @@ import { Dispatch, SetStateAction, useState } from 'react';
 import { FileRejection } from 'react-dropzone';
 
 import { useIntl } from 'react-intl';
-import { useCanEditProfile } from '~hooks';
 import { DropzoneErrors } from '~shared/AvatarUploader/helpers';
 import { getFileRejectionErrors } from '~shared/FileUpload/utils';
 import { FileReaderFile } from '~utils/fileReader/types';
@@ -11,6 +10,7 @@ import {
   getOptimisedThumbnail,
 } from '~images/optimisation';
 import { convertBytes } from '~utils/convertBytes';
+
 import { FileUploadOptions } from './types';
 
 export interface UseAvatarUploaderProps {
@@ -28,8 +28,6 @@ export const useAvatarUploader = ({ updateFn }: UseAvatarUploaderProps) => {
   const [showPropgress, setShowPropgress] = useState<boolean>();
   const [uploadProgress, setUploadProgress] = useState<number>(0);
   const [file, setFileName] = useState({ fileName: '', fileSize: '' });
-
-  const { user } = useCanEditProfile();
 
   const handleFileUpload = async (avatarFile: FileReaderFile | null) => {
     if (avatarFile) {
@@ -70,7 +68,6 @@ export const useAvatarUploader = ({ updateFn }: UseAvatarUploaderProps) => {
   };
 
   return {
-    user,
     uploadAvatarError,
     isLoading,
     handleFileReject,

--- a/src/components/v5/common/CreateColonyWizard/CreateColonyCardRow.tsx
+++ b/src/components/v5/common/CreateColonyWizard/CreateColonyCardRow.tsx
@@ -27,24 +27,31 @@ const MSG = defineMessages({
 });
 
 const CardRow = ({ updatedWizardValues, setStep }: CardRowProps) => {
+  const {
+    displayName: colonyDisplayName,
+    tokenName,
+    tokenSymbol,
+    tokenAvatar,
+    tokenAddress,
+    colonyName,
+  } = updatedWizardValues;
+
   const cards = [
     {
       title: 'colonyDetailsPage.title',
-      text: updatedWizardValues.displayName,
-      subText: `app.colony.io/${updatedWizardValues.colonyName}`,
+      text: colonyDisplayName,
+      subText: `app.colony.io/${colonyName}`,
       step: 0,
     },
     {
       title: MSG.nativeToken,
-      text: updatedWizardValues.tokenName,
-      subText: updatedWizardValues.tokenSymbol,
+      text: tokenName,
+      subText: tokenSymbol,
       step: 2,
       icon: (
         <Avatar
-          avatar={updatedWizardValues.tokenAvatar}
-          seed={
-            updatedWizardValues.tokenAddress || updatedWizardValues.tokenSymbol
-          }
+          avatar={tokenAvatar}
+          seed={tokenAddress || tokenName}
           size="s"
         />
       ),


### PR DESCRIPTION
## Description

This PR is a hot fix for the current inability to create a colony. 

It was breaking due to a rebase failing to completely remove the `AvatarUploaders` dependency on the user context.

Until the whole beta create colony flow is finished it is important to remember that you will need to run the `temp-create-colony` script in the scripts folder for the new beta flow to work as we are currently not creating a user before the colony and a user is now a hard requirement in the creation of a colony due to associating said user with beta invite codes
