### PR TITLE
Factor out the ColonyContext again

### DIFF
--- a/src/components/frame/Extensions/layouts/ColonyLayout.tsx
+++ b/src/components/frame/Extensions/layouts/ColonyLayout.tsx
@@ -1,13 +1,29 @@
 import React, { FC, PropsWithChildren } from 'react';
+import { Navigate } from 'react-router-dom';
 
+import UserHubButton from '~common/Extensions/UserHubButton';
 import { LEARN_MORE_PAYMENTS } from '~constants';
-import { useActionSidebarContext } from '~context/ActionSidebarContext';
+import {
+  useActionSidebarContext,
+  useMemberModalContext,
+  usePageHeadingContext,
+  useUserTransactionContext,
+  TransactionGroupStates,
+} from '~context';
+import { useMobile, useColonyContext } from '~hooks';
+import Logo from '~images/logo-new.svg';
+import { CREATE_COLONY_ROUTE, NOT_FOUND_ROUTE } from '~routes';
 import LearnMore from '~shared/Extensions/LearnMore';
 import { formatText } from '~utils/intl';
-import Button from '~v5/shared/Button';
+import ManageMemberModal from '~v5/common/Modals/ManageMemberModal';
+import PageLayout from '~v5/frame/PageLayout';
+import Button, { CompletedButton, PendingButton } from '~v5/shared/Button';
+import CalamityBanner from '~v5/shared/CalamityBanner';
 
-import { useMainMenuItems } from './hooks';
-import SharedLayout from './SharedLayout';
+import UserNavigationWrapper from './partials/UserNavigationWrapper';
+import { useCalamityBannerInfo, useMainMenuItems } from './hooks';
+import ColonySwitcherContent from './partials/ColonySwitcherContent';
+import { getChainIconName } from './utils';
 
 const displayName = 'frame.Extensions.layouts.ColonyLayout';
 
@@ -18,31 +34,129 @@ const ColonyLayout: FC<PropsWithChildren> = ({ children }) => {
     actionSidebarToggle: [, { toggle: toggleActionSideBar }],
   } = useActionSidebarContext();
 
+  const { colony, loading } = useColonyContext();
+  const { title: pageHeadingTitle, breadcrumbs = [] } = usePageHeadingContext();
+  const isMobile = useMobile();
+
+  const {
+    isMemberModalOpen,
+    setIsMemberModalOpen,
+    user: modalUser,
+  } = useMemberModalContext();
+
+  const { calamityBannerItems, canUpgrade } = useCalamityBannerInfo();
+
+  const { groupState } = useUserTransactionContext();
+
+  if (loading) {
+    // We have a spinner outside of this
+    return null;
+  }
+
+  if (!colony) {
+    return <Navigate to={NOT_FOUND_ROUTE} />;
+  }
+
+  const txButtons = isMobile
+    ? [
+        groupState === TransactionGroupStates.SomePending && <PendingButton />,
+        groupState === TransactionGroupStates.AllCompleted && (
+          <CompletedButton />
+        ),
+      ]
+    : null;
+
+  const { metadata, chainMetadata } = colony || {};
+  const { chainId } = chainMetadata || {};
+
+  const chainIcon = getChainIconName(chainId);
+
+  const userHub = <UserHubButton hideUserNameOnMobile />;
+
   return (
-    <SharedLayout
-      mainMenuItems={mainMenuItems}
-      mobileBottomContent={
-        <div className="w-full flex flex-col gap-6">
-          <Button
-            iconName="plus"
-            className="w-full"
-            onClick={() => toggleActionSideBar()}
-          >
-            {formatText({ id: 'button.createNewAction' })}
-          </Button>
-          <LearnMore
-            message={{
-              id: `${displayName}.helpText`,
-              defaultMessage: 'Need help and guidance? <a>Visit our docs</a>',
-            }}
-            href={LEARN_MORE_PAYMENTS}
-          />
-        </div>
-      }
-      hamburgerLabel={formatText({ id: 'menu' })}
-    >
-      {children}
-    </SharedLayout>
+    <>
+      <PageLayout
+        topContent={
+          canUpgrade ? (
+            <CalamityBanner items={calamityBannerItems} />
+          ) : undefined
+        }
+        headerProps={{
+          pageHeadingProps: pageHeadingTitle
+            ? {
+                title: pageHeadingTitle,
+                breadcrumbs: [
+                  ...(colony?.name
+                    ? [
+                        {
+                          key: '1',
+                          href: `/colony/${colony?.name}`,
+                          label: colony?.name,
+                        },
+                      ]
+                    : []),
+                  ...breadcrumbs,
+                ],
+              }
+            : undefined,
+          userNavigation: (
+            <UserNavigationWrapper txButtons={txButtons} userHub={userHub} />
+          ),
+        }}
+        navigationSidebarProps={{
+          logo: <Logo />,
+          additionalMobileContent: (
+            <UserNavigationWrapper txButtons={txButtons} userHub={userHub} />
+          ),
+          mobileBottomContent: (
+            <div className="w-full flex flex-col gap-6">
+              <Button
+                iconName="plus"
+                className="w-full"
+                onClick={() => toggleActionSideBar()}
+              >
+                {formatText({ id: 'button.createNewAction' })}
+              </Button>
+              <LearnMore
+                message={{
+                  id: `${displayName}.helpText`,
+                  defaultMessage:
+                    'Need help and guidance? <a>Visit our docs</a>',
+                }}
+                href={LEARN_MORE_PAYMENTS}
+              />
+            </div>
+          ),
+          hamburgerLabel: formatText({ id: 'menu' }),
+          colonySwitcherProps: {
+            avatarProps: {
+              colonyImageProps: metadata?.avatar
+                ? { src: metadata?.thumbnail || metadata?.avatar }
+                : undefined,
+              chainIconName: chainIcon,
+            },
+            content: {
+              title:
+                formatText({ id: 'navigation.colonySwitcher.title' }) || '',
+              content: <ColonySwitcherContent colony={colony} />,
+              bottomActionProps: {
+                text: formatText({ id: 'button.createNewColony' }),
+                iconName: 'plus',
+                to: CREATE_COLONY_ROUTE,
+              },
+            },
+          },
+          mainMenuItems,
+        }}
+      >
+        {children}
+      </PageLayout>
+      <ManageMemberModal
+        isOpen={isMemberModalOpen}
+        onClose={() => setIsMemberModalOpen(false)}
+        user={modalUser}
+      />
+    </>
   );
 };
 

--- a/src/components/frame/Extensions/layouts/MainLayout.tsx
+++ b/src/components/frame/Extensions/layouts/MainLayout.tsx
@@ -1,41 +1,22 @@
-import React, { FC, PropsWithChildren, useLayoutEffect } from 'react';
+import React, { FC, PropsWithChildren } from 'react';
 import { ToastContainer } from 'react-toastify';
 
 import { CREATE_COLONY_ROUTE } from '~routes';
-import { useAppContext } from '~hooks';
 import { usePageHeadingContext } from '~context';
 import Logo from '~images/logo-new.svg';
 import CloseButton from '~shared/Extensions/Toast/partials/CloseButton';
 import styles from '~shared/Extensions/Toast/Toast.module.css';
 import { formatText } from '~utils/intl';
 import PageLayout from '~v5/frame/PageLayout';
-import { isBasicWallet } from '~types';
-import { getLastWallet } from '~utils/autoLogin';
 
 import UserNavigationWrapper from './partials/UserNavigationWrapper';
-import { SharedLayoutProps } from './types';
+import { MainLayoutProps } from './types';
 import ColonySwitcherContent from './partials/ColonySwitcherContent';
 
-const displayName = 'frame.Extensions.layouts.SharedLayout';
+const displayName = 'frame.Extensions.layouts.MainLayout';
 
-const SharedLayout: FC<PropsWithChildren<SharedLayoutProps>> = ({
-  children,
-  mobileBottomContent,
-  hamburgerLabel,
-  mainMenuItems,
-}) => {
-  const { wallet, connectWallet } = useAppContext();
+const MainLayout: FC<PropsWithChildren<MainLayoutProps>> = ({ children }) => {
   const { title: pageHeadingTitle, breadcrumbs = [] } = usePageHeadingContext();
-
-  useLayoutEffect(() => {
-    if (
-      (!wallet || isBasicWallet(wallet)) &&
-      connectWallet &&
-      getLastWallet()
-    ) {
-      connectWallet();
-    }
-  }, [connectWallet, wallet]);
 
   return (
     <>
@@ -62,8 +43,6 @@ const SharedLayout: FC<PropsWithChildren<SharedLayoutProps>> = ({
         navigationSidebarProps={{
           logo: <Logo />,
           additionalMobileContent: <UserNavigationWrapper />,
-          mobileBottomContent,
-          hamburgerLabel,
           colonySwitcherProps: {
             avatarProps: {},
             content: {
@@ -77,7 +56,6 @@ const SharedLayout: FC<PropsWithChildren<SharedLayoutProps>> = ({
               },
             },
           },
-          mainMenuItems,
         }}
       >
         {children}
@@ -86,6 +64,6 @@ const SharedLayout: FC<PropsWithChildren<SharedLayoutProps>> = ({
   );
 };
 
-SharedLayout.displayName = displayName;
+MainLayout.displayName = displayName;
 
-export default SharedLayout;
+export default MainLayout;

--- a/src/components/frame/Extensions/layouts/SharedLayout.tsx
+++ b/src/components/frame/Extensions/layouts/SharedLayout.tsx
@@ -2,24 +2,19 @@ import React, { FC, PropsWithChildren, useLayoutEffect } from 'react';
 import { ToastContainer } from 'react-toastify';
 
 import { CREATE_COLONY_ROUTE } from '~routes';
-import { useAppContext, useColonyContext } from '~hooks';
+import { useAppContext } from '~hooks';
+import { usePageHeadingContext } from '~context';
 import Logo from '~images/logo-new.svg';
-import { useMemberModalContext } from '~context/MemberModalContext';
-import usePageHeadingContext from '~context/PageHeadingContext/hooks';
 import CloseButton from '~shared/Extensions/Toast/partials/CloseButton';
 import styles from '~shared/Extensions/Toast/Toast.module.css';
 import { formatText } from '~utils/intl';
-import ManageMemberModal from '~v5/common/Modals/ManageMemberModal';
-import CalamityBanner from '~v5/shared/CalamityBanner';
 import PageLayout from '~v5/frame/PageLayout';
 import { isBasicWallet } from '~types';
 import { getLastWallet } from '~utils/autoLogin';
 
 import UserNavigationWrapper from './partials/UserNavigationWrapper';
-import { useCalamityBannerInfo } from './hooks';
 import { SharedLayoutProps } from './types';
 import ColonySwitcherContent from './partials/ColonySwitcherContent';
-import { getChainIconName } from './utils';
 
 const displayName = 'frame.Extensions.layouts.SharedLayout';
 
@@ -30,21 +25,7 @@ const SharedLayout: FC<PropsWithChildren<SharedLayoutProps>> = ({
   mainMenuItems,
 }) => {
   const { wallet, connectWallet } = useAppContext();
-  const { colony } = useColonyContext();
   const { title: pageHeadingTitle, breadcrumbs = [] } = usePageHeadingContext();
-
-  const {
-    isMemberModalOpen,
-    setIsMemberModalOpen,
-    user: modalUser,
-  } = useMemberModalContext();
-
-  const { calamityBannerItems, canUpgrade } = useCalamityBannerInfo();
-
-  const { metadata, chainMetadata } = colony || {};
-  const { chainId } = chainMetadata || {};
-
-  const chainIcon = getChainIconName(chainId);
 
   useLayoutEffect(() => {
     if (
@@ -69,27 +50,11 @@ const SharedLayout: FC<PropsWithChildren<SharedLayoutProps>> = ({
         closeButton={CloseButton}
       />
       <PageLayout
-        topContent={
-          canUpgrade ? (
-            <CalamityBanner items={calamityBannerItems} />
-          ) : undefined
-        }
         headerProps={{
           pageHeadingProps: pageHeadingTitle
             ? {
                 title: pageHeadingTitle,
-                breadcrumbs: [
-                  ...(colony?.name
-                    ? [
-                        {
-                          key: '1',
-                          href: `/colony/${colony?.name}`,
-                          label: colony?.name,
-                        },
-                      ]
-                    : []),
-                  ...breadcrumbs,
-                ],
+                breadcrumbs,
               }
             : undefined,
           userNavigation: <UserNavigationWrapper />,
@@ -100,12 +65,7 @@ const SharedLayout: FC<PropsWithChildren<SharedLayoutProps>> = ({
           mobileBottomContent,
           hamburgerLabel,
           colonySwitcherProps: {
-            avatarProps: {
-              colonyImageProps: metadata?.avatar
-                ? { src: metadata?.thumbnail || metadata?.avatar }
-                : undefined,
-              chainIconName: chainIcon,
-            },
+            avatarProps: {},
             content: {
               title:
                 formatText({ id: 'navigation.colonySwitcher.title' }) || '',
@@ -122,11 +82,6 @@ const SharedLayout: FC<PropsWithChildren<SharedLayoutProps>> = ({
       >
         {children}
       </PageLayout>
-      <ManageMemberModal
-        isOpen={isMemberModalOpen}
-        onClose={() => setIsMemberModalOpen(false)}
-        user={modalUser}
-      />
     </>
   );
 };

--- a/src/components/frame/Extensions/layouts/index.ts
+++ b/src/components/frame/Extensions/layouts/index.ts
@@ -1,3 +1,3 @@
 export { default as ColonyLayout } from './ColonyLayout';
-export { default as SharedLayout } from './SharedLayout';
+export { default as MainLayout } from './MainLayout';
 export { default as UserNavigationWrapper } from './partials/UserNavigationWrapper';

--- a/src/components/frame/Extensions/layouts/partials/ColonySwitcherContent/ColonySwitcherContent.tsx
+++ b/src/components/frame/Extensions/layouts/partials/ColonySwitcherContent/ColonySwitcherContent.tsx
@@ -1,9 +1,10 @@
 import React, { FC, useMemo } from 'react';
 
-import { useAppContext, useColonyContext } from '~hooks';
+import { useAppContext } from '~hooks';
 import { SpinnerLoader } from '~shared/Preloaders';
 import { formatText } from '~utils/intl';
 import { notNull } from '~utils/arrays';
+import { Colony } from '~types';
 
 import { getChainIconName } from '../../utils';
 import ColonySwitcherItem from '../ColonySwitcherItem';
@@ -14,12 +15,15 @@ import { sortByDate } from './utils';
 
 const displayName = 'frame.Extensions.partials.ColonySwitcherContent';
 
+interface ColonySwitcherContentProps {
+  colony?: Colony;
+}
+
 // There's just a base logic added here, so that we can see other colonies and navigate between them.
 // The rest of the functionality will be added in the next PRs.
 // @todo: sreach, empty list indicator, etc.
-const ColonySwitcherContent: FC = () => {
+const ColonySwitcherContent: FC<ColonySwitcherContentProps> = ({ colony }) => {
   const { userLoading, user } = useAppContext();
-  const { colony } = useColonyContext();
 
   const userColonies = useMemo(
     () => (user?.watchlist?.items.filter(notNull) || []).sort(sortByDate),

--- a/src/components/frame/Extensions/layouts/partials/ColonySwitcherContent/ColonySwitcherContent.tsx
+++ b/src/components/frame/Extensions/layouts/partials/ColonySwitcherContent/ColonySwitcherContent.tsx
@@ -4,20 +4,15 @@ import { useAppContext } from '~hooks';
 import { SpinnerLoader } from '~shared/Preloaders';
 import { formatText } from '~utils/intl';
 import { notNull } from '~utils/arrays';
-import { Colony } from '~types';
 
 import { getChainIconName } from '../../utils';
 import ColonySwitcherItem from '../ColonySwitcherItem';
 import ColonySwitcherList from '../ColonySwitcherList';
 import { ColonySwitcherListItem } from '../ColonySwitcherList/types';
-
+import { ColonySwitcherContentProps } from './types';
 import { sortByDate } from './utils';
 
 const displayName = 'frame.Extensions.partials.ColonySwitcherContent';
-
-interface ColonySwitcherContentProps {
-  colony?: Colony;
-}
 
 // There's just a base logic added here, so that we can see other colonies and navigate between them.
 // The rest of the functionality will be added in the next PRs.

--- a/src/components/frame/Extensions/layouts/partials/ColonySwitcherContent/types.ts
+++ b/src/components/frame/Extensions/layouts/partials/ColonySwitcherContent/types.ts
@@ -1,0 +1,5 @@
+import { Colony } from '~types';
+
+export interface ColonySwitcherContentProps {
+  colony?: Colony;
+}

--- a/src/components/frame/Extensions/layouts/partials/UserNavigationWrapper.tsx
+++ b/src/components/frame/Extensions/layouts/partials/UserNavigationWrapper.tsx
@@ -1,24 +1,24 @@
-import React, { useEffect } from 'react';
+import React, { FC, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { AnimatePresence } from 'framer-motion';
 
-import { useMobile } from '~hooks';
 import { TX_SEARCH_PARAM } from '~routes';
-import {
-  TransactionGroupStates,
-  useUserTransactionContext,
-} from '~context/UserTransactionContext';
 import { useActionSidebarContext } from '~context/ActionSidebarContext';
-import UserHubButton from '~common/Extensions/UserHubButton';
 import HeaderAvatar from '~common/Extensions/UserNavigation/partials/HeaderAvatar';
 import UserNavigation from '~common/Extensions/UserNavigation';
 import ActionSidebar from '~v5/common/ActionSidebar';
-import { CompletedButton, PendingButton } from '~v5/shared/Button';
 
 const displayName = 'frame.Extensions.partials.UserNavigationWrapper';
 
-const UserNavigationWrapper = () => {
-  const isMobile = useMobile();
+interface UserNavigationWrapperProps {
+  txButtons?: React.ReactNode;
+  userHub?: React.ReactNode;
+}
+
+const UserNavigationWrapper: FC<UserNavigationWrapperProps> = ({
+  userHub,
+  txButtons,
+}) => {
   const {
     actionSidebarToggle: [
       isActionSidebarOpen,
@@ -34,18 +34,7 @@ const UserNavigationWrapper = () => {
       toggleActionSidebarOn();
     }
   }, [toggleActionSidebarOn, transactionId]);
-  const { groupState } = useUserTransactionContext();
 
-  const txButtons = isMobile
-    ? [
-        groupState === TransactionGroupStates.SomePending && <PendingButton />,
-        groupState === TransactionGroupStates.AllCompleted && (
-          <CompletedButton />
-        ),
-      ]
-    : null;
-
-  const userHub = <UserHubButton hideUserNameOnMobile />;
   const userHubComponent = userHub || <HeaderAvatar />;
   const userNavigation = (
     <UserNavigation txButtons={txButtons} userHub={userHubComponent} />

--- a/src/components/frame/Extensions/layouts/partials/UserNavigationWrapper/UserNavigationWrapper.tsx
+++ b/src/components/frame/Extensions/layouts/partials/UserNavigationWrapper/UserNavigationWrapper.tsx
@@ -8,12 +8,9 @@ import HeaderAvatar from '~common/Extensions/UserNavigation/partials/HeaderAvata
 import UserNavigation from '~common/Extensions/UserNavigation';
 import ActionSidebar from '~v5/common/ActionSidebar';
 
-const displayName = 'frame.Extensions.partials.UserNavigationWrapper';
+import { UserNavigationWrapperProps } from './types';
 
-interface UserNavigationWrapperProps {
-  txButtons?: React.ReactNode;
-  userHub?: React.ReactNode;
-}
+const displayName = 'frame.Extensions.partials.UserNavigationWrapper';
 
 const UserNavigationWrapper: FC<UserNavigationWrapperProps> = ({
   userHub,

--- a/src/components/frame/Extensions/layouts/partials/UserNavigationWrapper/index.ts
+++ b/src/components/frame/Extensions/layouts/partials/UserNavigationWrapper/index.ts
@@ -1,0 +1,1 @@
+export { default } from './UserNavigationWrapper';

--- a/src/components/frame/Extensions/layouts/partials/UserNavigationWrapper/types.ts
+++ b/src/components/frame/Extensions/layouts/partials/UserNavigationWrapper/types.ts
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react';
+
+export interface UserNavigationWrapperProps {
+  txButtons?: ReactNode;
+  userHub?: ReactNode;
+}

--- a/src/components/frame/Extensions/layouts/types.ts
+++ b/src/components/frame/Extensions/layouts/types.ts
@@ -6,7 +6,7 @@ export interface UseCalamityBannerInfoReturnType {
   calamityBannerItems: CalamityBannerItemProps[];
 }
 
-export interface SharedLayoutProps {
+export interface MainLayoutProps {
   mobileBottomContent?: NavigationSidebarProps['mobileBottomContent'];
   hamburgerLabel?: NavigationSidebarProps['hamburgerLabel'];
   mainMenuItems?: NavigationSidebarProps['mainMenuItems'];

--- a/src/context/PageHeadingContext/PageHeadingContext.tsx
+++ b/src/context/PageHeadingContext/PageHeadingContext.tsx
@@ -17,7 +17,9 @@ export const PageHeadingContext = createContext<PageHeadingContextValue>({
   setBreadcrumbs: () => {},
 });
 
-const PageHeadingContextProvider: FC<PropsWithChildren> = ({ children }) => {
+export const PageHeadingContextProvider: FC<PropsWithChildren> = ({
+  children,
+}) => {
   const [title, setTitle] = useState<string | undefined>(undefined);
   const [breadcrumbs, setBreadcrumbs] = useState<
     PageHeadingProps['breadcrumbs'] | undefined
@@ -39,5 +41,3 @@ const PageHeadingContextProvider: FC<PropsWithChildren> = ({ children }) => {
     </PageHeadingContext.Provider>
   );
 };
-
-export default PageHeadingContextProvider;

--- a/src/context/PageHeadingContext/hooks.ts
+++ b/src/context/PageHeadingContext/hooks.ts
@@ -2,10 +2,8 @@ import { useContext, useEffect } from 'react';
 import { PageHeadingContext } from './PageHeadingContext';
 import { PageHeadingContextValue } from './types';
 
-const usePageHeadingContext = (): PageHeadingContextValue =>
+export const usePageHeadingContext = (): PageHeadingContextValue =>
   useContext(PageHeadingContext);
-
-export default usePageHeadingContext;
 
 export const useSetPageHeadingTitle = (title: string | undefined) => {
   const { setTitle } = usePageHeadingContext();

--- a/src/context/PageHeadingContext/index.ts
+++ b/src/context/PageHeadingContext/index.ts
@@ -1,1 +1,2 @@
-export { default } from './PageHeadingContext';
+export * from './PageHeadingContext';
+export * from './hooks';

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -53,14 +53,13 @@ export const removeContext = <K extends keyof Context>(contextKey: K) => {
   context[contextKey] = undefined;
 };
 
-export { AppContext, AppContextProvider } from './AppContext';
+export * from './ActionSidebarContext';
+export * from './AppContext';
 export { ColonyManagerClass as ColonyManager };
-export { ColonyContext, ColonyContextProvider } from './ColonyContext';
-export { PageThemeContext, PageThemeContextProvider } from './PageThemeContext';
-export {
-  UserTokenBalanceContext,
-  UserTokenBalanceProvider,
-  useUserTokenBalanceContext,
-} from './UserTokenBalanceContext';
+export * from './ColonyContext';
 export * from './ColonyHomeContext';
+export * from './PageHeadingContext';
+export * from './PageThemeContext';
+export * from './MemberModalContext';
+export * from './UserTokenBalanceContext';
 export * from './UserTransactionContext';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -36,6 +36,7 @@ export { default as useTokenInfo, TokenInfoProvider } from './useTokenInfo';
 export { default as useUserAvatarImageFromIPFS } from './useUserAvatarImageFromIPFS';
 export { default as useCanEditProfile } from './useCanEditProfile';
 export { default as useWindowSize } from './useWindowSize';
+// @TODO: Put this into ~context
 export { default as useAppContext } from './useAppContext';
 export { default as useUserReputation } from './useUserReputation';
 export { default as useMobile } from './useMobile';
@@ -45,6 +46,7 @@ export {
   default as useUserReputationForTopDomains,
   UserDomainReputation,
 } from './useUserReputationForTopDomains';
+// @TODO: Put this into ~context
 export { default as useColonyContext } from './useColonyContext';
 export { default as useRichTextEditor } from './useRichTextEditor';
 export { default as useExtensionData } from './useExtensionData';

--- a/src/routes/ColonyMembersRoute.tsx
+++ b/src/routes/ColonyMembersRoute.tsx
@@ -2,7 +2,8 @@ import React, { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 
 import { MemberContextProviderWithSearchAndFilter as MemberContextProvider } from '~context/MemberContext';
-import usePageHeadingContext, {
+import {
+  usePageHeadingContext,
   useSetPageHeadingTitle,
 } from '~context/PageHeadingContext/hooks';
 import { formatText } from '~utils/intl';
@@ -73,7 +74,7 @@ const ColonyMembersRoute = () => {
     return () => {
       setBreadcrumbs([]);
     };
-  }, []);
+  }, [setBreadcrumbs]);
 
   return (
     <MemberContextProvider>

--- a/src/routes/ColonyRoute.tsx
+++ b/src/routes/ColonyRoute.tsx
@@ -5,7 +5,6 @@ import { ActionSidebarContextProvider } from '~context/ActionSidebarContext';
 import { ColonyContextProvider } from '~context/ColonyContext';
 import { ColonyDecisionProvider } from '~context/ColonyDecisionContext';
 import { MemberModalProvider } from '~context/MemberModalContext';
-import PageHeadingContextProvider from '~context/PageHeadingContext';
 import { UserTokenBalanceProvider } from '~context/UserTokenBalanceContext';
 import { UserTransactionContextProvider } from '~context/UserTransactionContext';
 import { ColonyLayout } from '~frame/Extensions/layouts';
@@ -17,11 +16,9 @@ const ColonyRoute = () => (
         <UserTokenBalanceProvider>
           <MemberModalProvider>
             <UserTransactionContextProvider>
-              <PageHeadingContextProvider>
-                <ColonyLayout>
-                  <Outlet />
-                </ColonyLayout>
-              </PageHeadingContextProvider>
+              <ColonyLayout>
+                <Outlet />
+              </ColonyLayout>
             </UserTransactionContextProvider>
           </MemberModalProvider>
         </UserTokenBalanceProvider>

--- a/src/routes/MainRoute.tsx
+++ b/src/routes/MainRoute.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 
-import { SharedLayout } from '~frame/Extensions/layouts';
+import { MainLayout } from '~frame/Extensions/layouts';
 
 const MainRoute = () => (
-  <SharedLayout>
+  <MainLayout>
     <Outlet />
-  </SharedLayout>
+  </MainLayout>
 );
 
 export default MainRoute;

--- a/src/routes/MainRoute.tsx
+++ b/src/routes/MainRoute.tsx
@@ -1,26 +1,12 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 
-import {
-  ColonyContextProvider,
-  UserTransactionContextProvider,
-} from '~context';
-import { MemberModalProvider } from '~context/MemberModalContext';
-import PageHeadingContextProvider from '~context/PageHeadingContext';
 import { SharedLayout } from '~frame/Extensions/layouts';
 
 const MainRoute = () => (
-  <ColonyContextProvider>
-    <MemberModalProvider>
-      <UserTransactionContextProvider>
-        <PageHeadingContextProvider>
-          <SharedLayout>
-            <Outlet />
-          </SharedLayout>
-        </PageHeadingContextProvider>
-      </UserTransactionContextProvider>
-    </MemberModalProvider>
-  </ColonyContextProvider>
+  <SharedLayout>
+    <Outlet />
+  </SharedLayout>
 );
 
 export default MainRoute;

--- a/src/routes/RootRoute.tsx
+++ b/src/routes/RootRoute.tsx
@@ -2,10 +2,11 @@ import React, { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 
 import {
+  AppContextProvider,
+  PageHeadingContextProvider,
   PageThemeContextProvider,
   usePageThemeContext,
-} from '~context/PageThemeContext';
-import { AppContextProvider } from '~context';
+} from '~context';
 import { applyTheme } from '~frame/Extensions/themes/utils';
 import { Theme } from '~frame/Extensions/themes/enum';
 import { DialogProvider } from '~shared/Dialog';
@@ -18,7 +19,9 @@ const RootRouteInner = () => {
   return (
     <AppContextProvider>
       <DialogProvider>
-        <Outlet />
+        <PageHeadingContextProvider>
+          <Outlet />
+        </PageHeadingContextProvider>
       </DialogProvider>
     </AppContextProvider>
   );

--- a/src/routes/RootRoute.tsx
+++ b/src/routes/RootRoute.tsx
@@ -7,29 +7,45 @@ import {
   PageThemeContextProvider,
   usePageThemeContext,
 } from '~context';
+import { useAppContext } from '~hooks';
 import { applyTheme } from '~frame/Extensions/themes/utils';
 import { Theme } from '~frame/Extensions/themes/enum';
 import { DialogProvider } from '~shared/Dialog';
+import { isBasicWallet } from '~types';
+import { getLastWallet } from '~utils/autoLogin';
 
 const RootRouteInner = () => {
   const { isDarkMode } = usePageThemeContext();
+  const { wallet, connectWallet } = useAppContext();
+
   useEffect(() => {
     applyTheme(isDarkMode ? Theme.dark : Theme.light);
   }, [isDarkMode]);
+
+  useEffect(() => {
+    if (
+      (!wallet || isBasicWallet(wallet)) &&
+      connectWallet &&
+      getLastWallet()
+    ) {
+      connectWallet();
+    }
+  }, [connectWallet, wallet]);
+
   return (
-    <AppContextProvider>
-      <DialogProvider>
-        <PageHeadingContextProvider>
-          <Outlet />
-        </PageHeadingContextProvider>
-      </DialogProvider>
-    </AppContextProvider>
+    <DialogProvider>
+      <PageHeadingContextProvider>
+        <Outlet />
+      </PageHeadingContextProvider>
+    </DialogProvider>
   );
 };
 
 const RootRoute = () => (
   <PageThemeContextProvider>
-    <RootRouteInner />
+    <AppContextProvider>
+      <RootRouteInner />
+    </AppContextProvider>
   </PageThemeContextProvider>
 );
 


### PR DESCRIPTION
## Description

In short: `useColonyContext` can only be used in a route that is a child of `ColonyRoute`.

I made a few changes to existing components, but tried to keep the general style. The main change is that `SharedRoute` is now `MainRoute` again and `ColonyRoute` has the `ColonyContext`.

This introduces a little bit of code duplication but that can be improved further down the line. It is late.

There will be a follow up to this as we need a more flexible sidebar component (e.g. for the create user and create colony wizards). I suggest just passing in a component instead of all of these props.

@joanna-pagepro, please give this a review and let me know if you're ok with it.