### PR TITLE
Fix: forwarding the disabled status for radio buttons

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/StakingStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/StakingStep.tsx
@@ -132,7 +132,10 @@ const StakingStep: FC<StakingStepProps> = ({ className, isActive }) => {
                 />
               ) : (
                 <StakingForm
-                  disableForm={!enoughReputationToStakeMinimum}
+                  disableForm={
+                    !enoughReputationToStakeMinimum ||
+                    !enoughTokensToStakeMinimum
+                  }
                   userActivatedTokens={userActivatedTokens}
                 />
               ),

--- a/src/components/v5/common/Fields/RadioButtons/ButtonRadioButtons/ButtonRadioButtons.tsx
+++ b/src/components/v5/common/Fields/RadioButtons/ButtonRadioButtons/ButtonRadioButtons.tsx
@@ -87,6 +87,7 @@ function ButtonRadioButtons<TValue = string>({
       {...rest}
       className={clsx(className, 'flex w-full gap-2 [&>li]:flex-1')}
       items={modifiedItems}
+      disabled={disabled}
     />
   );
 }


### PR DESCRIPTION
## Description

- I noticed that radio buttons aren't disabled when I create a motion, and I don't have enough reputation. It turned out that the 'disabled' state in the component wasn't being passed on. Now it's fixed.
