### PR TITLE
Run amplify folder repermissioning at container level

### DIFF
--- a/docker/colony-cdapp-dev-env-amplify
+++ b/docker/colony-cdapp-dev-env-amplify
@@ -32,14 +32,12 @@ ADD docker/files/amplify/amplify-meta.json.base /colonyCDappBackend/scripts/ampl
 ADD docker/files/amplify/config.base /home/node/.aws/config
 ADD docker/files/amplify/credentials.base /home/node/.aws/credentials
 
-RUN chown -R node:users /colonyCDapp
-RUN chown -R node:users /colonyCDappBackend
-
 # Opensearch cannot be run by root so we use the built in node user
 # We also add the node user to the users group so that the node user
 # can run commands on the mounted files and folders
 RUN usermod -aG users node
-USER node
+# Install gosu to allow us to run as the node user
+RUN apt-get update && apt-get install -y gosu
 
 #
 # Amplify

--- a/docker/files/amplify/run.sh.base
+++ b/docker/files/amplify/run.sh.base
@@ -19,5 +19,9 @@ mkdir --parents /colonyCDapp/amplify/\#current-cloud-backend
 cp /colonyCDappBackend/scripts/amplify-meta.json.base /colonyCDapp/amplify/backend/amplify-meta.json
 cp /colonyCDappBackend/scripts/amplify-meta.json.base /colonyCDapp/amplify/\#current-cloud-backend/amplify-meta.json
 
-# Liftoff!
-npm run amplify mock
+# Fix permissions for mounted volumes
+chown -R node:users /colonyCDapp
+chown -R node:users /colonyCDappBackend
+
+# Liftoff (now, drop privileges and run the main process as 'node' user)
+gosu node:users bash -c 'npm run amplify mock'


### PR DESCRIPTION
## Description

So here's an unexpected PR. I suddenly experienced some weird permission problems, I almost went crazy until I started some [helpful conversations](https://chat.openai.com/share/db30a4d9-e1ca-4f91-8c1c-c403528dec44) with ChatGPT. It was a little bit of a trial and error thing until _we_ realized that the permissions for mounted volumes are always mounted into the container using the `root` user. This can't be changed at the image build level but has to be done during the start up time of the container.

So what happens here is I basically moved the `chown` command and the privilege drop to the run script. 


~~I'm not exactly sure but this _should_ remove the need for the infamous~~
```bash
sudo chown -R $(whoami):$(ls -l package.json | awk '{print $4}') ./ && sudo chmod  -R g+rws  ./amplify
```
~~command.~~

Update: it does not.