### PR TITLE
Fix Message Signing

### DIFF
--- a/src/redux/sagas/utils/effects.ts
+++ b/src/redux/sagas/utils/effects.ts
@@ -16,6 +16,7 @@ import {
   transactionEstimateGas,
   transactionReady,
   transactionSend,
+  messageSign,
 } from '~redux/actionCreators';
 import { getCanUserSendMetatransactions } from './getCanUserSendMetatransactions';
 /*
@@ -126,4 +127,8 @@ export function* initiateTransaction({
   } else {
     yield put(transactionEstimateGas(id));
   }
+}
+
+export function* initiateMessageSigning(id: string) {
+  yield put(messageSign(id));
 }


### PR DESCRIPTION
This PR adds in a simple fix that makes message signing work again (or initialize again)

This was done by removing the `race` feature from the saga, and basically removing the "cancel" logic, as it will be controlled by metamask anyway.

Note that this is only for "direct" message signing used for vote and reveal. Message signing for meta transactions works separately from this system