### PR TITLE
Improve docker compatibility

### DIFF
--- a/amplify/backend/function/fetchColonyBalances/src/index.js
+++ b/amplify/backend/function/fetchColonyBalances/src/index.js
@@ -12,7 +12,7 @@ Logger.setLogLevel(Logger.levels.ERROR);
 
 let apiKey = 'da2-fakeApiId123456';
 let graphqlURL = 'http://localhost:20002/graphql';
-let rpcURL = 'http://network-contracts.docker:8545'; // this needs to be extended to all supported networks
+let rpcURL = 'http://network-contracts:8545'; // this needs to be extended to all supported networks
 let network = Network.Custom;
 let networkAddress;
 

--- a/amplify/backend/function/fetchColonyNativeFundsClaim/src/index.js
+++ b/amplify/backend/function/fetchColonyNativeFundsClaim/src/index.js
@@ -1,7 +1,7 @@
 const { constants, providers, Contract } = require('ethers');
 const basicColonyAbi = require('./basicColonyAbi.json');
 
-let rpcURL = 'http://network-contracts.docker:8545'; // this needs to be extended to all supported networks
+let rpcURL = 'http://network-contracts:8545'; // this needs to be extended to all supported networks
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;

--- a/amplify/backend/function/fetchExpenditureBalances/src/index.js
+++ b/amplify/backend/function/fetchExpenditureBalances/src/index.js
@@ -7,7 +7,7 @@ const {
 
 Logger.setLogLevel(Logger.levels.ERROR);
 
-let rpcURL = 'http://network-contracts.docker:8545'; // this needs to be extended to all supported networks
+let rpcURL = 'http://network-contracts:8545'; // this needs to be extended to all supported networks
 let network = Network.Custom;
 let networkAddress;
 

--- a/amplify/backend/function/fetchMotionState/src/utils.js
+++ b/amplify/backend/function/fetchMotionState/src/utils.js
@@ -18,9 +18,9 @@ const {
 
 let apiKey = 'da2-fakeApiId123456';
 let graphqlURL = 'http://localhost:20002/graphql';
-let rpcURL = 'http://network-contracts.docker:8545'; // this needs to be extended to all supported networks
+let rpcURL = 'http://network-contracts:8545'; // this needs to be extended to all supported networks
 let reputationOracleEndpoint =
-  'http://reputation-monitor.docker:3001/reputation/local';
+  'http://reputation-monitor:3001/reputation/local';
 let networkAddress;
 let network = Network.Custom;
 

--- a/amplify/backend/function/fetchMotionTimeoutPeriods/src/index.js
+++ b/amplify/backend/function/fetchMotionTimeoutPeriods/src/index.js
@@ -6,11 +6,11 @@ const {
   getBlockTime,
 } = require('@colony/colony-js');
 
-let rpcURL = 'http://network-contracts.docker:8545'; // this needs to be extended to all supported networks
+let rpcURL = 'http://network-contracts:8545'; // this needs to be extended to all supported networks
 let networkAddress;
 let network = Network.Custom;
 let reputationOracleEndpoint =
-  'http://reputation-monitor.docker:3001/reputation/local';
+  'http://reputation-monitor:3001/reputation/local';
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;

--- a/amplify/backend/function/fetchTokenFromChain/src/utils.js
+++ b/amplify/backend/function/fetchTokenFromChain/src/utils.js
@@ -85,7 +85,7 @@ const getDevRpcUrl = (network) => {
       return 'https://eth.drpc.org';
     case GANACHE_NETWORK.shortName:
     default:
-      return 'http://network-contracts.docker:8545'; // default for local testing
+      return 'http://network-contracts:8545'; // default for local testing
   }
 };
 

--- a/amplify/backend/function/fetchVoterRewards/src/utils.js
+++ b/amplify/backend/function/fetchVoterRewards/src/utils.js
@@ -11,11 +11,11 @@ const { default: fetch, Request } = require('node-fetch');
  */
 let apiKey = 'da2-fakeApiId123456';
 let graphqlURL = 'http://localhost:20002/graphql';
-let rpcURL = 'http://network-contracts.docker:8545'; // this needs to be extended to all supported networks
+let rpcURL = 'http://network-contracts:8545'; // this needs to be extended to all supported networks
 let networkAddress;
 let network = Network.Custom;
 let reputationOracleEndpoint =
-  'http://reputation-monitor.docker:3001/reputation/local';
+  'http://reputation-monitor:3001/reputation/local';
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;

--- a/amplify/backend/function/getMembersForColony/src/index.js
+++ b/amplify/backend/function/getMembersForColony/src/index.js
@@ -15,9 +15,9 @@ const { getWatchersInColony, getUserByAddress } = require('./graphql');
 
 let apiKey = 'da2-fakeApiId123456';
 let graphqlURL = 'http://localhost:20002/graphql';
-let rpcURL = 'http://network-contracts.docker:8545'; // this needs to be extended to all supported networks
+let rpcURL = 'http://network-contracts:8545'; // this needs to be extended to all supported networks
 let reputationOracleEndpoint =
-  'http://reputation-monitor.docker:3001/reputation/local';
+  'http://reputation-monitor:3001/reputation/local';
 let network = Network.Custom;
 let networkAddress;
 

--- a/amplify/backend/function/getReputationForTopDomains/src/index.js
+++ b/amplify/backend/function/getReputationForTopDomains/src/index.js
@@ -9,9 +9,9 @@ const { Decimal } = require('decimal.js');
 
 Logger.setLogLevel(Logger.levels.ERROR);
 
-let rpcURL = 'http://network-contracts.docker:8545'; // this needs to be extended to all supported networks
+let rpcURL = 'http://network-contracts:8545'; // this needs to be extended to all supported networks
 let reputationOracleEndpoint =
-  'http://reputation-monitor.docker:3001/reputation/local';
+  'http://reputation-monitor:3001/reputation/local';
 let network = Network.Custom;
 let networkAddress;
 

--- a/amplify/backend/function/getSafeTransactionStatus/src/index.js
+++ b/amplify/backend/function/getSafeTransactionStatus/src/index.js
@@ -10,7 +10,7 @@ const {
   isDev,
 } = require('./utils');
 
-let rpcURL = 'http://network-contracts.docker:8545'; // this needs to be extended to all supported networks
+let rpcURL = 'http://network-contracts:8545'; // this needs to be extended to all supported networks
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;

--- a/amplify/backend/function/getUserReputation/src/index.js
+++ b/amplify/backend/function/getUserReputation/src/index.js
@@ -6,10 +6,10 @@ const {
 
 Logger.setLogLevel(Logger.levels.ERROR);
 
-let rpcURL = 'http://network-contracts.docker:8545'; // this needs to be extended to all supported networks
+let rpcURL = 'http://network-contracts:8545'; // this needs to be extended to all supported networks
 let networkAddress;
 let reputationOracleEndpoint =
-  'http://reputation-monitor.docker:3001/reputation/local';
+  'http://reputation-monitor:3001/reputation/local';
 let network = Network.Custom;
 
 const setEnvVariables = async () => {

--- a/amplify/backend/function/getUserTokenBalance/src/index.js
+++ b/amplify/backend/function/getUserTokenBalance/src/index.js
@@ -14,7 +14,7 @@ const { getStakedTokens } = require('./utils');
 
 Logger.setLogLevel(Logger.levels.ERROR);
 
-let rpcURL = 'http://network-contracts.docker:8545'; // this needs to be extended to all supported networks
+let rpcURL = 'http://network-contracts:8545'; // this needs to be extended to all supported networks
 let network = Network.Custom;
 let networkAddress;
 let apiKey = 'da2-fakeApiId123456';

--- a/amplify/backend/function/updateContributorsWithReputation/src/index.js
+++ b/amplify/backend/function/updateContributorsWithReputation/src/index.js
@@ -31,10 +31,10 @@ Logger.setLogLevel(Logger.levels.ERROR);
 
 let apiKey = 'da2-fakeApiId123456';
 let graphqlURL = 'http://localhost:20002/graphql';
-let rpcURL = 'http://network-contracts.docker:8545'; // this needs to be extended to all supported networks
+let rpcURL = 'http://network-contracts:8545'; // this needs to be extended to all supported networks
 let networkAddress;
 let reputationOracleEndpoint =
-  'http://reputation-monitor.docker:3001/reputation/local';
+  'http://reputation-monitor:3001/reputation/local';
 let network = Network.Custom;
 
 const setEnvVariables = async () => {

--- a/docker/colony-cdapp-dev-env-amplify
+++ b/docker/colony-cdapp-dev-env-amplify
@@ -32,13 +32,20 @@ ADD docker/files/amplify/amplify-meta.json.base /colonyCDappBackend/scripts/ampl
 ADD docker/files/amplify/config.base /home/node/.aws/config
 ADD docker/files/amplify/credentials.base /home/node/.aws/credentials
 
-RUN chown -R node:users /colonyCDapp
-RUN chown -R node:users /colonyCDappBackend
-
 # Opensearch cannot be run by root so we use the built in node user
 # We also add the node user to the users group so that the node user
 # can run commands on the mounted files and folders
-RUN usermod -aG users node
+ARG USER_ID
+ARG USER_GROUP
+
+RUN getent group ${USER_GROUP} || groupadd --gid ${USER_GROUP} fuckamplify
+
+RUN usermod -u ${USER_ID} node
+RUN usermod -g ${USER_GROUP} node
+
+RUN chown -R ${USER_ID}:${USER_GROUP} /colonyCDapp
+RUN chown -R ${USER_ID}:${USER_GROUP} /colonyCDappBackend
+
 USER node
 
 #

--- a/docker/colony-cdapp-dev-env-orchestration-all.yaml
+++ b/docker/colony-cdapp-dev-env-orchestration-all.yaml
@@ -24,8 +24,6 @@ services:
     depends_on:
       network-contracts:
         condition: service_healthy
-    links:
-      - 'network-contracts:network-contracts.docker'
 
   block-ingestor:
     container_name: 'ingestor'
@@ -39,9 +37,6 @@ services:
         condition: service_healthy
       amplify:
         condition: service_healthy
-    links:
-      - 'network-contracts:network-contracts.docker'
-      - 'amplify:amplify.docker'
 
   amplify:
     container_name: 'amplify'
@@ -57,12 +52,10 @@ services:
       DEBUG_COLORS: 'true'
       TERM: xterm-256color
       COLORTERM: truecolor
-    links:
-      - 'network-contracts:network-contracts.docker'
-      - 'reputation-monitor:reputation-monitor.docker'
     ports:
       - '20002:20002'
       - '9200:9200'
+    userns_mode: 'keep-id'
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:9200']
       interval: 5s

--- a/docker/colony-cdapp-dev-env-orchestration.yaml
+++ b/docker/colony-cdapp-dev-env-orchestration.yaml
@@ -24,8 +24,6 @@ services:
     depends_on:
       network-contracts:
         condition: service_healthy
-    links:
-      - 'network-contracts:network-contracts.docker'
 
   block-ingestor:
     container_name: 'ingestor'
@@ -39,9 +37,6 @@ services:
         condition: service_healthy
       amplify:
         condition: service_healthy
-    links:
-      - 'network-contracts:network-contracts.docker'
-      - 'amplify:amplify.docker'
 
   amplify:
     container_name: 'amplify'
@@ -57,12 +52,10 @@ services:
       DEBUG_COLORS: 'true'
       TERM: xterm-256color
       COLORTERM: truecolor
-    links:
-      - 'network-contracts:network-contracts.docker'
-      - 'reputation-monitor:reputation-monitor.docker'
     ports:
       - '20002:20002'
       - '9200:9200'
+    userns_mode: 'keep-id'
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:9200']
       interval: 5s

--- a/docker/files/block-ingestor/env.base
+++ b/docker/files/block-ingestor/env.base
@@ -2,10 +2,10 @@ STATS_PORT=10001
 
 VERBOSE_OUTPUT=false
 
-CHAIN_RPC_ENDPOINT=http://network-contracts.docker:8545
+CHAIN_RPC_ENDPOINT=http://network-contracts:8545
 CHAIN_NETWORK_CONTRACT=0x5CC4a96B08e8C88f2c6FC5772496FeD9666e4D1F
 
-AWS_APPSYNC_ENDPOINT=http://amplify.docker:20002/graphql
+AWS_APPSYNC_ENDPOINT=http://amplify:20002/graphql
 AWS_APPSYNC_KEY=da2-fakeApiId123456
 
 NODE_ENV=development

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "docker:build:network": "DOCKER_BUILDKIT=1 docker build --tag colony-cdapp-dev-env/network --file ./docker/colony-cdapp-dev-env-network .",
     "docker:build:monitor": "DOCKER_BUILDKIT=1 docker build --tag colony-cdapp-dev-env/reputation-monitor --file ./docker/colony-cdapp-dev-env-reputation-monitor .",
     "docker:build:ingestor": "DOCKER_BUILDKIT=1 docker build  --build-arg BLOCK_INGESTOR_HASH='fix/docker-internal-link' --tag colony-cdapp-dev-env/block-ingestor --file ./docker/colony-cdapp-dev-env-block-ingestor .",
-    "docker:build:amplify": "DOCKER_BUILDKIT=1 docker build --tag colony-cdapp-dev-env/amplify --file ./docker/colony-cdapp-dev-env-amplify .",
+    "docker:build:amplify": "DOCKER_BUILDKIT=1 docker build --build-arg USER_ID=$(id -u) --build-arg USER_GROUP=$(id -g) --tag colony-cdapp-dev-env/amplify --file ./docker/colony-cdapp-dev-env-amplify .",
     "docker:build:safe": "DOCKER_BUILDKIT=1 docker build --tag colony-cdapp-dev-env/safe --file ./docker/colony-cdapp-dev-env-safe .",
     "docker:build:core": "npm run docker:build:base && npm run docker:build:network && npm run docker:build:monitor && npm run docker:build:ingestor && npm run docker:build:amplify",
     "docker:build:all": "npm run docker:build:base && npm run docker:build:network && npm run docker:build:monitor && npm run docker:build:ingestor && npm run docker:build:amplify && npm run docker:build:safe",


### PR DESCRIPTION
## Description

This PR improves the compatibility of our docker setup with newer docker versions and tools like podman which in turn enables us to run our setup as non-root users in Linux.

Most importantly the `links` entries were removed from the docker-compose files which is an option that's [long deprecated](https://docs.docker.com/network/links/) and not necessary anymore. 

-----

To use with `podman` if you like (rootless, on Linux - **DO NOT DO THIS IF YOU'RE ON A MAC OR WINDOWS**):

- Remove docker from your system :scream: 
- We need `podman` in version 4.7.x to support the `docker compose` command
- Use either `docker-compose` (standalone, without docker) or `podman-compose` (untested)
- Make sure you have the podman [`dnsname`](https://github.com/containers/dnsname/blob/main/README_PODMAN.md) plugin installed and configured
- Make sure you have `docker` aliased to `podman` ([`podman-docker`](https://packages.debian.org/sid/podman-docker) might help)
- Before running `npm run dev`, make sure to `export DOCKER_HOST=unix:///run/user/1000/podman/podman.sock` (this will be fixed in a future version of podman - https://github.com/containers/podman/pull/19917#issuecomment-1802805687)
