### PR TITLE
Add function url to createPrivateBeta lambda

### DIFF
--- a/amplify/backend/backend-config.json
+++ b/amplify/backend/backend-config.json
@@ -32,6 +32,7 @@
     },
     "createPrivateBetaInvite": {
       "build": true,
+      "dependsOn": [],
       "providerPlugin": "awscloudformation",
       "service": "Lambda"
     },

--- a/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
+++ b/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
@@ -42,7 +42,8 @@
                         }
                     ]
                 },
-                "Principal": "*"
+                "Principal": "*",
+                "FunctionUrlAuthType": "NONE"
             }
         },
         "LambdaFunction": {

--- a/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
+++ b/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
@@ -218,6 +218,26 @@
                   }
                 ]
               }
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "ssm:GetParameter",
+                "kms:Decrypt"
+              ],
+              "Resource": {
+                "Fn::Sub": [
+                  "arn:aws:ssm:${region}:${account}:parameter/*",
+                  {
+                    "region": {
+                      "Ref": "AWS::Region"
+                    },
+                    "account": {
+                      "Ref": "AWS::AccountId"
+                    }
+                  }
+                ]
+              }
             }
           ]
         }

--- a/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
+++ b/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
@@ -18,7 +18,10 @@
     },
     "CreateLambdaUrl": {
       "Type": "String",
-      "AllowedValues": ["true", "false"],
+      "AllowedValues": [
+        "true",
+        "false"
+      ],
       "Default": "false",
       "Description": "Specifies whether to create the Lambda function URL"
     }
@@ -34,7 +37,9 @@
     },
     "ShouldCreateLambdaUrl": {
       "Fn::Equals": [
-        { "Ref": "CreateLambdaUrl" },
+        {
+          "Ref": "CreateLambdaUrl"
+        },
         "true"
       ]
     }
@@ -116,6 +121,7 @@
         },
         "Runtime": "nodejs14.x",
         "Layers": [
+          "arn:aws:lambda:eu-west-2:204031746016:layer:colonycdappSSMAccess-qa:204",
           "arn:aws:lambda:eu-west-2:133256977650:layer:AWS-Parameters-and-Secrets-Lambda-Extension:4"
         ],
         "Timeout": 25
@@ -208,26 +214,6 @@
                     },
                     "lambda": {
                       "Ref": "LambdaFunction"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "Effect": "Allow",
-              "Action": [
-                "ssm:GetParameter",
-                "kms:Decrypt"
-              ],
-              "Resource": {
-                "Fn::Sub": [
-                  "arn:aws:ssm:${region}:${account}:parameter/*",
-                  {
-                    "region": {
-                      "Ref": "AWS::Region"
-                    },
-                    "account": {
-                      "Ref": "AWS::AccountId"
                     }
                   }
                 ]

--- a/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
+++ b/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
@@ -74,6 +74,19 @@
             "Timeout": 25
           }
         },
+        "LambdaUrl": {
+            "Type": "AWS::Lambda::Url",
+            "DependsOn": "LambdaFunction",
+            "Properties": {
+                "AuthType": "NONE",
+                "TargetFunctionArn": {
+                    "Fn::GetAtt": [
+                        "LambdaFunction",
+                        "Arn"
+                    ]
+                }
+            }
+        },
         "LambdaExecutionRole": {
             "Type": "AWS::IAM::Role",
             "Properties": {

--- a/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
+++ b/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
@@ -1,209 +1,253 @@
 {
-    "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "Lambda Function resource stack creation using Amplify CLI",
-    "Parameters": {
-        "CloudWatchRule": {
-            "Type": "String",
-            "Default": "NONE",
-            "Description": " Schedule Expression"
-        },
-        "deploymentBucketName": {
-            "Type": "String"
-        },
-        "env": {
-            "Type": "String"
-        },
-        "s3Key": {
-            "Type": "String"
-        }
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Lambda Function resource stack creation using Amplify CLI",
+  "Parameters": {
+    "CloudWatchRule": {
+      "Type": "String",
+      "Default": "NONE",
+      "Description": " Schedule Expression"
     },
-    "Conditions": {
-        "ShouldNotCreateEnvResources": {
-            "Fn::Equals": [
-                {
-                    "Ref": "env"
-                },
-                "NONE"
-            ]
-        }
+    "deploymentBucketName": {
+      "Type": "String"
     },
-    "Resources": {
-        "LambdaPermission": {
-            "Type": "AWS::Lambda::Permission",
-            "Properties": {
-                "Action": "lambda:InvokeFunctionUrl",
-                "FunctionName": {
-                    "Fn::Sub": [
-                        "arn:aws:lambda:${region}:${account}:function:${lambda}",
-                        {
-                            "region": { "Ref": "AWS::Region" },
-                            "account": { "Ref": "AWS::AccountId" },
-                            "lambda": { "Ref": "LambdaFunction" }
-                        }
-                    ]
-                },
-                "Principal": "*",
-                "FunctionUrlAuthType": "NONE"
-            }
-        },
-        "LambdaFunction": {
-            "Type": "AWS::Lambda::Function",
-            "Metadata": {
-                "aws:asset:path": "./src",
-                "aws:asset:property": "Code"
-            },
-            "Properties": {
-                "Code": {
-                    "S3Bucket": {
-                        "Ref": "deploymentBucketName"
-                    },
-                    "S3Key": {
-                        "Ref": "s3Key"
-                    }
-                },
-                "Handler": "index.handler",
-                "FunctionName": {
-                    "Fn::If": [
-                        "ShouldNotCreateEnvResources",
-                        "createPrivateBetaInvite",
-                        {
-                            "Fn::Join": [
-                                "",
-                                [
-                                    "createPrivateBetaInvite",
-                                    "-",
-                                    {
-                                        "Ref": "env"
-                                    }
-                                ]
-                            ]
-                        }
-                    ]
-                },
-                "Environment": {
-                    "Variables": {
-                        "ENV": { "Ref": "env" },
-                        "REGION": { "Ref": "AWS::Region" }
-                    }
-                },
-                "Role": { "Fn::GetAtt": ["LambdaExecutionRole", "Arn"] },
-                "Runtime": "nodejs14.x",
-                "Layers": [],
-                "Timeout": 25
-            }
-        },
-        "LambdaUrl": {
-            "Type": "AWS::Lambda::Url",
-            "DependsOn": "LambdaFunction",
-            "Properties": {
-                "AuthType": "NONE",
-                "TargetFunctionArn": {
-                    "Fn::GetAtt": ["LambdaFunction", "Arn"]
-                }
-            }
-        },
-        "LambdaExecutionRole": {
-            "Type": "AWS::IAM::Role",
-            "Properties": {
-                "RoleName": {
-                    "Fn::If": [
-                        "ShouldNotCreateEnvResources",
-                        "colonycdappLambdaRole5041e354",
-                        {
-                            "Fn::Join": [
-                                "",
-                                [
-                                    "colonycdappLambdaRole5041e354",
-                                    "-",
-                                    {
-                                        "Ref": "env"
-                                    }
-                                ]
-                            ]
-                        }
-                    ]
-                },
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Effect": "Allow",
-                            "Principal": {
-                                "Service": ["lambda.amazonaws.com"]
-                            },
-                            "Action": ["sts:AssumeRole"]
-                        }
-                    ]
-                }
-            }
-        },
-        "lambdaexecutionpolicy": {
-            "DependsOn": ["LambdaExecutionRole"],
-            "Type": "AWS::IAM::Policy",
-            "Properties": {
-                "PolicyName": "lambda-execution-policy",
-                "Roles": [{ "Ref": "LambdaExecutionRole" }],
-                "PolicyDocument": {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Effect": "Allow",
-                            "Action": [
-                                "logs:CreateLogGroup",
-                                "logs:CreateLogStream",
-                                "logs:PutLogEvents"
-                            ],
-                            "Resource": {
-                                "Fn::Sub": [
-                                    "arn:aws:logs:${region}:${account}:log-group:/aws/lambda/${lambda}:log-stream:*",
-                                    {
-                                        "region": { "Ref": "AWS::Region" },
-                                        "account": { "Ref": "AWS::AccountId" },
-                                        "lambda": { "Ref": "LambdaFunction" }
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "Effect": "Allow",
-                            "Action": ["ssm:GetParameter", "kms:Decrypt"],
-                            "Resource": {
-                                "Fn::Sub": [
-                                    "arn:aws:ssm:${region}:${account}:parameter/*",
-                                    {
-                                        "region": {
-                                            "Ref": "AWS::Region"
-                                        },
-                                        "account": {
-                                            "Ref": "AWS::AccountId"
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }
+    "env": {
+      "Type": "String"
     },
-    "Outputs": {
-        "Name": {
-            "Value": {
-                "Ref": "LambdaFunction"
-            }
-        },
-        "Arn": {
-            "Value": { "Fn::GetAtt": ["LambdaFunction", "Arn"] }
-        },
-        "Region": {
-            "Value": {
-                "Ref": "AWS::Region"
-            }
-        },
-        "LambdaExecutionRole": {
-            "Value": {
-                "Ref": "LambdaExecutionRole"
-            }
-        }
+    "s3Key": {
+      "Type": "String"
     }
+  },
+  "Conditions": {
+    "ShouldNotCreateEnvResources": {
+      "Fn::Equals": [
+        {
+          "Ref": "env"
+        },
+        "NONE"
+      ]
+    }
+  },
+  "Resources": {
+    "LambdaPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunctionUrl",
+        "FunctionName": {
+          "Fn::Sub": [
+            "arn:aws:lambda:${region}:${account}:function:${lambda}",
+            {
+              "region": {
+                "Ref": "AWS::Region"
+              },
+              "account": {
+                "Ref": "AWS::AccountId"
+              },
+              "lambda": {
+                "Ref": "LambdaFunction"
+              }
+            }
+          ]
+        },
+        "Principal": "*",
+        "FunctionUrlAuthType": "NONE"
+      }
+    },
+    "LambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Metadata": {
+        "aws:asset:path": "./src",
+        "aws:asset:property": "Code"
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "deploymentBucketName"
+          },
+          "S3Key": {
+            "Ref": "s3Key"
+          }
+        },
+        "Handler": "index.handler",
+        "FunctionName": {
+          "Fn::If": [
+            "ShouldNotCreateEnvResources",
+            "createPrivateBetaInvite",
+            {
+              "Fn::Join": [
+                "",
+                [
+                  "createPrivateBetaInvite",
+                  "-",
+                  {
+                    "Ref": "env"
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        "Environment": {
+          "Variables": {
+            "ENV": {
+              "Ref": "env"
+            },
+            "REGION": {
+              "Ref": "AWS::Region"
+            }
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "LambdaExecutionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Layers": [
+          "arn:aws:lambda:eu-west-2:133256977650:layer:AWS-Parameters-and-Secrets-Lambda-Extension:4"
+        ],
+        "Timeout": 25
+      }
+    },
+    "LambdaUrl": {
+      "Type": "AWS::Lambda::Url",
+      "DependsOn": "LambdaFunction",
+      "Properties": {
+        "AuthType": "NONE",
+        "TargetFunctionArn": {
+          "Fn::GetAtt": [
+            "LambdaFunction",
+            "Arn"
+          ]
+        }
+      }
+    },
+    "LambdaExecutionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "RoleName": {
+          "Fn::If": [
+            "ShouldNotCreateEnvResources",
+            "colonycdappLambdaRole5041e354",
+            {
+              "Fn::Join": [
+                "",
+                [
+                  "colonycdappLambdaRole5041e354",
+                  "-",
+                  {
+                    "Ref": "env"
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "lambdaexecutionpolicy": {
+      "DependsOn": [
+        "LambdaExecutionRole"
+      ],
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "lambda-execution-policy",
+        "Roles": [
+          {
+            "Ref": "LambdaExecutionRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+              ],
+              "Resource": {
+                "Fn::Sub": [
+                  "arn:aws:logs:${region}:${account}:log-group:/aws/lambda/${lambda}:log-stream:*",
+                  {
+                    "region": {
+                      "Ref": "AWS::Region"
+                    },
+                    "account": {
+                      "Ref": "AWS::AccountId"
+                    },
+                    "lambda": {
+                      "Ref": "LambdaFunction"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "ssm:GetParameter",
+                "kms:Decrypt"
+              ],
+              "Resource": {
+                "Fn::Sub": [
+                  "arn:aws:ssm:${region}:${account}:parameter/*",
+                  {
+                    "region": {
+                      "Ref": "AWS::Region"
+                    },
+                    "account": {
+                      "Ref": "AWS::AccountId"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "Name": {
+      "Value": {
+        "Ref": "LambdaFunction"
+      }
+    },
+    "Arn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "LambdaFunction",
+          "Arn"
+        ]
+      }
+    },
+    "Region": {
+      "Value": {
+        "Ref": "AWS::Region"
+      }
+    },
+    "LambdaExecutionRole": {
+      "Value": {
+        "Ref": "LambdaExecutionRole"
+      }
+    }
+  }
 }

--- a/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
+++ b/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
@@ -4,8 +4,8 @@
     "Parameters": {
         "CloudWatchRule": {
             "Type": "String",
-            "Default" : "NONE",
-            "Description" : " Schedule Expression"
+            "Default": "NONE",
+            "Description": " Schedule Expression"
         },
         "deploymentBucketName": {
             "Type": "String"
@@ -16,8 +16,6 @@
         "s3Key": {
             "Type": "String"
         }
-        
-    
     },
     "Conditions": {
         "ShouldNotCreateEnvResources": {
@@ -30,49 +28,75 @@
         }
     },
     "Resources": {
-        "LambdaFunction": {
-          "Type": "AWS::Lambda::Function",
-          "Metadata": {
-            "aws:asset:path": "./src",
-            "aws:asset:property": "Code"
-          },
-          "Properties": {
-            "Code": {
-                "S3Bucket": {
-                    "Ref": "deploymentBucketName"
+        "LambdaPermission": {
+            "Type": "AWS::Lambda::Permission",
+            "Properties": {
+                "Sid": "FunctionURLAllowPublicAccess",
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "lambda:InvokeFunctionUrl",
+                "Resource": {
+                    "Fn::Sub": [
+                        "arn:aws:lambda:${region}:${account}:function:${lambda}",
+                        {
+                            "region": { "Ref": "AWS::Region" },
+                            "account": { "Ref": "AWS::AccountId" },
+                            "lambda": { "Ref": "LambdaFunction" }
+                        }
+                    ]
                 },
-                "S3Key": {
-                    "Ref": "s3Key"
-                }
-            },
-            "Handler": "index.handler",
-            "FunctionName": {
-                "Fn::If": [
-                    "ShouldNotCreateEnvResources",
-                    "createPrivateBetaInvite",
-                    {
-
-                        "Fn::Join": [
-                            "",
-                            [
-                                "createPrivateBetaInvite",
-                                "-",
-                                {
-                                    "Ref": "env"
-                                }
-                            ]
-                        ]
+                "Condition": {
+                    "StringEquals": {
+                        "lambda:FunctionUrlAuthType": "NONE"
                     }
-                ]
+                }
+            }
+        },
+        "LambdaFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Metadata": {
+                "aws:asset:path": "./src",
+                "aws:asset:property": "Code"
             },
-            "Environment": {
-                "Variables" : {"ENV":{"Ref":"env"},"REGION":{"Ref":"AWS::Region"}}
-            },
-            "Role": { "Fn::GetAtt": ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs14.x",
-            "Layers": [],
-            "Timeout": 25
-          }
+            "Properties": {
+                "Code": {
+                    "S3Bucket": {
+                        "Ref": "deploymentBucketName"
+                    },
+                    "S3Key": {
+                        "Ref": "s3Key"
+                    }
+                },
+                "Handler": "index.handler",
+                "FunctionName": {
+                    "Fn::If": [
+                        "ShouldNotCreateEnvResources",
+                        "createPrivateBetaInvite",
+                        {
+                            "Fn::Join": [
+                                "",
+                                [
+                                    "createPrivateBetaInvite",
+                                    "-",
+                                    {
+                                        "Ref": "env"
+                                    }
+                                ]
+                            ]
+                        }
+                    ]
+                },
+                "Environment": {
+                    "Variables": {
+                        "ENV": { "Ref": "env" },
+                        "REGION": { "Ref": "AWS::Region" }
+                    }
+                },
+                "Role": { "Fn::GetAtt": ["LambdaExecutionRole", "Arn"] },
+                "Runtime": "nodejs14.x",
+                "Layers": [],
+                "Timeout": 25
+            }
         },
         "LambdaUrl": {
             "Type": "AWS::Lambda::Url",
@@ -80,10 +104,7 @@
             "Properties": {
                 "AuthType": "NONE",
                 "TargetFunctionArn": {
-                    "Fn::GetAtt": [
-                        "LambdaFunction",
-                        "Arn"
-                    ]
+                    "Fn::GetAtt": ["LambdaFunction", "Arn"]
                 }
             }
         },
@@ -95,7 +116,6 @@
                         "ShouldNotCreateEnvResources",
                         "colonycdappLambdaRole5041e354",
                         {
-
                             "Fn::Join": [
                                 "",
                                 [
@@ -115,19 +135,15 @@
                         {
                             "Effect": "Allow",
                             "Principal": {
-                                "Service": [
-                                    "lambda.amazonaws.com"
-                                ]
+                                "Service": ["lambda.amazonaws.com"]
                             },
-                            "Action": [
-                                "sts:AssumeRole"
-                            ]
+                            "Action": ["sts:AssumeRole"]
                         }
                     ]
                 }
             }
-        }
-        ,"lambdaexecutionpolicy": {
+        },
+        "lambdaexecutionpolicy": {
             "DependsOn": ["LambdaExecutionRole"],
             "Type": "AWS::IAM::Policy",
             "Properties": {
@@ -138,44 +154,43 @@
                     "Statement": [
                         {
                             "Effect": "Allow",
-                            "Action": ["logs:CreateLogGroup",
-                            "logs:CreateLogStream",
-                            "logs:PutLogEvents"],
-                            "Resource": { "Fn::Sub": [ "arn:aws:logs:${region}:${account}:log-group:/aws/lambda/${lambda}:log-stream:*", { "region": {"Ref": "AWS::Region"}, "account": {"Ref": "AWS::AccountId"}, "lambda": {"Ref": "LambdaFunction"}} ]}
-                        },
-                        {
-                            "Sid": "AllowUnauthenticatedInvoke",
-                            "Effect": "Allow",
-                            "Principal": "*",
-                            "Action": "lambda:InvokeFunctionUrl",
-                            "Resource": { "Fn::Sub": [ "arn:aws:lambda:${region}:${account}:function:${lambda}", { "region": {"Ref": "AWS::Region"}, "account": {"Ref": "AWS::AccountId"}, "lambda": {"Ref": "LambdaFunction"}} ]}
-                        },
-                        {
-                            "Effect": "Allow",
                             "Action": [
-                              "ssm:GetParameter",
-                              "kms:Decrypt"
+                                "logs:CreateLogGroup",
+                                "logs:CreateLogStream",
+                                "logs:PutLogEvents"
                             ],
                             "Resource": {
-                              "Fn::Sub": [
-                                "arn:aws:ssm:${region}:${account}:parameter/*",
-                                {
-                                  "region": {
-                                    "Ref": "AWS::Region"
-                                  },
-                                  "account": {
-                                    "Ref": "AWS::AccountId"
-                                  }
-                                }
-                              ]
+                                "Fn::Sub": [
+                                    "arn:aws:logs:${region}:${account}:log-group:/aws/lambda/${lambda}:log-stream:*",
+                                    {
+                                        "region": { "Ref": "AWS::Region" },
+                                        "account": { "Ref": "AWS::AccountId" },
+                                        "lambda": { "Ref": "LambdaFunction" }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Action": ["ssm:GetParameter", "kms:Decrypt"],
+                            "Resource": {
+                                "Fn::Sub": [
+                                    "arn:aws:ssm:${region}:${account}:parameter/*",
+                                    {
+                                        "region": {
+                                            "Ref": "AWS::Region"
+                                        },
+                                        "account": {
+                                            "Ref": "AWS::AccountId"
+                                        }
+                                    }
+                                ]
                             }
                         }
                     ]
                 }
             }
         }
-        
-        
     },
     "Outputs": {
         "Name": {
@@ -184,7 +199,7 @@
             }
         },
         "Arn": {
-            "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
+            "Value": { "Fn::GetAtt": ["LambdaFunction", "Arn"] }
         },
         "Region": {
             "Value": {
@@ -196,6 +211,5 @@
                 "Ref": "LambdaExecutionRole"
             }
         }
-        
     }
 }

--- a/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
+++ b/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
@@ -31,11 +31,8 @@
         "LambdaPermission": {
             "Type": "AWS::Lambda::Permission",
             "Properties": {
-                "Sid": "FunctionURLAllowPublicAccess",
-                "Effect": "Allow",
-                "Principal": "*",
                 "Action": "lambda:InvokeFunctionUrl",
-                "Resource": {
+                "FunctionName": {
                     "Fn::Sub": [
                         "arn:aws:lambda:${region}:${account}:function:${lambda}",
                         {
@@ -45,11 +42,7 @@
                         }
                     ]
                 },
-                "Condition": {
-                    "StringEquals": {
-                        "lambda:FunctionUrlAuthType": "NONE"
-                    }
-                }
+                "Principal": "*"
             }
         },
         "LambdaFunction": {

--- a/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
+++ b/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
@@ -15,6 +15,12 @@
     },
     "s3Key": {
       "Type": "String"
+    },
+    "CreateLambdaUrl": {
+      "Type": "String",
+      "AllowedValues": ["true", "false"],
+      "Default": "false",
+      "Description": "Specifies whether to create the Lambda function URL"
     }
   },
   "Conditions": {
@@ -24,6 +30,12 @@
           "Ref": "env"
         },
         "NONE"
+      ]
+    },
+    "ShouldCreateLambdaUrl": {
+      "Fn::Equals": [
+        { "Ref": "CreateLambdaUrl" },
+        "true"
       ]
     }
   },
@@ -111,6 +123,7 @@
     },
     "LambdaUrl": {
       "Type": "AWS::Lambda::Url",
+      "Condition": "ShouldCreateLambdaUrl",
       "DependsOn": "LambdaFunction",
       "Properties": {
         "AuthType": "NONE",

--- a/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
+++ b/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
@@ -150,6 +150,26 @@
                             "Action": "lambda:InvokeFunctionUrl",
                             "Resource": { "Fn::Sub": [ "arn:aws:lambda:${region}:${account}:function:${lambda}", { "region": {"Ref": "AWS::Region"}, "account": {"Ref": "AWS::AccountId"}, "lambda": {"Ref": "LambdaFunction"}} ]}
                         },
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                              "ssm:GetParameter",
+                              "kms:Decrypt"
+                            ],
+                            "Resource": {
+                              "Fn::Sub": [
+                                "arn:aws:ssm:${region}:${account}:parameter/*",
+                                {
+                                  "region": {
+                                    "Ref": "AWS::Region"
+                                  },
+                                  "account": {
+                                    "Ref": "AWS::AccountId"
+                                  }
+                                }
+                              ]
+                            }
+                        }
                     ]
                 }
             }

--- a/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
+++ b/amplify/backend/function/createPrivateBetaInvite/createPrivateBetaInvite-cloudformation-template.json
@@ -142,7 +142,14 @@
                             "logs:CreateLogStream",
                             "logs:PutLogEvents"],
                             "Resource": { "Fn::Sub": [ "arn:aws:logs:${region}:${account}:log-group:/aws/lambda/${lambda}:log-stream:*", { "region": {"Ref": "AWS::Region"}, "account": {"Ref": "AWS::AccountId"}, "lambda": {"Ref": "LambdaFunction"}} ]}
-                        }
+                        },
+                        {
+                            "Sid": "AllowUnauthenticatedInvoke",
+                            "Effect": "Allow",
+                            "Principal": "*",
+                            "Action": "lambda:InvokeFunctionUrl",
+                            "Resource": { "Fn::Sub": [ "arn:aws:lambda:${region}:${account}:function:${lambda}", { "region": {"Ref": "AWS::Region"}, "account": {"Ref": "AWS::AccountId"}, "lambda": {"Ref": "LambdaFunction"}} ]}
+                        },
                     ]
                 }
             }

--- a/amplify/backend/function/createPrivateBetaInvite/function-parameters.json
+++ b/amplify/backend/function/createPrivateBetaInvite/function-parameters.json
@@ -1,3 +1,8 @@
 {
-  "lambdaLayers": []
+  "lambdaLayers": [
+    {
+      "type": "ExternalLayer",
+      "arn": "arn:aws:lambda:eu-west-2:133256977650:layer:AWS-Parameters-and-Secrets-Lambda-Extension:4"
+    }
+  ]
 }

--- a/amplify/backend/function/createPrivateBetaInvite/function-parameters.json
+++ b/amplify/backend/function/createPrivateBetaInvite/function-parameters.json
@@ -2,6 +2,10 @@
   "lambdaLayers": [
     {
       "type": "ExternalLayer",
+      "arn": "arn:aws:lambda:eu-west-2:204031746016:layer:colonycdappSSMAccess-qa:204"
+    },
+    {
+      "type": "ExternalLayer",
       "arn": "arn:aws:lambda:eu-west-2:133256977650:layer:AWS-Parameters-and-Secrets-Lambda-Extension:4"
     }
   ]


### PR DESCRIPTION
## Description

This PR adds the function url to the `createPrivateBeta` lambda and fixes a bug with the lambda that stopped it from being able to access the AWS Param store to correctly set the environment variables it needed.

A new `parameter` has been added to the lambda Parameters:
```json
    "CreateLambdaUrl": {
      "Type": "String",
      "AllowedValues": [
        "true",
        "false"
      ],
      "Default": "false",
      "Description": "Specifies whether to create the Lambda function URL"
    }
```

in order to control the condition on wherever the lambda url is created or not.

This condition is by default false and only needs to be run once. It mainly serves as documentation in code that this function url is required.

The bug fixes which have added the required layers to the lambda in order for it to gain access to the AWS param store are accompanied by an update to the notion documentation reflecting the steps required to give the lambda functions the correct access https://www.notion.so/colony/Getting-Started-with-CDapp-Lambda-Functions-82295a2197314973a57bd7c3c0a0759e?pvs=4#c027f2b288f2429ca0fb6d3a69179aa3 