### PR TITLE
Fix[15661600]: border radius for verified members table

### DIFF
--- a/src/components/frame/v5/pages/VerifiedPage/partials/VerifiedTable/VerifiedTable.tsx
+++ b/src/components/frame/v5/pages/VerifiedPage/partials/VerifiedTable/VerifiedTable.tsx
@@ -41,7 +41,6 @@ const VerifiedTable: FC<TableProps> = ({ list }) => {
       }
       verticalOnMobile={false}
       hasPagination
-      className="rounded-t-none"
       getRowId={({ contributorAddress }) => contributorAddress}
       columns={columns}
       data={list}


### PR DESCRIPTION
## Description

Task: https://tw.auroracreation.com/app/tasks/15661600

This task is already resolved on master branch, but I realised that, the top border radius is incorrect.

**Changes** 🏗

before:

![image](https://github.com/JoinColony/colonyCDapp/assets/90605528/d33671d2-4038-4b77-b6a7-84ea0097a881)

after:

![image](https://github.com/JoinColony/colonyCDapp/assets/90605528/0ba04d93-d583-4e1d-a49d-40289884c6fa)