### PR TITLE
Fix[15661610]: change icon size for filter items

### DIFF
--- a/src/components/shared/Icon/Icon.tsx
+++ b/src/components/shared/Icon/Icon.tsx
@@ -14,20 +14,22 @@ import styles from './Icon.module.css';
 
 const displayName = 'Icon';
 
+export type IconSize =
+  | 'extraExtraTiny'
+  | 'extraTiny'
+  | 'tiny'
+  | 'extraSmall'
+  | 'small'
+  | 'normal'
+  | 'medium'
+  | 'big'
+  | 'extraBig'
+  | 'large'
+  | 'huge';
+
 type Appearance = {
   theme?: 'primary' | 'invert';
-  size?:
-    | 'extraExtraTiny'
-    | 'extraTiny'
-    | 'tiny'
-    | 'extraSmall'
-    | 'small'
-    | 'normal'
-    | 'medium'
-    | 'big'
-    | 'extraBig'
-    | 'large'
-    | 'huge';
+  size?: IconSize;
 };
 
 export interface IconProps extends Omit<HTMLAttributes<HTMLElement>, 'title'> {

--- a/src/components/v5/common/Filter/partials/FilterOptions.tsx
+++ b/src/components/v5/common/Filter/partials/FilterOptions.tsx
@@ -32,6 +32,7 @@ const FilterOptions: FC = () => {
               title={title}
               option={filterType}
               nestedFilters={content}
+              iconSize="tiny"
             />
           ))}
         </ul>

--- a/src/components/v5/shared/SubNavigationItem/SubNavigationItem.tsx
+++ b/src/components/v5/shared/SubNavigationItem/SubNavigationItem.tsx
@@ -20,6 +20,7 @@ const SubNavigationItem: FC<SubNavigationItemProps> = ({
   isCopyTriggered,
   nestedFilters,
   onClick,
+  iconSize = 'extraSmall',
 }) => {
   const { formatMessage } = useIntl();
   const { getTooltipProps, setTooltipRef, setTriggerRef, visible } =
@@ -28,7 +29,7 @@ const SubNavigationItem: FC<SubNavigationItemProps> = ({
 
   const tooltipContent = (
     <>
-      <Icon name={iconName} appearance={{ size: 'extraSmall' }} />
+      <Icon name={iconName} appearance={{ size: iconSize }} />
       <span className="ml-2">{formatMessage({ id: title })}</span>
     </>
   );

--- a/src/components/v5/shared/SubNavigationItem/types.ts
+++ b/src/components/v5/shared/SubNavigationItem/types.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import { MessageDescriptor } from 'react-intl';
+import { IconSize } from '~shared/Icon/Icon';
 
 import { FilterOptionProps } from '~v5/common/Filter/types';
 import { FilterType } from '~v5/common/TableFiltering/types';
@@ -13,6 +14,7 @@ export type SubNavigationItemProps = {
   tooltipText?: string[];
   nestedFilters?: FilterOptionProps[];
   onClick?: (e: React.SyntheticEvent) => void;
+  iconSize?: IconSize;
 };
 
 export type NestedOptionsProps = {

--- a/src/components/v5/shared/SubNavigationItem/types.ts
+++ b/src/components/v5/shared/SubNavigationItem/types.ts
@@ -1,9 +1,9 @@
 import React from 'react';
 import { MessageDescriptor } from 'react-intl';
-import { IconSize } from '~shared/Icon/Icon';
 
 import { FilterOptionProps } from '~v5/common/Filter/types';
 import { FilterType } from '~v5/common/TableFiltering/types';
+import { IconSize } from '~shared/Icon/Icon';
 
 export type SubNavigationItemProps = {
   iconName: string;


### PR DESCRIPTION
## Description

Task: https://tw.auroracreation.com/app/tasks/15661610

**Changes** 🏗

before:

![image](https://github.com/JoinColony/colonyCDapp/assets/90605528/351514e0-8507-472e-9c6b-a81b9b34fecf)

after:

![image](https://github.com/JoinColony/colonyCDapp/assets/90605528/39ef4fee-ae3f-4acd-be4c-78fea1ab3c74)
