### PR TITLE
cicd: Enable on-demand dev environments log streaming to cloudwatch logs

### DIFF
--- a/.github/workflows/scripts/on-demand-env-script.sh
+++ b/.github/workflows/scripts/on-demand-env-script.sh
@@ -75,7 +75,7 @@ read -r -d '' PAYLOAD << EOM
   "embeds": [
     {
       "title": "Dev Environment Setup",
-      "description": "Hey <@$DISCORD_USER_ID>, your dev environment for $SOURCE_USED is getting ready, you can keep an eye on it [here]($CLOUDWATCH_URL).",
+      "description": "Hey <@$DISCORD_USER_ID>, your dev environment is getting ready, you can keep an eye on it [here]($CLOUDWATCH_URL).",
       "color": 5814783
     }
   ]

--- a/.github/workflows/scripts/on-demand-env-script.sh
+++ b/.github/workflows/scripts/on-demand-env-script.sh
@@ -25,8 +25,11 @@ sudo apt-get -y install docker-compose-plugin
 sudo usermod -aG docker ubuntu
 sudo systemctl start docker
 
-# Install CloudWatch Agent
-sudo apt-get install -y amazon-cloudwatch-agent
+# Download the CloudWatch agent
+wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+
+# Install the CloudWatch agent
+dpkg -i -E ./amazon-cloudwatch-agent.deb
 
 # Create a directory for the CloudWatch Agent configuration file
 mkdir -p /opt/aws/amazon-cloudwatch-agent/etc


### PR DESCRIPTION
## Description

Enable on demand log streaming to cloudwatch logs and send notification to discord with link to logs.

**New stuff** ✨

* New stuff goes here

**Changes** 🏗

* Changes go here

**Deletions** ⚰️

* Deletions go here

## TODO

- [ ] Add TODOs

(Resolves | Contributes to) #31415
