### PR TITLE
Fix Message Signing, User Transaction Persistance

### DIFF
--- a/src/components/common/Extensions/UserNavigation/hooks.ts
+++ b/src/components/common/Extensions/UserNavigation/hooks.ts
@@ -148,7 +148,6 @@ export const useGroupedTransactionsAndMessages = (): {
 
   const { data, fetchMore, refetch } = useGetUserTransactionsQuery({
     variables: {
-      colonyAddress,
       userAddress: walletAddress,
       transactionsOlderThan,
       limit: TRANSACTION_LIST_PAGE_SIZE * 3,

--- a/src/components/common/Extensions/UserNavigation/hooks.ts
+++ b/src/components/common/Extensions/UserNavigation/hooks.ts
@@ -7,7 +7,7 @@ import { TransactionOrMessageGroups } from '~frame/GasStation/transactionGroup';
 import { GetUserTransactionsQuery, useGetUserTransactionsQuery } from '~gql';
 import { useAppContext, useColonyContext } from '~hooks';
 import { TransactionType } from '~redux/immutable';
-import { groupedTransactionsAndMessages } from '~redux/selectors';
+import { groupedTransactions as groupedTransactionsSelector } from '~redux/selectors';
 import { ExtendedClientType, Transaction } from '~types';
 import { notNull } from '~utils/arrays';
 import { groupBy, unionBy } from '~utils/lodash';
@@ -131,18 +131,16 @@ export const useGroupedTransactionsAndMessages = (): {
   const { walletAddress = '' } = user ?? {};
   const { colonyAddress = '' } = colony ?? {};
 
-  const transactionAndMessageGroups = useSelector(
-    groupedTransactionsAndMessages,
-  );
+  const transactionGroups = useSelector(groupedTransactionsSelector);
 
   // @ts-ignore
-  const currentTransactionsAndMessages: TransactionOrMessageGroups = useMemo(
-    () => transactionAndMessageGroups.toJS(),
-    [transactionAndMessageGroups],
+  const currentTransactions: TransactionOrMessageGroups = useMemo(
+    () => transactionGroups.toJS(),
+    [transactionGroups],
   );
 
   // This is the oldest transaction in a user's session
-  const transactionsOlderThan = currentTransactionsAndMessages
+  const transactionsOlderThan = currentTransactions
     .at(-1)?.[0]
     ?.createdAt?.toISOString();
 
@@ -161,12 +159,12 @@ export const useGroupedTransactionsAndMessages = (): {
     const transactions = items?.filter(notNull) ?? [];
     const groupedHistoricTransactions = sortAndGroupTransactions(transactions);
     return [
-      ...currentTransactionsAndMessages,
+      ...currentTransactions,
       ...groupedHistoricTransactions.map((group) =>
         group.map(convertTransactionType),
       ),
     ];
-  }, [items, currentTransactionsAndMessages]);
+  }, [items, currentTransactions]);
 
   useEffect(() => {
     if (mergedTransactions.length < visibleItems && nextToken) {

--- a/src/components/common/Extensions/UserNavigation/hooks.ts
+++ b/src/components/common/Extensions/UserNavigation/hooks.ts
@@ -1,6 +1,6 @@
 import { ApolloQueryResult } from '@apollo/client';
 import { ClientTypeTokens } from '@colony/colony-js';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { TransactionOrMessageGroups } from '~frame/GasStation/transactionGroup';
@@ -169,9 +169,11 @@ export const useGroupedTransactionsAndMessages = (): {
     ];
   }, [items, currentTransactionsAndMessages]);
 
-  if (mergedTransactions.length < visibleItems && nextToken) {
-    fetchMore({ variables: { nextToken }, updateQuery });
-  }
+  useEffect(() => {
+    if (mergedTransactions.length < visibleItems && nextToken) {
+      fetchMore({ variables: { nextToken }, updateQuery });
+    }
+  }, [mergedTransactions, visibleItems, nextToken, fetchMore]);
 
   const visibleTransactions = useMemo(
     () => mergedTransactions.slice(0, visibleItems),

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -8886,7 +8886,7 @@ export type GetUserTokenBalanceQuery = { __typename?: 'Query', getUserTokenBalan
 
 export type GetUserTransactionsQueryVariables = Exact<{
   userAddress: Scalars['ID'];
-  colonyAddress: Scalars['ID'];
+  colonyAddress?: InputMaybe<Scalars['ID']>;
   transactionsOlderThan?: InputMaybe<Scalars['String']>;
   nextToken?: InputMaybe<Scalars['String']>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -12027,7 +12027,7 @@ export type GetUserTokenBalanceQueryHookResult = ReturnType<typeof useGetUserTok
 export type GetUserTokenBalanceLazyQueryHookResult = ReturnType<typeof useGetUserTokenBalanceLazyQuery>;
 export type GetUserTokenBalanceQueryResult = Apollo.QueryResult<GetUserTokenBalanceQuery, GetUserTokenBalanceQueryVariables>;
 export const GetUserTransactionsDocument = gql`
-    query GetUserTransactions($userAddress: ID!, $colonyAddress: ID!, $transactionsOlderThan: String, $nextToken: String, $limit: Int) {
+    query GetUserTransactions($userAddress: ID!, $colonyAddress: ID, $transactionsOlderThan: String, $nextToken: String, $limit: Int) {
   getTransactionsByUser(
     from: $userAddress
     createdAt: {lt: $transactionsOlderThan}

--- a/src/graphql/queries/transactions.graphql
+++ b/src/graphql/queries/transactions.graphql
@@ -1,6 +1,6 @@
 query GetUserTransactions(
   $userAddress: ID!
-  $colonyAddress: ID!
+  $colonyAddress: ID
   $transactionsOlderThan: String
   $nextToken: String
   $limit: Int

--- a/src/redux/sagas/transactions/transactionsToDb.ts
+++ b/src/redux/sagas/transactions/transactionsToDb.ts
@@ -336,8 +336,8 @@ function* updateTransactionInDb({
     }
   } catch (e) {
     console.error(
-      `Unable to update transaction with id: ${id} in db. 
-       Action type: ${type}. 
+      `Unable to update transaction with id: ${id} in db.
+       Action type: ${type}.
        Reason: ${e}`,
     );
   }


### PR DESCRIPTION
This PR is two-parter:
- First, fix UserHub transaction persistence
- Second, prevent messages from showing up in the UserHub transactions list

**UserHub Transaction Persistence**

This was implemented using a wrong spec, as it tried to only load transactions based on the currently selected colony, which should not be case.

I refactored this to fetch all transactions from the database that were initiated by this user.

**Prevent messages from showing up in UserHub**

Messages should not show up (at least for now) in the transactions list. So I refactored the hook to use the `transactionsGroup` selector vs. the original `transactionsAndMessagesGroup`. 

This was both a UI issue, as the messages that showed up in the list were unstyled, and both a logic one, as the mutation would try to save the message to the database, where the format is unsupported