### PR TITLE
Fix UserAvatar showing alternating blockies

### DIFF
--- a/src/components/common/Extensions/SpecificSidePanel/hooks.tsx
+++ b/src/components/common/Extensions/SpecificSidePanel/hooks.tsx
@@ -77,7 +77,7 @@ export const useSpecificSidePanel = (extensionData: AnyExtensionData) => {
         },
         installedBy: {
           title: formatMessage({ id: 'installed.by' }),
-          component: <UserAvatar user={user} />,
+          component: user ? <UserAvatar user={user} /> : null,
           user,
         },
         versionInstalled: {

--- a/src/components/common/Extensions/SpecificSidePanel/types.ts
+++ b/src/components/common/Extensions/SpecificSidePanel/types.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { ColonyRole } from '@colony/colony-js';
 
 import { AnyExtensionData } from '~types';
@@ -21,7 +22,7 @@ export type SidePanelDataProps = {
   };
   installedBy: {
     title: string;
-    component: JSX.Element;
+    component: ReactNode;
   };
   versionInstalled: {
     title: string;

--- a/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
+++ b/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
@@ -7,10 +7,10 @@ import {
   useAppContext,
   useColonyContext,
   useDetectClickOutside,
+  useMobile,
   useTablet,
 } from '~hooks';
 import MemberReputation from '~common/Extensions/UserNavigation/partials/MemberReputation';
-import { splitWalletAddress } from '~utils/splitWalletAddress';
 import Button from '~v5/shared/Button';
 import UserAvatar from '~v5/shared/UserAvatar';
 import PopoverBase from '~v5/shared/PopoverBase';
@@ -27,9 +27,9 @@ const UserHubButton: FC<UserHubButtonProps> = ({
   hideUserNameOnMobile,
 }) => {
   const isTablet = useTablet();
+  const isMobile = useMobile();
   const { colony } = useColonyContext();
   const { wallet, user } = useAppContext();
-  const { profile } = user || {};
   const walletAddress = wallet?.address;
   const [isUserHubOpen, setIsUserHubOpen] = useState(false);
   const { setOpenItemIndex, mobileMenuToggle } = useNavigationSidebarContext();
@@ -84,21 +84,21 @@ const UserHubButton: FC<UserHubButtonProps> = ({
         }}
       >
         <div className="flex items-center gap-3">
-          <UserAvatar
-            user={user}
-            userName={
-              profile?.displayName ?? splitWalletAddress(walletAddress ?? '')
-            }
-            hideUserNameOnMobile={hideUserNameOnMobile}
-            size="xxs"
-          />
-          {walletAddress && (
-            <MemberReputation
-              colonyAddress={colony?.colonyAddress}
-              hideOnMobile={hideMemberReputationOnMobile}
-              walletAddress={walletAddress}
-            />
-          )}
+          {/* If there's a user, there's a wallet */}
+          {walletAddress ? (
+            <>
+              <UserAvatar
+                user={user || walletAddress}
+                showUsername={!(hideUserNameOnMobile && isMobile)}
+                size="xxs"
+              />
+              <MemberReputation
+                colonyAddress={colony?.colonyAddress}
+                hideOnMobile={hideMemberReputationOnMobile}
+                walletAddress={walletAddress}
+              />
+            </>
+          ) : null}
         </div>
       </Button>
       {(visible || isUserHubOpen) && (

--- a/src/components/common/Extensions/UserNavigation/partials/HeaderAvatar/HeaderAvatar.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/HeaderAvatar/HeaderAvatar.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { useAppContext } from '~hooks';
-import { splitWalletAddress } from '~utils/splitWalletAddress';
 import UserAvatar from '~v5/shared/UserAvatar';
 
 export const displayName =
@@ -9,16 +8,15 @@ export const displayName =
 
 const HeaderAvatar = () => {
   const { wallet, user } = useAppContext();
+
+  // Prevent content flashes
+  if (!wallet) {
+    return null;
+  }
+
   return (
     <div className="flex items-center justify-center min-w-[2.625rem] min-h-[2.5rem] px-[0.875rem] py-[0.625rem] bg-base-white border rounded-full border-gray-200">
-      <UserAvatar
-        user={user}
-        userName={
-          user?.profile?.displayName ??
-          splitWalletAddress(wallet?.address ?? '')
-        }
-        size="xxs"
-      />
+      <UserAvatar user={user || wallet?.address} showUsername size="xxs" />
     </div>
   );
 };

--- a/src/components/common/Extensions/UserNavigation/partials/UserMenu/UserMenu.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserMenu/UserMenu.tsx
@@ -54,7 +54,7 @@ const UserMenu: FC<UserMenuProps> = ({
           '-translate-x-[100vw] absolute': activeSubmenu,
         })}
       >
-        {isWalletConnected ? (
+        {walletAddress ? (
           <div className="px-6">
             <WalletConnectedTopMenu
               userName={

--- a/src/components/frame/v5/pages/UserProfilePage/partials/UserProfilePageForm.tsx
+++ b/src/components/frame/v5/pages/UserProfilePage/partials/UserProfilePageForm.tsx
@@ -42,7 +42,7 @@ const UserProfilePageForm = ({
     getValues,
     reset,
   } = useFormContext();
-  const { updateUser } = useAppContext();
+  const { updateUser, wallet } = useAppContext();
   const [updateAvatar] = useUpdateUserProfileMutation();
   const isMobile = useMobile();
   const { displayName: displayNameDirty } = dirtyFields;
@@ -187,7 +187,13 @@ const UserProfilePageForm = ({
         />
         <div className="w-full">
           <AvatarUploader
-            avatarPlaceholder={<Avatar size="xm" avatar={avatarUrl} />}
+            avatarPlaceholder={
+              <Avatar
+                size="xm"
+                avatar={avatarUrl}
+                seed={wallet?.address.toLowerCase()}
+              />
+            }
             fileOptions={{
               fileFormat: ['.PNG', '.JPG', '.SVG'],
               fileDimension: '250x250px',

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/hooks.tsx
@@ -91,12 +91,10 @@ export const useStakingInformation = (
         return result;
       }
 
-      const userName = users?.length
-        ? users?.find((user) => user?.walletAddress === item.address)?.profile
-            ?.displayName
-        : undefined;
+      const user = users?.find((u) => u?.walletAddress === item.address)
+        ?.profile?.displayName;
 
-      if (!userName) {
+      if (!user) {
         return result;
       }
 
@@ -117,7 +115,7 @@ export const useStakingInformation = (
             },
           ),
           userProps: {
-            userName,
+            user,
           },
         },
       ];

--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
@@ -57,7 +57,6 @@ const UserSelect: FC<UserSelectProps> = ({ name }) => {
         <>
           <UserAvatar
             user={userByAddress || field.value}
-            userName={userDisplayName}
             size="xs"
             className={clsx({
               'text-warning-400': !isUserVerified,
@@ -89,7 +88,6 @@ const UserSelect: FC<UserSelectProps> = ({ name }) => {
               <>
                 <UserAvatar
                   user={userByAddress || field.value}
-                  userName={userDisplayName}
                   size="xs"
                   className={clsx({
                     'text-warning-400': !isUserVerified,

--- a/src/components/v5/shared/UserAvatar/UserAvatar.tsx
+++ b/src/components/v5/shared/UserAvatar/UserAvatar.tsx
@@ -5,24 +5,28 @@ import styles from './UserAvatar.module.css';
 import { UserAvatarProps } from './types';
 import Avatar from '~v5/shared/Avatar';
 import Link from '~v5/shared/Link';
+import { splitWalletAddress } from '~utils/splitWalletAddress';
 
 const displayName = 'v5.UserAvatar';
 
 const UserAvatar: FC<UserAvatarProps> = ({
-  user,
+  avatarSize,
+  className,
+  isContributorsList,
   isLink = false,
   preferThumbnail = true,
-  userName,
+  showUsername = false,
   size = 'xxs',
-  avatarSize,
+  user,
   userStatus,
-  isContributorsList,
-  className,
-  hideUserNameOnMobile,
   ...rest
 }) => {
-  const address = user?.walletAddress;
-  const { profile } = user || {};
+  const address = typeof user == 'string' ? user : user.walletAddress;
+  const profile = typeof user == 'string' ? null : user.profile;
+  const username =
+    typeof user != 'string'
+      ? user.profile?.displayName
+      : splitWalletAddress(address);
   const imageString = preferThumbnail ? profile?.thumbnail : profile?.avatar;
 
   const avatar = (
@@ -49,17 +53,16 @@ const UserAvatar: FC<UserAvatarProps> = ({
           {...rest}
         />
       </span>
-      {userName && (
+      {showUsername ? (
         <p
           className={clsx(className, 'font-medium truncate', {
             'text-sm ml-1': size === 'xxs',
             'text-md ml-2': size === 'xs' || size === 'sm',
-            'hidden md:block': hideUserNameOnMobile,
           })}
         >
-          {userName}
+          {username}
         </p>
-      )}
+      ) : null}
     </span>
   );
 

--- a/src/components/v5/shared/UserAvatar/types.ts
+++ b/src/components/v5/shared/UserAvatar/types.ts
@@ -1,16 +1,17 @@
+import { Optional } from 'utility-types';
 import { User } from '~types';
 import { UserStatusMode } from '~v5/common/Pills/types';
 import { AvatarSize } from '../Avatar/types';
 
 export interface UserAvatarProps {
-  userName?: string | null;
-  preferThumbnail?: boolean;
-  user?: User | null;
-  isLink?: boolean;
-  size?: AvatarSize;
   avatarSize?: AvatarSize;
-  userStatus?: UserStatusMode | null;
-  isContributorsList?: boolean;
-  hideUserNameOnMobile?: boolean;
   className?: string;
+  isContributorsList?: boolean;
+  isLink?: boolean;
+  preferThumbnail?: boolean;
+  showUsername?: boolean;
+  size?: AvatarSize;
+  // This is deliberately brief to easily support stories
+  user: (Optional<User, 'profile'> & Pick<User, 'walletAddress'>) | string;
+  userStatus?: UserStatusMode | null;
 }

--- a/src/components/v5/shared/UserAvatarDetails/UserAvatarDetails.tsx
+++ b/src/components/v5/shared/UserAvatarDetails/UserAvatarDetails.tsx
@@ -36,6 +36,7 @@ const UserAvatarDetails: FC<UserAvatarDetailsProps> = ({
           title={userName}
           avatar={avatar}
           mode={userStatus}
+          seed={walletAddress.toLowerCase()}
         />
       ) : (
         <div className="flex relative justify-center">
@@ -55,6 +56,7 @@ const UserAvatarDetails: FC<UserAvatarDetailsProps> = ({
               title={userName}
               avatar={avatar}
               mode={userStatus ?? 'general'}
+              seed={walletAddress.toLowerCase()}
             />
           </div>
           {!!userStatus && userStatus !== 'general' && isContributorsList && (

--- a/src/components/v5/shared/UserAvatarDetails/types.ts
+++ b/src/components/v5/shared/UserAvatarDetails/types.ts
@@ -4,7 +4,7 @@ import { UserStatusMode } from '~v5/common/Pills/types';
 export interface UserAvatarDetailsProps extends AvatarProps {
   userName?: string | null;
   isVerified?: boolean;
-  walletAddress?: string;
+  walletAddress: string;
   userStatus?: UserStatusMode | null;
   isContributorsList?: boolean;
   isBordered?: boolean;

--- a/src/components/v5/shared/UserAvatarPopover/UserAvatarPopover.tsx
+++ b/src/components/v5/shared/UserAvatarPopover/UserAvatarPopover.tsx
@@ -7,15 +7,14 @@ import UserPopover from '../UserPopover';
 const displayName = 'v5.UserAvatarPopover';
 
 const UserAvatarPopover: FC<UserAvatarPopoverProps> = ({ size, ...props }) => {
-  const { user, userName, walletAddress, userStatus, isContributorsList } =
-    props;
+  const { user, walletAddress, userStatus, isContributorsList } = props;
 
   return (
     <UserPopover {...props}>
       <UserAvatar
         size={size || 'xs'}
-        userName={userName ?? walletAddress}
-        user={user}
+        user={user || walletAddress}
+        showUsername
         userStatus={userStatus}
         isContributorsList={isContributorsList}
       />

--- a/src/stories/common/UserNavigation.stories.tsx
+++ b/src/stories/common/UserNavigation.stories.tsx
@@ -74,7 +74,13 @@ const UserNavigationWithData = () => {
             onClick={() => setIsOpen(!isOpen)}
           >
             <div className="flex items-center gap-3">
-              <UserAvatar userName="panda" size="xxs" />
+              <UserAvatar
+                user={{
+                  profile: { displayName: 'Panda' },
+                  walletAddress: '0x',
+                }}
+                size="xxs"
+              />
             </div>
           </Button>
           <Button mode="tertiary" isFullRounded iconName="list" />

--- a/src/stories/shared/UserAvatar.stories.tsx
+++ b/src/stories/shared/UserAvatar.stories.tsx
@@ -12,10 +12,10 @@ const meta: Meta<typeof UserAvatar> = {
     },
   },
   argTypes: {
-    userName: {
-      name: 'User name',
+    user: {
+      name: 'User',
       control: {
-        type: 'text',
+        type: 'object',
       },
     },
     isLink: {
@@ -33,7 +33,10 @@ const meta: Meta<typeof UserAvatar> = {
     },
   },
   args: {
-    userName: 'Panda',
+    user: {
+      profile: { displayName: 'Panda' },
+      walletAddress: '0x0',
+    },
     isLink: false,
   },
 };

--- a/src/stories/shared/UserAvatarPopover.stories.tsx
+++ b/src/stories/shared/UserAvatarPopover.stories.tsx
@@ -6,10 +6,10 @@ const meta: Meta<typeof UserAvatarPopover> = {
   title: 'Shared/User Avatar Popover',
   component: UserAvatarPopover,
   argTypes: {
-    userName: {
-      name: 'User name',
+    user: {
+      name: 'User',
       control: {
-        type: 'text',
+        type: 'object',
       },
     },
     walletAddress: {
@@ -26,7 +26,10 @@ const meta: Meta<typeof UserAvatarPopover> = {
     },
   },
   args: {
-    userName: 'Panda',
+    user: {
+      profile: { displayName: 'Panda' },
+      walletAddress: '0x0',
+    },
     walletAddress: '0x155....1051',
     aboutDescription: `Passionate about sustainability and living a zero-waste lifestyle. Lover of all things vintage and retro. High-tops are my everything.`,
   },

--- a/src/stories/shared/UserInfoList.stories.tsx
+++ b/src/stories/shared/UserInfoList.stories.tsx
@@ -10,21 +10,30 @@ const userInfoListMeta: Meta<typeof UserInfoList> = {
         key: '1',
         info: 'Staked 5.67 CLNY',
         userProps: {
-          userName: 'JohnnyBravo',
+          user: {
+            profile: { displayName: 'JohnnyBravo' },
+            walletAddress: '0x0',
+          },
         },
       },
       {
         key: '2',
         info: 'Staked 4.95 CLNY',
         userProps: {
-          userName: 'ChuckieChuckie',
+          user: {
+            profile: { displayName: 'ChuckieChukie' },
+            walletAddress: '0x1',
+          },
         },
       },
       {
         key: '3',
         info: 'Staked 1.23 CLNY',
         userProps: {
-          userName: 'Reallylongusername',
+          user: {
+            profile: { displayName: 'Reallylongusername' },
+            walletAddress: '0x2',
+          },
         },
       },
     ],

--- a/src/stories/shared/UserInfoSectionList.stories.tsx
+++ b/src/stories/shared/UserInfoSectionList.stories.tsx
@@ -16,21 +16,30 @@ const userInfoSectionListMeta: Meta<typeof UserInfoSectionList> = {
             key: '1',
             info: 'Staked 5.67 CLNY',
             userProps: {
-              userName: 'JohnnyBravo',
+              user: {
+                profile: { displayName: 'JohnnyBravo' },
+                walletAddress: '0x0',
+              },
             },
           },
           {
             key: '2',
             info: 'Staked 4.95 CLNY',
             userProps: {
-              userName: 'ChuckieChuckie',
+              user: {
+                profile: { displayName: 'ChuckieChukie' },
+                walletAddress: '0x1',
+              },
             },
           },
           {
             key: '3',
             info: 'Staked 1.23 CLNY',
             userProps: {
-              userName: 'Reallylongusername',
+              user: {
+                profile: { displayName: 'Reallylongusername' },
+                walletAddress: '0x2',
+              },
             },
           },
         ],
@@ -45,21 +54,30 @@ const userInfoSectionListMeta: Meta<typeof UserInfoSectionList> = {
             key: '1',
             info: 'Staked 5.67 CLNY',
             userProps: {
-              userName: 'JohnnyBravo',
+              user: {
+                profile: { displayName: 'JohnnyBravo' },
+                walletAddress: '0x0',
+              },
             },
           },
           {
             key: '2',
             info: 'Staked 4.95 CLNY',
             userProps: {
-              userName: 'ChuckieChuckie',
+              user: {
+                profile: { displayName: 'ChuckieChukie' },
+                walletAddress: '0x1',
+              },
             },
           },
           {
             key: '3',
             info: 'Staked 1.23 CLNY',
             userProps: {
-              userName: 'Reallylongusername',
+              user: {
+                profile: { displayName: 'Reallylongusername' },
+                walletAddress: '0x2',
+              },
             },
           },
         ],


### PR DESCRIPTION
## Description

On my journey through the dapp I noticed that the UserAvatar would show a new blockie on every reload. That's not cool, so I fixed it.

Also I think I improved the UserAvatar in a way that it takes some of the mental load off the developers. The experience should be pretty consistent now, basically pass in a user object or a wallet address as string as the `user` prop. Then `showUsername` will do the right thing.
Mind that `user` is a _required_ prop now. I would argue if we don't have a wallet connected, we shouldn't render this component in any case.

@joanna-pagepro can you maybe make sure that I didn't break any of the stories?