### PR TITLE
fix: update appsync api id with correct value

### DIFF
--- a/amplify/backend/function/getTotalMemberCount/getTotalMemberCount-cloudformation-template.json
+++ b/amplify/backend/function/getTotalMemberCount/getTotalMemberCount-cloudformation-template.json
@@ -64,7 +64,7 @@
                 ]
             },
             "Environment": {
-                "Variables" : {"ENV":{"Ref":"env"},"REGION":{"Ref":"AWS::Region"}, "APPSYNC_API_ID": "nyc3o2a3i5by7hdrgoihsqfszm"}
+                "Variables" : {"ENV":{"Ref":"env"},"REGION":{"Ref":"AWS::Region"}, "APPSYNC_API_ID": "j4tejwfujzcydjwmcvk2zzio6q"}
             },
             "Role": { "Fn::GetAtt": ["LambdaExecutionRole", "Arn"] },
             "Runtime": "nodejs18.x",


### PR DESCRIPTION
## Description

- Appsync api id changed as a consequence of redeploying the cdapp amplify stack a while back.

**New stuff** ✨

* New stuff goes here

**Changes** 🏗

* Changes go here

**Deletions** ⚰️

* Deletions go here

## TODO

- [ ] Add TODOs

(Resolves | Contributes to) #31415
