### PR TITLE
fix: align modal background colour

### DIFF
--- a/src/components/v5/shared/Modal/ModalBase.tsx
+++ b/src/components/v5/shared/Modal/ModalBase.tsx
@@ -22,7 +22,7 @@ const ModalBase: FC<ModalBaseProps> = ({
       role={role}
       overlayClassName={{
         base: clsx(
-          'flex justify-center items-center fixed inset-0 z-[999] bg-base-sprite/50',
+          'flex justify-center items-center fixed inset-0 z-[999] bg-base-sprite',
           {
             'py-4': !isFullOnMobile,
           },


### PR DESCRIPTION
## Description

Our base modal component had a lighter background than it is in the designs.
This PR addresses that.

**Changes** 🏗

* Colour of the modal overlay aligned

Resolves  #1255 
