### PR TITLE
Activate tokens link should open the Activate tokens modal

### DIFF
--- a/codegen.js
+++ b/codegen.js
@@ -8,7 +8,6 @@ const {
   printSchema,
 } = require('graphql');
 const fetch = require('node-fetch');
-const http = require('http');
 
 const SCHEMA_LOCATION = './tmp-schema.graphql';
 
@@ -55,38 +54,9 @@ const codegen = async () => {
       },
       watch: graphqlFiles,
     });
-  } catch {
-    console.error('Error when fetching Amplify schema, retrying...');
-    setTimeout(codegen, 5000);
+  } catch (error) {
+    console.error('Error when generating types: ', error);
   }
 };
 
-const SERVICE_PORT = 20002;
-
-function isServiceResponsive(callback) {
-  http
-    .get(`http://localhost:${SERVICE_PORT}`, (res) => {
-      if (res.statusCode === 200) {
-        callback(true);
-      } else {
-        callback(false);
-      }
-    })
-    .on('error', (err) => {
-      callback(false);
-    });
-}
-
-function waitForServiceToBeResponsive(callback) {
-  isServiceResponsive((isResponsive) => {
-    if (isResponsive) {
-      callback();
-    } else {
-      setTimeout(() => {
-        waitForServiceToBeResponsive(callback);
-      }, 1000); // Check every second
-    }
-  });
-}
-
-waitForServiceToBeResponsive(codegen);
+codegen();

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -3,9 +3,3 @@
 npm run docker:build:"$1"
 
 npm run docker:compose:"$1" up -- --force-recreate -V &
-
-# Give some time for the previous docker containers to be stopped
-# otherwise codegen will run too quickly
-sleep 10
-
-node codegen

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/NotEnoughTokensInfo/NotEnoughTokensInfo.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/NotEnoughTokensInfo/NotEnoughTokensInfo.tsx
@@ -1,12 +1,13 @@
 import React, { FC } from 'react';
 import { useTokensModalContext } from '~context';
 import { formatText } from '~utils/intl';
+import { TOKENS_MODAL_TYPES } from '~v5/common/TokensModal/consts';
 
 const displayName =
   'v5.common.ActionSidebar.partials.motions.MotionSimplePayment.steps.StakingStep.partials.NotEnoughTokensInfo';
 
 const NotEnoughTokensInfo: FC = () => {
-  const { toggleOnTokensModal } = useTokensModalContext();
+  const { toggleOnTokensModal, setTokensModalType } = useTokensModalContext();
 
   return (
     <>
@@ -18,7 +19,10 @@ const NotEnoughTokensInfo: FC = () => {
       <button
         type="button"
         className="text-4 underline transition-all md:hover:opacity-80"
-        onClick={() => toggleOnTokensModal()}
+        onClick={() => {
+          toggleOnTokensModal();
+          setTokensModalType(TOKENS_MODAL_TYPES.activate);
+        }}
       >
         {formatText({
           id: 'motion.staking.activateTokens',

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/NotEnoughTokensInfo/NotEnoughTokensInfo.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/NotEnoughTokensInfo/NotEnoughTokensInfo.tsx
@@ -1,28 +1,32 @@
 import React, { FC } from 'react';
+import { useTokensModalContext } from '~context';
 import { formatText } from '~utils/intl';
 
 const displayName =
   'v5.common.ActionSidebar.partials.motions.MotionSimplePayment.steps.StakingStep.partials.NotEnoughTokensInfo';
 
-const NotEnoughTokensInfo: FC = () => (
-  <>
-    <p className="text-sm mb-1">
-      {formatText({
-        id: 'motion.staking.notEnoughTokens',
-      })}
-    </p>
-    <button
-      type="button"
-      className="text-4 underline transition-all md:hover:opacity-80"
-      // @todo: add a toggler to open activate tokens modal
-      onClick={() => {}}
-    >
-      {formatText({
-        id: 'motion.staking.activateTokens',
-      })}
-    </button>
-  </>
-);
+const NotEnoughTokensInfo: FC = () => {
+  const { toggleOnTokensModal } = useTokensModalContext();
+
+  return (
+    <>
+      <p className="text-sm mb-1">
+        {formatText({
+          id: 'motion.staking.notEnoughTokens',
+        })}
+      </p>
+      <button
+        type="button"
+        className="text-4 underline transition-all md:hover:opacity-80"
+        onClick={() => toggleOnTokensModal()}
+      >
+        {formatText({
+          id: 'motion.staking.activateTokens',
+        })}
+      </button>
+    </>
+  );
+};
 
 NotEnoughTokensInfo.displayName = displayName;
 


### PR DESCRIPTION
## Description

When clicking on the activate link, the modal should open:

https://github.com/JoinColony/colonyCDapp/assets/112586815/63974122-4180-4f2b-a5d0-09c994c378aa

This PR also removes codegen starting automatically and running in a loop.

Resolves #1364 
