### PR TITLE
fix: removed overflow-hidden on mobile when isMotion

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -103,8 +103,10 @@ const ActionSidebarContent: FC<ActionSidebarContentProps> = ({
 
   return (
     <div
-      className={clsx('flex w-full flex-grow overflow-hidden', {
-        'flex-col-reverse md:flex-row': isMotion,
+      className={clsx('flex w-full flex-grow', {
+        'flex-col-reverse overflow-auto sm:overflow-hidden md:flex-row':
+          isMotion,
+        'overflow-hidden': !isMotion,
       })}
     >
       <div className="flex-grow px-6 py-8">


### PR DESCRIPTION
https://tw.auroracreation.com/app/tasks/15629368

Fixed action sidebar disabled scroll when there is too much content:
![image](https://github.com/JoinColony/colonyCDapp/assets/76940796/e33b217a-27ee-4980-a4e2-666a39fece67)
