### PR TITLE
fix: updated cleave package, formatted input prefix, chart colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "bn.js": "^5.1.1",
     "camelcase": "^6.0.0",
     "classnames": "^2.2.6",
-    "cleave.js": "1.4.10",
+    "cleave.js": "^1.6.0",
     "clsx": "^1.2.1",
     "constants-browserify": "^1.0.0",
     "copy-to-clipboard": "^3.0.8",

--- a/src/components/common/Extensions/UserNavigation/UserNavigation.tsx
+++ b/src/components/common/Extensions/UserNavigation/UserNavigation.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
 
-import { useMatch } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useAppContext, useGetNetworkToken, useTablet } from '~hooks';
 import Button, { Hamburger } from '~v5/shared/Button';
 import Token from './partials/Token';
@@ -21,7 +21,8 @@ const UserNavigation: FC<UserNavigationProps> = ({
   const isTablet = useTablet();
   const { setOpenItemIndex, mobileMenuToggle } = useNavigationSidebarContext();
   const [, { toggleOff }] = mobileMenuToggle;
-  const isOnColonyRoute = useMatch('/colony/:colonyName/*');
+  const { colonyName = '' } = useParams();
+  const isOnColonyRoute = colonyName !== '';
 
   const isWalletConnected = !!wallet?.address;
   const nativeToken = useGetNetworkToken();

--- a/src/components/v5/common/ActionSidebar/partials/Motions/consts.ts
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/consts.ts
@@ -26,6 +26,6 @@ export const opposeOption = {
 };
 
 export const STAKING_RADIO_BUTTONS: ButtonRadioButtonItem<MotionVote>[] = [
-  supportOption,
   opposeOption,
+  supportOption,
 ];

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/StakingForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/StakingForm.tsx
@@ -124,7 +124,7 @@ const StakingForm: FC<StakingFormProps> = ({
                     </span>
                     <span className="text-sm text-gray-600">
                       {formatText(
-                        { id: 'motion.staking.input.balance' },
+                        { id: 'motion.staking.input.label.balance' },
                         {
                           balance: (
                             <Numeral

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/StakingForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/StakingForm.tsx
@@ -146,9 +146,11 @@ const StakingForm: FC<StakingFormProps> = ({
                         getTokenDecimalsWithFallback(tokenDecimals),
                       numeralPositiveOnly: true,
                       rawValueTrimPrefix: true,
-                      prefix: tokenSymbol,
+                      prefix: ` ${tokenSymbol}`,
                       tailPrefix: true,
+                      noImmediatePrefix: true,
                     }}
+                    placeholder="0"
                     buttonProps={{
                       label: formatText({ id: 'button.max' }) || '',
                       onClick: () => {

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditTeamForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditTeamForm/hooks.ts
@@ -62,7 +62,7 @@ export const useEditTeam = (
       pipe(
         mapPayload((payload: EditTeamFormValues) => {
           const values = {
-            domainId: payload.team,
+            domainId: parseFloat(payload.team),
             domainName: payload.teamName,
             domainPurpose: payload.domainPurpose,
             domainColor: payload.domainColor,

--- a/src/components/v5/common/Fields/InputBase/FormattedInput.tsx
+++ b/src/components/v5/common/Fields/InputBase/FormattedInput.tsx
@@ -32,6 +32,8 @@ const FormattedInput: FC<FormattedInputProps> = ({
     buttonRef,
     wrapperRef,
     customPrefixRef,
+    handlePrefixTrim,
+    inputRef,
   } = useFormattedInput(value, options);
 
   const stateClassNames = useStateClassNames(
@@ -87,6 +89,9 @@ const FormattedInput: FC<FormattedInputProps> = ({
         )}
         <Cleave
           {...rest}
+          htmlRef={(ref) => {
+            inputRef.current = ref;
+          }}
           disabled={disabled}
           key={dynamicCleaveOptionKey}
           placeholder={placeholder || ''}
@@ -96,7 +101,10 @@ const FormattedInput: FC<FormattedInputProps> = ({
            */
           options={options}
           onInit={(cleaveInstance) => setCleave(cleaveInstance)}
-          onChange={onChange}
+          onChange={(e) => {
+            handlePrefixTrim(options.prefix);
+            onChange?.(e);
+          }}
           className={clsx(
             className,
             state ? stateClassNames[state] : undefined,

--- a/src/components/v5/common/Fields/InputBase/hooks.ts
+++ b/src/components/v5/common/Fields/InputBase/hooks.ts
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
   useImperativeHandle,
+  useCallback,
 } from 'react';
 import { getInputTextWidth } from '~utils/elements';
 import { FormattedInputProps } from './types';
@@ -53,10 +54,9 @@ export const useFormattedInput = (
 ) => {
   const [cleave, setCleave] = useState<ReactInstanceWithCleave | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const customPrefixRef = useRef<HTMLDivElement | null>(null);
-
-  const { prefix, tailPrefix } = options || {};
 
   /**
    * Sync the cleave raw value with value prop
@@ -67,12 +67,8 @@ export const useFormattedInput = (
       return;
     }
 
-    cleave?.setRawValue(
-      `${prefix && !tailPrefix ? prefix : ''}${value}${
-        prefix && tailPrefix ? ` ${prefix}` : ''
-      }`,
-    );
-  }, [cleave, prefix, tailPrefix, value]);
+    cleave?.setRawValue(value);
+  }, [cleave, value]);
 
   useEffect(() => {
     addWidthProperty(buttonRef.current, wrapperRef.current, 'button');
@@ -81,6 +77,18 @@ export const useFormattedInput = (
       wrapperRef.current,
       'custom-prefix',
     );
+  }, []);
+
+  const handlePrefixTrim = useCallback((prefix?: string) => {
+    if (inputRef.current) {
+      const input = inputRef.current;
+      const prefixLength = prefix?.length ?? 0;
+
+      input.setSelectionRange(
+        input.value.length,
+        input.value.length - prefixLength,
+      );
+    }
   }, []);
 
   // /*
@@ -97,5 +105,7 @@ export const useFormattedInput = (
     wrapperRef,
     buttonRef,
     customPrefixRef,
+    inputRef,
+    handlePrefixTrim,
   };
 };

--- a/src/components/v5/shared/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/v5/shared/Breadcrumbs/Breadcrumbs.tsx
@@ -27,7 +27,7 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({ items, className }) => {
                   <Link
                     to={href}
                     className={clsx({
-                      'flex items-center w-full gap-2 px-4 py-2 transition-none duration-0 sm:hover:!text-gray-900':
+                      'flex items-center w-full gap-2 px-4 py-2 transition-none sm:hover:!text-gray-900':
                         !!color,
                     })}
                   >

--- a/src/components/v5/shared/VoteChart/VoteChart.tsx
+++ b/src/components/v5/shared/VoteChart/VoteChart.tsx
@@ -43,9 +43,13 @@ const VoteChart: FC<VoteChartProps> = ({
       predictPercentageVotesAgainst
     : undefined;
 
+  const shouldHideIndicator =
+    !(predictedForValue && threshold && predictedForValue > threshold) ||
+    (threshold && forValue > threshold);
+
   return (
     <div className={clsx(className, 'w-full')}>
-      {!!threshold && (
+      {!!threshold && shouldHideIndicator && (
         <p className="text-xs font-medium text-center mb-1 text-blue-400">
           {thresholdLabel ||
             formatText(
@@ -63,7 +67,7 @@ const VoteChart: FC<VoteChartProps> = ({
           <VoteChartBar
             value={againstValue}
             barBackgroundClassName="bg-negative-300"
-            predictionBarClassName="border-negative-300 bg-negative-100"
+            predictionBarClassName="border-negative-300 bg-negative-300"
             predictedValue={predictedAgainstValue}
             direction={VOTE_CHART_BAR_DIRECTION.Left}
           />
@@ -79,7 +83,7 @@ const VoteChart: FC<VoteChartProps> = ({
         </div>
         <div className="flex flex-1 flex-col items-center gap-1">
           <div className="relative w-full">
-            {!!threshold && (
+            {shouldHideIndicator && !!threshold && (
               <div
                 className="absolute top-0 bottom-0 h-full z-[3]"
                 style={{
@@ -93,15 +97,14 @@ const VoteChart: FC<VoteChartProps> = ({
               value={forValue}
               predictedValue={predictedForValue}
               barBackgroundClassName="bg-purple-200"
-              predictionBarClassName="border-purple-200 bg-purple-100"
+              predictionBarClassName="border-purple-200 bg-purple-200"
               direction={VOTE_CHART_BAR_DIRECTION.Right}
             />
           </div>
           <span
             className={clsx('text-xs text-center transition', {
-              'text-purple-400 font-medium':
-                predictedAgainstValue || forValue > 0,
-              'text-gray-500': forValue === 0 && !predictedAgainstValue,
+              'text-purple-400 font-medium': predictedForValue || forValue > 0,
+              'text-gray-500': forValue === 0 && !predictedForValue,
             })}
           >
             {predictedForValue || forValue}% {forLabel}

--- a/src/components/v5/shared/VoteChart/VoteChart.tsx
+++ b/src/components/v5/shared/VoteChart/VoteChart.tsx
@@ -43,9 +43,7 @@ const VoteChart: FC<VoteChartProps> = ({
       predictPercentageVotesAgainst
     : undefined;
 
-  const shouldHideIndicator =
-    !(predictedForValue && threshold && predictedForValue > threshold) ||
-    (threshold && forValue > threshold);
+  const shouldHideIndicator = !(threshold && forValue > threshold);
 
   return (
     <div className={clsx(className, 'w-full')}>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1221,6 +1221,7 @@
     "motion.staking.activateTokens": "Activate tokens",
     "motion.staking.staked": "Staked {value}",
     "motion.staking.input.label": "Stake amount",
+    "motion.staking.input.balance": "Balance {balance}",
     "motion.staking.input.label.balance": "Balance {balance}",
     "motion.staking.input.error.amountRequired": "A stake amount is required",
     "motion.staking.input.error.moreThanRemaining": "You can't stake more than remaining stake",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1221,7 +1221,6 @@
     "motion.staking.activateTokens": "Activate tokens",
     "motion.staking.staked": "Staked {value}",
     "motion.staking.input.label": "Stake amount",
-    "motion.staking.input.balance": "Balance {balance}",
     "motion.staking.input.label.balance": "Balance {balance}",
     "motion.staking.input.error.amountRequired": "A stake amount is required",
     "motion.staking.input.error.moreThanRemaining": "You can't stake more than remaining stake",


### PR DESCRIPTION
https://tw.auroracreation.com/app/tasks/15649439
https://tw.auroracreation.com/app/tasks/15655944

Things that I've fixed in this PR:
- Cleave.js package update to make tailPrefix work
- Fixed colors of staking chart progress bar
- Hiding indicator of staking chart when for vote is higher than minimum value

![image](https://github.com/JoinColony/colonyCDapp/assets/76940796/897c007e-072a-48f2-9fe2-1d795d2e0576)
![image](https://github.com/JoinColony/colonyCDapp/assets/76940796/ce0a1a19-500e-411a-9161-84b63ae33aab)
