### PR TITLE
fix: added max width to pills, truncating long names, if more than 3 …

### DIFF
--- a/src/components/v5/common/Pills/UserStatus/UserStatus.tsx
+++ b/src/components/v5/common/Pills/UserStatus/UserStatus.tsx
@@ -11,10 +11,11 @@ const UserStatus: FC<PropsWithChildren<PillsProps>> = ({
   mode,
   children,
   text,
+  className,
   ...rest
 }) => (
   <PillsBase
-    className={clsx({
+    className={clsx(className, {
       'text-blue-400 bg-blue-100': mode === 'dedicated',
       'text-base-white bg-blue-400': mode === 'dedicated-filled',
       'text-warning-400 bg-warning-100': mode === 'active',
@@ -24,6 +25,7 @@ const UserStatus: FC<PropsWithChildren<PillsProps>> = ({
       'text-purple-400 bg-purple-100': mode === 'top',
       'text-base-white bg-purple-400': mode === 'top-filled' || mode === 'team',
       'text-negative-400 bg-negative-100': mode === 'banned',
+      'max-w-[4.5rem] w-full justify-center truncate': mode === 'team',
     })}
     iconName={getIconName(mode)}
     pillSize="small"

--- a/src/components/v5/shared/UserPopover/partials/UserInfo.tsx
+++ b/src/components/v5/shared/UserPopover/partials/UserInfo.tsx
@@ -11,6 +11,7 @@ import Tooltip from '~shared/Extensions/Tooltip/Tooltip';
 import { getRole } from '~constants/permissions';
 import PermissionsBadge from '~v5/common/Pills/PermissionsBadge';
 import Numeral from '~shared/Numeral';
+import { multiLineTextEllipsis } from '~utils/strings';
 
 const displayName = 'v5.UserAvatarPopover.partials.UserInfo';
 
@@ -64,9 +65,18 @@ const UserInfo: FC<UserInfoProps> = ({
               text={formatText({ id: 'userInfo.top.contributor.in' })}
             />
             <div className="flex gap-1">
-              {domains?.map(({ domainName, domainId }) => (
-                <UserStatus key={domainId} mode="team" text={domainName} />
+              {domains?.slice(0, 3).map(({ domainName, domainId }) => (
+                <UserStatus
+                  key={domainId}
+                  mode="team"
+                  text={multiLineTextEllipsis(domainName, 7)}
+                />
               ))}
+              {domains?.length > 3 && (
+                <UserStatus mode="team" className="!max-w-none !w-auto">
+                  +{domains.length - 3}
+                </UserStatus>
+              )}
             </div>
           </>
         )}


### PR DESCRIPTION
https://tw.auroracreation.com/app/tasks/15671662

Changes in PR:
- Added max width to pills to be 72px
- Truncating long team names
- If there are more than 3 teams - showing additional pill with number of truncated teams

![image](https://github.com/JoinColony/colonyCDapp/assets/76940796/11e0e0cc-3894-4440-826f-edd25cde025c)
