### PR TITLE
Move colors out of extend to only allow styleguide colors

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/CancelTransaction.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/CancelTransaction.tsx
@@ -21,7 +21,7 @@ const CancelTransaction: FC<CancelTransactionProps> = ({
         <div className="flex gap-2">
           <TextButton
             type="button"
-            className="text-red-400"
+            className="text-negative-400"
             onClick={handleCancelTransaction}
           >
             {formatMessage({ id: 'button.yes' })}

--- a/src/components/shared/FeedbackButton/FeedbackButton.tsx
+++ b/src/components/shared/FeedbackButton/FeedbackButton.tsx
@@ -17,7 +17,7 @@ const MSG = {
 const FeedbackButton = ({ onClick }: Props) => (
   <button
     type="button"
-    className="md:transition-all mt-auto flex items-center text-gray-900 md:hover:bg-gray-900 md:hover:text-white rounded-lg py-2 px-2.5 group/feedback-button z-10"
+    className="md:transition-all mt-auto flex items-center text-gray-900 md:hover:bg-gray-900 md:hover:text-base-white rounded-lg py-2 px-2.5 group/feedback-button z-10"
     onClick={onClick}
   >
     <Icon name="chats-circle" appearance={{ size: 'mediumSmall' }} />

--- a/src/components/v5/common/AvatarUploader/partials/DefaultContent.tsx
+++ b/src/components/v5/common/AvatarUploader/partials/DefaultContent.tsx
@@ -29,7 +29,7 @@ const DefaultContent: FC<DefaultContentProps> = ({
         {
           'py-4': !isSimpleOnMobile,
           'py-2': isSimpleOnMobile,
-          'border-gray-200 bg-white-100': !isDragAccept,
+          'border-gray-200 bg-base-white': !isDragAccept,
           'border-blue-400 bg-blue-100': isDragAccept,
         },
       )}

--- a/src/components/v5/common/Fields/RadioButtons/ButtonRadioButtons/ButtonRadioButtons.tsx
+++ b/src/components/v5/common/Fields/RadioButtons/ButtonRadioButtons/ButtonRadioButtons.tsx
@@ -65,7 +65,7 @@ function ButtonRadioButtons<TValue = string>({
                   iconClassName,
                   'h-[1em] w-[1em] text-[1.125rem]',
                   {
-                    'text-white': checked,
+                    'text-base-white': checked,
                     'text-current': !checked,
                     '!text-gray-300': disabledButton || disabled,
                   },
@@ -78,7 +78,7 @@ function ButtonRadioButtons<TValue = string>({
                 'text-gray-900 md:group-hover/wrapper:text-current':
                   !checked && (!disabled || !disabledButton),
                 '!text-gray-300': disabledButton || disabled,
-                'text-white': checked && (!disabled || !disabledButton),
+                'text-base-white': checked && (!disabled || !disabledButton),
               })}
             >
               {label}

--- a/src/components/v5/common/Fields/RadioButtons/TileRadioButtons/TileRadioButtons.tsx
+++ b/src/components/v5/common/Fields/RadioButtons/TileRadioButtons/TileRadioButtons.tsx
@@ -33,7 +33,8 @@ function TileRadioButtons<TValue = string>({
               duration-75
             `,
             {
-              'text-white bg-gray-900 border-gray-900': checked && !disabled,
+              'text-base-white bg-gray-900 border-gray-900':
+                checked && !disabled,
               'text-gray-300 border-gray-900': disabled,
               'text-gray-900 border-gray-300 md:hover:border-gray-900':
                 !checked && !disabled,

--- a/src/components/v5/common/Fields/Select/Select.module.css
+++ b/src/components/v5/common/Fields/Select/Select.module.css
@@ -27,7 +27,7 @@
 }
 
 .wrapper :global(.select__menu) {
-  @apply bg-red-500;
+  @apply bg-negative-400;
 }
 
 .menu {

--- a/src/components/v5/common/Filter/partials/SearchInput/SearchInput.module.css
+++ b/src/components/v5/common/Filter/partials/SearchInput/SearchInput.module.css
@@ -7,7 +7,7 @@
 }
 
 .searchButton {
-  @apply z-[1] text-white sm:text-gray-500 flex items-center transition-all duration-normal justify-center h-full absolute top-0 right-0 px-4 bg-blue-400 rounded-lg;
+  @apply z-[1] text-base-white sm:text-gray-500 flex items-center transition-all duration-normal justify-center h-full absolute top-0 right-0 px-4 bg-blue-400 rounded-lg;
 }
 
 .icon {

--- a/src/components/v5/common/SubNavigation/partials/SubNavigationItem/SubNavigationItem.module.css
+++ b/src/components/v5/common/SubNavigation/partials/SubNavigationItem/SubNavigationItem.module.css
@@ -1,5 +1,5 @@
 .tooltipContainer {
-  @apply font-normal z-50 relative text-sm bg-white shadow-default border border-gray-200 rounded-lg overflow-y-scroll max-h-[36rem] min-w-[20.5rem];
+  @apply font-normal z-50 relative text-sm bg-base-white shadow-default border border-gray-200 rounded-lg overflow-y-scroll max-h-[36rem] min-w-[20.5rem];
 
   &::-webkit-scrollbar {
     @apply hidden;

--- a/src/components/v5/frame/NavigationSidebar/NavigationSidebar.tsx
+++ b/src/components/v5/frame/NavigationSidebar/NavigationSidebar.tsx
@@ -251,7 +251,7 @@ const NavigationSidebarContent: FC<NavigationSidebarProps> = ({
                 animate={isThirdLevelMenuOpen ? 'visible' : 'hidden'}
                 className="absolute top-0 bottom-0 h-full left-[calc(100%-.625rem)] -z-[1] overflow-hidden"
               >
-                <div className="pb-6 pr-6 pl-9 pt-[1.8125rem] bg-gray-900 text-white rounded-r-lg h-full overflow-auto">
+                <div className="pb-6 pr-6 pl-9 pt-[1.8125rem] bg-gray-900 text-base-white rounded-r-lg h-full overflow-auto">
                   <NavigationSidebarThirdLevel
                     title={relatedActions?.title}
                     items={relatedActions?.items || []}

--- a/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarButton/NavigationSidebarButton.tsx
+++ b/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarButton/NavigationSidebarButton.tsx
@@ -43,8 +43,9 @@ const NavigationSidebarButton: FC<NavigationSidebarButtonProps> = ({
           md:transition-all
         `,
         {
-          'text-blue-400 md:text-white md:bg-gray-900': isActive && !isTablet,
-          'text-gray-900 md:hover:bg-gray-900 md:hover:text-white':
+          'text-blue-400 md:text-base-white md:bg-gray-900':
+            isActive && !isTablet,
+          'text-gray-900 md:hover:bg-gray-900 md:hover:text-base-white':
             !isActive && !isHighlighted,
           'bg-blue-100 text-blue-400': isHighlighted,
         },

--- a/src/components/v5/shared/Modal/Modal.tsx
+++ b/src/components/v5/shared/Modal/Modal.tsx
@@ -48,7 +48,7 @@ const Modal: FC<PropsWithChildren<ModalProps>> = ({
           className={clsx(
             'flex items-center justify-center w-[2.5rem] h-[2.5rem] rounded border shadow-content mb-4 border-gray-200 flex-shrink-0',
             {
-              'border-red-200 text-negative-400': isWarning,
+              'border-negative-200 text-negative-400': isWarning,
             },
           )}
         >

--- a/src/stories/common/UserNavigation.stories.tsx
+++ b/src/stories/common/UserNavigation.stories.tsx
@@ -88,7 +88,7 @@ const UserNavigationWithData = () => {
         </div>
         {!isMobile && isOpen && (
           <div
-            className={`flex absolute right-[4.25rem] h-auto bg-white shadow-default
+            className={`flex absolute right-[4.25rem] h-auto bg-base-white shadow-default
             border border-gray-200 rounded-lg mt-2 w-[44.375rem]`}
             ref={setTooltipRef}
           >

--- a/src/stories/shared/MenuWithSections.stories.tsx
+++ b/src/stories/shared/MenuWithSections.stories.tsx
@@ -33,7 +33,7 @@ export const WithCustomClasses: StoryObj<typeof MenuWithSections> = {
       {
         key: '2',
         content: 'Section 2',
-        className: 'bg-red-100',
+        className: 'bg-negative-100',
       },
     ],
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,109 @@ module.exports = {
   mode: 'jit',
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
   theme: {
+    colors: {
+      transparent: 'transparent',
+      current: 'currentColor',
+      gray: {
+        25: 'var(--color-gray-25)',
+        50: 'var(--color-gray-50)',
+        100: 'var(--color-gray-100)',
+        200: 'var(--color-gray-200)',
+        300: 'var(--color-gray-300)',
+        400: 'var(--color-gray-400)',
+        500: 'var(--color-gray-500)',
+        600: 'var(--color-gray-600)',
+        700: 'var(--color-gray-700)',
+        900: 'var(--color-gray-900)',
+      },
+      base: {
+        white: 'var(--color-base-white)',
+        black: 'var(--color-base-black)',
+        bg: 'var(--color-base-bg)',
+        sprite: 'var(--color-base-sprite)',
+      },
+      blue: {
+        100: 'var(--color-blue-100)',
+        200: 'var(--color-blue-200)',
+        300: 'var(--color-blue-300)',
+        400: 'var(--color-blue-400)',
+      },
+      negative: {
+        100: 'var(--color-negative-100)',
+        200: 'var(--color-negative-200)',
+        300: 'var(--color-negative-300)',
+        400: 'var(--color-negative-400)',
+      },
+      warning: {
+        100: 'var(--color-warning-100)',
+        200: 'var(--color-warning-200)',
+        400: 'var(--color-warning-400)',
+      },
+      success: {
+        100: 'var(--color-success-100)',
+        200: 'var(--color-success-200)',
+        400: 'var(--color-success-400)',
+      },
+      indigo: {
+        100: 'var(--color-indigo-100)',
+        200: 'var(--color-indigo-200)',
+        400: 'var(--color-indigo-400)',
+      },
+      purple: {
+        100: 'var(--color-purple-100)',
+        200: 'var(--color-purple-200)',
+        400: 'var(--color-purple-400)',
+      },
+      'teams-yellow': {
+        50: 'var(--color-teams-yellow-50)',
+        100: 'var(--color-teams-yellow-100)',
+        500: 'var(--color-teams-yellow-500)',
+      },
+      'teams-red': {
+        50: 'var(--color-teams-red-50)',
+        100: 'var(--color-teams-red-100)',
+        400: 'var(--color-teams-red-400)',
+        600: 'var(--color-teams-red-600)',
+      },
+      'teams-pink': {
+        50: 'var(--color-teams-pink-50)',
+        100: 'var(--color-teams-pink-100)',
+        150: 'var(--color-teams-pink-150)',
+        400: 'var(--color-teams-pink-400)',
+        500: 'var(--color-teams-pink-500)',
+        600: 'var(--color-teams-pink-600)',
+      },
+      'teams-green': {
+        50: 'var(--color-teams-green-50)',
+        100: 'var(--color-teams-green-100)',
+        300: 'var(--color-teams-green-300)',
+        400: 'var(--color-teams-green-400)',
+        500: 'var(--color-teams-green-500)',
+      },
+      'teams-teal': {
+        50: 'var(--color-teams-teal-50)',
+        500: 'var(--color-teams-teal-500)',
+      },
+      'teams-blue': {
+        50: 'var(--color-teams-blue-50)',
+        400: 'var(--color-teams-blue-400)',
+        500: 'var(--color-teams-blue-500)',
+      },
+      'teams-indigo': {
+        50: 'var(--color-teams-indigo-50)',
+        500: 'var(--color-teams-indigo-500)',
+      },
+      'teams-purple': {
+        100: 'var(--color-teams-purple-100)',
+        400: 'var(--color-teams-purple-400)',
+        500: 'var(--color-teams-purple-500)',
+      },
+      'teams-grey': {
+        50: 'var(--color-teams-grey-50)',
+        100: 'var(--color-teams-grey-100)',
+        500: 'var(--color-teams-grey-500)',
+      },
+    },
     fontFamily: {
       inter: ['Inter', 'sans-serif'],
     },
@@ -20,107 +123,6 @@ module.exports = {
     extend: {
       height: {
         screen: ['100vh /* fallback for Opera, IE and etc. */', '100dvh'],
-      },
-      colors: {
-        gray: {
-          25: 'var(--color-gray-25)',
-          50: 'var(--color-gray-50)',
-          100: 'var(--color-gray-100)',
-          200: 'var(--color-gray-200)',
-          300: 'var(--color-gray-300)',
-          400: 'var(--color-gray-400)',
-          500: 'var(--color-gray-500)',
-          600: 'var(--color-gray-600)',
-          700: 'var(--color-gray-700)',
-          900: 'var(--color-gray-900)',
-        },
-        base: {
-          white: 'var(--color-base-white)',
-          black: 'var(--color-base-black)',
-          bg: 'var(--color-base-bg)',
-          sprite: 'var(--color-base-sprite)',
-        },
-        blue: {
-          100: 'var(--color-blue-100)',
-          200: 'var(--color-blue-200)',
-          300: 'var(--color-blue-300)',
-          400: 'var(--color-blue-400)',
-        },
-        negative: {
-          100: 'var(--color-negative-100)',
-          200: 'var(--color-negative-200)',
-          300: 'var(--color-negative-300)',
-          400: 'var(--color-negative-400)',
-        },
-        warning: {
-          100: 'var(--color-warning-100)',
-          200: 'var(--color-warning-200)',
-          400: 'var(--color-warning-400)',
-        },
-        success: {
-          100: 'var(--color-success-100)',
-          200: 'var(--color-success-200)',
-          400: 'var(--color-success-400)',
-        },
-        indigo: {
-          100: 'var(--color-indigo-100)',
-          200: 'var(--color-indigo-200)',
-          400: 'var(--color-indigo-400)',
-        },
-        purple: {
-          100: 'var(--color-purple-100)',
-          200: 'var(--color-purple-200)',
-          400: 'var(--color-purple-400)',
-        },
-        'teams-yellow': {
-          50: 'var(--color-teams-yellow-50)',
-          100: 'var(--color-teams-yellow-100)',
-          500: 'var(--color-teams-yellow-500)',
-        },
-        'teams-red': {
-          50: 'var(--color-teams-red-50)',
-          100: 'var(--color-teams-red-100)',
-          400: 'var(--color-teams-red-400)',
-          600: 'var(--color-teams-red-600)',
-        },
-        'teams-pink': {
-          50: 'var(--color-teams-pink-50)',
-          100: 'var(--color-teams-pink-100)',
-          150: 'var(--color-teams-pink-150)',
-          400: 'var(--color-teams-pink-400)',
-          500: 'var(--color-teams-pink-500)',
-          600: 'var(--color-teams-pink-600)',
-        },
-        'teams-green': {
-          50: 'var(--color-teams-green-50)',
-          100: 'var(--color-teams-green-100)',
-          300: 'var(--color-teams-green-300)',
-          400: 'var(--color-teams-green-400)',
-          500: 'var(--color-teams-green-500)',
-        },
-        'teams-teal': {
-          50: 'var(--color-teams-teal-50)',
-          500: 'var(--color-teams-teal-500)',
-        },
-        'teams-blue': {
-          50: 'var(--color-teams-blue-50)',
-          400: 'var(--color-teams-blue-400)',
-          500: 'var(--color-teams-blue-500)',
-        },
-        'teams-indigo': {
-          50: 'var(--color-teams-indigo-50)',
-          500: 'var(--color-teams-indigo-500)',
-        },
-        'teams-purple': {
-          100: 'var(--color-teams-purple-100)',
-          400: 'var(--color-teams-purple-400)',
-          500: 'var(--color-teams-purple-500)',
-        },
-        'teams-grey': {
-          50: 'var(--color-teams-grey-50)',
-          100: 'var(--color-teams-grey-100)',
-          500: 'var(--color-teams-grey-500)',
-        },
       },
       boxShadow: {
         default: '0px 10px 30px rgba(0, 0, 0, 0.05)',
@@ -139,7 +141,7 @@ module.exports = {
         lg: '90rem',
       },
       zIndex: {
-        '1': '1',
+        1: '1',
       },
     },
   },


### PR DESCRIPTION
## Description

We need to limit the color palette of tailwind to only colors that are defined in the style guide. Two advantages here:

- People won't get tempted to use colors that aren't in our palette
- Dark mode will work if light mode looks good

## TODO

- [x] Find all occurrences of invallid colors and replace them with valid ones