### PR TITLE
Fix broken form error display

### DIFF
--- a/src/components/v5/common/Fields/Input/Input.tsx
+++ b/src/components/v5/common/Fields/Input/Input.tsx
@@ -131,7 +131,7 @@ const Input: FC<InputProps> = ({
             {isDecoratedError ? (
               <InputPills message={customErrorMessage} status="error" />
             ) : (
-              <FormError isFullSize alignment="left">
+              <FormError isFullSize alignment="left" allowLayoutShift={false}>
                 {customErrorMessage ||
                   (errorMaxChar
                     ? formatMessage(

--- a/src/components/v5/shared/FormError/FormError.tsx
+++ b/src/components/v5/shared/FormError/FormError.tsx
@@ -8,14 +8,19 @@ const FormError: FC<PropsWithChildren<FormErrorProps>> = ({
   alignment = 'right',
   isFullSize,
   children,
+  allowLayoutShift = true,
 }) => (
   <div
-    className={clsx(`flex w-[8.75rem] absolute`, {
-      'w-full': isFullSize,
-      'text-right justify-end': alignment === 'right',
-      'text-left justify-start': alignment === 'left',
-      'text-center justify-center': alignment === 'center',
-    })}
+    className={clsx(
+      `flex w-[8.75rem]`,
+      allowLayoutShift ? 'mt-1' : 'absolute',
+      {
+        'w-full': isFullSize,
+        'text-right justify-end': alignment === 'right',
+        'text-left justify-start': alignment === 'left',
+        'text-center justify-center': alignment === 'center',
+      },
+    )}
   >
     <span className="font-normal text-sm text-negative-400">{children}</span>
   </div>

--- a/src/components/v5/shared/FormError/types.ts
+++ b/src/components/v5/shared/FormError/types.ts
@@ -1,6 +1,7 @@
 export interface FormErrorProps {
   alignment?: TextAlignment;
   isFullSize?: boolean;
+  allowLayoutShift?: boolean;
 }
 
 type TextAlignment = 'right' | 'left' | 'center';


### PR DESCRIPTION
## Description

This PR fixes the broken form error display in #1415 by allowing in some cases the original design of layout shifting to occur on error:

![image](https://github.com/JoinColony/colonyCDapp/assets/32598350/829b236b-1126-4fc8-b54e-111b18c84e36)


Resolves #1415
