### PR TITLE
fix: add https to rpc url

### DIFF
--- a/amplify/backend/custom/lambdaParams/lambdaParams-cloudformation-template.json
+++ b/amplify/backend/custom/lambdaParams/lambdaParams-cloudformation-template.json
@@ -37,7 +37,7 @@
           "Fn::Sub": "/amplify/cdapp/${env}/chain_rpc_endpoint"
         },
         "Type": "String",
-        "Value": "http://qa-cdapp.colony.io/rpc/",
+        "Value": "https://qa-cdapp.colony.io/rpc/",
         "Description": "Xdai chain RPC endpoint"
       }
     },


### PR DESCRIPTION
## Description

- Update rpc url to https due to security changes on the webserver not allowing http anymore.

**New stuff** ✨

* New stuff goes here

**Changes** 🏗

* Changes go here

**Deletions** ⚰️

* Deletions go here

## TODO

- [ ] Add TODOs

(Resolves | Contributes to) #31415
