### PR TITLE
Fixes Action metadata alignment and unneeded icon string

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -51,9 +51,9 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
           `}
           message={false}
         />
-        <p className="text-gray-900 text-md flex gap-1">
+        <div className="text-gray-900 text-md flex gap-1">
           {descriptionMetadata}
-        </p>
+        </div>
 
         <ActionTypeSelect className="mt-7 mb-3 min-h-[1.875rem] flex flex-col justify-center" />
 

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -51,7 +51,9 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
           `}
           message={false}
         />
-        <p className="text-gray-900 text-md">{descriptionMetadata}</p>
+        <p className="text-gray-900 text-md flex gap-1">
+          {descriptionMetadata}
+        </p>
 
         <ActionTypeSelect className="mt-7 mb-3 min-h-[1.875rem] flex flex-col justify-center" />
 

--- a/src/components/v5/shared/MeatBallMenu/MeatBallMenu.tsx
+++ b/src/components/v5/shared/MeatBallMenu/MeatBallMenu.tsx
@@ -100,13 +100,10 @@ const MeatBallMenu: FC<MeatBallMenuProps> = ({
                         },
                         <>
                           {typeof icon === 'string' ? (
-                            <>
-                              {icon}
-                              <Icon
-                                name={icon}
-                                appearance={{ size: 'extraSmall' }}
-                              />
-                            </>
+                            <Icon
+                              name={icon}
+                              appearance={{ size: 'extraSmall' }}
+                            />
                           ) : (
                             icon
                           )}


### PR DESCRIPTION
## Description
Quick PR to fix a couple of small issues introduced in this PR https://github.com/JoinColony/colonyCDapp/pull/1406 and this PR https://github.com/JoinColony/colonyCDapp/pull/1384.

- Fixes alignment of text in action metadata.
- Removes unnecessary icon string.

**Before**
![image](https://github.com/JoinColony/colonyCDapp/assets/33682027/846cae73-2755-4afb-a586-18831a21abe1)
![image](https://github.com/JoinColony/colonyCDapp/assets/33682027/2a6ba032-f0a8-4d91-a074-f17478e0c92e)

**After**
![image](https://github.com/JoinColony/colonyCDapp/assets/33682027/7ddc20d0-e548-491c-b09c-37eee60d179a)
![image](https://github.com/JoinColony/colonyCDapp/assets/33682027/d6f1ad83-4bac-4b5b-b262-3b9d57ef4908)
