### PR TITLE
Add missing colony logo and breadcrumb to landing page

### DIFF
--- a/src/components/frame/Extensions/layouts/MainLayout.tsx
+++ b/src/components/frame/Extensions/layouts/MainLayout.tsx
@@ -23,12 +23,13 @@ const MainLayout: FC<PropsWithChildren<MainLayoutProps>> = ({
   return (
     <PageLayout
       headerProps={{
-        pageHeadingProps: pageHeadingTitle
-          ? {
-              title: pageHeadingTitle,
-              breadcrumbs,
-            }
-          : undefined,
+        pageHeadingProps:
+          pageHeadingTitle || breadcrumbs.length
+            ? {
+                title: pageHeadingTitle,
+                breadcrumbs,
+              }
+            : undefined,
         userNavigation: <UserNavigationWrapper />,
       }}
       sidebar={Sidebar}

--- a/src/components/frame/LandingPage/LandingPage.tsx
+++ b/src/components/frame/LandingPage/LandingPage.tsx
@@ -100,7 +100,6 @@ const LandingPage = () => {
       {
         key: 'landing-page',
         label: 'Colony App',
-        href: '/',
       },
     ]);
   }, [setBreadcrumbs]);

--- a/src/components/frame/LandingPage/LandingPage.tsx
+++ b/src/components/frame/LandingPage/LandingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 import { nanoid } from 'nanoid';
@@ -8,6 +8,7 @@ import CreateAColonyBanner from '~images/create-colony-banner.png';
 import CreateAProfileBanner from '~images/create-profile-banner.png';
 import { useAppContext } from '~hooks';
 import InvitationBlock from '~common/InvitationBlock';
+import { usePageHeadingContext } from '~context';
 
 import {
   CREATE_COLONY_ROUTE_BASE,
@@ -92,6 +93,17 @@ const LandingPage = () => {
   const [, setHoveredItem] = useState<number>(1);
   const navigate = useNavigate();
   const { user, connectWallet, wallet, userLoading } = useAppContext();
+  const { setBreadcrumbs } = usePageHeadingContext();
+
+  useEffect(() => {
+    setBreadcrumbs([
+      {
+        key: 'landing-page',
+        label: 'Colony App',
+        href: '/',
+      },
+    ]);
+  }, [setBreadcrumbs]);
 
   const landingPageItems = [
     {

--- a/src/components/v5/frame/PageLayout/partials/PageHeader/PageHeader.tsx
+++ b/src/components/v5/frame/PageLayout/partials/PageHeader/PageHeader.tsx
@@ -15,8 +15,12 @@ const PageHeader: FC<PageHeaderProps> = ({
   return (
     <header
       className={clsx(className, 'flex items-start', {
-        'justify-between gap-4': pageHeadingProps,
+        'justify-between gap-4': pageHeadingProps && pageHeadingProps.title,
         'justify-end': !pageHeadingProps,
+        'items-center':
+          pageHeadingProps &&
+          !pageHeadingProps.title &&
+          pageHeadingProps.breadcrumbs,
       })}
     >
       {pageHeadingProps && (

--- a/src/components/v5/frame/PageLayout/partials/PageHeading/PageHeading.tsx
+++ b/src/components/v5/frame/PageLayout/partials/PageHeading/PageHeading.tsx
@@ -1,4 +1,6 @@
 import React, { FC } from 'react';
+import clsx from 'clsx';
+
 import Breadcrumbs from '~v5/shared/Breadcrumbs';
 import { PageHeadingProps } from './types';
 
@@ -10,7 +12,7 @@ const PageHeading: FC<PageHeadingProps> = ({
   className,
 }) => (
   <div className={className}>
-    <Breadcrumbs className="mb-2" items={breadcrumbs} />
+    <Breadcrumbs className={clsx({ 'mb-2': title })} items={breadcrumbs} />
     {title && <h1 className="heading-3 text-gray-900">{title}</h1>}
   </div>
 );

--- a/src/components/v5/shared/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/v5/shared/Breadcrumbs/Breadcrumbs.tsx
@@ -1,15 +1,28 @@
 import React, { FC } from 'react';
 import clsx from 'clsx';
 
-import { CardSelect } from '~v5/common/Fields/CardSelect';
-import Icon from '~shared/Icon';
-import { formatText } from '~utils/intl';
-
 import Link from '../Link';
 
-import { BreadcrumbsProps } from './types';
+import { BreadcrumbsItem, BreadcrumbsProps } from './types';
+import BreadcrumbsCardSelect from './BreadcrumbsCardSelect';
 
 const displayName = 'v5.Breadcrumbs';
+
+const getBreadcrumbItem = (item: BreadcrumbsItem) => {
+  if ('href' in item && item.href) {
+    return (
+      <Link to={item.href} className="text-inherit">
+        {item.label}
+      </Link>
+    );
+  }
+
+  if ('dropdownOptions' in item) {
+    return <BreadcrumbsCardSelect item={item} />;
+  }
+
+  return <h5>{item.label}</h5>;
+};
 
 const Breadcrumbs: FC<BreadcrumbsProps> = ({ items, className }) => {
   return items.length ? (
@@ -19,76 +32,14 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({ items, className }) => {
         'flex flex-wrap items-center uppercase tracking-[.075rem] text-gray-900 text-3',
       )}
     >
-      {items.map(({ key, ...item }) => {
-        const options =
-          'dropdownOptions' in item
-            ? item.dropdownOptions.map(({ href, label, color, ...option }) => ({
-                label: (
-                  <Link
-                    to={href}
-                    className={clsx({
-                      'flex items-center w-full gap-2 px-4 py-2 transition-none duration-0 sm:hover:!text-gray-900':
-                        !!color,
-                    })}
-                  >
-                    {color && (
-                      <span className={clsx(color, 'w-3.5 h-3.5 rounded')} />
-                    )}
-                    {label}
-                  </Link>
-                ),
-                value: href,
-                ...option,
-              }))
-            : [];
-
-        return (
-          <li
-            className='after:content-["/"] after:mx-2 last:after:hidden'
-            key={key}
-          >
-            {'href' in item ? (
-              <Link to={item.href} className="text-inherit">
-                {item.label}
-              </Link>
-            ) : (
-              <CardSelect<string>
-                togglerClassName="uppercase tracking-[.075rem] text-3 md:hover:!text-blue-400"
-                options={options}
-                title={formatText({ id: 'breadcrumbs.teams' })}
-                value={item.selectedValue}
-                cardClassName="sm:!max-w-[13.5rem] !w-full"
-                renderOptionWrapper={(props, label) => (
-                  <div {...props}>{label}</div>
-                )}
-                itemClassName="text-md md:transition-colors md:hover:font-medium md:hover:bg-gray-50 rounded w-full cursor-pointer"
-                renderSelectedValue={(_, placeholder, isSelectVisible) => {
-                  const { dropdownOptions } = item;
-                  const selectedOption = dropdownOptions?.find(
-                    ({ href }) => href === item.selectedValue,
-                  )?.label;
-
-                  return (
-                    <span className="flex items-center">
-                      {selectedOption || placeholder}{' '}
-                      <Icon
-                        name="caret-down"
-                        appearance={{ size: 'extraExtraTiny' }}
-                        className={clsx(
-                          '!h-[0.75rem] !w-[0.75rem] text-[.625rem] fill-current ml-2 transition-transform',
-                          {
-                            'rotate-180': isSelectVisible,
-                          },
-                        )}
-                      />
-                    </span>
-                  );
-                }}
-              />
-            )}
-          </li>
-        );
-      })}
+      {items.map((item) => (
+        <li
+          className='after:content-["/"] after:mx-2 last:after:hidden'
+          key={item.key}
+        >
+          {getBreadcrumbItem(item)}
+        </li>
+      ))}
     </ul>
   ) : null;
 };

--- a/src/components/v5/shared/Breadcrumbs/BreadcrumbsCardSelect.tsx
+++ b/src/components/v5/shared/Breadcrumbs/BreadcrumbsCardSelect.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import clsx from 'clsx';
+
+import { CardSelect } from '~v5/common/Fields/CardSelect';
+import Icon from '~shared/Icon';
+import { formatText } from '~utils/intl';
+
+import Link from '../Link';
+
+import { BreadCrumbsCardSelectItem } from './types';
+
+const displayName = 'v5.Breadcrumbs.BreadcrumbsCardSelect';
+
+interface Props {
+  item: BreadCrumbsCardSelectItem;
+}
+
+const BreadcrumbsCardSelect = ({ item }: Props) => {
+  const options =
+    'dropdownOptions' in item
+      ? item.dropdownOptions.map(({ href, label, color, ...option }) => ({
+          label: (
+            <Link
+              to={href}
+              className={clsx({
+                'flex items-center w-full gap-2 px-4 py-2 transition-none duration-0 sm:hover:!text-gray-900':
+                  !!color,
+              })}
+            >
+              {color && <span className={clsx(color, 'w-3.5 h-3.5 rounded')} />}
+              {label}
+            </Link>
+          ),
+          value: href,
+          ...option,
+        }))
+      : [];
+  return (
+    <CardSelect<string>
+      togglerClassName="uppercase tracking-[.075rem] text-3 md:hover:!text-blue-400"
+      options={options}
+      title={formatText({ id: 'breadcrumbs.teams' })}
+      value={item.selectedValue}
+      cardClassName="sm:!max-w-[13.5rem] !w-full"
+      renderOptionWrapper={(props, label) => <div {...props}>{label}</div>}
+      itemClassName="text-md md:transition-colors md:hover:font-medium md:hover:bg-gray-50 rounded w-full cursor-pointer"
+      renderSelectedValue={(_, placeholder, isSelectVisible) => {
+        const { dropdownOptions } = item;
+        const selectedOption = dropdownOptions?.find(
+          ({ href }) => href === item.selectedValue,
+        )?.label;
+
+        return (
+          <span className="flex items-center">
+            {selectedOption || placeholder}{' '}
+            <Icon
+              name="caret-down"
+              appearance={{ size: 'extraExtraTiny' }}
+              className={clsx(
+                '!h-[0.75rem] !w-[0.75rem] text-[.625rem] fill-current ml-2 transition-transform',
+                {
+                  'rotate-180': isSelectVisible,
+                },
+              )}
+            />
+          </span>
+        );
+      }}
+    />
+  );
+};
+
+BreadcrumbsCardSelect.displayName = displayName;
+
+export default BreadcrumbsCardSelect;

--- a/src/components/v5/shared/Breadcrumbs/types.ts
+++ b/src/components/v5/shared/Breadcrumbs/types.ts
@@ -7,11 +7,16 @@ export interface BreadcrumbDropdownOption
 }
 
 export type BreadcrumbsItem = { key: string } & (
-  | { label: string; href: string }
-  | { dropdownOptions: BreadcrumbDropdownOption[]; selectedValue: string }
+  | { label: string; href?: string }
+  | BreadCrumbsCardSelectItem
 );
 
 export interface BreadcrumbsProps {
   items: BreadcrumbsItem[];
   className?: string;
+}
+
+export interface BreadCrumbsCardSelectItem {
+  dropdownOptions: BreadcrumbDropdownOption[];
+  selectedValue: string;
 }

--- a/src/components/v5/shared/SimpleSidebar/SimpleSidebar.tsx
+++ b/src/components/v5/shared/SimpleSidebar/SimpleSidebar.tsx
@@ -5,8 +5,10 @@ import ColonyLogo from '~images/logo-new.svg';
 
 const SimpleSidebar: FC = () => {
   return (
-    <nav className="flex flex-col items-center justify-between border text-center border-gray-200 rounded-lg p-4 h-full ">
-      <Icon appearance={{ size: 'extraBig' }} name="colony-icon" />
+    <nav className="flex flex-col items-center justify-between border text-center border-gray-200 rounded-lg px-4 pt-4 pb-6 h-full ">
+      <div className="flex items-center justify-center w-11 h-11">
+        <Icon appearance={{ size: 'extraBig' }} name="colony-icon" />
+      </div>
       <ColonyLogo />
     </nav>
   );

--- a/src/components/v5/shared/SimpleSidebar/SimpleSidebar.tsx
+++ b/src/components/v5/shared/SimpleSidebar/SimpleSidebar.tsx
@@ -1,12 +1,13 @@
 import React, { FC } from 'react';
 
 import Icon from '~shared/Icon';
+import ColonyLogo from '~images/logo-new.svg';
 
 const SimpleSidebar: FC = () => {
   return (
-    <nav className="border text-center border-gray-200 rounded-lg p-4 h-full">
+    <nav className="flex flex-col items-center justify-between border text-center border-gray-200 rounded-lg p-4 h-full ">
       <Icon appearance={{ size: 'extraBig' }} name="colony-icon" />
-      {/* @TODO: Add feedback button? */}
+      <ColonyLogo />
     </nav>
   );
 };

--- a/src/components/v5/shared/SimpleSidebar/index.ts
+++ b/src/components/v5/shared/SimpleSidebar/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SimpleSidebar';

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -109,9 +109,9 @@ export const AppContextProvider = ({ children }: { children: ReactNode }) => {
    * Handle wallet connection
    */
   const connectWallet = useCallback(async () => {
-    setWalletConnecting(true);
     try {
       await setupUserContext(undefined);
+      setWalletConnecting(true);
       updateWallet();
     } catch (error) {
       console.error('Could not connect wallet', error);

--- a/src/routes/LandingPageRoute/LandingPageRoute.tsx
+++ b/src/routes/LandingPageRoute/LandingPageRoute.tsx
@@ -2,11 +2,17 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 
 import { MainLayout, MainSidebar } from '~frame/Extensions/layouts';
+import LoadingTemplate from '~frame/LoadingTemplate';
 import { useAppContext } from '~hooks';
 import SimpleSidebar from '~v5/shared/SimpleSidebar';
 
 const LandingPageRoute = () => {
-  const { user } = useAppContext();
+  const { user, userLoading, walletConnecting } = useAppContext();
+
+  if (userLoading || walletConnecting) {
+    return <LoadingTemplate />;
+  }
+
   return (
     <MainLayout sidebar={user ? <MainSidebar /> : <SimpleSidebar />}>
       <Outlet />

--- a/src/routes/LandingPageRoute/LandingPageRoute.tsx
+++ b/src/routes/LandingPageRoute/LandingPageRoute.tsx
@@ -3,8 +3,7 @@ import { Outlet } from 'react-router-dom';
 
 import { MainLayout, MainSidebar } from '~frame/Extensions/layouts';
 import { useAppContext } from '~hooks';
-
-import SimpleSidebar from './SimpleSidebar';
+import SimpleSidebar from '~v5/shared/SimpleSidebar';
 
 const LandingPageRoute = () => {
   const { user } = useAppContext();


### PR DESCRIPTION
I've updated the page headers to allow the breadcrumbs to show without the need for a title, which is the case for the landing page. The changes introduced should be specifically for this, but they are made in general components so make sure to test the breadcrumbs and titles of other pages in order to check that they haven't changed with this.

![FireShot Capture 239 - Welcome to Colony - localhost](https://github.com/JoinColony/colonyCDapp/assets/18473896/e13bcf1d-ea00-416b-bec2-ab51a433bbce)

Resolves #1412 
