### PR TITLE
Add missing permission banner to action form

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/SidebarBanner.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/SidebarBanner.tsx
@@ -1,17 +1,49 @@
 import React, { FC } from 'react';
+import { Extension, Id } from '@colony/colony-js';
 
 import { useFormContext, useWatch } from 'react-hook-form';
-import { Action } from '~constants/actions';
-import { useFlatFormErrors } from '~hooks';
+import { ACTION, Action } from '~constants/actions';
+import { useColonyContext, useExtensionData, useFlatFormErrors } from '~hooks';
+import { formatText } from '~utils/intl';
+import NotificationBanner from '~v5/shared/NotificationBanner';
+import { AnyExtensionData, Colony } from '~types';
+import { addressHasRoles } from '~utils/checks';
+
 import {
   ACTION_TYPE_FIELD_NAME,
   useCreateActionTypeNotification,
   useCreateActionTypeNotificationHref,
 } from '../../../consts';
-import { formatText } from '~utils/intl';
-import NotificationBanner from '~v5/shared/NotificationBanner';
+
+const checkOneTxPaymentPermissions = (
+  extensionData: AnyExtensionData,
+  colony: Colony | undefined,
+) => {
+  const {
+    neededColonyPermissions,
+    // address will be undefined if the extension hasn't been installed / initialized yet
+    // @ts-expect-error
+    address,
+    isInitialized,
+    isDeprecated,
+  } = extensionData;
+
+  // If the extension itself doesn't have the correct permissions, show the banner
+  const noPermissions =
+    isInitialized &&
+    !isDeprecated &&
+    !addressHasRoles({
+      requiredRolesDomains: [Id.RootDomain],
+      colony,
+      requiredRoles: neededColonyPermissions,
+      address,
+    });
+
+  return noPermissions;
+};
 
 export const SidebarBanner: FC = () => {
+  const { colony } = useColonyContext();
   const { formState } = useFormContext();
   const hasErrors = !formState.isValid && formState.isSubmitted;
   const selectedAction: Action | undefined = useWatch({
@@ -26,11 +58,18 @@ export const SidebarBanner: FC = () => {
   const actionTypeNofiticationHref =
     useCreateActionTypeNotificationHref(selectedAction);
 
+  const oneTxPaymentExtensionId =
+    selectedAction === ACTION.SIMPLE_PAYMENT ? Extension.OneTxPayment : '';
+  const { extensionData } = useExtensionData(oneTxPaymentExtensionId);
+  const oneTxPaymentPermissionNeeded = extensionData
+    ? checkOneTxPaymentPermissions(extensionData, colony)
+    : false;
+
   if (actionTypeNotificationTitle) {
     return (
       <div className="mt-7">
         <NotificationBanner
-          status="error"
+          status={oneTxPaymentPermissionNeeded ? 'warning' : 'error'}
           icon="warning-circle"
           callToAction={
             <a

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/SidebarBanner.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/SidebarBanner.tsx
@@ -66,6 +66,13 @@ export const SidebarBanner: FC = () => {
     : false;
 
   if (actionTypeNotificationTitle) {
+    if (
+      selectedAction === ACTION.SIMPLE_PAYMENT &&
+      !oneTxPaymentPermissionNeeded
+    ) {
+      return null;
+    }
+
     return (
       <div className="mt-7">
         <NotificationBanner


### PR DESCRIPTION
With this PR, if the action is executed by an extension and that extension doesn't have all the required permissions, it should show a banner warning the user. For the actions that we currently have, this could apply to simple payment and any motions, for example.

![FireShot Capture 249 - One Transaction Payment Extension - Colony - Planet Express - localhost](https://github.com/JoinColony/colonyCDapp/assets/18473896/5ec74c8e-a594-4fb0-995d-63ee3797d9e9)
![FireShot Capture 250 - One Transaction Payment Extension - Colony - Planet Express - localhost](https://github.com/JoinColony/colonyCDapp/assets/18473896/feb33f7e-67b3-47a1-b8d8-f702a9f563d2)
![FireShot Capture 251 - One Transaction Payment Extension - Colony - Planet Express - localhost](https://github.com/JoinColony/colonyCDapp/assets/18473896/e084a6e6-aa32-4af4-a0dd-dd4200172928)

Resolves #1092 
