### PR TITLE
fix: social links on mobile

### DIFF
--- a/src/components/frame/v5/pages/ColonyPreviewPage/ColonyPreviewPage.tsx
+++ b/src/components/frame/v5/pages/ColonyPreviewPage/ColonyPreviewPage.tsx
@@ -222,7 +222,7 @@ const ColonyPreviewPage = () => {
           ) : null
         }
         title={
-          <div className="flex items-center gap-4 w-full">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-4 w-full sm:flex-nowrap">
             <ColonyAvatar
               colonyImageProps={
                 colonyMetadata?.avatar
@@ -234,7 +234,10 @@ const ColonyPreviewPage = () => {
               size="mediumSmallMediumLargeSmallTinyBigMediumLargeSmall"
             />
             <h1 className="text-md font-medium inline">{colonyDisplayName}</h1>
-            <SocialLinks className="ml-auto" externalLinks={socialLinks} />
+            <SocialLinks
+              className="w-full sm:w-auto sm:ml-auto"
+              externalLinks={socialLinks}
+            />
           </div>
         }
       >

--- a/src/components/v5/shared/SocialLinks/SocialLinks.tsx
+++ b/src/components/v5/shared/SocialLinks/SocialLinks.tsx
@@ -20,7 +20,7 @@ const SocialLinks = ({
   return (
     <div
       className={clsx(
-        `${className} flex flex-wrap items-start gap-4 sm:flex-row sm:items-center`,
+        `${className} flex items-start gap-4 sm:flex-row sm:items-center`,
         {
           // If there are labels to show, we want to stack the links vertically (on mobile only)
           'flex-col': showLabels,

--- a/src/components/v5/shared/SocialLinks/SocialLinks.tsx
+++ b/src/components/v5/shared/SocialLinks/SocialLinks.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import React from 'react';
 
 import { ExternalLink as ExternalLinkFragment } from '~gql';
@@ -18,7 +19,13 @@ const SocialLinks = ({
 }: SocialLinksProps) => {
   return (
     <div
-      className={`${className} flex flex-col sm:flex-row flex-wrap items-start sm:items-center gap-4`}
+      className={clsx(
+        `${className} flex flex-wrap items-start gap-4 sm:flex-row sm:items-center`,
+        {
+          // If there are labels to show, we want to stack the links vertically (on mobile only)
+          'flex-col': showLabels,
+        },
+      )}
     >
       {externalLinks.map(({ name: linkName, link }) => {
         const { label, LinkIcon } = COLONY_LINK_CONFIG[linkName];


### PR DESCRIPTION
## Description

This PR fixes the display of social links on mobile. When there are no labels (like on the colony beta splash page - "request access"), the icons are no longer stacked on mobile.
