### PR TITLE
Fix metatransaction toggle

### DIFF
--- a/amplify/backend/function/createUniqueUser/src/index.js
+++ b/amplify/backend/function/createUniqueUser/src/index.js
@@ -1,5 +1,7 @@
 const { utils } = require('ethers');
 
+const isDev = process.env.ENV === 'dev';
+
 // const basicTokenAbi = require('./basicTokenAbi.json');
 const { graphqlRequest } = require('./utils');
 
@@ -78,7 +80,7 @@ exports.handler = async (event) => {
         id: checksummedWalletAddress,
         displayNameChanged: new Date().toISOString(),
         meta: {
-          metatransactionsEnabled: true,
+          metatransactionsEnabled: !isDev,
         },
       },
     },

--- a/amplify/backend/function/createUniqueUser/src/index.js
+++ b/amplify/backend/function/createUniqueUser/src/index.js
@@ -74,9 +74,12 @@ exports.handler = async (event) => {
     createProfile,
     {
       input: {
-        id: checksummedWalletAddress,
         ...profile,
+        id: checksummedWalletAddress,
         displayNameChanged: new Date().toISOString(),
+        meta: {
+          metatransactionsEnabled: true,
+        },
       },
     },
     graphqlURL,

--- a/src/components/common/Onboarding/wizardSteps/CreateColony/StepConfirmTransactions.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/StepConfirmTransactions.tsx
@@ -99,7 +99,7 @@ const StepConfirmTransactions = ({ wizardValues: { colonyName } }: Props) => {
     getGroupStatus(newestGroup) === TransactionStatus.Succeeded &&
     getGroupKey(newestGroup) === 'group.createColony'
   ) {
-    updateUser?.(user?.walletAddress, true);
+    updateUser(user?.walletAddress, true);
     return (
       <Navigate
         to={`/${colonyName}`}

--- a/src/components/common/UserProfileEdit/UserAdvancedSettings.tsx
+++ b/src/components/common/UserProfileEdit/UserAdvancedSettings.tsx
@@ -96,7 +96,7 @@ const UserAdvancedSettings = ({ user: { walletAddress, profile } }: Props) => {
       },
     });
 
-    updateUser?.(walletAddress, true);
+    updateUser(walletAddress, true);
   };
 
   return (

--- a/src/components/common/UserProfileEdit/UserAvatarUploader.tsx
+++ b/src/components/common/UserProfileEdit/UserAvatarUploader.tsx
@@ -63,7 +63,7 @@ const UserAvatarUploader = ({
         },
       });
 
-      await updateUser?.(user.walletAddress, true);
+      await updateUser(user.walletAddress, true);
     } catch (e) {
       if (e.message.includes('exceeded the maximum')) {
         setError(DropzoneErrors.TOO_LARGE);

--- a/src/components/common/UserProfileEdit/UserMainSettings.tsx
+++ b/src/components/common/UserProfileEdit/UserMainSettings.tsx
@@ -91,7 +91,7 @@ const UserMainSettings = ({
       },
     });
 
-    updateUser?.(walletAddress, true);
+    updateUser(walletAddress, true);
   };
 
   return (

--- a/src/components/frame/v5/pages/UserAdvancedPage/partials/FeesForm/FeesForm.tsx
+++ b/src/components/frame/v5/pages/UserAdvancedPage/partials/FeesForm/FeesForm.tsx
@@ -9,14 +9,14 @@ const FeesForm = () => {
     handleFeesOnChange,
     handleSubmit,
     metatransactionsValidationSchema,
-    metatransasctionsDefault,
+    metatransactionsDefault,
   } = useFeesForm();
 
   return (
     <Form
       validationSchema={metatransactionsValidationSchema}
       defaultValues={{
-        metatransactionsEnabled: !!metatransasctionsDefault,
+        metatransactionsEnabled: !!metatransactionsDefault,
       }}
       onSubmit={handleSubmit}
     >
@@ -26,7 +26,7 @@ const FeesForm = () => {
           description={{ id: 'advancedSettings.fees.description' }}
           tooltipMessage={{ id: 'advancedSettings.fees.tooltip' }}
           id="metatransactionsEnabled"
-          onChange={handleFeesOnChange}
+          handleOnChange={handleFeesOnChange}
           register={register}
         />
       )}

--- a/src/components/frame/v5/pages/UserAdvancedPage/partials/FeesForm/hooks.tsx
+++ b/src/components/frame/v5/pages/UserAdvancedPage/partials/FeesForm/hooks.tsx
@@ -20,7 +20,7 @@ export const useFeesForm = () => {
 
   const [editUser] = useUpdateUserProfileMutation();
 
-  const metatransasctionsDefault = metatransactionsAvailable
+  const metatransactionsDefault = metatransactionsAvailable
     ? metatransactionsEnabled
     : false;
 
@@ -56,7 +56,7 @@ export const useFeesForm = () => {
 
   return {
     metatransactionsValidationSchema,
-    metatransasctionsDefault,
+    metatransactionsDefault,
     handleSubmit,
     handleFeesOnChange,
   };

--- a/src/components/frame/v5/pages/UserAdvancedPage/partials/FeesForm/hooks.tsx
+++ b/src/components/frame/v5/pages/UserAdvancedPage/partials/FeesForm/hooks.tsx
@@ -14,7 +14,7 @@ export const useFeesForm = () => {
 
   const metatransactionsAvailable = canUseMetatransactions();
 
-  const { user } = useAppContext();
+  const { user, updateUser } = useAppContext();
   const { metatransactionsEnabled, customRpc, decentralizedModeEnabled } =
     user?.profile?.meta ?? {};
 
@@ -37,6 +37,7 @@ export const useFeesForm = () => {
         },
       },
     });
+    await updateUser(user?.walletAddress, true);
   };
 
   const handleFeesOnChange = (value: boolean) => {

--- a/src/components/frame/v5/pages/UserAdvancedPage/partials/RpcForm/RpcForm.tsx
+++ b/src/components/frame/v5/pages/UserAdvancedPage/partials/RpcForm/RpcForm.tsx
@@ -31,7 +31,7 @@ const RpcForm = () => {
             description={{ id: 'advancedSettings.rpc.description' }}
             tooltipMessage={{ id: 'advancedSettings.rpc.tooltip' }}
             id="decentralizedModeEnabled"
-            onChange={handleDecentarlizedOnChange}
+            handleOnChange={handleDecentarlizedOnChange}
           />
           <SettingsInputRow
             isOpen={isInputVisible}

--- a/src/components/frame/v5/pages/UserPreferencesPage/hooks.tsx
+++ b/src/components/frame/v5/pages/UserPreferencesPage/hooks.tsx
@@ -59,7 +59,7 @@ export const useUserPreferencesPage = () => {
         },
       });
 
-      updateUser?.(user?.walletAddress, true);
+      updateUser(user?.walletAddress, true);
 
       toast.success(
         <Toast

--- a/src/components/frame/v5/pages/UserProfilePage/hooks.tsx
+++ b/src/components/frame/v5/pages/UserProfilePage/hooks.tsx
@@ -51,7 +51,7 @@ export const useUserProfile = () => {
         },
       });
 
-      updateUser?.(user?.walletAddress, true);
+      updateUser(user?.walletAddress, true);
 
       toast.success(
         <Toast

--- a/src/components/frame/v5/pages/UserProfilePage/partials/UserProfilePageForm.tsx
+++ b/src/components/frame/v5/pages/UserProfilePage/partials/UserProfilePageForm.tsx
@@ -111,7 +111,7 @@ const UserProfilePageForm = ({
       },
     });
 
-    await updateUser?.(user?.walletAddress, true);
+    await updateUser(user?.walletAddress, true);
 
     toast.success(
       <Toast

--- a/src/components/v5/common/Fields/Switch/FormSwitch.tsx
+++ b/src/components/v5/common/Fields/Switch/FormSwitch.tsx
@@ -5,12 +5,17 @@ import Switch from './Switch';
 
 const displayName = 'v5.common.Fields.FormSwitch';
 
-const FormSwitch: FC<FormSwitchProps> = ({ name, ...rest }) => {
+const FormSwitch: FC<FormSwitchProps> = ({ name, handleOnChange, ...rest }) => {
   const {
-    field: { value, ...field },
+    field: { value, onChange: formOnChange, ...field },
   } = useController({ name });
 
-  return <Switch {...rest} {...field} checked={value} />;
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    formOnChange(event);
+    handleOnChange?.(event.target.checked);
+  };
+
+  return <Switch {...rest} {...field} checked={value} onChange={onChange} />;
 };
 
 FormSwitch.displayName = displayName;

--- a/src/components/v5/common/Fields/Switch/types.ts
+++ b/src/components/v5/common/Fields/Switch/types.ts
@@ -3,4 +3,5 @@ export type SwitchProps = React.InputHTMLAttributes<HTMLInputElement>;
 export interface FormSwitchProps
   extends Omit<SwitchProps, 'onChange' | 'value'> {
   name: string;
+  handleOnChange?: (value: boolean) => void;
 }

--- a/src/components/v5/common/SettingsRow/SettingsRow.tsx
+++ b/src/components/v5/common/SettingsRow/SettingsRow.tsx
@@ -20,7 +20,7 @@ const SettingsRow = <
   buttonIcon,
   buttonLabel,
   buttonMode,
-  onChange,
+  handleOnChange,
   onClick,
   id,
 }: SettingsRowProps<TFieldValues, TFieldName>) => {
@@ -45,7 +45,9 @@ const SettingsRow = <
           {formatMessage(description)}
         </p>
       </div>
-      {onChange && <FormSwitch name={id || ''} />}
+      {handleOnChange && (
+        <FormSwitch name={id || ''} handleOnChange={handleOnChange} />
+      )}
       {onClick && buttonLabel && (
         <Button
           mode={buttonMode}

--- a/src/components/v5/common/SettingsRow/types.ts
+++ b/src/components/v5/common/SettingsRow/types.ts
@@ -10,7 +10,7 @@ export interface SettingsRowProps<
   title: MessageDescriptor;
   description: MessageDescriptor;
   tooltipMessage?: MessageDescriptor;
-  onChange?: (value: boolean) => void;
+  handleOnChange?: (value: boolean) => void;
   onClick?: () => void;
   buttonLabel?: MessageDescriptor;
   buttonIcon?: string;

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -30,7 +30,7 @@ export interface AppContextValues {
   connectWallet: () => void;
   disconnectWallet: () => void;
   updateUser: (
-    address?: string,
+    address: string | undefined,
     shouldBackgroundUpdate?: boolean,
   ) => Promise<void>;
 }
@@ -48,7 +48,7 @@ export const AppContextProvider = ({ children }: { children: ReactNode }) => {
   const [walletConnecting, setWalletConnecting] = useState(true);
 
   const updateUser = useCallback(
-    async (address?: string, shouldBackgroundUpdate = false) => {
+    async (address: string | undefined, shouldBackgroundUpdate = false) => {
       if (address) {
         try {
           if (!shouldBackgroundUpdate) {

--- a/src/hooks/useColonySubscription.ts
+++ b/src/hooks/useColonySubscription.ts
@@ -50,7 +50,7 @@ const useColonySubscription = () => {
       },
     ],
     onCompleted() {
-      updateUser?.(user?.walletAddress);
+      updateUser(user?.walletAddress);
     },
   });
 
@@ -81,7 +81,7 @@ const useColonySubscription = () => {
       },
     ],
     onCompleted() {
-      updateUser?.(user?.walletAddress);
+      updateUser(user?.walletAddress);
     },
   });
 

--- a/src/redux/types/actions/index.ts
+++ b/src/redux/types/actions/index.ts
@@ -125,7 +125,7 @@ export type MetaWithSetter<M> = {
   setTxHash?: (txHash: string) => void;
   updateUser?:
     | ((
-        address?: string | undefined,
+        address: string | undefined,
         shouldBackgroundUpdate?: boolean | undefined,
       ) => Promise<void>)
     | undefined;


### PR DESCRIPTION
With this PR, whenever you create a user, either via the script or manually, it should have meta transactions already enabled by default.

Also, the toggle in the advance settings page should work as expected, and change your settings. You can check this by refreshing the page after toggling it off or on, and by querying the value through amplify's playground.

![FireShot Capture 241 - Advanced Settings - Colony - localhost](https://github.com/JoinColony/colonyCDapp/assets/18473896/a39d9834-a289-4477-8b7a-a823c47bdc24)

[screenity (6).webm](https://github.com/JoinColony/colonyCDapp/assets/18473896/7313e175-78b2-4e21-abad-773b9e6a9c72)


Resolves #1422 
