### PR TITLE
Fix: disable fields when extenstion is not installed in create decision action

### DIFF
--- a/src/components/v5/common/ActionFormRow/ActionFormRow.tsx
+++ b/src/components/v5/common/ActionFormRow/ActionFormRow.tsx
@@ -20,6 +20,7 @@ const ActionFormRow = React.forwardRef<HTMLDivElement, ActionFormRowProps>(
       fieldName,
       tooltips = {},
       className,
+      isDisabled,
     },
     ref,
   ) => {
@@ -33,6 +34,7 @@ const ActionFormRow = React.forwardRef<HTMLDivElement, ActionFormRowProps>(
     const textColorClassNames = {
       'text-negative-400': isError,
       'text-gray-900': !isError,
+      'text-gray-400': isDisabled && !isError,
     };
 
     const rowContent =
@@ -60,9 +62,11 @@ const ActionFormRow = React.forwardRef<HTMLDivElement, ActionFormRowProps>(
           {isExpandable && (
             <span
               className={clsx(
-                'flex text-gray-900 transition-all duration-normal group-hover:text-blue-400',
+                'flex transition-all duration-normal group-hover:text-blue-400',
                 {
                   'rotate-90': isExpanded,
+                  'text-gray-900': !isError && !isDisabled,
+                  'text-gray-400': isDisabled && !isError,
                 },
               )}
             >

--- a/src/components/v5/common/ActionFormRow/types.ts
+++ b/src/components/v5/common/ActionFormRow/types.ts
@@ -17,4 +17,5 @@ export interface ActionFormRowProps {
     label?: TooltipProps;
     content?: TooltipProps;
   };
+  isDisabled?: boolean;
 }

--- a/src/components/v5/common/ActionSidebar/consts.tsx
+++ b/src/components/v5/common/ActionSidebar/consts.tsx
@@ -1,13 +1,9 @@
 import { type Variants } from 'framer-motion';
-import React from 'react';
-import { FormattedMessage } from 'react-intl';
 import { object, string } from 'yup';
 
 // Do not import these from `./hooks` to avoid circular dependencies
 
-import { ACTION, type Action } from '~constants/actions.ts';
-import { MAX_ANNOTATION_LENGTH } from '~constants/index.ts';
-import { useColonyContext } from '~context/ColonyContext.tsx';
+import { MAX_ANNOTATION_LENGTH } from '~constants';
 import { stripHTMLFromText } from '~utils/elements.ts';
 import { formatText } from '~utils/intl.ts';
 
@@ -16,47 +12,6 @@ import { reputationValidationSchema } from './hooks/useReputationValidation.ts';
 
 export const ACTION_TYPE_FIELD_NAME = 'actionType';
 export const DECISION_METHOD_FIELD_NAME = 'decisionMethod';
-
-export const useCreateActionTypeNotification = (action: Action | undefined) => {
-  const { colony } = useColonyContext();
-  const isNativeTokenUnlocked = !!colony.status?.nativeToken?.unlocked;
-
-  if (!action) {
-    return undefined;
-  }
-
-  switch (action) {
-    case ACTION.UNLOCK_TOKEN:
-      return (
-        <FormattedMessage
-          id={
-            isNativeTokenUnlocked
-              ? 'actionSidebar.unlocked.token'
-              : 'actionSidebar.unlock.token.error'
-          }
-        />
-      );
-    case ACTION.ENTER_RECOVERY_MODE:
-      return <FormattedMessage id="actionSidebar.enterRecoveryMode.error" />;
-    default:
-      return undefined;
-  }
-};
-
-export const useCreateActionTypeNotificationHref = (
-  action: Action | undefined,
-) => {
-  if (!action) {
-    return undefined;
-  }
-
-  switch (action) {
-    case ACTION.UNLOCK_TOKEN:
-      return 'https://docs.colony.io/use/managing-funds/unlock-token/';
-    default:
-      return undefined;
-  }
-};
 
 export const actionSidebarAnimation: Variants = {
   hidden: {

--- a/src/components/v5/common/ActionSidebar/hooks/useGetActionData.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useGetActionData.ts
@@ -208,6 +208,9 @@ export const useGetActionData = (transactionId: string | undefined) => {
           createdIn: decisionData?.motionDomainId,
           title: decisionData?.title,
           description: decisionData?.description,
+          decisionMethod: action.isMotion
+            ? DecisionMethod.Reputation
+            : DecisionMethod.Permissions,
         };
       case ColonyActionType.UnlockToken:
       case ColonyActionType.UnlockTokenMotion:

--- a/src/components/v5/common/ActionSidebar/partials/ActionButtons.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionButtons.tsx
@@ -10,7 +10,11 @@ import Button, { TxButton } from '~v5/shared/Button/index.ts';
 import { useCloseSidebarClick } from '../hooks/index.ts';
 import { type ActionButtonsProps } from '../types.ts';
 
-import { useSubmitButtonDisabled, useSubmitButtonText } from './hooks.ts';
+import {
+  useIsFieldDisabled,
+  useSubmitButtonDisabled,
+  useSubmitButtonText,
+} from './hooks.ts';
 
 const displayName = 'v5.common.ActionSidebar.partials.ActionButtons';
 
@@ -26,6 +30,7 @@ const ActionButtons: FC<ActionButtonsProps> = ({ isActionDisabled }) => {
     cancelModalToggle: [isCancelModalOpen, { toggleOn: toggleCancelModalOn }],
   } = useActionSidebarContext();
   const { closeSidebarClick } = useCloseSidebarClick();
+  const isFieldDisabled = useIsFieldDisabled();
 
   useRegisterOnBeforeCloseCallback((element) => {
     const isClickedInside = isElementInsideModalOrPortal(element);
@@ -72,7 +77,7 @@ const ActionButtons: FC<ActionButtonsProps> = ({ isActionDisabled }) => {
       ) : (
         <Button
           mode="primarySolid"
-          disabled={isActionDisabled || isButtonDisabled}
+          disabled={isActionDisabled || isButtonDisabled || isFieldDisabled}
           text={submitText}
           isFullSize={isMobile}
           type="submit"

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -84,7 +84,7 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
           <ActionSidebarDescription />
         </div>
         <SidebarBanner />
-        <ActionTypeSelect className="mt-7 mb-3 min-h-[1.875rem] flex flex-col justify-center" />
+        <ActionTypeSelect className="my-3 min-h-[1.875rem] flex flex-col justify-center" />
 
         {FormComponent && <FormComponent getFormOptions={getFormOptions} />}
 

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/SidebarBanner.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/SidebarBanner.tsx
@@ -10,12 +10,11 @@ import useExtensionsData from '~hooks/useExtensionsData.ts';
 import { canColonyBeUpgraded } from '~utils/checks/canColonyBeUpgraded.ts';
 import { formatText } from '~utils/intl.ts';
 import { DecisionMethod } from '~v5/common/ActionSidebar/hooks/index.ts';
+import ActionTypeNotification from '~v5/shared/ActionTypeNotification/ActionTypeNotification.tsx';
 import NotificationBanner from '~v5/shared/NotificationBanner/index.ts';
 
 import {
   ACTION_TYPE_FIELD_NAME,
-  useCreateActionTypeNotification,
-  useCreateActionTypeNotificationHref,
   DECISION_METHOD_FIELD_NAME,
 } from '../../../consts.tsx';
 
@@ -36,11 +35,6 @@ export const SidebarBanner: FC = () => {
     ACTION_TYPE_FIELD_NAME,
     DECISION_METHOD_FIELD_NAME,
   ]);
-
-  const actionTypeNotificationTitle =
-    useCreateActionTypeNotification(selectedAction);
-  const actionTypeNofiticationHref =
-    useCreateActionTypeNotificationHref(selectedAction);
 
   const { installedExtensionsData } = useExtensionsData();
 
@@ -69,25 +63,10 @@ export const SidebarBanner: FC = () => {
 
   return (
     <>
-      {actionTypeNotificationTitle && (
-        <div className="mt-6">
-          <NotificationBanner
-            status="error"
-            icon="warning-circle"
-            callToAction={
-              <a
-                href={actionTypeNofiticationHref}
-                target="_blank"
-                rel="noreferrer"
-              >
-                {formatText({ id: 'learn.more' })}
-              </a>
-            }
-          >
-            {actionTypeNotificationTitle}
-          </NotificationBanner>
-        </div>
-      )}
+      <ActionTypeNotification
+        selectedAction={selectedAction}
+        className="mt-7"
+      />
       {requiredExtensionsWithoutPermission.map((extension) => (
         <div className="mt-6" key={extension.extensionId}>
           <NotificationBanner status="warning" icon="warning-circle">

--- a/src/components/v5/common/ActionSidebar/partials/DescriptionField/DescriptionField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/DescriptionField/DescriptionField.tsx
@@ -15,6 +15,7 @@ const DescriptionField: FC<DescriptionFieldProps> = ({
   toggleOnDecriptionSelect,
   fieldName,
   maxDescriptionLength,
+  disabled,
 }) => {
   const {
     fieldState: { error },
@@ -39,6 +40,7 @@ const DescriptionField: FC<DescriptionFieldProps> = ({
           <RichText
             name={fieldName}
             isReadonly={readonly}
+            isDisabled={disabled}
             isDecriptionFieldExpanded={isDecriptionFieldExpanded}
             maxDescriptionLength={maxDescriptionLength}
             toggleOffDecriptionSelect={toggleOffDecriptionSelect}
@@ -68,6 +70,7 @@ const DescriptionField: FC<DescriptionFieldProps> = ({
                 name={fieldName}
                 isReadonly={readonly}
                 maxDescriptionLength={maxDescriptionLength}
+                isDisabled={disabled}
                 isDecriptionFieldExpanded={isDecriptionFieldExpanded}
                 toggleOffDecriptionSelect={toggleOffDecriptionSelect}
                 toggleOnDecriptionSelect={toggleOnDecriptionSelect}

--- a/src/components/v5/common/ActionSidebar/partials/DescriptionField/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/DescriptionField/types.ts
@@ -4,4 +4,5 @@ export type DescriptionFieldProps = {
   toggleOnDecriptionSelect: () => void;
   fieldName: string;
   maxDescriptionLength?: number;
+  disabled?: boolean;
 };

--- a/src/components/v5/common/ActionSidebar/partials/DescriptionRow/DescriptionRow.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/DescriptionRow/DescriptionRow.tsx
@@ -11,7 +11,10 @@ import { type DescriptionRowProps } from './types.ts';
 
 const displayName = 'v5.common.ActionSidebar.partials.DescriptionRow';
 
-const DescriptionRow: FC<DescriptionRowProps> = ({ maxDescriptionLength }) => {
+const DescriptionRow: FC<DescriptionRowProps> = ({
+  disabled,
+  maxDescriptionLength,
+}) => {
   const { readonly } = useAdditionalFormOptionsContext();
   const { watch } = useFormContext();
   const descriptionValue = watch('description');
@@ -29,7 +32,8 @@ const DescriptionRow: FC<DescriptionRowProps> = ({ maxDescriptionLength }) => {
       //   },
       // }}
       title={formatText({ id: 'actionSidebar.description' })}
-      isExpandable
+      isExpandable={!disabled}
+      isDisabled={disabled}
     >
       {([
         isDecriptionFieldExpanded,
@@ -44,6 +48,7 @@ const DescriptionRow: FC<DescriptionRowProps> = ({ maxDescriptionLength }) => {
           toggleOnDecriptionSelect={toggleOnDecriptionSelect}
           maxDescriptionLength={maxDescriptionLength}
           fieldName="description"
+          disabled={disabled}
         />
       )}
     </ActionFormRow>

--- a/src/components/v5/common/ActionSidebar/partials/DescriptionRow/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/DescriptionRow/types.ts
@@ -1,3 +1,4 @@
 export interface DescriptionRowProps {
   maxDescriptionLength?: number;
+  disabled?: boolean;
 }

--- a/src/components/v5/common/ActionSidebar/partials/TeamsSelect/TeamsSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TeamsSelect/TeamsSelect.tsx
@@ -18,6 +18,7 @@ const TeamsSelect: FC<TeamSelectProps> = ({
   name,
   readonly: readonlyProp,
   filterOptionsFn,
+  disabled,
 }) => {
   const {
     field,
@@ -63,17 +64,16 @@ const TeamsSelect: FC<TeamSelectProps> = ({
           <button
             type="button"
             ref={relativeElementRef}
-            className={clsx(
-              'flex text-md transition-colors md:hover:text-blue-400',
-              {
-                'text-gray-400': !isError && !isTeamSelectVisible,
-                'text-negative-400': isError,
-                'text-blue-400': isTeamSelectVisible,
-              },
-            )}
+            className={clsx('flex text-md transition-colors', {
+              'text-gray-400': !isError && !isTeamSelectVisible,
+              'text-negative-400': isError,
+              'text-blue-400': isTeamSelectVisible,
+              'md:hover:text-blue-400': !disabled,
+            })}
             onClick={toggleTeamSelect}
+            disabled={disabled}
           >
-            {selectedOption ? (
+            {selectedOption && !disabled ? (
               <TeamBadge
                 name={
                   typeof selectedOption.label === 'object'

--- a/src/components/v5/common/ActionSidebar/partials/TeamsSelect/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/TeamsSelect/types.ts
@@ -4,4 +4,5 @@ export interface TeamSelectProps {
   name: string;
   readonly?: boolean;
   filterOptionsFn?: (option: SearchSelectOption) => boolean;
+  disabled?: boolean;
 }

--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/CreateDecisionForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/CreateDecisionForm.tsx
@@ -1,13 +1,17 @@
 import React, { type FC } from 'react';
+import { useWatch } from 'react-hook-form';
 
+import { ACTION, type Action } from '~constants/actions.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
+import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.tsx';
 import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/index.ts';
 import { FormCardSelect } from '~v5/common/Fields/CardSelect/index.ts';
 
-import { useDecisionMethods } from '../../../hooks/index.ts';
+import { DecisionMethod, useDecisionMethods } from '../../../hooks/index.ts';
 import { type ActionFormBaseProps } from '../../../types.ts';
 import DescriptionRow from '../../DescriptionRow/index.ts';
+import { useIsFieldDisabled } from '../../hooks.ts';
 
 import { useCreateDecision } from './hooks.ts';
 
@@ -15,6 +19,17 @@ const displayName = 'v5.common.ActionSidebar.partials.SinglePaymentForm';
 
 const CreateDecisionForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
   const { decisionMethods } = useDecisionMethods();
+  const isFieldDisabled = useIsFieldDisabled();
+  const selectedAction: Action | undefined = useWatch({
+    name: ACTION_TYPE_FIELD_NAME,
+  });
+
+  const filteredDecisionMethods =
+    selectedAction === ACTION.CREATE_DECISION
+      ? decisionMethods.filter(
+          (method) => method.value !== DecisionMethod.Permissions,
+        )
+      : decisionMethods;
 
   useCreateDecision(getFormOptions);
 
@@ -31,14 +46,16 @@ const CreateDecisionForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
           },
         }}
         title={formatText({ id: 'actionSidebar.decisionMethod' })}
+        isDisabled={isFieldDisabled}
       >
         <FormCardSelect
           name="decisionMethod"
           placeholder={formatText({
             id: 'actionSidebar.decisionMethod.placeholder',
           })}
-          options={decisionMethods}
-          title={formatText({ id: 'actionSidebar.availableDecisions' })}
+          options={filteredDecisionMethods}
+          title={formatText({ id: 'actionSidebar.decisionMethod' })}
+          disabled={isFieldDisabled}
         />
       </ActionFormRow>
       <ActionFormRow
@@ -52,10 +69,11 @@ const CreateDecisionForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
           },
         }}
         title={formatText({ id: 'actionSidebar.createdIn' })}
+        isDisabled={isFieldDisabled}
       >
-        <TeamsSelect name="createdIn" />
+        <TeamsSelect name="createdIn" disabled={isFieldDisabled} />
       </ActionFormRow>
-      <DescriptionRow />
+      <DescriptionRow disabled={isFieldDisabled} />
     </>
   );
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/hooks.ts
@@ -68,7 +68,7 @@ export const useCreateDecision = (
             decisionMethod: payload.decisionMethod,
             motionParams: [],
             draftDecision: {
-              motionDomainId: payload.createdIn,
+              motionDomainId: Number(payload.createdIn),
               title: payload.title,
               description: payload.description,
               walletAddress,

--- a/src/components/v5/common/ActionSidebar/partials/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/hooks.ts
@@ -1,10 +1,13 @@
+import { Extension } from '@colony/colony-js';
 import { useMemo } from 'react';
 import { useWatch } from 'react-hook-form';
 
 import { ACTION, type Action } from '~constants/actions.ts';
 import { useColonyContext } from '~context/ColonyContext.tsx';
 import useColonyContractVersion from '~hooks/useColonyContractVersion.ts';
+import useExtensionData from '~hooks/useExtensionData.ts';
 import { canColonyBeUpgraded } from '~utils/checks/index.ts';
+import { isInstalledExtensionData } from '~utils/extensions.ts';
 import { formatText } from '~utils/intl.ts';
 
 import { ACTION_TYPE_FIELD_NAME } from '../consts.tsx';
@@ -66,4 +69,21 @@ export const useSubmitButtonDisabled = () => {
     default:
       return false;
   }
+};
+
+export const useIsFieldDisabled = () => {
+  const { extensionData } = useExtensionData(Extension.VotingReputation);
+  const selectedAction: Action | undefined = useWatch({
+    name: ACTION_TYPE_FIELD_NAME,
+  });
+  const isExtensionEnabled =
+    extensionData &&
+    isInstalledExtensionData(extensionData) &&
+    extensionData.isEnabled;
+
+  if (selectedAction === ACTION.CREATE_DECISION && !isExtensionEnabled) {
+    return true;
+  }
+
+  return false;
 };

--- a/src/components/v5/common/CompletedAction/partials/CreateDecision/CreateDecision.tsx
+++ b/src/components/v5/common/CompletedAction/partials/CreateDecision/CreateDecision.tsx
@@ -66,8 +66,8 @@ const CreateDecision = ({ action }: CreateDecisionProps) => {
           />
         )}
       </ActionDataGrid>
-      {action.annotation?.message && (
-        <DescriptionRow description={action.annotation.message} />
+      {action.decisionData?.description && (
+        <DescriptionRow description={action.decisionData.description} />
       )}
     </>
   );

--- a/src/components/v5/common/CompletedAction/partials/rows/Description.tsx
+++ b/src/components/v5/common/CompletedAction/partials/rows/Description.tsx
@@ -59,9 +59,9 @@ const DescriptionRow = ({ description }: DescriptionRowProps) => {
         </button>
       </div>
       <div
-        className={clsx('flex flex-1', {
+        className={clsx('flex flex-1 items-start', {
           'h-10': !isExpanded,
-          'flex-col items-start mt-4': isExpanded,
+          'flex-col mt-4': isExpanded,
         })}
       >
         <RichTextDisplay

--- a/src/components/v5/shared/ActionTypeNotification/ActionTypeNotification.tsx
+++ b/src/components/v5/shared/ActionTypeNotification/ActionTypeNotification.tsx
@@ -1,16 +1,16 @@
 import { Extension } from '@colony/colony-js';
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { defineMessages } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 
-import { ACTION } from '~constants/actions';
-import { useActionSidebarContext } from '~context';
-import { useColonyContext } from '~hooks';
-import { formatText } from '~utils/intl';
-import { useIsFieldDisabled } from '~v5/common/ActionSidebar/partials/hooks';
-import NotificationBanner from '~v5/shared/NotificationBanner';
+import { ACTION } from '~constants/actions.ts';
+import { useActionSidebarContext } from '~context/ActionSidebarContext/index.tsx';
+import { useColonyContext } from '~context/ColonyContext.tsx';
+import { formatText } from '~utils/intl.ts';
+import { useIsFieldDisabled } from '~v5/common/ActionSidebar/partials/hooks.ts';
+import NotificationBanner from '~v5/shared/NotificationBanner/index.ts';
 
-import { ActionTypeNotificationProps } from './types';
+import { type ActionTypeNotificationProps } from './types.ts';
 
 const displayName = 'v5.ActionTypeNotification';
 

--- a/src/components/v5/shared/ActionTypeNotification/ActionTypeNotification.tsx
+++ b/src/components/v5/shared/ActionTypeNotification/ActionTypeNotification.tsx
@@ -1,0 +1,123 @@
+import { Extension } from '@colony/colony-js';
+import React, { FC } from 'react';
+import { defineMessages } from 'react-intl';
+import { useNavigate } from 'react-router-dom';
+
+import { ACTION } from '~constants/actions';
+import { useActionSidebarContext } from '~context';
+import { useColonyContext } from '~hooks';
+import { formatText } from '~utils/intl';
+import { useIsFieldDisabled } from '~v5/common/ActionSidebar/partials/hooks';
+import NotificationBanner from '~v5/shared/NotificationBanner';
+
+import { ActionTypeNotificationProps } from './types';
+
+const displayName = 'v5.ActionTypeNotification';
+
+const MSG = defineMessages({
+  unlockedToken: {
+    id: `${displayName}.unlockedToken`,
+    defaultMessage: `This Colony's native token has already been unlocked and can be traded.`,
+  },
+  unlockedTokenError: {
+    id: `${displayName}.unlockedTokenError`,
+    defaultMessage: 'This action is irreversible. Use with caution.',
+  },
+  enterRecoveryModeError: {
+    id: `${displayName}.enterRecoveryModeError`,
+    defaultMessage:
+      'This will disable the Colony and prevent any further activity until resolved.',
+  },
+  createDecisionError: {
+    id: `${displayName}.createDecisionError`,
+    defaultMessage:
+      'Agreements requires the Reputation weighted extension to be enabled.',
+  },
+  learnMore: {
+    id: `${displayName}.learnMore`,
+    defaultMessage: 'Learn more',
+  },
+  viewExtension: {
+    id: `${displayName}.viewExtension`,
+    defaultMessage: 'View extension',
+  },
+});
+
+export const ActionTypeNotification: FC<ActionTypeNotificationProps> = ({
+  selectedAction,
+  className,
+}) => {
+  const { colony } = useColonyContext();
+  const isNativeTokenUnlocked = !!colony?.status?.nativeToken?.unlocked;
+  const isFieldDisabled = useIsFieldDisabled();
+  const navigate = useNavigate();
+  const {
+    actionSidebarToggle: [, { toggleOff: toggleActionSidebarOff }],
+  } = useActionSidebarContext();
+
+  const actionTypeNotificationHref =
+    (selectedAction === ACTION.UNLOCK_TOKEN &&
+      'https://docs.colony.io/use/managing-funds/unlock-token/') ||
+    undefined;
+
+  const getNotificationTitle = (): string | undefined => {
+    switch (selectedAction) {
+      case ACTION.UNLOCK_TOKEN:
+        return formatText(
+          isNativeTokenUnlocked ? MSG.unlockedToken : MSG.unlockedTokenError,
+        );
+      case ACTION.ENTER_RECOVERY_MODE:
+        return formatText(MSG.enterRecoveryModeError);
+      case ACTION.CREATE_DECISION:
+        return isFieldDisabled
+          ? formatText(MSG.createDecisionError)
+          : undefined;
+      default:
+        return undefined;
+    }
+  };
+
+  const notificationTitle = getNotificationTitle();
+
+  return (
+    <>
+      {notificationTitle && (
+        <div className={className}>
+          <NotificationBanner
+            status="error"
+            icon="warning-circle"
+            callToAction={
+              actionTypeNotificationHref ? (
+                <a
+                  href={actionTypeNotificationHref}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {formatText(MSG.learnMore)}
+                </a>
+              ) : (
+                selectedAction === ACTION.CREATE_DECISION && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      navigate(`extensions/${Extension.VotingReputation}`);
+                      toggleActionSidebarOff();
+                    }}
+                  >
+                    {formatText(MSG.viewExtension)}
+                  </button>
+                )
+              )
+            }
+          >
+            {notificationTitle}
+          </NotificationBanner>
+        </div>
+      )}
+    </>
+  );
+};
+
+ActionTypeNotification.displayName = displayName;
+
+export default ActionTypeNotification;

--- a/src/components/v5/shared/ActionTypeNotification/index.ts
+++ b/src/components/v5/shared/ActionTypeNotification/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ActionTypeNotification';

--- a/src/components/v5/shared/ActionTypeNotification/index.ts
+++ b/src/components/v5/shared/ActionTypeNotification/index.ts
@@ -1,1 +1,1 @@
-export { default } from './ActionTypeNotification';
+export { default } from './ActionTypeNotification.tsx';

--- a/src/components/v5/shared/ActionTypeNotification/types.ts
+++ b/src/components/v5/shared/ActionTypeNotification/types.ts
@@ -1,0 +1,6 @@
+import { Action } from '~constants/actions';
+
+export interface ActionTypeNotificationProps {
+  selectedAction: Action;
+  className?: string;
+}

--- a/src/components/v5/shared/ActionTypeNotification/types.ts
+++ b/src/components/v5/shared/ActionTypeNotification/types.ts
@@ -1,4 +1,4 @@
-import { Action } from '~constants/actions';
+import { type Action } from '~constants/actions.ts';
 
 export interface ActionTypeNotificationProps {
   selectedAction: Action;

--- a/src/components/v5/shared/RichText/RichText.tsx
+++ b/src/components/v5/shared/RichText/RichText.tsx
@@ -22,6 +22,7 @@ const RichText: FC<RichTextProps> = ({
   toggleOnDecriptionSelect,
   toggleOffDecriptionSelect,
   shouldFocus,
+  isDisabled,
 }) => {
   const { editor, notFormattedContent, field, characterCount } = useRichText(
     name,
@@ -116,10 +117,12 @@ const RichText: FC<RichTextProps> = ({
               <button
                 type="button"
                 onClick={toggleOnDecriptionSelect}
-                className={clsx('transition sm:hover:text-blue-400 text-left', {
+                className={clsx('transition text-left', {
                   'text-gray-900': characterCount,
                   'text-gray-400': !characterCount,
+                  'sm:hover:text-blue-400': !isDisabled,
                 })}
+                disabled={isDisabled}
               >
                 <span
                   ref={(ref) => {

--- a/src/components/v5/shared/RichText/types.ts
+++ b/src/components/v5/shared/RichText/types.ts
@@ -10,4 +10,5 @@ export type RichTextProps = Omit<DescriptionFieldProps, 'fieldName'> & {
   name: string;
   isReadonly?: boolean;
   shouldFocus?: boolean;
+  isDisabled?: boolean;
 };

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -836,7 +836,7 @@
     "actions.userPermissions": "User permissions",
     "actions.recipient": "Colony members",
     "actions.manageReputation": "Manage reputation",
-    "actions.createAgreement": "Create agreement",
+    "actions.createAgreement": "Create an Agreement",
     "actions.simpleDiscussion": "Simple Discussion",
     "connectWallet": "Connect wallet",
     "copyWalletAddress": "Copy wallet address",
@@ -1030,9 +1030,6 @@
     "actionSidebar.mint.token.permission.error": "You don't have the right permissions to create this action type. Please choose another action type.",
     "actionSidebar.placeholder.teamName": "Enter team name",
     "actionSidebar.placeholder.purpose": "Enter short description",
-    "actionSidebar.unlock.token.error": "This action is irreversible. Use with caution.",
-    "actionSidebar.unlocked.token": "This Colony's native token has already been unlocked and can be traded.",
-    "actionSidebar.enterRecoveryMode.error": "This will disable the Colony and prevent any further activity until resolved.",
     "actionSidebar.fields.error": "Oops! Something went wrong. Please check highlighted fields and try again.",
     "actionSidebar.tooltip.actionType": "Identifies the type of action.",
     "actionSidebar.tooltip.decisionMethod": "Mechanism behind the decision-making process.",
@@ -1548,5 +1545,6 @@
     "teamsPage.menu.viewTeamDecisions": "View team decisions",
     "teamsPage.menu.viewTeamDashboard": "View team dashboard",
     "teamsPage.links.agreements": "Agreements",
-    "teamsPage.links.activity": "Activity"
+    "teamsPage.links.activity": "Activity",
+    "view.extension": "View extension"
 }

--- a/src/utils/objects/index.ts
+++ b/src/utils/objects/index.ts
@@ -9,3 +9,7 @@ export const excludeTypenameKey = <T>(
   const { __typename, ...objectWithoutTypename } = objectWithTypename;
   return objectWithoutTypename;
 };
+
+export const getProperty = <T>(obj: T, key: string, defaultValue?: any) => {
+  return typeof obj === 'object' && obj && key in obj ? obj[key] : defaultValue;
+};


### PR DESCRIPTION
https://tw.auroracreation.com/app/tasks/15687539

- disable fields when extension is not installed
- display banner
- redirect to extension

<img width="1054" alt="Screen Shot 2023-12-04 at 14 16 53" src="https://github.com/JoinColony/colonyCDapp/assets/119587095/682e3cff-1590-454b-bc2d-8bbd6af8d771">
