### PR TITLE
Use dynamic colony name and description in sidebar

### DIFF
--- a/src/components/frame/Extensions/layouts/hooks.tsx
+++ b/src/components/frame/Extensions/layouts/hooks.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
-
 import clsx from 'clsx';
+
 import { ColonyFragment } from '~gql';
 import {
   useAppContext,
@@ -19,6 +19,9 @@ import { COLONY_MEMBERS_ROUTE } from '~routes/routeConstants';
 import { NavigationSidebarItem } from '~v5/frame/NavigationSidebar/partials/NavigationSidebarMainMenu/types';
 import { CalamityBannerItemProps } from '~v5/shared/CalamityBanner/types';
 import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts';
+import { TransactionGroupStates, useUserTransactionContext } from '~context';
+import { TxButton } from '~v5/shared/Button';
+import Icon from '~shared/Icon';
 
 import type { UseCalamityBannerInfoReturnType } from './types';
 import {
@@ -32,9 +35,6 @@ import {
 } from './consts';
 import { checkIfIsActive } from './utils';
 import DashboardContent from './partials/DashboardContent';
-import { TransactionGroupStates, useUserTransactionContext } from '~context';
-import { TxButton } from '~v5/shared/Button';
-import Icon from '~shared/Icon';
 
 export const useCalamityBannerInfo = (): UseCalamityBannerInfoReturnType => {
   const { colony } = useColonyContext();
@@ -88,6 +88,9 @@ export const useCalamityBannerInfo = (): UseCalamityBannerInfoReturnType => {
 };
 
 export const useMainMenuItems = () => {
+  const { colony } = useColonyContext();
+  const { metadata } = colony || {};
+
   const {
     actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
   } = useActionSidebarContext();
@@ -113,9 +116,9 @@ export const useMainMenuItems = () => {
         ...dashboardMenu,
       ]),
       secondLevelMenuProps: {
-        title: formatText({ id: 'navigation.dashboard.title' }),
+        title: metadata?.displayName || '',
         content: <DashboardContent />,
-        description: formatText({ id: 'navigation.dashboard.description' }),
+        description: metadata?.description || '',
         bottomActionProps: {
           text: formatText({ id: 'button.createNewAction' }),
           iconName: 'plus',

--- a/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarSecondLevel/NavigationSidebarSecondLevel.tsx
+++ b/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarSecondLevel/NavigationSidebarSecondLevel.tsx
@@ -4,15 +4,18 @@ import clsx from 'clsx';
 import { useTablet } from '~hooks';
 import Icon from '~shared/Icon';
 import Button from '~v5/shared/Button';
+import { multiLineTextEllipsis } from '~utils/strings';
+import ButtonLink from '~v5/shared/Button/ButtonLink';
 
 import { NavigationSidebarSecondLevelProps } from './types';
 import useNavigationSidebarContext from '../NavigationSidebarContext/hooks';
-import ButtonLink from '~v5/shared/Button/ButtonLink';
 import NavigationSidebarLinksList from '../NavigationSidebarLinksList';
 import NavigationFeedbackWidget from '../NavigationFeedbackWidget';
 
 const displayName =
   'v5.frame.NavigationSidebar.partials.NavigationSidebarSecondLevel';
+
+const MAX_DESCRIPTION_LENGTH = 115;
 
 const NavigationSidebarSecondLevel: FC<NavigationSidebarSecondLevelProps> = ({
   title,
@@ -57,7 +60,7 @@ const NavigationSidebarSecondLevel: FC<NavigationSidebarSecondLevelProps> = ({
         )}
         {description && (
           <p className="md:mt-1 text-md text-gray-600 px-2 md:px-0">
-            {description}
+            {multiLineTextEllipsis(description, MAX_DESCRIPTION_LENGTH)}
           </p>
         )}
         {isContentList ? (

--- a/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarSecondLevel/NavigationSidebarSecondLevel.tsx
+++ b/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarSecondLevel/NavigationSidebarSecondLevel.tsx
@@ -59,9 +59,9 @@ const NavigationSidebarSecondLevel: FC<NavigationSidebarSecondLevelProps> = ({
           </div>
         )}
         {description && (
-          <p className="md:mt-1 text-md text-gray-600 px-2 md:px-0">
-            {multiLineTextEllipsis(description, MAX_DESCRIPTION_LENGTH)}
-          </p>
+          <div className="h-15 line-clamp-3 md:mt-1 text-md text-gray-600 px-2 md:px-0">
+            <p>{multiLineTextEllipsis(description, MAX_DESCRIPTION_LENGTH)}</p>
+          </div>
         )}
         {isContentList ? (
           <NavigationSidebarLinksList

--- a/src/styles/main.global.css
+++ b/src/styles/main.global.css
@@ -140,6 +140,30 @@
   .break-word {
     word-break: break-word;
   }
+
+  .line-clamp-1 {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+    line-clamp: 1;
+  }
+
+  .line-clamp-2 {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+  }
+
+  .line-clamp-3 {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Description

This PR uses the colony values for the colonyName and description in the Navigation Sidebar

![image](https://github.com/JoinColony/colonyCDapp/assets/32598350/358cc45d-b275-4761-8a1c-cf17d1a7900d)


Resolves #1474
