### PR TITLE
Add team filtering to widget boxes on colony home

### DIFF
--- a/src/components/common/ColonyHome/ColonyHome.tsx
+++ b/src/components/common/ColonyHome/ColonyHome.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
 import clsx from 'clsx';
+import { useLocation } from 'react-router-dom';
 
 import { useSetPageBreadcrumbs } from '~context/PageHeadingContext/hooks';
 import { useColonyContext, useColonySubscription, useMobile } from '~hooks';
@@ -88,6 +89,8 @@ const ColonyHome = () => {
 
   useSetPageBreadcrumbs(teamsBreadcrumbs);
 
+  const { search: searchParams } = useLocation();
+
   if (!colony) {
     return null;
   }
@@ -97,8 +100,6 @@ const ColonyHome = () => {
       [ACTION_TYPE_FIELD_NAME]: ACTION.MANAGE_COLONY_OBJECTIVES,
     });
   };
-
-  const searchParams = selectedTeam && `?team=${selectedTeam.nativeId}`;
 
   return (
     <div className="flex flex-col gap-10">

--- a/src/components/common/ColonyHome/ColonyHome.tsx
+++ b/src/components/common/ColonyHome/ColonyHome.tsx
@@ -98,6 +98,8 @@ const ColonyHome = () => {
     });
   };
 
+  const searchParams = selectedTeam && `?team=${selectedTeam.nativeId}`;
+
   return (
     <div className="flex flex-col gap-10">
       <ColonyDashboardHeader {...headerProps} />
@@ -112,6 +114,7 @@ const ColonyHome = () => {
               'bg-gray-900 border-gray-900': !selectedTeam,
             }),
             href: COLONY_ACTIVITY_ROUTE,
+            searchParams,
           },
           {
             key: '2',
@@ -130,6 +133,7 @@ const ColonyHome = () => {
                 showRemainingAvatars={false}
               />
             ),
+            searchParams,
           },
           {
             key: '3',
@@ -144,6 +148,7 @@ const ColonyHome = () => {
               </div>
             ),
             href: COLONY_BALANCES_ROUTE,
+            searchParams,
           },
         ]}
       />

--- a/src/components/v5/common/WidgetBox/WidgetBox.tsx
+++ b/src/components/v5/common/WidgetBox/WidgetBox.tsx
@@ -11,6 +11,7 @@ const WidgetBox: FC<WidgetBoxProps> = ({
   value,
   additionalContent,
   href,
+  searchParams = '',
   className = 'bg-base-white border-gray-200 text-gray-900',
   iconName,
   iconClassName = 'text-blue-400',
@@ -58,7 +59,7 @@ const WidgetBox: FC<WidgetBoxProps> = ({
         hoverStyles,
         'sm:hover:text-gray-900 sm:hover:bg-base-white',
       )}
-      to={href}
+      to={href + searchParams}
     >
       {content}
     </Link>

--- a/src/components/v5/common/WidgetBox/WidgetBox.tsx
+++ b/src/components/v5/common/WidgetBox/WidgetBox.tsx
@@ -11,7 +11,7 @@ const WidgetBox: FC<WidgetBoxProps> = ({
   value,
   additionalContent,
   href,
-  searchParams = '',
+  searchParams,
   className = 'bg-base-white border-gray-200 text-gray-900',
   iconName,
   iconClassName = 'text-blue-400',
@@ -59,7 +59,7 @@ const WidgetBox: FC<WidgetBoxProps> = ({
         hoverStyles,
         'sm:hover:text-gray-900 sm:hover:bg-base-white',
       )}
-      to={href + searchParams}
+      to={{ pathname: href, search: searchParams || '' }}
     >
       {content}
     </Link>

--- a/src/components/v5/common/WidgetBox/types.ts
+++ b/src/components/v5/common/WidgetBox/types.ts
@@ -4,6 +4,7 @@ export interface WidgetBoxProps {
   additionalContent?: React.ReactNode;
   className?: string;
   href?: string;
+  searchParams?: string | null;
   iconName?: string;
   iconClassName?: string;
   contentClassName?: string;

--- a/src/components/v5/common/WidgetBox/types.ts
+++ b/src/components/v5/common/WidgetBox/types.ts
@@ -4,7 +4,7 @@ export interface WidgetBoxProps {
   additionalContent?: React.ReactNode;
   className?: string;
   href?: string;
-  searchParams?: string | null;
+  searchParams?: string;
   iconName?: string;
   iconClassName?: string;
   contentClassName?: string;


### PR DESCRIPTION
Now when you filter by teams in the dashboard, the 3 top widgets should also take you to their related pages with the filter you applied beforehand.

Resolves #1416 
