### PR TITLE
Add "Not enough funds" error to finalize step

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
@@ -155,7 +155,7 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
                   items={items}
                   className={clsx({
                     'mb-6':
-                      (!actionData.motionData.isFinalized && isFinalizable) ||
+                      !actionData.motionData.isFinalized ||
                       (!isClaimed && canClaimStakes),
                   })}
                 />

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import React, { type FC, useEffect, useState } from 'react';
+import { defineMessages } from 'react-intl';
 
 import { useAppContext } from '~context/AppContext.tsx';
 import { useColonyContext } from '~context/ColonyContext.tsx';
@@ -20,6 +21,13 @@ import { type FinalizeStepProps, FinalizeStepSections } from './types.ts';
 
 const displayName =
   'v5.common.ActionSidebar.partials.motions.MotionSimplePayment.steps.FinalizeStep';
+
+const MSG = defineMessages({
+  finalizeError: {
+    id: `${displayName}.finalizeError`,
+    defaultMessage: `There are not enough funds in the team to finalize. Ensure there are enough funds in the team before trying again.`,
+  },
+});
 
 const FinalizeStep: FC<FinalizeStepProps> = ({
   actionData,
@@ -114,6 +122,17 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
         iconSize: 'extraSmall',
       }}
       sections={[
+        ...(!isFinalizable
+          ? [
+              {
+                key: `${actionData.motionData.transactionHash}-not-enough-balance`,
+                content: (
+                  <p className="text-sm">{formatText(MSG.finalizeError)}</p>
+                ),
+                className: 'bg-negative-100 text-negative-400',
+              },
+            ]
+          : []),
         {
           key: FinalizeStepSections.Finalize,
           content: (
@@ -156,17 +175,15 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
                       }
                     />
                   )}
-                  {!isPolling &&
-                    !actionData.motionData.isFinalized &&
-                    isFinalizable && (
-                      <Button
-                        mode="primarySolid"
-                        disabled={!isFinalizable || wrongMotionState}
-                        isFullSize
-                        text={formatText({ id: 'motion.finalizeStep.submit' })}
-                        type="submit"
-                      />
-                    )}
+                  {!isPolling && !actionData.motionData.isFinalized && (
+                    <Button
+                      mode="primarySolid"
+                      disabled={!isFinalizable || wrongMotionState}
+                      isFullSize
+                      text={formatText({ id: 'motion.finalizeStep.submit' })}
+                      type="submit"
+                    />
+                  )}
                   {!isPolling &&
                     (actionData.motionData.isFinalized ||
                       actionData.motionData.motionStateHistory

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
@@ -39,8 +39,11 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
   const { canInteract } = useAppContext();
   const [isPolling, setIsPolling] = useState(false);
   const { refetchColony } = useColonyContext();
-  const { isFinalizable, transform: finalizePayload } =
-    useFinalizeStep(actionData);
+  const {
+    isFinalizable,
+    transform: finalizePayload,
+    hasEnoughFundsToFinalize,
+  } = useFinalizeStep(actionData);
   const {
     items,
     isClaimed,
@@ -122,7 +125,7 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
         iconSize: 'extraSmall',
       }}
       sections={[
-        ...(!isFinalizable
+        ...(!hasEnoughFundsToFinalize
           ? [
               {
                 key: `${actionData.motionData.transactionHash}-not-enough-balance`,

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/hooks.tsx
@@ -50,11 +50,13 @@ export const useFinalizeStep = (actionData: MotionAction) => {
     type !== ColonyActionType.EmitDomainReputationPenaltyMotion &&
     type !== ColonyActionType.EmitDomainReputationRewardMotion;
 
+  const hasEnoughFundsToFinalize =
+    !requiresDomainFunds ||
+    // Safe casting since if requiresDomainFunds is true, we know amount is a string
+    BigNumber.from(domainBalance ?? '0').gte(amount as string);
+
   const isFinalizable =
-    (!requiresDomainFunds ||
-      // Safe casting since if requiresDomainFunds is true, we know amount is a string
-      BigNumber.from(domainBalance ?? '0').gte(amount as string)) &&
-    !motionStateHistory.hasFailedNotFinalizable;
+    hasEnoughFundsToFinalize && !motionStateHistory.hasFailedNotFinalizable;
 
   const transform = mapPayload(
     (): MotionFinalizePayload => ({
@@ -68,6 +70,7 @@ export const useFinalizeStep = (actionData: MotionAction) => {
   return {
     transform,
     isFinalizable,
+    hasEnoughFundsToFinalize,
   };
 };
 

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/hooks.tsx
@@ -48,7 +48,8 @@ export const useFinalizeStep = (actionData: MotionAction) => {
     !!amount &&
     type !== ColonyActionType.MintTokensMotion &&
     type !== ColonyActionType.EmitDomainReputationPenaltyMotion &&
-    type !== ColonyActionType.EmitDomainReputationRewardMotion;
+    type !== ColonyActionType.EmitDomainReputationRewardMotion &&
+    motionStateHistory.hasPassed;
 
   const hasEnoughFundsToFinalize =
     !requiresDomainFunds ||

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/hooks.tsx
@@ -1,4 +1,4 @@
-import { Extension } from '@colony/colony-js';
+import { Extension, Id } from '@colony/colony-js';
 import { BigNumber } from 'ethers';
 import React, { useEffect, useMemo, useState } from 'react';
 
@@ -26,12 +26,7 @@ import { WinningsItems } from './types.ts';
 
 export const useFinalizeStep = (actionData: MotionAction) => {
   const {
-    motionData: {
-      nativeMotionDomainId,
-      motionId,
-      gasEstimate,
-      motionStateHistory,
-    },
+    motionData: { motionId, gasEstimate, motionStateHistory },
     type,
     amount,
     fromDomain,
@@ -45,7 +40,7 @@ export const useFinalizeStep = (actionData: MotionAction) => {
   const domainBalance = getBalanceForTokenAndDomain(
     balances,
     tokenAddress ?? '',
-    Number(nativeMotionDomainId),
+    fromDomain?.nativeId || Id.RootDomain,
   );
 
   const requiresDomainFunds: boolean =


### PR DESCRIPTION
The logic was already there, althought a bit wrong as it was considering the motion domain instead of `fromDomain` which actually has the domain from which the funds are going to be extracted.

Besides that, now you should see this error whenever you create a simple payment or transfer funds motion with an amount that by the time the motion is ready to be finalized, is larger than the domain's balance:

![FireShot Capture 256 - Transaction - 0x8c79399a21594e2c41e7eee957c3cbcf1fa725bda8503970f04ba_ - localhost](https://github.com/JoinColony/colonyCDapp/assets/18473896/9e830f9e-8645-4f59-bbd4-0414e1570da4)


Resolves #1482 
