### PR TITLE
Updates team colors to match design

### DIFF
--- a/src/components/common/ColonyHome/consts.ts
+++ b/src/components/common/ColonyHome/consts.ts
@@ -18,40 +18,40 @@ export const MAX_TEXT_LENGTH = 250;
 
 export const setTeamColor = (color?: DomainColor) => {
   switch (color) {
-    case DomainColor.Purple:
-      return 'bg-teams-purple-400 border-teams-purple-400';
-    case DomainColor.LightPink:
-      return 'bg-teams-pink-400 border-teams-pink-400';
-    case DomainColor.Yellow:
-      return 'bg-teams-yellow-500 border-teams-yellow-500';
-    case DomainColor.Blue:
-      return 'bg-indigo-400 border-indigo-400';
-    case DomainColor.Green:
-      return 'bg-teams-green-500 border-teams-green-500';
     case DomainColor.Aqua:
-      return 'bg-teams-teal-500 border-teams-teal-500';
+      return 'bg-teams-yellow-500';
     case DomainColor.Black:
-      return 'bg-teams-grey-500 border-teams-grey-500';
+      return 'bg-teams-red-400';
+    case DomainColor.Blue:
+      return 'bg-teams-red-600';
     case DomainColor.BlueGrey:
-      return 'bg-teams-grey-100 border-teams-grey-100';
+      return 'bg-teams-pink-400';
     case DomainColor.EmeraldGreen:
-      return 'bg-teams-green-400 border-teams-green-400';
+      return 'bg-teams-pink-500';
     case DomainColor.Gold:
-      return 'bg-teams-yellow-100 border-teams-yellow-100';
+      return 'bg-teams-pink-600';
+    case DomainColor.Green:
+      return 'bg-teams-purple-400';
+    case DomainColor.LightPink:
+      return 'bg-teams-purple-500';
     case DomainColor.Magenta:
-      return 'bg-teams-pink-600 border-teams-pink-600';
+      return 'bg-teams-green-300';
     case DomainColor.Orange:
-      return 'bg-teams-red-400 border-teams-red-400';
-    case DomainColor.Pink:
-      return 'bg-teams-pink-500 border-teams-pink-500';
+      return 'bg-teams-green-400';
     case DomainColor.Periwinkle:
-      return 'bg-teams-indigo-500 border-teams-indigo-500';
+      return 'bg-teams-green-500';
+    case DomainColor.Pink:
+      return 'bg-teams-teal-500';
+    case DomainColor.Purple:
+      return 'bg-teams-blue-500';
     case DomainColor.PurpleGrey:
-      return 'bg-teams-purple-400 border-teams-purple-400';
+      return 'bg-teams-blue-400';
     case DomainColor.Red:
-      return 'bg-teams-red-600 border-teams-red-600';
+      return 'bg-teams-indigo-500';
+    case DomainColor.Yellow:
+      return 'bg-teams-grey-500';
     default:
-      return 'bg-teams-purple-400 border-teams-purple-400';
+      return 'bg-blue-400';
   }
 };
 

--- a/src/components/v5/common/TeamReputationSummary/utils.ts
+++ b/src/components/v5/common/TeamReputationSummary/utils.ts
@@ -2,118 +2,118 @@ import { DomainColor } from '~gql';
 
 export const setTeamColor = (color?: DomainColor) => {
   switch (color) {
-    case DomainColor.Purple:
+    case DomainColor.Aqua:
+      return 'bg-teams-yellow-500';
+    case DomainColor.Black:
+      return 'bg-teams-red-400';
+    case DomainColor.Blue:
+      return 'bg-teams-red-600';
+    case DomainColor.BlueGrey:
+      return 'bg-teams-pink-400';
+    case DomainColor.EmeraldGreen:
+      return 'bg-teams-pink-500';
+    case DomainColor.Gold:
+      return 'bg-teams-pink-600';
+    case DomainColor.Green:
       return 'bg-teams-purple-400';
     case DomainColor.LightPink:
-      return 'bg-teams-pink-400';
-    case DomainColor.Yellow:
-      return 'bg-teams-yellow-500';
-    case DomainColor.Blue:
-      return 'bg-indigo-400';
-    case DomainColor.Green:
-      return 'bg-teams-green-500';
-    case DomainColor.Aqua:
-      return 'bg-teams-teal-500';
-    case DomainColor.Black:
-      return 'bg-teams-grey-500';
-    case DomainColor.BlueGrey:
-      return 'bg-teams-grey-100';
-    case DomainColor.EmeraldGreen:
-      return 'bg-teams-green-400';
-    case DomainColor.Gold:
-      return 'bg-teams-yellow-100';
+      return 'bg-teams-purple-500';
     case DomainColor.Magenta:
-      return 'bg-teams-pink-600';
+      return 'bg-teams-green-300';
     case DomainColor.Orange:
-      return 'bg-teams-red-400';
-    case DomainColor.Pink:
-      return 'bg-teams-pink-500';
+      return 'bg-teams-green-400';
     case DomainColor.Periwinkle:
-      return 'bg-teams-indigo-500';
+      return 'bg-teams-green-500';
+    case DomainColor.Pink:
+      return 'bg-teams-teal-500';
+    case DomainColor.Purple:
+      return 'bg-teams-blue-500';
     case DomainColor.PurpleGrey:
-      return 'bg-teams-purple-400';
+      return 'bg-teams-blue-400';
     case DomainColor.Red:
-      return 'bg-teams-red-600';
+      return 'bg-teams-indigo-500';
+    case DomainColor.Yellow:
+      return 'bg-teams-grey-500';
     default:
-      return 'bg-teams-purple-400';
+      return 'bg-blue-400';
   }
 };
 
 export const setHexTeamColor = (color?: DomainColor) => {
   switch (color) {
-    case DomainColor.Purple:
+    case DomainColor.Aqua:
+      return '--color-teams-yellow-500';
+    case DomainColor.Black:
+      return '--color-teams-red-400';
+    case DomainColor.Blue:
+      return '--color-teams-red-600';
+    case DomainColor.BlueGrey:
+      return '--color-teams-pink-400';
+    case DomainColor.EmeraldGreen:
+      return '--color-teams-pink-500';
+    case DomainColor.Gold:
+      return '--color-teams-pink-600';
+    case DomainColor.Green:
       return '--color-teams-purple-400';
     case DomainColor.LightPink:
-      return '--color-teams-pink-400';
-    case DomainColor.Yellow:
-      return '--color-teams-yellow-500';
-    case DomainColor.Blue:
-      return '--color-indigo-400';
-    case DomainColor.Green:
-      return '--color-teams-green-500';
-    case DomainColor.Aqua:
-      return '--color-teams-teal-500';
-    case DomainColor.Black:
-      return '--color-teams-grey-500';
-    case DomainColor.BlueGrey:
-      return '--color-teams-grey-100';
-    case DomainColor.EmeraldGreen:
-      return '--color-teams-green-400';
-    case DomainColor.Gold:
-      return '--color-teams-yellow-100';
+      return '--color-teams-purple-500';
     case DomainColor.Magenta:
-      return '--color-teams-pink-600';
+      return '--color-teams-green-300';
     case DomainColor.Orange:
-      return '--color-teams-red-400';
-    case DomainColor.Pink:
-      return '--color-teams-pink-500';
+      return '--color-teams-green-400';
     case DomainColor.Periwinkle:
-      return '--color-teams-indigo-500';
+      return '--color-teams-green-500';
+    case DomainColor.Pink:
+      return '--color-teams-teal-500';
+    case DomainColor.Purple:
+      return '--color-teams-blue-500';
     case DomainColor.PurpleGrey:
-      return '--color-teams-purple-400';
+      return '--color-teams-blue-400';
     case DomainColor.Red:
-      return '--color-teams-red-600';
+      return '--color-teams-indigo-500';
+    case DomainColor.Yellow:
+      return '--color-teams-grey-500';
     default:
-      return '--color-teams-purple-400';
+      return '--color-blue-400';
   }
 };
 
 export const setTeamBadge = (color?: DomainColor) => {
   switch (color) {
-    case DomainColor.Purple:
+    case DomainColor.Aqua:
+      return 'text-teams-yellow-500 border-teams-yellow-100';
+    case DomainColor.Black:
+      return 'text-teams-red-400 border-teams-red-100';
+    case DomainColor.Blue:
+      return 'text-teams-red-600 border-teams-red-50';
+    case DomainColor.BlueGrey:
+      return 'text-teams-pink-400 border-teams-pink-100';
+    case DomainColor.EmeraldGreen:
+      return 'text-teams-pink-500 border-teams-pink-100';
+    case DomainColor.Gold:
+      return 'text-teams-pink-600 border-teams-pink-150';
+    case DomainColor.Green:
       return 'text-teams-purple-400 border-teams-purple-100';
     case DomainColor.LightPink:
-      return 'text-teams-pink-400 border-teams-pink-100';
-    case DomainColor.Yellow:
-      return 'text-teams-yellow-500 border-teams-yellow-100';
-    case DomainColor.Blue:
-      return 'text-indigo-400 border-indigo-100';
-    case DomainColor.Green:
-      return 'text-teams-green-500 border-teams-green-100';
-    case DomainColor.Aqua:
-      return 'text-teams-teal-500 border-teams-teal-100';
-    case DomainColor.Black:
-      return 'text-gray-900 border-teams-grey-100';
-    case DomainColor.BlueGrey:
-      return 'text-teams-grey-500 border-teams-grey-100';
-    case DomainColor.EmeraldGreen:
-      return 'text-teams-green-400 border-teams-green-50';
-    case DomainColor.Gold:
-      return 'text-teams-red-400 border-teams-red-100';
+      return 'text-teams-purple-500 border-teams-purple-100';
     case DomainColor.Magenta:
-      return 'text-teams-pink-600 border-teams-pink-150';
+      return 'text-teams-green-300 border-teams-green-100';
     case DomainColor.Orange:
-      return 'text-teams-red-400 border-teams-yellow-50';
-    case DomainColor.Pink:
-      return 'text-teams-pink-500 border-teams-pink-100';
+      return 'text-teams-green-400 border-teams-green-50';
     case DomainColor.Periwinkle:
-      return 'text-teams-indigo-500 border-teams-indigo-50';
+      return 'text-teams-green-500 border-teams-green-100';
+    case DomainColor.Pink:
+      return 'text-teams-teal-500 border-teams-teal-50';
+    case DomainColor.Purple:
+      return 'text-teams-blue-500 border-teams-blue-50';
     case DomainColor.PurpleGrey:
-      return 'text-teams-purple-400 border-teams-purple-100';
+      return 'text-teams-blue-400 border-teams-blue-50';
     case DomainColor.Red:
-      return 'text-teams-red-600 border-teams-red-50';
+      return 'text-teams-indigo-500 border-teams-indigo-50';
+    case DomainColor.Yellow:
+      return 'text-teams-grey-500 border-teams-grey-100';
     default:
-      return 'text-teams-red-600 border-teams-red-50';
+      return 'text-blue-400 border-blue-100';
   }
 };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -94,6 +94,7 @@ module.exports = {
         'teams-green': {
           50: 'var(--color-teams-green-50)',
           100: 'var(--color-teams-green-100)',
+          300: 'var(--color-teams-green-300)',
           400: 'var(--color-teams-green-400)',
           500: 'var(--color-teams-green-500)',
         },
@@ -104,6 +105,7 @@ module.exports = {
         'teams-blue': {
           50: 'var(--color-teams-blue-50)',
           400: 'var(--color-teams-blue-400)',
+          500: 'var(--color-teams-blue-500)',
         },
         'teams-indigo': {
           50: 'var(--color-teams-indigo-50)',


### PR DESCRIPTION
## Description

In order to align team colors to match the design and also to reduce accessibility issues with the previously used colors, this PR updates the color at a surface level.

To avoid confusion with the name of `DomainColor` mappings, it would be ideal to update the names to more generic ids which would also need to be done in the block-ingestor.