### PR TITLE
fix: colony details styles, new native token pill

### DIFF
--- a/src/components/frame/Extensions/pages/ColonyDetailsPage/ColonyDetailsPage.tsx
+++ b/src/components/frame/Extensions/pages/ColonyDetailsPage/ColonyDetailsPage.tsx
@@ -9,7 +9,6 @@ import { useColonyContext, useMobile } from '~hooks';
 import Icon from '~shared/Icon';
 import Tooltip from '~shared/Extensions/Tooltip';
 import { formatText } from '~utils/intl';
-import { multiLineTextEllipsis } from '~utils/strings';
 import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts';
 import ObjectiveBox from '~v5/common/ObjectiveBox';
 import Button from '~v5/shared/Button';
@@ -21,8 +20,6 @@ import { ADDRESS_ZERO } from '~constants';
 import styles from './ColonyDetailsPage.module.css';
 
 const displayName = 'frame.Extensions.pages.ColonyDetailsPage';
-
-const MAX_DESCRIPTION_LENGTH = 250;
 
 const MSG = defineMessages({
   lockedToken: {
@@ -59,9 +56,15 @@ const ColonyDetailsPage: FC = () => {
     formatMessage({ id: 'navigation.admin.colonyDetails' }),
   );
 
-  const { name, metadata, colonyAddress, nativeToken, status } = colony || {};
-  const { avatar, thumbnail, description, externalLinks, objective } =
-    metadata || {};
+  const { metadata, colonyAddress, nativeToken, status } = colony || {};
+  const {
+    avatar,
+    thumbnail,
+    displayName: colonyDisplayName,
+    description,
+    externalLinks,
+    objective,
+  } = metadata || {};
   const isNativeTokenLocked = !status?.nativeToken?.unlocked;
 
   const {
@@ -81,7 +84,7 @@ const ColonyDetailsPage: FC = () => {
           />
           <div className="flex flex-col items-start gap-2">
             <div className="flex flex-row items-end gap-3">
-              <h2 className="heading-2">{name}</h2>
+              <h2 className="heading-2">{colonyDisplayName}</h2>
               {nativeToken && (
                 <div className="flex flex-row items-center p-2 border border-gray-200 rounded-lg bg-base-white">
                   <span className="text-sm font-medium">
@@ -111,8 +114,8 @@ const ColonyDetailsPage: FC = () => {
             'text-gray-700': !!description,
           })}
         >
-          {description
-            ? multiLineTextEllipsis(description, MAX_DESCRIPTION_LENGTH)
+          {description && description.length > 0
+            ? description
             : formatMessage(MSG.descriptionPlaceholder)}
         </p>
         {externalLinks && externalLinks.length ? (

--- a/src/components/frame/Extensions/pages/ColonyDetailsPage/ColonyDetailsPage.tsx
+++ b/src/components/frame/Extensions/pages/ColonyDetailsPage/ColonyDetailsPage.tsx
@@ -6,9 +6,6 @@ import { ACTION } from '~constants/actions';
 import { useActionSidebarContext } from '~context/ActionSidebarContext';
 import { useSetPageHeadingTitle } from '~context/PageHeadingContext/hooks';
 import { useColonyContext, useMobile } from '~hooks';
-import Icon from '~shared/Icon';
-import Tooltip from '~shared/Extensions/Tooltip';
-import { formatText } from '~utils/intl';
 import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts';
 import ObjectiveBox from '~v5/common/ObjectiveBox';
 import Button from '~v5/shared/Button';
@@ -18,15 +15,11 @@ import ColonyAvatar from '~v5/shared/ColonyAvatar';
 import { ADDRESS_ZERO } from '~constants';
 
 import styles from './ColonyDetailsPage.module.css';
+import NativeTokenPill from '~v5/common/NativeTokenPill/NativeTokenPill';
 
 const displayName = 'frame.Extensions.pages.ColonyDetailsPage';
 
 const MSG = defineMessages({
-  lockedToken: {
-    id: `${displayName}.lockedToken`,
-    defaultMessage:
-      'This token is locked. Colony native tokens are locked and non-transferrable by default to avoid unwanted project token transfer outside of the colony.',
-  },
   descriptionPlaceholder: {
     id: `${displayName}.desciptionPlaceholder`,
     defaultMessage:
@@ -86,24 +79,10 @@ const ColonyDetailsPage: FC = () => {
             <div className="flex flex-row items-end gap-3">
               <h2 className="heading-2">{colonyDisplayName}</h2>
               {nativeToken && (
-                <div className="flex flex-row items-center p-2 border border-gray-200 rounded-lg bg-base-white">
-                  <span className="text-sm font-medium">
-                    {nativeToken.symbol}
-                  </span>
-                  {isNativeTokenLocked && (
-                    <Tooltip
-                      tooltipContent={
-                        <span>{formatText(MSG.lockedToken)}</span>
-                      }
-                    >
-                      <Icon
-                        name="lock-key"
-                        appearance={{ size: 'extraExtraTiny' }}
-                        className="ml-1"
-                      />
-                    </Tooltip>
-                  )}
-                </div>
+                <NativeTokenPill
+                  tokenName={nativeToken.symbol}
+                  isLocked={isNativeTokenLocked}
+                />
               )}
             </div>
             {colonyAddress && <CopyableAddress address={colonyAddress} />}

--- a/src/components/frame/Extensions/pages/ColonyDetailsPage/ColonyDetailsPage.tsx
+++ b/src/components/frame/Extensions/pages/ColonyDetailsPage/ColonyDetailsPage.tsx
@@ -12,10 +12,10 @@ import Button from '~v5/shared/Button';
 import CopyableAddress from '~v5/shared/CopyableAddress';
 import SocialLinks from '~v5/shared/SocialLinks';
 import ColonyAvatar from '~v5/shared/ColonyAvatar';
+import NativeTokenPill from '~v5/common/NativeTokenPill';
 import { ADDRESS_ZERO } from '~constants';
 
 import styles from './ColonyDetailsPage.module.css';
-import NativeTokenPill from '~v5/common/NativeTokenPill/NativeTokenPill';
 
 const displayName = 'frame.Extensions.pages.ColonyDetailsPage';
 
@@ -80,6 +80,7 @@ const ColonyDetailsPage: FC = () => {
               <h2 className="heading-2">{colonyDisplayName}</h2>
               {nativeToken && (
                 <NativeTokenPill
+                  variant="secondary"
                   tokenName={nativeToken.symbol}
                   isLocked={isNativeTokenLocked}
                 />

--- a/src/components/v5/common/ColonyDashboardHeader/ColonyDashboardHeader.tsx
+++ b/src/components/v5/common/ColonyDashboardHeader/ColonyDashboardHeader.tsx
@@ -1,9 +1,6 @@
 import React, { FC } from 'react';
-import { LockKey } from 'phosphor-react';
 
-import { formatText } from '~utils/intl';
-import Tooltip from '~shared/Extensions/Tooltip';
-
+import NativeTokenPill from '../NativeTokenPill/NativeTokenPill';
 import ColonyLinks from './partials/ColonyLinks';
 import { ColonyDashboardHeaderProps } from './types';
 
@@ -26,16 +23,7 @@ const ColonyDashboardHeader: FC<
       <h1 className="heading-2 text-gray-900 capitalize truncate">
         {colonyName}
       </h1>
-      <div className="flex items-center gap-[0.225rem] text-gray-900 bg-base-bg rounded-lg p-1.5">
-        <span className="text-3">{tokenName}</span>
-        {!isTokenUnlocked && (
-          <Tooltip
-            tooltipContent={formatText({ id: 'colony.tooltip.lockedToken' })}
-          >
-            <LockKey size={11} />
-          </Tooltip>
-        )}
-      </div>
+      <NativeTokenPill tokenName={tokenName} isLocked={!isTokenUnlocked} />
     </div>
     <div className="flex flex-col md:flex-row gap-[1.7rem] sm:gap-4 items-start justify-between">
       <p className="text-gray-700 max-w-[52.75rem] text-md line-clamp-2">

--- a/src/components/v5/common/ColonyDashboardHeader/ColonyDashboardHeader.tsx
+++ b/src/components/v5/common/ColonyDashboardHeader/ColonyDashboardHeader.tsx
@@ -19,7 +19,7 @@ const ColonyDashboardHeader: FC<
   isTokenUnlocked,
 }) => (
   <div className="flex flex-col gap-4">
-    <div className="flex items-center gap-3">
+    <div className="flex items-end gap-3">
       <h1 className="heading-2 text-gray-900 capitalize truncate">
         {colonyName}
       </h1>

--- a/src/components/v5/common/NativeTokenPill/NativeTokenPill.tsx
+++ b/src/components/v5/common/NativeTokenPill/NativeTokenPill.tsx
@@ -16,7 +16,7 @@ const NativeTokenPill = ({
   isLocked = false,
 }: NativeTokenPillProps) => {
   return (
-    <div className="h-[1.875rem] flex flex-row items-center px-[.375rem] border border-gray-200 rounded-lg bg-base-white text-gray-900">
+    <div className="h-[1.875rem] flex flex-row items-center px-1.5 border border-gray-200 rounded-lg bg-base-white text-gray-900">
       <span className="text-sm font-medium">{tokenName}</span>
       {isLocked && (
         <Tooltip
@@ -24,7 +24,7 @@ const NativeTokenPill = ({
             <span>{formatText({ id: 'tooltip.lockedToken' })}</span>
           }
         >
-          <LockKey size={12} className="ml-[.125rem] -translate-x-px" />
+          <LockKey size={12} className="ml-0.5 -translate-x-px" />
         </Tooltip>
       )}
     </div>

--- a/src/components/v5/common/NativeTokenPill/NativeTokenPill.tsx
+++ b/src/components/v5/common/NativeTokenPill/NativeTokenPill.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { LockKey } from 'phosphor-react';
+import clsx from 'clsx';
 
 import Tooltip from '~shared/Extensions/Tooltip';
 import { formatText } from '~utils/intl';
 
 interface NativeTokenPillProps {
+  variant?: 'primary' | 'secondary';
   tokenName: string;
   isLocked?: boolean;
 }
@@ -12,11 +14,20 @@ interface NativeTokenPillProps {
 const displayName = 'v5.shared.NativeTokenPill';
 
 const NativeTokenPill = ({
+  variant = 'primary',
   tokenName,
   isLocked = false,
 }: NativeTokenPillProps) => {
   return (
-    <div className="h-[1.875rem] flex flex-row items-center px-1.5 border border-gray-200 rounded-lg bg-base-white text-gray-900">
+    <div
+      className={clsx(
+        'h-[1.875rem] flex flex-row items-center px-1.5 rounded-lg text-gray-900',
+        {
+          'bg-base-bg': variant === 'primary',
+          'border border-gray-200 bg-base-white': variant === 'secondary',
+        },
+      )}
+    >
       <span className="text-sm font-medium">{tokenName}</span>
       {isLocked && (
         <Tooltip
@@ -24,7 +35,7 @@ const NativeTokenPill = ({
             <span>{formatText({ id: 'tooltip.lockedToken' })}</span>
           }
         >
-          <LockKey size={12} className="ml-0.5 -translate-x-px" />
+          <LockKey size={11} className="ml-0.5" />
         </Tooltip>
       )}
     </div>

--- a/src/components/v5/common/NativeTokenPill/NativeTokenPill.tsx
+++ b/src/components/v5/common/NativeTokenPill/NativeTokenPill.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { LockKey } from 'phosphor-react';
+
+import Tooltip from '~shared/Extensions/Tooltip';
+import { formatText } from '~utils/intl';
+
+interface NativeTokenPillProps {
+  tokenName: string;
+  isLocked?: boolean;
+}
+
+const displayName = 'v5.shared.NativeTokenPill';
+
+const NativeTokenPill = ({
+  tokenName,
+  isLocked = false,
+}: NativeTokenPillProps) => {
+  return (
+    <div className="flex flex-row items-center p-[.375rem] border border-gray-200 rounded-lg bg-base-white text-gray-900">
+      <span className="text-sm font-medium">{tokenName}</span>
+      {isLocked && (
+        <Tooltip
+          tooltipContent={
+            <span>{formatText({ id: 'tooltip.lockedToken' })}</span>
+          }
+        >
+          <LockKey size={12} className="ml-[.125rem]" />
+        </Tooltip>
+      )}
+    </div>
+  );
+};
+
+NativeTokenPill.displayName = displayName;
+export default NativeTokenPill;

--- a/src/components/v5/common/NativeTokenPill/NativeTokenPill.tsx
+++ b/src/components/v5/common/NativeTokenPill/NativeTokenPill.tsx
@@ -16,7 +16,7 @@ const NativeTokenPill = ({
   isLocked = false,
 }: NativeTokenPillProps) => {
   return (
-    <div className="flex flex-row items-center p-[.375rem] border border-gray-200 rounded-lg bg-base-white text-gray-900">
+    <div className="h-[1.875rem] flex flex-row items-center px-[.375rem] border border-gray-200 rounded-lg bg-base-white text-gray-900">
       <span className="text-sm font-medium">{tokenName}</span>
       {isLocked && (
         <Tooltip
@@ -24,7 +24,7 @@ const NativeTokenPill = ({
             <span>{formatText({ id: 'tooltip.lockedToken' })}</span>
           }
         >
-          <LockKey size={12} className="ml-[.125rem]" />
+          <LockKey size={12} className="ml-[.125rem] -translate-x-px" />
         </Tooltip>
       )}
     </div>

--- a/src/components/v5/common/NativeTokenPill/index.ts
+++ b/src/components/v5/common/NativeTokenPill/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NativeTokenPill';


### PR DESCRIPTION
## Description

Fix styles according to the issue.
Added a new native token pill so we can reuse it between the details page and the dashboard header.

**New stuff** ✨

* `NativeTokenPill` component which displays a tooltip 

**Changes** 🏗

* Use the new component instead of doing it twice

Resolves  #1389
