### PR TITLE
Fix GTM ID being set during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ RUN if [ -z "$DEV" ]; then export PROCESS_VAR='[a-z]'; else export PROCESS_VAR='
         "&& sed -i \"s|${PROCESS_VAR}.env.AUTH_PROXY_ENDPOINT|\\\"\$AUTH_PROXY_ENDPOINT\\\"|g\" *.js" \
         "&& sed -i \"s/${PROCESS_VAR}.env.METATRANSACTIONS/\\\"\$METATRANSACTIONS\\\"/g\" *.js" \
         "&& sed -i \"s|${PROCESS_VAR}.env.REPUTATION_ORACLE_ENDPOINT|\\\"\$REPUTATION_ORACLE_ENDPOINT\\\"|g\" *.js" \
+        "&& sed -i \"s|${PROCESS_VAR}.env.GOOGLE_TAG_MANAGER_ID|\\\"\$GOOGLE_TAG_MANAGER_ID\\\"|g\" *.js" \
         " && nginx -g 'daemon off;'" > ./run.sh
 RUN chmod +x ./run.sh
 


### PR DESCRIPTION
## Description

This quick PR correctly includes the newly added env variable into the docker build for Webpack for GTM.
