### PR TITLE
fix: use name and link instead of linkType and url for external links

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "webpack-dev-server": "^4.11.1"
   },
   "dependencies": {
-    "@apollo/client": "^3.6.9",
+    "@apollo/client": "^3.8.8",
     "@colony/abis": "^1.2.0-next.3",
     "@colony/colony-event-metadata-parser": "^2.0.2",
     "@colony/colony-js": "^7.0.1",

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/consts.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/consts.ts
@@ -18,8 +18,8 @@ export const validationSchema = object()
       .of(
         object()
           .shape({
-            linkType: string().defined().oneOf(Object.values(ExternalLinks)),
-            url: string().url().required(),
+            name: string().defined().oneOf(Object.values(ExternalLinks)),
+            link: string().url().required(),
           })
           .defined(),
       )

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/hooks.ts
@@ -33,11 +33,7 @@ export const useEditColonyDetails = (
           thumbnail: metadata?.thumbnail,
         },
         createdIn: Id.RootDomain.toString(),
-        externalLinks:
-          metadata?.externalLinks?.map(({ name, link }) => ({
-            link,
-            name,
-          })) || [],
+        externalLinks: metadata?.externalLinks ?? [],
       }),
       [
         metadata?.avatar,

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/hooks.ts
@@ -35,8 +35,8 @@ export const useEditColonyDetails = (
         createdIn: Id.RootDomain.toString(),
         externalLinks:
           metadata?.externalLinks?.map(({ name, link }) => ({
-            url: link,
-            linkType: name,
+            link,
+            name,
           })) || [],
       }),
       [

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/SocialLinksTable.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/SocialLinksTable.tsx
@@ -68,27 +68,27 @@ const SocialLinksTable: FC<SocialLinksTableProps> = ({ name }) => {
         defaultValues={data}
         initialLinkType={
           socialLinkIndex !== undefined
-            ? data[socialLinkIndex]?.linkType
+            ? data[socialLinkIndex]?.name
             : undefined
         }
-        onSubmit={({ linkType, url }) => {
+        onSubmit={({ name: linkName, link }) => {
           if (socialLinkIndex === undefined) {
             return;
           }
 
           const existingSocialLinkIndex = data.findIndex(
-            (socialLink) => socialLink.linkType === linkType,
+            (socialLink) => socialLink.name === linkName,
           );
 
           if (existingSocialLinkIndex === -1) {
             fieldArrayMethods.append({
-              linkType,
-              url,
+              name: linkName,
+              link,
             });
           } else {
             fieldArrayMethods.update(existingSocialLinkIndex, {
-              linkType,
-              url,
+              name: linkName,
+              link,
             });
           }
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/hooks.tsx
@@ -17,7 +17,7 @@ export const useSocialLinksTableColumns = (): ColumnDef<
 
   const columns: ColumnDef<SocialLinksTableModel, string>[] = useMemo(
     () => [
-      columnHelper.accessor('linkType', {
+      columnHelper.accessor('name', {
         enableSorting: false,
         header: () => (
           <span className="text-sm text-gray-600">
@@ -29,7 +29,7 @@ export const useSocialLinksTableColumns = (): ColumnDef<
         ),
         size: 23,
       }),
-      columnHelper.accessor('url', {
+      columnHelper.accessor('link', {
         enableSorting: false,
         header: () => (
           <span className="text-sm text-gray-600">

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/partials/SocialLinkModal/SocialLinkModal.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/partials/SocialLinkModal/SocialLinkModal.tsx
@@ -46,16 +46,16 @@ const SocialLinkFormModal: FC<SocialLinkFormModalProps> = ({
               {formatText({ id: 'editColony.socialLinks.modal.subtitle' })}
             </p>
             <FormTileRadioButtons
-              name="linkType"
+              name="name"
               className="grid md:grid-cols-3 gap-y-3 gap-x-4"
               items={LINK_TYPE_RADIO_BUTTONS}
             />
-            {getValues('linkType') && (
+            {getValues('name') && (
               <>
                 <FormInputBase
                   wrapperClassName="mt-6"
-                  name="url"
-                  label={LINK_TYPE_TO_LABEL_MAP[getValues('linkType')]}
+                  name="link"
+                  label={LINK_TYPE_TO_LABEL_MAP[getValues('name')]}
                 />
                 <div className="flex flex-col-reverse gap-3 mt-[5.625rem] md:mt-8 sm:flex-row">
                   <Button
@@ -69,7 +69,7 @@ const SocialLinkFormModal: FC<SocialLinkFormModalProps> = ({
                   <Button mode="primarySolid" isFullSize type="submit">
                     {formatText({
                       id: defaultValuesProp.some(
-                        ({ linkType }) => linkType === getValues('linkType'),
+                        ({ name }) => name === getValues('name'),
                       )
                         ? 'button.editLink'
                         : 'button.addLink',

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/partials/SocialLinkModal/consts.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/partials/SocialLinkModal/consts.tsx
@@ -18,8 +18,8 @@ import { formatText } from '~utils/intl';
 
 export const SOCIAL_LINK_FORM_MODAL_VALIDATION_SCHEMA = object()
   .shape({
-    linkType: string().oneOf(Object.values(ExternalLinks)).required(),
-    url: string()
+    name: string().oneOf(Object.values(ExternalLinks)).required(),
+    link: string()
       .url(formatText({ id: 'editColony.socialLinks.modal.invalidUrl' }))
       .required(formatText({ id: 'editColony.socialLinks.modal.requiredUrl' })),
   })

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/partials/SocialLinkModal/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/partials/SocialLinkModal/hooks.ts
@@ -10,16 +10,16 @@ export const useResetFormOnLinkTypeChange = (
     useState<UseFormReturn<SocialLinkModalFormValues> | null>(null);
 
   formRef?.watch((data, { name, type }) => {
-    if (name !== 'linkType' || type !== 'change') {
+    if (name !== 'name' || type !== 'change') {
       return;
     }
 
     formRef.reset(
       defaultValuesProp.find(
-        (defaultValue) => defaultValue.linkType === data.linkType,
+        (defaultValue) => defaultValue.name === data.name,
       ) || {
-        linkType: data.linkType,
-        url: '',
+        name: data.name,
+        link: '',
       },
     );
   });
@@ -31,9 +31,9 @@ export const useResetFormOnLinkTypeChange = (
 
     formRef.reset(
       defaultValuesProp.find(
-        (defaultValue) => defaultValue.linkType === initialLinkType,
+        (defaultValue) => defaultValue.name === initialLinkType,
       ) || {
-        linkType: initialLinkType,
+        name: initialLinkType,
       },
     );
   }, [defaultValuesProp, formRef, initialLinkType]);

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/partials/SocialLinkModal/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/partials/SocialLinkModal/types.ts
@@ -1,6 +1,5 @@
 import { InferType } from 'yup';
-import { ExternalLinks } from '~gql';
-import { FormProps } from '~shared/Fields/Form/Form';
+import { ExternalLink, ExternalLinks } from '~gql';
 import { ModalProps } from '~v5/shared/Modal/types';
 
 import { SOCIAL_LINK_FORM_MODAL_VALIDATION_SCHEMA } from './consts';
@@ -10,7 +9,7 @@ export type SocialLinkModalFormValues = InferType<
 >;
 
 export interface SocialLinkFormModalProps extends ModalProps {
-  onSubmit: FormProps<SocialLinkModalFormValues>['onSubmit'];
+  onSubmit: (link: ExternalLink) => void;
   initialLinkType?: ExternalLinks;
   defaultValues: Partial<SocialLinkModalFormValues>[];
 }

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/types.ts
@@ -6,8 +6,8 @@ export interface SocialLinksTableProps {
 
 export interface SocialLinksTableModel {
   key: string;
-  linkType: ExternalLinks;
-  url: string;
+  name: ExternalLinks;
+  link: string;
 }
 
 export interface SocialLinksButtonsProps {

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/utils.tsx
@@ -44,10 +44,7 @@ export const getEditColonyDetailsPayload = (
       typeof colonyThumbnail === 'string' || colonyThumbnail === null
         ? colonyThumbnail
         : colony.metadata?.thumbnail,
-    colonyExternalLinks: externalLinks.map(({ url, linkType }) => ({
-      link: url,
-      name: linkType,
-    })),
+    colonyExternalLinks: externalLinks || [],
     annotationMessage,
     customActionTitle: title,
   };

--- a/src/components/v5/common/Fields/RadioButtons/TileRadioButtons/TileRadioButtons.tsx
+++ b/src/components/v5/common/Fields/RadioButtons/TileRadioButtons/TileRadioButtons.tsx
@@ -27,7 +27,7 @@ function TileRadioButtons<TValue = string>({
               border
               transition-all
               rounded-lg
-              align-center
+              items-center
               justify-center
               duration-75
             `,

--- a/src/context/apolloClient.ts
+++ b/src/context/apolloClient.ts
@@ -1,14 +1,18 @@
-import { ApolloClient, HttpLink } from '@apollo/client';
+import { ApolloClient, from, HttpLink } from '@apollo/client';
+import { removeTypenameFromVariables } from '@apollo/client/link/remove-typename';
 
 import cache from '~cache';
 
+const removeTypenameLink = removeTypenameFromVariables();
 const httpLink = new HttpLink({
   uri: `${process.env.AUTH_PROXY_ENDPOINT || 'http://localhost:3005'}/graphql`,
   credentials: 'include',
 });
 
+const link = from([removeTypenameLink, httpLink]);
+
 export default new ApolloClient({
-  link: httpLink,
+  link,
   connectToDevTools: true,
   cache,
   /*

--- a/src/utils/yup/tests/index.ts
+++ b/src/utils/yup/tests/index.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from 'ethers';
 import { DocumentNode, OperationDefinitionNode } from 'graphql';
 import { TestContext, ValidationError, TestFunction } from 'yup';
+import { OperationVariables } from '@apollo/client';
 import moveDecimal from 'move-decimal-point';
 
 import { ContextModule, getContext } from '~context';
@@ -25,13 +26,13 @@ const apolloClient = getContext(ContextModule.ApolloClient);
  * @param createError createError function that returns a Validation Error. Taken from yup's TestContext.
  * @returns Query Data or network error message
  */
-export async function runQuery<Q, V>(
+export async function runQuery<Q>(
   queryDocument: DocumentNode,
-  variables: V,
+  variables: OperationVariables,
   createError: TestContext['createError'],
 ): Promise<Q | ValidationError> {
   try {
-    const { data } = await apolloClient.query<Q, V>({
+    const { data } = await apolloClient.query<Q>({
       query: queryDocument,
       variables,
       fetchPolicy: 'no-cache',


### PR DESCRIPTION
## Description

This PR fixes editing of social links.
The issue was that we used `linkType` and `url` as the values, which wasn't the case anymore.
Also fixed a minor CSS alignment on the links modal.

I updated our version of apollo, so we could strip `__typename` on the mutation and so that the `haveExternalLinksChanged` flag isn't always true when editing details. 

**Changes** 🏗
* renamed the attributes accordingly
* updated apollo client version

Resolves  #1522
