### PR TITLE
Store display preferences in local storage

### DIFF
--- a/src/components/frame/v5/pages/UserPreferencesPage/UserPreferencesPage.tsx
+++ b/src/components/frame/v5/pages/UserPreferencesPage/UserPreferencesPage.tsx
@@ -7,15 +7,14 @@ import Input from '~v5/common/Fields/Input';
 import Button from '~v5/shared/Button';
 import Icon from '~shared/Icon';
 import { useCopyToClipboard } from '~hooks/useCopyToClipboard';
-// @BETA: Disabled for now
-// import Switch from '~v5/common/Fields/Switch';
+import Switch from '~v5/common/Fields/Switch';
 import { multiLineTextEllipsis } from '~utils/strings';
 import LoadingTemplate from '~frame/LoadingTemplate';
 import { LANDING_PAGE_ROUTE } from '~routes';
 import { formatText } from '~utils/intl';
 
 import LeftColumn from '../UserProfilePage/partials/LeftColumn';
-import { useUserPreferencesPage } from './hooks';
+import { useFullScreenMode, useUserPreferencesPage } from './hooks';
 import { UserPreferencesPageProps } from './types';
 import styles from './UserPreferencesPage.module.css';
 
@@ -35,6 +34,7 @@ const UserPreferencesPage: FC<UserPreferencesPageProps> = ({
   const { user, userLoading, walletConnecting } = useAppContext();
   const isMobile = useMobile();
   const { handleClipboardCopy, isCopied } = useCopyToClipboard(5000);
+  const { isFullScreenMode, toggleFullScreenMode } = useFullScreenMode();
 
   const {
     errors,
@@ -173,20 +173,25 @@ const UserPreferencesPage: FC<UserPreferencesPageProps> = ({
         {/*   /> */}
         {/*   <Switch id="disable-notifications" /> */}
         {/* </div> */}
-        {/* <span className="divider" /> */}
-        {/* <h5 className="heading-5"> */}
-        {/*   {formatText({ */}
-        {/*     id: 'userPreferencesPage.displayPreferences', */}
-        {/*   })} */}
-        {/* </h5> */}
-        {/* <div className={styles.switchRow}> */}
-        {/*   <LeftColumn */}
-        {/*     fieldTitle={{ id: 'field.display' }} */}
-        {/*     fieldDescription={{ id: 'description.display' }} */}
-        {/*   /> */}
-        {/*   <Switch id="display" /> */}
-        {/* </div> */}
-        {/* <span className="divider" /> */}
+        <span className="divider" />
+        <h5 className="heading-5">
+          {formatText({
+            id: 'userPreferencesPage.displayPreferences',
+          })}
+        </h5>
+        <div className={styles.switchRow}>
+          <LeftColumn
+            fieldTitle={{ id: 'field.display' }}
+            fieldDescription={{ id: 'description.display' }}
+            className=""
+          />
+          <Switch
+            id="display"
+            checked={isFullScreenMode}
+            onChange={toggleFullScreenMode}
+          />
+        </div>
+        <span className="divider" />
         {/* <div className={styles.row}> */}
         {/*   <LeftColumn */}
         {/*     fieldTitle={{ id: 'field.switchAccount' }} */}

--- a/src/components/frame/v5/pages/UserPreferencesPage/hooks.tsx
+++ b/src/components/frame/v5/pages/UserPreferencesPage/hooks.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useIntl } from 'react-intl';
@@ -9,6 +9,7 @@ import { isEmailAlreadyRegistered } from '~common/Onboarding/wizardSteps/StepCre
 import { useUpdateUserProfileMutation } from '~gql';
 import { useAppContext } from '~hooks';
 import Toast from '~shared/Extensions/Toast';
+import { isFullScreen } from '~constants';
 
 import { UserPreferencesFormProps } from './types';
 
@@ -92,4 +93,25 @@ export const useUserPreferencesPage = () => {
     setIsEmailInputVisible,
     errors,
   };
+};
+
+export const useFullScreenMode = () => {
+  const [isFullScreenMode, setIsFullScreenMode] = useState(false);
+
+  useLayoutEffect(() => {
+    setIsFullScreenMode(localStorage.getItem(isFullScreen) === 'true');
+  }, []);
+
+  const toggleFullScreenMode = () => {
+    // Keep localStorage in sync with toggle state
+    if (isFullScreenMode) {
+      localStorage.setItem(isFullScreen, 'false');
+      setIsFullScreenMode(false);
+    } else {
+      localStorage.setItem(isFullScreen, 'true');
+      setIsFullScreenMode(true);
+    }
+  };
+
+  return { isFullScreenMode, toggleFullScreenMode };
 };

--- a/src/components/frame/v5/pages/UserProfilePage/partials/LeftColumn.tsx
+++ b/src/components/frame/v5/pages/UserProfilePage/partials/LeftColumn.tsx
@@ -5,11 +5,15 @@ import { LeftColumnProps } from '../types';
 
 const displayName = 'v5.pages.UserProfilePage.partials.LeftColumn';
 
-const LeftColumn: FC<LeftColumnProps> = ({ fieldTitle, fieldDescription }) => {
+const LeftColumn: FC<LeftColumnProps> = ({
+  fieldTitle,
+  fieldDescription,
+  className = 'md:w-[16.375rem]',
+}) => {
   const { formatMessage } = useIntl();
 
   return (
-    <div className="flex flex-col md:w-[16.375rem]">
+    <div className={`flex flex-col ${className}`}>
       <span className="text-1 leading-5">{formatMessage(fieldTitle)}</span>
       <span className="text-gray-600 text-sm">
         {formatMessage(fieldDescription)}

--- a/src/components/frame/v5/pages/UserProfilePage/types.ts
+++ b/src/components/frame/v5/pages/UserProfilePage/types.ts
@@ -3,6 +3,7 @@ import { MessageDescriptor } from 'react-intl';
 export type LeftColumnProps = {
   fieldTitle: MessageDescriptor;
   fieldDescription: MessageDescriptor;
+  className?: string;
 };
 
 export type UserProfileFormProps = {

--- a/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion';
-import React, { FC, PropsWithChildren } from 'react';
+import React, { FC, PropsWithChildren, useLayoutEffect } from 'react';
 import clsx from 'clsx';
 
 import Icon from '~shared/Icon';
@@ -10,6 +10,7 @@ import Modal from '~v5/shared/Modal';
 import { formatText } from '~utils/intl';
 import useDisableBodyScroll from '~hooks/useDisableBodyScroll';
 import { SpinnerLoader } from '~shared/Preloaders';
+import { isFullScreen } from '~constants';
 
 import ActionSidebarContent from './partials/ActionSidebarContent/ActionSidebarContent';
 import {
@@ -37,8 +38,15 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
     ],
     cancelModalToggle: [isCancelModalOpen, { toggleOff: toggleCancelModalOff }],
   } = useActionSidebarContext();
-  const [isSidebarFullscreen, { toggle: toggleIsSidebarFullscreen }] =
+  const [isSidebarFullscreen, { toggle: toggleIsSidebarFullscreen, toggleOn }] =
     useToggle();
+
+  useLayoutEffect(() => {
+    if (localStorage.getItem(isFullScreen) === 'true') {
+      toggleOn();
+    }
+  }, [toggleOn]);
+
   const { formRef, closeSidebarClick } = useCloseSidebarClick();
   const isMobile = useMobile();
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -285,3 +285,5 @@ export const GNOSIS_AMB_BRIDGES: { [x: number]: AmbBridge } = {
 };
 
 export const FETCH_ABORTED = 'fetchAborted';
+
+export const isFullScreen = 'isFullScreen';


### PR DESCRIPTION
## Description

This PR stores a user's action panel display preferences in local storage, so they can be retrieved by the component whenever it is rendered. 

## Testing

1. Toggle the display preference in user preferences. It should persist even when reloading.

![image](https://github.com/JoinColony/colonyCDapp/assets/64402732/67e43aaa-132a-43f5-8a4a-e23442a1da96)

2. Open the actions panel, either by adding `?tx={tx_hash}` to the url or directly via the ui. It should open to the width stored in your preferences.

**New stuff** ✨

* Display preferences toggle 

**Changes** 🏗

* If present, use display preference value from local storage for action panel width


Resolves #1168
