### PR TITLE
fix: native token in table popup

### DIFF
--- a/src/components/frame/v5/pages/BalancePage/partials/TokenAvatar/TokenAvatar.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/TokenAvatar/TokenAvatar.tsx
@@ -1,15 +1,17 @@
 import React, { FC } from 'react';
 import clsx from 'clsx';
 
+import { LockKey } from 'phosphor-react';
 import { useMobile, useRelativePortalElement, useToggle } from '~hooks';
 import CopyableAddress from '~shared/CopyableAddress';
-import IconTooltip from '~shared/IconTooltip';
 import TokenIcon from '~shared/TokenIcon';
 import Modal from '~v5/shared/Modal';
 import MenuContainer from '~v5/shared/MenuContainer';
 import Portal from '~v5/shared/Portal';
 
 import { TokenAvatarProps } from './types';
+import Tooltip from '~shared/Extensions/Tooltip';
+import { formatText } from '~utils/intl';
 
 const displayName = 'v5.pages.BalancePage.partials.TokenAvatar';
 // @TODO: implement token popover according to the design
@@ -52,13 +54,15 @@ const TokenAvatar: FC<TokenAvatarProps> = ({
           <CopyableAddress>{token.tokenAddress}</CopyableAddress>
         )}
         {isTokenNative && !nativeTokenStatus?.unlocked && (
-          <span>
-            <IconTooltip
-              icon="lock"
-              tooltipText={{ id: 'tooltip.lockedToken' }}
-              appearance={{ size: 'tiny' }}
-            />
-          </span>
+          <Tooltip
+            tooltipContent={
+              <span className="sm:w-64 text-left">
+                {formatText({ id: 'tooltip.lockedToken' })}
+              </span>
+            }
+          >
+            <LockKey size={14} className="mt-[1px]" />
+          </Tooltip>
         )}
       </div>
     </div>

--- a/src/components/frame/v5/pages/BalancePage/partials/TokenAvatar/TokenAvatar.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/TokenAvatar/TokenAvatar.tsx
@@ -61,7 +61,7 @@ const TokenAvatar: FC<TokenAvatarProps> = ({
               </span>
             }
           >
-            <LockKey size={14} className="mt-[1px]" />
+            <LockKey size={14} className="mt-px" />
           </Tooltip>
         )}
       </div>

--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -60,17 +60,11 @@ const Table = <T,>({
   const shouldShowEmptyContent = emptyContent && data.length === 0;
 
   return (
-    <div
-      className={clsx(
-        className,
-        'border border-gray-200 rounded-lg overflow-hidden',
-      )}
-    >
+    <div className={clsx(className, 'border border-gray-200 rounded-lg')}>
       <table
         className={`
           border-separate
           border-spacing-0
-          overflow-hidden
           table-fixed
           w-full
         `}

--- a/src/components/v5/common/TableWithMeatballMenu/TableWithMeatballMenu.tsx
+++ b/src/components/v5/common/TableWithMeatballMenu/TableWithMeatballMenu.tsx
@@ -40,8 +40,7 @@ const TableWithMeatballMenu = <T,>({
     <Table<T>
       verticalOnMobile={verticalOnMobile}
       getRowClassName={() =>
-        // scale-[1] is added here to fix the issue with table on safari because it's not working with position: relative. It's related to stacking context.
-        'relative scale-[1] [&>tr:last-child>th]:p-0 [&>tr:last-child>td]:p-0 [&>tr:first-child>td]:pr-9'
+        'relative translate-z-0 [&>tr:last-child>th]:p-0 [&>tr:last-child>td]:p-0 [&>tr:first-child>td]:pr-9'
       }
       columns={columnsWithMenu}
       {...rest}


### PR DESCRIPTION
## Description

Changed the icon so it fits the designs, also had to use a different popup.
Our table rows had `scale(1)` which brought them to the very forefront of our app, thus displaying over the popup.
The hack was introduced due to Safari not handling `position: relative` on table rows, but I think we shouldn't be relying on those, our popups are mostly on single cells or components in there.

**Changes** 🏗

* new icon and tooltip for the native token popup
* removed the scale transform on the entire table row

Resolves #1523
