### PR TITLE
fix: filtering out params that are unavailable

### DIFF
--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/ParamDetailsTab.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/ParamDetailsTab.tsx
@@ -20,6 +20,7 @@ const ParamDetailsTab: FC<ParamDetailsTabProps> = ({ extension, params }) => {
     <li>
       {Object.keys(params)
         .filter((key) => key !== '__typename')
+        .filter((param) => paramsMap[extension][param])
         .map((param) => {
           const { title, complementaryLabel, description } =
             paramsMap[extension][param];


### PR DESCRIPTION
https://tw.auroracreation.com/app/tasks/15705120

![image](https://github.com/JoinColony/colonyCDapp/assets/76940796/e5fea4da-1b88-4847-b3e1-9f816bf28dd1)

**Changes** 🏗

* Filtering out params that are not available in `paramsMap` const.

Resolves [#1554](https://github.com/JoinColony/colonyCDapp/issues/1554)
