### PR TITLE
Wire action title and metadata with User Hub stakes tab

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/StakesTab/helpers.ts
+++ b/src/components/common/Extensions/UserHub/partials/StakesTab/helpers.ts
@@ -33,9 +33,7 @@ export const getStakeStatus = (
     return UserStakeStatus.Claimed;
   }
 
-  const motionState = statesMap.get(
-    stake.action?.motionData?.nativeMotionId ?? '',
-  );
+  const motionState = statesMap.get(stake.action?.motionData?.motionId ?? '');
   if (!motionState) {
     return UserStakeStatus.Unknown;
   }

--- a/src/components/common/Extensions/UserHub/partials/StakesTab/partials/ClaimAllButton.tsx
+++ b/src/components/common/Extensions/UserHub/partials/StakesTab/partials/ClaimAllButton.tsx
@@ -39,7 +39,7 @@ const ClaimAllButton = ({
         colonyAddress,
         extensionAddress: votingReputationAddress ?? '',
         motionIds: claimableStakes.map(
-          (stake) => stake.action?.motionData?.id ?? '',
+          (stake) => stake.action?.motionData?.databaseMotionId ?? '',
         ),
       });
       updateClaimedStakesCache(claimableStakes.map((stake) => stake.id));

--- a/src/components/common/Extensions/UserHub/partials/StakesTab/partials/StakeItem.tsx
+++ b/src/components/common/Extensions/UserHub/partials/StakesTab/partials/StakeItem.tsx
@@ -1,5 +1,7 @@
 import React, { FC } from 'react';
-import { FormattedDate } from 'react-intl';
+import { FormattedDate, useIntl } from 'react-intl';
+
+import { getActionTitleValues } from '~common/ColonyActions';
 
 import Numeral from '~shared/Numeral';
 import UserStakeStatusBadge from '~v5/common/Pills/UserStakeStatusBadge';
@@ -11,34 +13,44 @@ import styles from './StakeItem.css';
 const displayName =
   'common.Extensions.UserHub.partials.StakesTab.partials.StakeItem';
 
-const StakeItem: FC<StakeItemProps> = ({ nativeToken, stake }) => (
-  <li className={styles.stakesItem}>
-    <div className="relative w-full">
-      <div className="flex justify-between items-center">
-        <div className="flex items-center mr-2 min-w-0">
-          <p className="text-1 mr-2 truncate min-w-0">
-            {stake.action?.metadata?.customTitle ?? stake.action?.type}
-          </p>
-          <span className="text-gray-400 text-xs">
-            <FormattedDate value={stake.createdAt} />
-          </span>
+const StakeItem: FC<StakeItemProps> = ({ nativeToken, stake, colony }) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <li className={styles.stakesItem}>
+      <div className="relative w-full">
+        <div className="flex justify-between items-center">
+          <div className="flex items-center mr-2 min-w-0">
+            <p className="text-1 mr-2 truncate min-w-0">
+              {stake.action?.metadata?.customTitle ?? stake.action?.type}
+            </p>
+            <span className="text-gray-400 text-xs">
+              <FormattedDate value={stake.createdAt} />
+            </span>
+          </div>
+          <UserStakeStatusBadge status={stake.status} />
         </div>
-        <UserStakeStatusBadge status={stake.status} />
-      </div>
-      <div className="flex text-xs">
-        <div className="font-medium mr-2">
-          <Numeral
-            value={stake.amount}
-            decimals={nativeToken.decimals}
-            suffix={nativeToken.symbol}
-          />
+        <div className="flex text-xs">
+          <div className="font-medium mr-2">
+            <Numeral
+              value={stake.amount}
+              decimals={nativeToken.decimals}
+              suffix={nativeToken.symbol}
+            />
+          </div>
+          <div className="text-gray-600">
+            {stake.action
+              ? formatMessage(
+                  { id: 'action.title' },
+                  getActionTitleValues(stake.action, colony),
+                )
+              : '-'}
+          </div>
         </div>
-        {/* @TODO: Replace with action metadata title */}
-        <div className="text-gray-600">Pay X 1,000 ETH</div>
       </div>
-    </div>
-  </li>
-);
+    </li>
+  );
+};
 
 StakeItem.displayName = displayName;
 

--- a/src/components/common/Extensions/UserHub/partials/StakesTab/partials/StakeItem.tsx
+++ b/src/components/common/Extensions/UserHub/partials/StakesTab/partials/StakeItem.tsx
@@ -16,8 +16,9 @@ const StakeItem: FC<StakeItemProps> = ({ nativeToken, stake }) => (
     <div className="relative w-full">
       <div className="flex justify-between items-center">
         <div className="flex items-center mr-2 min-w-0">
-          {/* @TODO: Replace with action custom title */}
-          <p className="text-1 mr-2 truncate min-w-0">{stake.action?.type}</p>
+          <p className="text-1 mr-2 truncate min-w-0">
+            {stake.action?.metadata?.customTitle ?? stake.action?.type}
+          </p>
           <span className="text-gray-400 text-xs">
             <FormattedDate value={stake.createdAt} />
           </span>

--- a/src/components/common/Extensions/UserHub/partials/StakesTab/partials/StakesList.tsx
+++ b/src/components/common/Extensions/UserHub/partials/StakesTab/partials/StakesList.tsx
@@ -42,7 +42,7 @@ const StakesList = ({ stakes, loading, colony }: StakesListProps) => {
           key={stake.id}
           stake={stake}
           nativeToken={colony.nativeToken}
-          colonyAddress={colony.colonyAddress}
+          colony={colony}
         />
       ))}
     </div>

--- a/src/components/common/Extensions/UserHub/partials/StakesTab/types.ts
+++ b/src/components/common/Extensions/UserHub/partials/StakesTab/types.ts
@@ -10,7 +10,7 @@ export interface StakesListProps {
 export interface StakeItemProps {
   stake: UserStakeWithStatus;
   nativeToken: Token;
-  colonyAddress: string;
+  colony: Colony;
 }
 
 export type StakesFilterType = 'all' | 'finalizable' | 'claimable';

--- a/src/components/common/Extensions/UserHub/partials/StakesTab/useStakesByFilterType.ts
+++ b/src/components/common/Extensions/UserHub/partials/StakesTab/useStakesByFilterType.ts
@@ -39,7 +39,7 @@ export const useStakesByFilterType = () => {
     () =>
       userStakes
         .filter((stake) => !!stake.action?.motionData)
-        .map((stake) => stake.action?.motionData?.nativeMotionId ?? ''),
+        .map((stake) => stake.action?.motionData?.motionId ?? ''),
     [userStakes],
   );
   const { motionStatesMap, loading: motionStatesLoading } =

--- a/src/graphql/fragments/stake.graphql
+++ b/src/graphql/fragments/stake.graphql
@@ -15,6 +15,9 @@ fragment UserStake on UserStake {
         ...MotionStakes
       }
     }
+    metadata {
+      customTitle
+    }
   }
   isClaimed
   createdAt

--- a/src/graphql/fragments/stake.graphql
+++ b/src/graphql/fragments/stake.graphql
@@ -2,22 +2,7 @@ fragment UserStake on UserStake {
   id
   amount
   action {
-    id
-    type
-    motionData {
-      id
-      nativeMotionId
-      motionStakes {
-        ...MotionStakes
-      }
-      requiredStake
-      revealedVotes {
-        ...MotionStakes
-      }
-    }
-    metadata {
-      customTitle
-    }
+    ...ColonyAction
   }
   isClaimed
   createdAt

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -8363,7 +8363,7 @@ export type SafeTransactionDataFragment = { __typename?: 'SafeTransactionData', 
 
 export type SafeTransactionFragment = { __typename?: 'SafeTransaction', id: string, safe: { __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }, transactions?: { __typename?: 'ModelSafeTransactionDataConnection', items: Array<{ __typename?: 'SafeTransactionData', transactionType: SafeTransactionType, amount?: string | null, rawAmount?: string | null, data?: string | null, abi?: string | null, contractFunction?: string | null, token?: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } | null, recipient?: { __typename?: 'SimpleTarget', id: string, walletAddress: string, profile: { __typename?: 'SimpleTargetProfile', avatarHash?: string | null, displayName?: string | null } } | null, contract?: { __typename?: 'SimpleTarget', id: string, walletAddress: string, profile: { __typename?: 'SimpleTargetProfile', avatarHash?: string | null, displayName?: string | null } } | null, nft?: { __typename?: 'NFT', id: string, walletAddress: string, profile: { __typename?: 'NFTProfile', displayName: string } } | null, nftData?: { __typename?: 'NFTData', address: string, description?: string | null, id: string, imageUri?: string | null, logoUri: string, name?: string | null, tokenName: string, tokenSymbol: string, uri: string } | null, functionParams?: Array<{ __typename?: 'FunctionParam', name: string, type: string, value: string } | null> | null } | null> } | null };
 
-export type UserStakeFragment = { __typename?: 'UserStake', id: string, amount: string, isClaimed: boolean, createdAt: string, action?: { __typename?: 'ColonyAction', id: string, type: ColonyActionType, motionData?: { __typename?: 'ColonyMotion', id: string, nativeMotionId: string, requiredStake: string, motionStakes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } }, revealedVotes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } } } | null, metadata?: { __typename?: 'ColonyActionMetadata', customTitle: string } | null } | null };
+export type UserStakeFragment = { __typename?: 'UserStake', id: string, amount: string, isClaimed: boolean, createdAt: string, action?: { __typename?: 'ColonyAction', type: ColonyActionType, blockNumber: number, initiatorAddress: string, recipientAddress?: string | null, amount?: string | null, tokenAddress?: string | null, createdAt: string, newColonyVersion?: number | null, individualEvents?: string | null, isMotion?: boolean | null, showInActionsList: boolean, transactionHash: string, colonyAddress: string, initiatorUser?: { __typename?: 'User', walletAddress: string, profile?: { __typename?: 'Profile', displayName?: string | null, displayNameChanged?: string | null, avatar?: string | null, thumbnail?: string | null } | null } | null, initiatorColony?: { __typename?: 'Colony', name: string, version: number, reputation?: string | null, expendituresGlobalClaimDelay?: number | null, private?: boolean | null, colonyAddress: string, metadata?: { __typename?: 'ColonyMetadata', avatar?: string | null, displayName: string, thumbnail?: string | null, description?: string | null, isWhitelistActivated?: boolean | null, whitelistedAddresses?: Array<string> | null, externalLinks?: Array<{ __typename?: 'ExternalLink', link: string, name: ExternalLinks }> | null, modifiedTokenAddresses?: { __typename?: 'PendingModifiedTokenAddresses', added?: Array<string> | null, removed?: Array<string> | null } | null, objective?: { __typename?: 'ColonyObjective', title: string, description: string, progress: number } | null, changelog?: Array<{ __typename?: 'ColonyMetadataChangelog', transactionHash: string, newDisplayName: string, oldDisplayName: string, hasAvatarChanged: boolean, hasWhitelistChanged: boolean, haveTokensChanged: boolean, hasDescriptionChanged?: boolean | null, haveExternalLinksChanged?: boolean | null, hasObjectiveChanged?: boolean | null, newSafes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null, oldSafes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null }> | null, safes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null } | null, nativeToken: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string }, status?: { __typename?: 'ColonyStatus', recovery?: boolean | null, nativeToken?: { __typename?: 'NativeTokenStatus', mintable?: boolean | null, unlockable?: boolean | null, unlocked?: boolean | null } | null } | null, chainMetadata: { __typename?: 'ChainMetadata', chainId: number, network?: Network | null }, tokens?: { __typename?: 'ModelColonyTokensConnection', items: Array<{ __typename?: 'ColonyTokens', colonyTokensId: string, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> } | null, motionsWithUnclaimedStakes?: Array<{ __typename?: 'ColonyUnclaimedStake', motionId: string, unclaimedRewards: Array<{ __typename?: 'StakerRewards', address: string, rewards: { __typename?: 'MotionStakeValues', nay: string, yay: string } }> }> | null, domains?: { __typename?: 'ModelDomainConnection', items: Array<{ __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, nativeSkillId: number, reputation?: string | null, reputationPercentage?: string | null, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, id: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null } | null> } | null, balances?: { __typename?: 'ColonyBalances', items?: Array<{ __typename?: 'ColonyBalance', id: string, balance: string, domain?: { __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, nativeSkillId: number, reputation?: string | null, reputationPercentage?: string | null, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, id: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null } | null, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> | null } | null, fundsClaims?: { __typename?: 'ModelColonyFundsClaimConnection', items: Array<{ __typename?: 'ColonyFundsClaim', id: string, createdAtBlock: number, createdAt: string, amount: string, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> } | null, chainFundsClaim?: { __typename?: 'ColonyChainFundsClaim', id: string, createdAtBlock: number, createdAt: string, amount: string } | null, roles?: { __typename?: 'ModelColonyRoleConnection', items: Array<{ __typename?: 'ColonyRole', id: string, targetAddress: string, role_0?: boolean | null, role_1?: boolean | null, role_2?: boolean | null, role_3?: boolean | null, role_5?: boolean | null, role_6?: boolean | null, domain: { __typename?: 'Domain', id: string, nativeId: number } } | null> } | null, colonyMemberInvite?: { __typename?: 'ColonyMemberInvite', id: string, invitesRemaining: number, valid: boolean } | null } | null, initiatorExtension?: { __typename?: 'ColonyExtension', hash: string, installedBy: string, installedAt: number, isDeprecated: boolean, isDeleted: boolean, isInitialized: boolean, address: string, colonyAddress: string, currentVersion: number, params?: { __typename?: 'ExtensionParams', votingReputation?: { __typename?: 'VotingReputationParams', maxVoteFraction: string, totalStakeFraction: string, voterRewardFraction: string, userMinStakeFraction: string, stakePeriod: string, submitPeriod: string, revealPeriod: string, escalationPeriod: string } | null, stakedExpenditure?: { __typename?: 'StakedExpenditureParams', stakeFraction: string } | null } | null } | null, initiatorToken?: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } | null, recipientUser?: { __typename?: 'User', walletAddress: string, profile?: { __typename?: 'Profile', displayName?: string | null, displayNameChanged?: string | null, avatar?: string | null, thumbnail?: string | null } | null } | null, recipientColony?: { __typename?: 'Colony', name: string, version: number, reputation?: string | null, expendituresGlobalClaimDelay?: number | null, private?: boolean | null, colonyAddress: string, metadata?: { __typename?: 'ColonyMetadata', avatar?: string | null, displayName: string, thumbnail?: string | null, description?: string | null, isWhitelistActivated?: boolean | null, whitelistedAddresses?: Array<string> | null, externalLinks?: Array<{ __typename?: 'ExternalLink', link: string, name: ExternalLinks }> | null, modifiedTokenAddresses?: { __typename?: 'PendingModifiedTokenAddresses', added?: Array<string> | null, removed?: Array<string> | null } | null, objective?: { __typename?: 'ColonyObjective', title: string, description: string, progress: number } | null, changelog?: Array<{ __typename?: 'ColonyMetadataChangelog', transactionHash: string, newDisplayName: string, oldDisplayName: string, hasAvatarChanged: boolean, hasWhitelistChanged: boolean, haveTokensChanged: boolean, hasDescriptionChanged?: boolean | null, haveExternalLinksChanged?: boolean | null, hasObjectiveChanged?: boolean | null, newSafes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null, oldSafes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null }> | null, safes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null } | null, nativeToken: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string }, status?: { __typename?: 'ColonyStatus', recovery?: boolean | null, nativeToken?: { __typename?: 'NativeTokenStatus', mintable?: boolean | null, unlockable?: boolean | null, unlocked?: boolean | null } | null } | null, chainMetadata: { __typename?: 'ChainMetadata', chainId: number, network?: Network | null }, tokens?: { __typename?: 'ModelColonyTokensConnection', items: Array<{ __typename?: 'ColonyTokens', colonyTokensId: string, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> } | null, motionsWithUnclaimedStakes?: Array<{ __typename?: 'ColonyUnclaimedStake', motionId: string, unclaimedRewards: Array<{ __typename?: 'StakerRewards', address: string, rewards: { __typename?: 'MotionStakeValues', nay: string, yay: string } }> }> | null, domains?: { __typename?: 'ModelDomainConnection', items: Array<{ __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, nativeSkillId: number, reputation?: string | null, reputationPercentage?: string | null, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, id: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null } | null> } | null, balances?: { __typename?: 'ColonyBalances', items?: Array<{ __typename?: 'ColonyBalance', id: string, balance: string, domain?: { __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, nativeSkillId: number, reputation?: string | null, reputationPercentage?: string | null, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, id: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null } | null, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> | null } | null, fundsClaims?: { __typename?: 'ModelColonyFundsClaimConnection', items: Array<{ __typename?: 'ColonyFundsClaim', id: string, createdAtBlock: number, createdAt: string, amount: string, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> } | null, chainFundsClaim?: { __typename?: 'ColonyChainFundsClaim', id: string, createdAtBlock: number, createdAt: string, amount: string } | null, roles?: { __typename?: 'ModelColonyRoleConnection', items: Array<{ __typename?: 'ColonyRole', id: string, targetAddress: string, role_0?: boolean | null, role_1?: boolean | null, role_2?: boolean | null, role_3?: boolean | null, role_5?: boolean | null, role_6?: boolean | null, domain: { __typename?: 'Domain', id: string, nativeId: number } } | null> } | null, colonyMemberInvite?: { __typename?: 'ColonyMemberInvite', id: string, invitesRemaining: number, valid: boolean } | null } | null, recipientExtension?: { __typename?: 'ColonyExtension', hash: string, installedBy: string, installedAt: number, isDeprecated: boolean, isDeleted: boolean, isInitialized: boolean, address: string, colonyAddress: string, currentVersion: number, params?: { __typename?: 'ExtensionParams', votingReputation?: { __typename?: 'VotingReputationParams', maxVoteFraction: string, totalStakeFraction: string, voterRewardFraction: string, userMinStakeFraction: string, stakePeriod: string, submitPeriod: string, revealPeriod: string, escalationPeriod: string } | null, stakedExpenditure?: { __typename?: 'StakedExpenditureParams', stakeFraction: string } | null } | null } | null, recipientToken?: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } | null, token?: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } | null, fromDomain?: { __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, nativeSkillId: number, reputation?: string | null, reputationPercentage?: string | null, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, id: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null } | null, toDomain?: { __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, nativeSkillId: number, reputation?: string | null, reputationPercentage?: string | null, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, id: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null } | null, roles?: { __typename?: 'ColonyActionRoles', role_0?: boolean | null, role_1?: boolean | null, role_2?: boolean | null, role_3?: boolean | null, role_5?: boolean | null, role_6?: boolean | null } | null, payments?: Array<{ __typename?: 'Payment', amount: string, tokenAddress: string, recipientAddress: string }> | null, motionData?: { __typename?: 'ColonyMotion', remainingStakes: Array<string>, userMinStake: string, requiredStake: string, rootHash: string, nativeMotionDomainId: string, isFinalized: boolean, skillRep: string, repSubmitted: string, hasObjection: boolean, isDecision: boolean, gasEstimate: string, transactionHash: string, databaseMotionId: string, motionId: string, motionStakes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } }, usersStakes: Array<{ __typename?: 'UserMotionStakes', address: string, stakes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } } }>, motionDomain: { __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, nativeSkillId: number, reputation?: string | null, reputationPercentage?: string | null, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, id: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null }, stakerRewards: Array<{ __typename?: 'StakerRewards', address: string, isClaimed: boolean, rewards: { __typename?: 'MotionStakeValues', yay: string, nay: string } }>, voterRecord: Array<{ __typename?: 'VoterRecord', address: string, voteCount: string, vote?: number | null }>, revealedVotes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } }, motionStateHistory: { __typename?: 'MotionStateHistory', hasVoted: boolean, hasPassed: boolean, hasFailed: boolean, hasFailedNotFinalizable: boolean, inRevealPhase: boolean }, messages?: { __typename?: 'ModelMotionMessageConnection', items: Array<{ __typename?: 'MotionMessage', initiatorAddress: string, name: string, messageKey: string, vote?: string | null, amount?: string | null, initiatorUser?: { __typename?: 'User', walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, displayNameChanged?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null, meta?: { __typename?: 'ProfileMetadata', metatransactionsEnabled?: boolean | null, decentralizedModeEnabled?: boolean | null, customRpc?: string | null } | null } | null, privateBetaInviteCode?: { __typename?: 'PrivateBetaInviteCode', id: string, shareableInvites?: number | null } | null } | null } | null> } | null, objectionAnnotation?: { __typename?: 'Annotation', createdAt: string, message: string } | null, action?: { __typename?: 'ColonyAction', type: ColonyActionType } | null } | null, colony: { __typename?: 'Colony', colonyAddress: string, nativeToken: { __typename?: 'Token', nativeTokenDecimals: number, nativeTokenSymbol: string, tokenAddress: string }, tokens?: { __typename?: 'ModelColonyTokensConnection', items: Array<{ __typename?: 'ColonyTokens', colonyTokensId: string, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> } | null, metadata?: { __typename?: 'ColonyMetadata', displayName: string, avatar?: string | null, description?: string | null, thumbnail?: string | null, isWhitelistActivated?: boolean | null, whitelistedAddresses?: Array<string> | null, externalLinks?: Array<{ __typename?: 'ExternalLink', name: ExternalLinks, link: string }> | null, modifiedTokenAddresses?: { __typename?: 'PendingModifiedTokenAddresses', added?: Array<string> | null, removed?: Array<string> | null } | null, objective?: { __typename?: 'ColonyObjective', title: string, description: string, progress: number } | null, changelog?: Array<{ __typename?: 'ColonyMetadataChangelog', transactionHash: string, newDisplayName: string, oldDisplayName: string, hasAvatarChanged: boolean, hasWhitelistChanged: boolean, haveTokensChanged: boolean, hasDescriptionChanged?: boolean | null, haveExternalLinksChanged?: boolean | null, hasObjectiveChanged?: boolean | null, newSafes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null, oldSafes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null }> | null, safes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null } | null }, pendingDomainMetadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, id: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null, pendingColonyMetadata?: { __typename?: 'ColonyMetadata', displayName: string, avatar?: string | null, description?: string | null, thumbnail?: string | null, isWhitelistActivated?: boolean | null, whitelistedAddresses?: Array<string> | null, externalLinks?: Array<{ __typename?: 'ExternalLink', name: ExternalLinks, link: string }> | null, modifiedTokenAddresses?: { __typename?: 'PendingModifiedTokenAddresses', added?: Array<string> | null, removed?: Array<string> | null } | null, objective?: { __typename?: 'ColonyObjective', title: string, description: string, progress: number } | null, changelog?: Array<{ __typename?: 'ColonyMetadataChangelog', transactionHash: string, newDisplayName: string, oldDisplayName: string, hasAvatarChanged: boolean, hasWhitelistChanged: boolean, haveTokensChanged: boolean, hasDescriptionChanged?: boolean | null, haveExternalLinksChanged?: boolean | null, hasObjectiveChanged?: boolean | null, newSafes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null, oldSafes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null }> | null, safes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null } | null, annotation?: { __typename?: 'Annotation', createdAt: string, message: string } | null, decisionData?: { __typename?: 'ColonyDecision', title: string, description: string, motionDomainId: number, walletAddress: string, createdAt: string, actionId: string, colonyAddress: string } | null, safeTransaction?: { __typename?: 'SafeTransaction', id: string, safe: { __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }, transactions?: { __typename?: 'ModelSafeTransactionDataConnection', items: Array<{ __typename?: 'SafeTransactionData', transactionType: SafeTransactionType, amount?: string | null, rawAmount?: string | null, data?: string | null, abi?: string | null, contractFunction?: string | null, token?: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } | null, recipient?: { __typename?: 'SimpleTarget', id: string, walletAddress: string, profile: { __typename?: 'SimpleTargetProfile', avatarHash?: string | null, displayName?: string | null } } | null, contract?: { __typename?: 'SimpleTarget', id: string, walletAddress: string, profile: { __typename?: 'SimpleTargetProfile', avatarHash?: string | null, displayName?: string | null } } | null, nft?: { __typename?: 'NFT', id: string, walletAddress: string, profile: { __typename?: 'NFTProfile', displayName: string } } | null, nftData?: { __typename?: 'NFTData', address: string, description?: string | null, id: string, imageUri?: string | null, logoUri: string, name?: string | null, tokenName: string, tokenSymbol: string, uri: string } | null, functionParams?: Array<{ __typename?: 'FunctionParam', name: string, type: string, value: string } | null> | null } | null> } | null } | null, metadata?: { __typename?: 'ColonyActionMetadata', customTitle: string } | null } | null };
 
 export type TokenFragment = { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string };
 
@@ -8808,7 +8808,7 @@ export type GetUserStakesQueryVariables = Exact<{
 }>;
 
 
-export type GetUserStakesQuery = { __typename?: 'Query', getUserStakes?: { __typename?: 'ModelUserStakeConnection', items: Array<{ __typename?: 'UserStake', id: string, amount: string, isClaimed: boolean, createdAt: string, action?: { __typename?: 'ColonyAction', id: string, type: ColonyActionType, motionData?: { __typename?: 'ColonyMotion', id: string, nativeMotionId: string, requiredStake: string, motionStakes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } }, revealedVotes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } } } | null, metadata?: { __typename?: 'ColonyActionMetadata', customTitle: string } | null } | null } | null> } | null };
+export type GetUserStakesQuery = { __typename?: 'Query', getUserStakes?: { __typename?: 'ModelUserStakeConnection', items: Array<{ __typename?: 'UserStake', id: string, amount: string, isClaimed: boolean, createdAt: string, action?: { __typename?: 'ColonyAction', type: ColonyActionType, blockNumber: number, initiatorAddress: string, recipientAddress?: string | null, amount?: string | null, tokenAddress?: string | null, createdAt: string, newColonyVersion?: number | null, individualEvents?: string | null, isMotion?: boolean | null, showInActionsList: boolean, transactionHash: string, colonyAddress: string, initiatorUser?: { __typename?: 'User', walletAddress: string, profile?: { __typename?: 'Profile', displayName?: string | null, displayNameChanged?: string | null, avatar?: string | null, thumbnail?: string | null } | null } | null, initiatorColony?: { __typename?: 'Colony', name: string, version: number, reputation?: string | null, expendituresGlobalClaimDelay?: number | null, private?: boolean | null, colonyAddress: string, metadata?: { __typename?: 'ColonyMetadata', avatar?: string | null, displayName: string, thumbnail?: string | null, description?: string | null, isWhitelistActivated?: boolean | null, whitelistedAddresses?: Array<string> | null, externalLinks?: Array<{ __typename?: 'ExternalLink', link: string, name: ExternalLinks }> | null, modifiedTokenAddresses?: { __typename?: 'PendingModifiedTokenAddresses', added?: Array<string> | null, removed?: Array<string> | null } | null, objective?: { __typename?: 'ColonyObjective', title: string, description: string, progress: number } | null, changelog?: Array<{ __typename?: 'ColonyMetadataChangelog', transactionHash: string, newDisplayName: string, oldDisplayName: string, hasAvatarChanged: boolean, hasWhitelistChanged: boolean, haveTokensChanged: boolean, hasDescriptionChanged?: boolean | null, haveExternalLinksChanged?: boolean | null, hasObjectiveChanged?: boolean | null, newSafes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null, oldSafes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null }> | null, safes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null } | null, nativeToken: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string }, status?: { __typename?: 'ColonyStatus', recovery?: boolean | null, nativeToken?: { __typename?: 'NativeTokenStatus', mintable?: boolean | null, unlockable?: boolean | null, unlocked?: boolean | null } | null } | null, chainMetadata: { __typename?: 'ChainMetadata', chainId: number, network?: Network | null }, tokens?: { __typename?: 'ModelColonyTokensConnection', items: Array<{ __typename?: 'ColonyTokens', colonyTokensId: string, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> } | null, motionsWithUnclaimedStakes?: Array<{ __typename?: 'ColonyUnclaimedStake', motionId: string, unclaimedRewards: Array<{ __typename?: 'StakerRewards', address: string, rewards: { __typename?: 'MotionStakeValues', nay: string, yay: string } }> }> | null, domains?: { __typename?: 'ModelDomainConnection', items: Array<{ __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, nativeSkillId: number, reputation?: string | null, reputationPercentage?: string | null, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, id: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null } | null> } | null, balances?: { __typename?: 'ColonyBalances', items?: Array<{ __typename?: 'ColonyBalance', id: string, balance: string, domain?: { __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, nativeSkillId: number, reputation?: string | null, reputationPercentage?: string | null, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, id: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null } | null, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> | null } | null, fundsClaims?: { __typename?: 'ModelColonyFundsClaimConnection', items: Array<{ __typename?: 'ColonyFundsClaim', id: string, createdAtBlock: number, createdAt: string, amount: string, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> } | null, chainFundsClaim?: { __typename?: 'ColonyChainFundsClaim', id: string, createdAtBlock: number, createdAt: string, amount: string } | null, roles?: { __typename?: 'ModelColonyRoleConnection', items: Array<{ __typename?: 'ColonyRole', id: string, targetAddress: string, role_0?: boolean | null, role_1?: boolean | null, role_2?: boolean | null, role_3?: boolean | null, role_5?: boolean | null, role_6?: boolean | null, domain: { __typename?: 'Domain', id: string, nativeId: number } } | null> } | null, colonyMemberInvite?: { __typename?: 'ColonyMemberInvite', id: string, invitesRemaining: number, valid: boolean } | null } | null, initiatorExtension?: { __typename?: 'ColonyExtension', hash: string, installedBy: string, installedAt: number, isDeprecated: boolean, isDeleted: boolean, isInitialized: boolean, address: string, colonyAddress: string, currentVersion: number, params?: { __typename?: 'ExtensionParams', votingReputation?: { __typename?: 'VotingReputationParams', maxVoteFraction: string, totalStakeFraction: string, voterRewardFraction: string, userMinStakeFraction: string, stakePeriod: string, submitPeriod: string, revealPeriod: string, escalationPeriod: string } | null, stakedExpenditure?: { __typename?: 'StakedExpenditureParams', stakeFraction: string } | null } | null } | null, initiatorToken?: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } | null, recipientUser?: { __typename?: 'User', walletAddress: string, profile?: { __typename?: 'Profile', displayName?: string | null, displayNameChanged?: string | null, avatar?: string | null, thumbnail?: string | null } | null } | null, recipientColony?: { __typename?: 'Colony', name: string, version: number, reputation?: string | null, expendituresGlobalClaimDelay?: number | null, private?: boolean | null, colonyAddress: string, metadata?: { __typename?: 'ColonyMetadata', avatar?: string | null, displayName: string, thumbnail?: string | null, description?: string | null, isWhitelistActivated?: boolean | null, whitelistedAddresses?: Array<string> | null, externalLinks?: Array<{ __typename?: 'ExternalLink', link: string, name: ExternalLinks }> | null, modifiedTokenAddresses?: { __typename?: 'PendingModifiedTokenAddresses', added?: Array<string> | null, removed?: Array<string> | null } | null, objective?: { __typename?: 'ColonyObjective', title: string, description: string, progress: number } | null, changelog?: Array<{ __typename?: 'ColonyMetadataChangelog', transactionHash: string, newDisplayName: string, oldDisplayName: string, hasAvatarChanged: boolean, hasWhitelistChanged: boolean, haveTokensChanged: boolean, hasDescriptionChanged?: boolean | null, haveExternalLinksChanged?: boolean | null, hasObjectiveChanged?: boolean | null, newSafes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null, oldSafes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null }> | null, safes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null } | null, nativeToken: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string }, status?: { __typename?: 'ColonyStatus', recovery?: boolean | null, nativeToken?: { __typename?: 'NativeTokenStatus', mintable?: boolean | null, unlockable?: boolean | null, unlocked?: boolean | null } | null } | null, chainMetadata: { __typename?: 'ChainMetadata', chainId: number, network?: Network | null }, tokens?: { __typename?: 'ModelColonyTokensConnection', items: Array<{ __typename?: 'ColonyTokens', colonyTokensId: string, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> } | null, motionsWithUnclaimedStakes?: Array<{ __typename?: 'ColonyUnclaimedStake', motionId: string, unclaimedRewards: Array<{ __typename?: 'StakerRewards', address: string, rewards: { __typename?: 'MotionStakeValues', nay: string, yay: string } }> }> | null, domains?: { __typename?: 'ModelDomainConnection', items: Array<{ __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, nativeSkillId: number, reputation?: string | null, reputationPercentage?: string | null, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, id: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null } | null> } | null, balances?: { __typename?: 'ColonyBalances', items?: Array<{ __typename?: 'ColonyBalance', id: string, balance: string, domain?: { __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, nativeSkillId: number, reputation?: string | null, reputationPercentage?: string | null, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, id: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null } | null, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> | null } | null, fundsClaims?: { __typename?: 'ModelColonyFundsClaimConnection', items: Array<{ __typename?: 'ColonyFundsClaim', id: string, createdAtBlock: number, createdAt: string, amount: string, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> } | null, chainFundsClaim?: { __typename?: 'ColonyChainFundsClaim', id: string, createdAtBlock: number, createdAt: string, amount: string } | null, roles?: { __typename?: 'ModelColonyRoleConnection', items: Array<{ __typename?: 'ColonyRole', id: string, targetAddress: string, role_0?: boolean | null, role_1?: boolean | null, role_2?: boolean | null, role_3?: boolean | null, role_5?: boolean | null, role_6?: boolean | null, domain: { __typename?: 'Domain', id: string, nativeId: number } } | null> } | null, colonyMemberInvite?: { __typename?: 'ColonyMemberInvite', id: string, invitesRemaining: number, valid: boolean } | null } | null, recipientExtension?: { __typename?: 'ColonyExtension', hash: string, installedBy: string, installedAt: number, isDeprecated: boolean, isDeleted: boolean, isInitialized: boolean, address: string, colonyAddress: string, currentVersion: number, params?: { __typename?: 'ExtensionParams', votingReputation?: { __typename?: 'VotingReputationParams', maxVoteFraction: string, totalStakeFraction: string, voterRewardFraction: string, userMinStakeFraction: string, stakePeriod: string, submitPeriod: string, revealPeriod: string, escalationPeriod: string } | null, stakedExpenditure?: { __typename?: 'StakedExpenditureParams', stakeFraction: string } | null } | null } | null, recipientToken?: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } | null, token?: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } | null, fromDomain?: { __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, nativeSkillId: number, reputation?: string | null, reputationPercentage?: string | null, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, id: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null } | null, toDomain?: { __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, nativeSkillId: number, reputation?: string | null, reputationPercentage?: string | null, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, id: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null } | null, roles?: { __typename?: 'ColonyActionRoles', role_0?: boolean | null, role_1?: boolean | null, role_2?: boolean | null, role_3?: boolean | null, role_5?: boolean | null, role_6?: boolean | null } | null, payments?: Array<{ __typename?: 'Payment', amount: string, tokenAddress: string, recipientAddress: string }> | null, motionData?: { __typename?: 'ColonyMotion', remainingStakes: Array<string>, userMinStake: string, requiredStake: string, rootHash: string, nativeMotionDomainId: string, isFinalized: boolean, skillRep: string, repSubmitted: string, hasObjection: boolean, isDecision: boolean, gasEstimate: string, transactionHash: string, databaseMotionId: string, motionId: string, motionStakes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } }, usersStakes: Array<{ __typename?: 'UserMotionStakes', address: string, stakes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } } }>, motionDomain: { __typename?: 'Domain', id: string, nativeId: number, isRoot: boolean, nativeFundingPotId: number, nativeSkillId: number, reputation?: string | null, reputationPercentage?: string | null, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, id: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null }, stakerRewards: Array<{ __typename?: 'StakerRewards', address: string, isClaimed: boolean, rewards: { __typename?: 'MotionStakeValues', yay: string, nay: string } }>, voterRecord: Array<{ __typename?: 'VoterRecord', address: string, voteCount: string, vote?: number | null }>, revealedVotes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } }, motionStateHistory: { __typename?: 'MotionStateHistory', hasVoted: boolean, hasPassed: boolean, hasFailed: boolean, hasFailedNotFinalizable: boolean, inRevealPhase: boolean }, messages?: { __typename?: 'ModelMotionMessageConnection', items: Array<{ __typename?: 'MotionMessage', initiatorAddress: string, name: string, messageKey: string, vote?: string | null, amount?: string | null, initiatorUser?: { __typename?: 'User', walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, displayNameChanged?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null, meta?: { __typename?: 'ProfileMetadata', metatransactionsEnabled?: boolean | null, decentralizedModeEnabled?: boolean | null, customRpc?: string | null } | null } | null, privateBetaInviteCode?: { __typename?: 'PrivateBetaInviteCode', id: string, shareableInvites?: number | null } | null } | null } | null> } | null, objectionAnnotation?: { __typename?: 'Annotation', createdAt: string, message: string } | null, action?: { __typename?: 'ColonyAction', type: ColonyActionType } | null } | null, colony: { __typename?: 'Colony', colonyAddress: string, nativeToken: { __typename?: 'Token', nativeTokenDecimals: number, nativeTokenSymbol: string, tokenAddress: string }, tokens?: { __typename?: 'ModelColonyTokensConnection', items: Array<{ __typename?: 'ColonyTokens', colonyTokensId: string, token: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } } | null> } | null, metadata?: { __typename?: 'ColonyMetadata', displayName: string, avatar?: string | null, description?: string | null, thumbnail?: string | null, isWhitelistActivated?: boolean | null, whitelistedAddresses?: Array<string> | null, externalLinks?: Array<{ __typename?: 'ExternalLink', name: ExternalLinks, link: string }> | null, modifiedTokenAddresses?: { __typename?: 'PendingModifiedTokenAddresses', added?: Array<string> | null, removed?: Array<string> | null } | null, objective?: { __typename?: 'ColonyObjective', title: string, description: string, progress: number } | null, changelog?: Array<{ __typename?: 'ColonyMetadataChangelog', transactionHash: string, newDisplayName: string, oldDisplayName: string, hasAvatarChanged: boolean, hasWhitelistChanged: boolean, haveTokensChanged: boolean, hasDescriptionChanged?: boolean | null, haveExternalLinksChanged?: boolean | null, hasObjectiveChanged?: boolean | null, newSafes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null, oldSafes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null }> | null, safes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null } | null }, pendingDomainMetadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor, description: string, id: string, changelog?: Array<{ __typename?: 'DomainMetadataChangelog', transactionHash: string, oldName: string, newName: string, oldColor: DomainColor, newColor: DomainColor, oldDescription: string, newDescription: string }> | null } | null, pendingColonyMetadata?: { __typename?: 'ColonyMetadata', displayName: string, avatar?: string | null, description?: string | null, thumbnail?: string | null, isWhitelistActivated?: boolean | null, whitelistedAddresses?: Array<string> | null, externalLinks?: Array<{ __typename?: 'ExternalLink', name: ExternalLinks, link: string }> | null, modifiedTokenAddresses?: { __typename?: 'PendingModifiedTokenAddresses', added?: Array<string> | null, removed?: Array<string> | null } | null, objective?: { __typename?: 'ColonyObjective', title: string, description: string, progress: number } | null, changelog?: Array<{ __typename?: 'ColonyMetadataChangelog', transactionHash: string, newDisplayName: string, oldDisplayName: string, hasAvatarChanged: boolean, hasWhitelistChanged: boolean, haveTokensChanged: boolean, hasDescriptionChanged?: boolean | null, haveExternalLinksChanged?: boolean | null, hasObjectiveChanged?: boolean | null, newSafes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null, oldSafes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null }> | null, safes?: Array<{ __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }> | null } | null, annotation?: { __typename?: 'Annotation', createdAt: string, message: string } | null, decisionData?: { __typename?: 'ColonyDecision', title: string, description: string, motionDomainId: number, walletAddress: string, createdAt: string, actionId: string, colonyAddress: string } | null, safeTransaction?: { __typename?: 'SafeTransaction', id: string, safe: { __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }, transactions?: { __typename?: 'ModelSafeTransactionDataConnection', items: Array<{ __typename?: 'SafeTransactionData', transactionType: SafeTransactionType, amount?: string | null, rawAmount?: string | null, data?: string | null, abi?: string | null, contractFunction?: string | null, token?: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } | null, recipient?: { __typename?: 'SimpleTarget', id: string, walletAddress: string, profile: { __typename?: 'SimpleTargetProfile', avatarHash?: string | null, displayName?: string | null } } | null, contract?: { __typename?: 'SimpleTarget', id: string, walletAddress: string, profile: { __typename?: 'SimpleTargetProfile', avatarHash?: string | null, displayName?: string | null } } | null, nft?: { __typename?: 'NFT', id: string, walletAddress: string, profile: { __typename?: 'NFTProfile', displayName: string } } | null, nftData?: { __typename?: 'NFTData', address: string, description?: string | null, id: string, imageUri?: string | null, logoUri: string, name?: string | null, tokenName: string, tokenSymbol: string, uri: string } | null, functionParams?: Array<{ __typename?: 'FunctionParam', name: string, type: string, value: string } | null> | null } | null> } | null } | null, metadata?: { __typename?: 'ColonyActionMetadata', customTitle: string } | null } | null } | null> } | null };
 
 export type GetTokenByAddressQueryVariables = Exact<{
   address: Scalars['ID'];
@@ -8910,6 +8910,377 @@ export type GetCurrentColonyVersionQueryVariables = Exact<{ [key: string]: never
 
 export type GetCurrentColonyVersionQuery = { __typename?: 'Query', getCurrentVersionByKey?: { __typename?: 'ModelCurrentVersionConnection', items: Array<{ __typename?: 'CurrentVersion', version: number } | null> } | null };
 
+export const ColonyObjectiveFragmentDoc = gql`
+    fragment ColonyObjective on ColonyObjective {
+  title
+  description
+  progress
+}
+    `;
+export const SafeFragmentDoc = gql`
+    fragment Safe on Safe {
+  name
+  address
+  chainId
+  moduleContractAddress
+}
+    `;
+export const ColonyMetadataFragmentDoc = gql`
+    fragment ColonyMetadata on ColonyMetadata {
+  displayName
+  avatar
+  description
+  externalLinks {
+    name
+    link
+  }
+  thumbnail
+  isWhitelistActivated
+  whitelistedAddresses
+  modifiedTokenAddresses {
+    added
+    removed
+  }
+  objective {
+    ...ColonyObjective
+  }
+  changelog {
+    transactionHash
+    newDisplayName
+    oldDisplayName
+    hasAvatarChanged
+    hasWhitelistChanged
+    haveTokensChanged
+    hasDescriptionChanged
+    haveExternalLinksChanged
+    hasObjectiveChanged
+    newSafes {
+      ...Safe
+    }
+    oldSafes {
+      ...Safe
+    }
+  }
+  safes {
+    ...Safe
+  }
+}
+    ${ColonyObjectiveFragmentDoc}
+${SafeFragmentDoc}`;
+export const JoinedColonyFragmentDoc = gql`
+    fragment JoinedColony on Colony {
+  colonyAddress: id
+  name
+  metadata {
+    ...ColonyMetadata
+  }
+  chainMetadata {
+    chainId
+    network
+  }
+}
+    ${ColonyMetadataFragmentDoc}`;
+export const ContributorRolesFragmentDoc = gql`
+    fragment ContributorRoles on ColonyRole {
+  domainId
+  domain {
+    id
+    metadata {
+      name
+    }
+    nativeId
+  }
+  role_0
+  role_1
+  role_2
+  role_3
+  role_5
+  role_6
+  id
+}
+    `;
+export const ContributorReputationFragmentDoc = gql`
+    fragment ContributorReputation on ContributorReputation {
+  reputationPercentage
+  reputationRaw
+  domainId
+  domain {
+    id
+    metadata {
+      name
+    }
+    nativeId
+  }
+  id
+}
+    `;
+export const ProfileFragmentDoc = gql`
+    fragment Profile on Profile {
+  avatar
+  bio
+  displayName
+  displayNameChanged
+  email
+  location
+  thumbnail
+  website
+  meta {
+    metatransactionsEnabled
+    decentralizedModeEnabled
+    customRpc
+  }
+}
+    `;
+export const ColonyContributorFragmentDoc = gql`
+    fragment ColonyContributor on ColonyContributor {
+  contributorAddress
+  isVerified
+  hasPermissions
+  hasReputation
+  isWatching
+  colonyReputationPercentage
+  roles(colonyAddress: {eq: $colonyAddress}) {
+    items {
+      ...ContributorRoles
+    }
+  }
+  reputation(
+    colonyAddress: {eq: $colonyAddress}
+    filter: {reputationRaw: {ne: "0"}}
+  ) {
+    items {
+      ...ContributorReputation
+    }
+  }
+  user {
+    walletAddress: id
+    profile {
+      ...Profile
+    }
+  }
+  type
+}
+    ${ContributorRolesFragmentDoc}
+${ContributorReputationFragmentDoc}
+${ProfileFragmentDoc}`;
+export const ExpenditurePayoutFragmentDoc = gql`
+    fragment ExpenditurePayout on ExpenditurePayout {
+  tokenAddress
+  amount
+  isClaimed
+}
+    `;
+export const ExpenditureSlotFragmentDoc = gql`
+    fragment ExpenditureSlot on ExpenditureSlot {
+  id
+  recipientAddress
+  claimDelay
+  payoutModifier
+  payouts {
+    ...ExpenditurePayout
+  }
+}
+    ${ExpenditurePayoutFragmentDoc}`;
+export const ExpenditureStageFragmentDoc = gql`
+    fragment ExpenditureStage on ExpenditureStage {
+  slotId
+  name
+  isReleased
+}
+    `;
+export const MotionStakeValuesFragmentDoc = gql`
+    fragment MotionStakeValues on MotionStakeValues {
+  yay
+  nay
+}
+    `;
+export const MotionStakesFragmentDoc = gql`
+    fragment MotionStakes on MotionStakes {
+  raw {
+    ...MotionStakeValues
+  }
+  percentage {
+    ...MotionStakeValues
+  }
+}
+    ${MotionStakeValuesFragmentDoc}`;
+export const DomainMetadataFragmentDoc = gql`
+    fragment DomainMetadata on DomainMetadata {
+  name
+  color
+  description
+  id
+  changelog {
+    transactionHash
+    oldName
+    newName
+    oldColor
+    newColor
+    oldDescription
+    newDescription
+  }
+}
+    `;
+export const DomainFragmentDoc = gql`
+    fragment Domain on Domain {
+  id
+  nativeId
+  isRoot
+  nativeFundingPotId
+  nativeSkillId
+  metadata {
+    ...DomainMetadata
+  }
+  reputation
+  reputationPercentage
+}
+    ${DomainMetadataFragmentDoc}`;
+export const VoterRecordFragmentDoc = gql`
+    fragment VoterRecord on VoterRecord {
+  address
+  voteCount
+  vote
+}
+    `;
+export const UserFragmentDoc = gql`
+    fragment User on User {
+  profile {
+    ...Profile
+  }
+  walletAddress: id
+  privateBetaInviteCode {
+    id
+    shareableInvites
+  }
+}
+    ${ProfileFragmentDoc}`;
+export const MotionMessageFragmentDoc = gql`
+    fragment MotionMessage on MotionMessage {
+  initiatorAddress
+  name
+  messageKey
+  initiatorUser {
+    ...User
+  }
+  vote
+  amount
+}
+    ${UserFragmentDoc}`;
+export const AnnotationFragmentDoc = gql`
+    fragment Annotation on Annotation {
+  createdAt
+  message
+}
+    `;
+export const ColonyMotionFragmentDoc = gql`
+    fragment ColonyMotion on ColonyMotion {
+  databaseMotionId: id
+  motionId: nativeMotionId
+  motionStakes {
+    ...MotionStakes
+  }
+  usersStakes {
+    address
+    stakes {
+      raw {
+        ...MotionStakeValues
+      }
+      percentage {
+        ...MotionStakeValues
+      }
+    }
+  }
+  remainingStakes
+  userMinStake
+  requiredStake
+  rootHash
+  motionDomain {
+    ...Domain
+  }
+  nativeMotionDomainId
+  stakerRewards {
+    address
+    rewards {
+      yay
+      nay
+    }
+    isClaimed
+  }
+  isFinalized
+  voterRecord {
+    ...VoterRecord
+  }
+  revealedVotes {
+    ...MotionStakes
+  }
+  skillRep
+  repSubmitted
+  hasObjection
+  motionStateHistory {
+    hasVoted
+    hasPassed
+    hasFailed
+    hasFailedNotFinalizable
+    inRevealPhase
+  }
+  messages {
+    items {
+      ...MotionMessage
+    }
+  }
+  objectionAnnotation {
+    ...Annotation
+  }
+  isDecision
+  gasEstimate
+  transactionHash
+  action {
+    type
+  }
+}
+    ${MotionStakesFragmentDoc}
+${MotionStakeValuesFragmentDoc}
+${DomainFragmentDoc}
+${VoterRecordFragmentDoc}
+${MotionMessageFragmentDoc}
+${AnnotationFragmentDoc}`;
+export const ExpenditureFragmentDoc = gql`
+    fragment Expenditure on Expenditure {
+  id
+  nativeId
+  ownerAddress
+  status
+  slots {
+    ...ExpenditureSlot
+  }
+  nativeFundingPotId
+  nativeDomainId
+  metadata {
+    fundFromDomainNativeId
+    stages {
+      ...ExpenditureStage
+    }
+    stakeAmount
+  }
+  balances {
+    tokenAddress
+    amount
+    requiredAmount
+  }
+  finalizedAt
+  hasReclaimedStake
+  motions {
+    items {
+      ...ColonyMotion
+    }
+  }
+  type
+  isStaked
+  isStakeForfeited
+}
+    ${ExpenditureSlotFragmentDoc}
+${ExpenditureStageFragmentDoc}
+${ColonyMotionFragmentDoc}`;
 export const UserDisplayFragmentDoc = gql`
     fragment UserDisplay on User {
   walletAddress: id
@@ -8975,37 +9346,6 @@ export const UnclaimedStakesFragmentDoc = gql`
   }
 }
     `;
-export const DomainMetadataFragmentDoc = gql`
-    fragment DomainMetadata on DomainMetadata {
-  name
-  color
-  description
-  id
-  changelog {
-    transactionHash
-    oldName
-    newName
-    oldColor
-    newColor
-    oldDescription
-    newDescription
-  }
-}
-    `;
-export const DomainFragmentDoc = gql`
-    fragment Domain on Domain {
-  id
-  nativeId
-  isRoot
-  nativeFundingPotId
-  nativeSkillId
-  metadata {
-    ...DomainMetadata
-  }
-  reputation
-  reputationPercentage
-}
-    ${DomainMetadataFragmentDoc}`;
 export const ColonyBalanceFragmentDoc = gql`
     fragment ColonyBalance on ColonyBalance {
   id
@@ -9045,63 +9385,6 @@ export const ChainFundsClaimFragmentDoc = gql`
   amount
 }
     `;
-export const ColonyObjectiveFragmentDoc = gql`
-    fragment ColonyObjective on ColonyObjective {
-  title
-  description
-  progress
-}
-    `;
-export const SafeFragmentDoc = gql`
-    fragment Safe on Safe {
-  name
-  address
-  chainId
-  moduleContractAddress
-}
-    `;
-export const ColonyMetadataFragmentDoc = gql`
-    fragment ColonyMetadata on ColonyMetadata {
-  displayName
-  avatar
-  description
-  externalLinks {
-    name
-    link
-  }
-  thumbnail
-  isWhitelistActivated
-  whitelistedAddresses
-  modifiedTokenAddresses {
-    added
-    removed
-  }
-  objective {
-    ...ColonyObjective
-  }
-  changelog {
-    transactionHash
-    newDisplayName
-    oldDisplayName
-    hasAvatarChanged
-    hasWhitelistChanged
-    haveTokensChanged
-    hasDescriptionChanged
-    haveExternalLinksChanged
-    hasObjectiveChanged
-    newSafes {
-      ...Safe
-    }
-    oldSafes {
-      ...Safe
-    }
-  }
-  safes {
-    ...Safe
-  }
-}
-    ${ColonyObjectiveFragmentDoc}
-${SafeFragmentDoc}`;
 export const ColonyRoleFragmentDoc = gql`
     fragment ColonyRole on ColonyRole {
   id
@@ -9218,148 +9501,6 @@ export const ExtensionFragmentDoc = gql`
   }
 }
     `;
-export const MotionStakeValuesFragmentDoc = gql`
-    fragment MotionStakeValues on MotionStakeValues {
-  yay
-  nay
-}
-    `;
-export const MotionStakesFragmentDoc = gql`
-    fragment MotionStakes on MotionStakes {
-  raw {
-    ...MotionStakeValues
-  }
-  percentage {
-    ...MotionStakeValues
-  }
-}
-    ${MotionStakeValuesFragmentDoc}`;
-export const VoterRecordFragmentDoc = gql`
-    fragment VoterRecord on VoterRecord {
-  address
-  voteCount
-  vote
-}
-    `;
-export const ProfileFragmentDoc = gql`
-    fragment Profile on Profile {
-  avatar
-  bio
-  displayName
-  displayNameChanged
-  email
-  location
-  thumbnail
-  website
-  meta {
-    metatransactionsEnabled
-    decentralizedModeEnabled
-    customRpc
-  }
-}
-    `;
-export const UserFragmentDoc = gql`
-    fragment User on User {
-  profile {
-    ...Profile
-  }
-  walletAddress: id
-  privateBetaInviteCode {
-    id
-    shareableInvites
-  }
-}
-    ${ProfileFragmentDoc}`;
-export const MotionMessageFragmentDoc = gql`
-    fragment MotionMessage on MotionMessage {
-  initiatorAddress
-  name
-  messageKey
-  initiatorUser {
-    ...User
-  }
-  vote
-  amount
-}
-    ${UserFragmentDoc}`;
-export const AnnotationFragmentDoc = gql`
-    fragment Annotation on Annotation {
-  createdAt
-  message
-}
-    `;
-export const ColonyMotionFragmentDoc = gql`
-    fragment ColonyMotion on ColonyMotion {
-  databaseMotionId: id
-  motionId: nativeMotionId
-  motionStakes {
-    ...MotionStakes
-  }
-  usersStakes {
-    address
-    stakes {
-      raw {
-        ...MotionStakeValues
-      }
-      percentage {
-        ...MotionStakeValues
-      }
-    }
-  }
-  remainingStakes
-  userMinStake
-  requiredStake
-  rootHash
-  motionDomain {
-    ...Domain
-  }
-  nativeMotionDomainId
-  stakerRewards {
-    address
-    rewards {
-      yay
-      nay
-    }
-    isClaimed
-  }
-  isFinalized
-  voterRecord {
-    ...VoterRecord
-  }
-  revealedVotes {
-    ...MotionStakes
-  }
-  skillRep
-  repSubmitted
-  hasObjection
-  motionStateHistory {
-    hasVoted
-    hasPassed
-    hasFailed
-    hasFailedNotFinalizable
-    inRevealPhase
-  }
-  messages {
-    items {
-      ...MotionMessage
-    }
-  }
-  objectionAnnotation {
-    ...Annotation
-  }
-  isDecision
-  gasEstimate
-  transactionHash
-  action {
-    type
-  }
-}
-    ${MotionStakesFragmentDoc}
-${MotionStakeValuesFragmentDoc}
-${DomainFragmentDoc}
-${VoterRecordFragmentDoc}
-${MotionMessageFragmentDoc}
-${AnnotationFragmentDoc}`;
 export const ColonyDecisionFragmentDoc = gql`
     fragment ColonyDecision on ColonyDecision {
   title
@@ -9578,173 +9719,17 @@ ${DomainMetadataFragmentDoc}
 ${AnnotationFragmentDoc}
 ${ColonyDecisionFragmentDoc}
 ${SafeTransactionFragmentDoc}`;
-export const JoinedColonyFragmentDoc = gql`
-    fragment JoinedColony on Colony {
-  colonyAddress: id
-  name
-  metadata {
-    ...ColonyMetadata
-  }
-  chainMetadata {
-    chainId
-    network
-  }
-}
-    ${ColonyMetadataFragmentDoc}`;
-export const ContributorRolesFragmentDoc = gql`
-    fragment ContributorRoles on ColonyRole {
-  domainId
-  domain {
-    id
-    metadata {
-      name
-    }
-    nativeId
-  }
-  role_0
-  role_1
-  role_2
-  role_3
-  role_5
-  role_6
-  id
-}
-    `;
-export const ContributorReputationFragmentDoc = gql`
-    fragment ContributorReputation on ContributorReputation {
-  reputationPercentage
-  reputationRaw
-  domainId
-  domain {
-    id
-    metadata {
-      name
-    }
-    nativeId
-  }
-  id
-}
-    `;
-export const ColonyContributorFragmentDoc = gql`
-    fragment ColonyContributor on ColonyContributor {
-  contributorAddress
-  isVerified
-  hasPermissions
-  hasReputation
-  isWatching
-  colonyReputationPercentage
-  roles(colonyAddress: {eq: $colonyAddress}) {
-    items {
-      ...ContributorRoles
-    }
-  }
-  reputation(
-    colonyAddress: {eq: $colonyAddress}
-    filter: {reputationRaw: {ne: "0"}}
-  ) {
-    items {
-      ...ContributorReputation
-    }
-  }
-  user {
-    walletAddress: id
-    profile {
-      ...Profile
-    }
-  }
-  type
-}
-    ${ContributorRolesFragmentDoc}
-${ContributorReputationFragmentDoc}
-${ProfileFragmentDoc}`;
-export const ExpenditurePayoutFragmentDoc = gql`
-    fragment ExpenditurePayout on ExpenditurePayout {
-  tokenAddress
-  amount
-  isClaimed
-}
-    `;
-export const ExpenditureSlotFragmentDoc = gql`
-    fragment ExpenditureSlot on ExpenditureSlot {
-  id
-  recipientAddress
-  claimDelay
-  payoutModifier
-  payouts {
-    ...ExpenditurePayout
-  }
-}
-    ${ExpenditurePayoutFragmentDoc}`;
-export const ExpenditureStageFragmentDoc = gql`
-    fragment ExpenditureStage on ExpenditureStage {
-  slotId
-  name
-  isReleased
-}
-    `;
-export const ExpenditureFragmentDoc = gql`
-    fragment Expenditure on Expenditure {
-  id
-  nativeId
-  ownerAddress
-  status
-  slots {
-    ...ExpenditureSlot
-  }
-  nativeFundingPotId
-  nativeDomainId
-  metadata {
-    fundFromDomainNativeId
-    stages {
-      ...ExpenditureStage
-    }
-    stakeAmount
-  }
-  balances {
-    tokenAddress
-    amount
-    requiredAmount
-  }
-  finalizedAt
-  hasReclaimedStake
-  motions {
-    items {
-      ...ColonyMotion
-    }
-  }
-  type
-  isStaked
-  isStakeForfeited
-}
-    ${ExpenditureSlotFragmentDoc}
-${ExpenditureStageFragmentDoc}
-${ColonyMotionFragmentDoc}`;
 export const UserStakeFragmentDoc = gql`
     fragment UserStake on UserStake {
   id
   amount
   action {
-    id
-    type
-    motionData {
-      id
-      nativeMotionId
-      motionStakes {
-        ...MotionStakes
-      }
-      requiredStake
-      revealedVotes {
-        ...MotionStakes
-      }
-    }
-    metadata {
-      customTitle
-    }
+    ...ColonyAction
   }
   isClaimed
   createdAt
 }
-    ${MotionStakesFragmentDoc}`;
+    ${ColonyActionFragmentDoc}`;
 export const UserTokenBalanceDataFragmentDoc = gql`
     fragment UserTokenBalanceData on GetUserTokenBalanceReturn {
   balance

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -8363,7 +8363,7 @@ export type SafeTransactionDataFragment = { __typename?: 'SafeTransactionData', 
 
 export type SafeTransactionFragment = { __typename?: 'SafeTransaction', id: string, safe: { __typename?: 'Safe', name: string, address: string, chainId: number, moduleContractAddress: string }, transactions?: { __typename?: 'ModelSafeTransactionDataConnection', items: Array<{ __typename?: 'SafeTransactionData', transactionType: SafeTransactionType, amount?: string | null, rawAmount?: string | null, data?: string | null, abi?: string | null, contractFunction?: string | null, token?: { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } | null, recipient?: { __typename?: 'SimpleTarget', id: string, walletAddress: string, profile: { __typename?: 'SimpleTargetProfile', avatarHash?: string | null, displayName?: string | null } } | null, contract?: { __typename?: 'SimpleTarget', id: string, walletAddress: string, profile: { __typename?: 'SimpleTargetProfile', avatarHash?: string | null, displayName?: string | null } } | null, nft?: { __typename?: 'NFT', id: string, walletAddress: string, profile: { __typename?: 'NFTProfile', displayName: string } } | null, nftData?: { __typename?: 'NFTData', address: string, description?: string | null, id: string, imageUri?: string | null, logoUri: string, name?: string | null, tokenName: string, tokenSymbol: string, uri: string } | null, functionParams?: Array<{ __typename?: 'FunctionParam', name: string, type: string, value: string } | null> | null } | null> } | null };
 
-export type UserStakeFragment = { __typename?: 'UserStake', id: string, amount: string, isClaimed: boolean, createdAt: string, action?: { __typename?: 'ColonyAction', id: string, type: ColonyActionType, motionData?: { __typename?: 'ColonyMotion', id: string, nativeMotionId: string, requiredStake: string, motionStakes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } }, revealedVotes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } } } | null } | null };
+export type UserStakeFragment = { __typename?: 'UserStake', id: string, amount: string, isClaimed: boolean, createdAt: string, action?: { __typename?: 'ColonyAction', id: string, type: ColonyActionType, motionData?: { __typename?: 'ColonyMotion', id: string, nativeMotionId: string, requiredStake: string, motionStakes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } }, revealedVotes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } } } | null, metadata?: { __typename?: 'ColonyActionMetadata', customTitle: string } | null } | null };
 
 export type TokenFragment = { __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string };
 
@@ -8808,7 +8808,7 @@ export type GetUserStakesQueryVariables = Exact<{
 }>;
 
 
-export type GetUserStakesQuery = { __typename?: 'Query', getUserStakes?: { __typename?: 'ModelUserStakeConnection', items: Array<{ __typename?: 'UserStake', id: string, amount: string, isClaimed: boolean, createdAt: string, action?: { __typename?: 'ColonyAction', id: string, type: ColonyActionType, motionData?: { __typename?: 'ColonyMotion', id: string, nativeMotionId: string, requiredStake: string, motionStakes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } }, revealedVotes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } } } | null } | null } | null> } | null };
+export type GetUserStakesQuery = { __typename?: 'Query', getUserStakes?: { __typename?: 'ModelUserStakeConnection', items: Array<{ __typename?: 'UserStake', id: string, amount: string, isClaimed: boolean, createdAt: string, action?: { __typename?: 'ColonyAction', id: string, type: ColonyActionType, motionData?: { __typename?: 'ColonyMotion', id: string, nativeMotionId: string, requiredStake: string, motionStakes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } }, revealedVotes: { __typename?: 'MotionStakes', raw: { __typename?: 'MotionStakeValues', yay: string, nay: string }, percentage: { __typename?: 'MotionStakeValues', yay: string, nay: string } } } | null, metadata?: { __typename?: 'ColonyActionMetadata', customTitle: string } | null } | null } | null> } | null };
 
 export type GetTokenByAddressQueryVariables = Exact<{
   address: Scalars['ID'];
@@ -9736,6 +9736,9 @@ export const UserStakeFragmentDoc = gql`
       revealedVotes {
         ...MotionStakes
       }
+    }
+    metadata {
+      customTitle
     }
   }
   isClaimed

--- a/src/redux/sagas/motions/rootMotion.ts
+++ b/src/redux/sagas/motions/rootMotion.ts
@@ -136,8 +136,6 @@ function* createRootMotionSaga({
       ActionTypes.TRANSACTION_HASH_RECEIVED,
     );
 
-    setTxHash?.(txHash);
-
     yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
@@ -154,6 +152,8 @@ function* createRootMotionSaga({
       type: ActionTypes.ROOT_MOTION_SUCCESS,
       meta,
     });
+
+    setTxHash?.(txHash);
 
     if (colonyName && navigate) {
       navigate(`/${colonyName}?tx=${txHash}`, {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,7 +62,7 @@ export type ComplexMessageValues = Record<string, ReactNode>;
  */
 export type AnyMessageValues = Record<
   string,
-  PrimitiveType | ReactNode | ((chunks: string[]) => JSX.Element)
+  PrimitiveType | JSX.Element | ((chunks: string[]) => JSX.Element)
 >;
 
 export type UniversalMessageValues =


### PR DESCRIPTION
## Description

This PR wires the action title and metadata with stakes shown in the User Hub:
<img width="709" alt="image" src="https://github.com/JoinColony/colonyCDapp/assets/112586815/76c3ec25-6e27-4ba4-a489-c862cc2feb60">

Resolves #1575
