### PR TITLE
Add currency conversion util

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -892,6 +892,22 @@ type Mutation {
 }
 
 """
+Represents the currencies/tokens that users' balances can be converted to (for display purposes)
+"""
+enum SupportedCurrencies {
+  USD # US Dollar
+  JPY # Japanese Yen
+  GBP # British Pound Sterling
+  EUR # Euro
+  CAD # Canadian Dollar
+  KRW # South Korean Won
+  INR # Indian Rupee
+  BRL # Brazilian Real
+  ETH # Ethereum
+  CLNY # Colony Network Token.
+}
+
+"""
 Represents a user's profile within the Colony Network
 """
 type Profile @model {

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -7461,6 +7461,19 @@ export type SubscriptionOnUpdateUserTokensArgs = {
   filter?: InputMaybe<ModelSubscriptionUserTokensFilterInput>;
 };
 
+export enum SupportedCurrencies {
+  Brl = 'BRL',
+  Cad = 'CAD',
+  Clny = 'CLNY',
+  Eth = 'ETH',
+  Eur = 'EUR',
+  Gbp = 'GBP',
+  Inr = 'INR',
+  Jpy = 'JPY',
+  Krw = 'KRW',
+  Usd = 'USD'
+}
+
 /** Represents an ERC20-compatible token that is used by Colonies and users */
 export type Token = {
   __typename?: 'Token';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -78,6 +78,7 @@ export { default as useColors } from './useColors';
 export { default as useTeamsOptions } from './useTeamsOptions';
 export { default as useUsersByAddresses } from './useUsersByAddresses';
 export { default as useJoinedColonies } from './useJoinedColonies';
+export { default as useCurrency } from './useCurrency';
 
 export {
   default as useSafeTransactionStatus,

--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { Network, SupportedCurrencies } from '~gql';
+import { fetchCurrentPrice } from '~utils/currency/currency';
+import { FetchCurrentPriceArgs } from '~utils/currency/types';
+
+const useCurrency = ({
+  contractAddress,
+  chainId = Network.Gnosis,
+  conversionDenomination = SupportedCurrencies.Usd,
+}: FetchCurrentPriceArgs) => {
+  const [price, setPrice] = useState(0);
+
+  useEffect(() => {
+    if (!contractAddress) return;
+
+    const getPrice = async () => {
+      const currentPrice = await fetchCurrentPrice({
+        contractAddress,
+        chainId,
+        conversionDenomination,
+      });
+      setPrice(currentPrice);
+    };
+
+    getPrice();
+  }, [chainId, contractAddress, conversionDenomination]);
+
+  return price;
+};
+
+export default useCurrency;

--- a/src/utils/currency/config.ts
+++ b/src/utils/currency/config.ts
@@ -1,0 +1,30 @@
+import { Network, SupportedCurrencies } from '~gql';
+
+// For walkthrough, see: https://apiguide.coingecko.com/getting-started/10-min-tutorial-guide/1-get-data-by-id-or-address
+export const currencyApiConfig = {
+  endpoint: 'https://api.coingecko.com/api/v3/simple/token_price/',
+  searchParams: {
+    from: 'contract_addresses',
+    to: 'vs_currencies',
+  },
+};
+export const coinGeckoMappings = {
+  // This is a map between our internal reference to a supported currency, and the reference the api uses.
+  // For full list: https://api.coingecko.com/api/v3/simple/supported_vs_currencies
+  currencies: {
+    [SupportedCurrencies.Usd]: 'usd',
+    [SupportedCurrencies.Jpy]: 'jpy',
+    [SupportedCurrencies.Gbp]: 'gbp',
+    [SupportedCurrencies.Eur]: 'eur',
+    [SupportedCurrencies.Cad]: 'cad',
+    [SupportedCurrencies.Krw]: 'krw',
+    [SupportedCurrencies.Inr]: 'inr',
+    [SupportedCurrencies.Brl]: 'brl',
+    [SupportedCurrencies.Eth]: 'eth',
+  },
+  // For full list: https://api.coingecko.com/api/v3/asset_platforms
+  chains: {
+    [Network.Gnosis]: 'xdai',
+    [Network.Mainnet]: 'ethereum',
+  },
+};

--- a/src/utils/currency/currency.ts
+++ b/src/utils/currency/currency.ts
@@ -1,0 +1,137 @@
+import { Tokens } from '@colony/colony-js';
+import { Network, SupportedCurrencies } from '~gql';
+import {
+  CoinGeckoPriceRequestSuccessResponse,
+  FetchCurrentPriceArgs,
+  CoinGeckoSupportedCurrencies,
+  SupportedChains,
+  CoinGeckoPriceRequestResponse,
+} from './types';
+import {
+  buildAPIEndpoint,
+  convertTokenToCLNY,
+  fetchData,
+  mapToAPIFormat,
+} from './utils';
+import { currencyApiConfig, coinGeckoMappings } from './config';
+
+// The functions defined in this file assume something about the shape of the api response.
+// If that changes, or if we change the api, these functions will need to be updated.
+
+const { chains, currencies } = coinGeckoMappings;
+
+const buildCoinGeckoURL = (
+  contractAddress: string,
+  chainId: SupportedChains = Network.Gnosis,
+  conversionDenomination: CoinGeckoSupportedCurrencies = SupportedCurrencies.Usd,
+) => {
+  const chain = mapToAPIFormat(chains, chainId);
+  const denomination = mapToAPIFormat(currencies, conversionDenomination);
+
+  return buildAPIEndpoint(new URL(`${currencyApiConfig.endpoint}${chain}`), {
+    [currencyApiConfig.searchParams.from]: contractAddress,
+    [currencyApiConfig.searchParams.to]: denomination,
+  });
+};
+
+const extractPriceFromCoinGeckoResponse = (
+  data: CoinGeckoPriceRequestSuccessResponse,
+  contractAddress: string,
+  conversionDenomination: CoinGeckoSupportedCurrencies,
+) => {
+  try {
+    return data[contractAddress.toLowerCase()][
+      mapToAPIFormat(currencies, conversionDenomination)
+    ];
+  } catch (e) {
+    console.error(
+      'Could not get price from CoinGecko response. Response shape might have changed.',
+      e,
+    );
+    return 0;
+  }
+};
+
+const isCoinGeckoSuccessResponse = (
+  data: CoinGeckoPriceRequestResponse,
+): data is CoinGeckoPriceRequestSuccessResponse => {
+  if (
+    typeof data === 'undefined' || // undefined
+    data == null || // null
+    (typeof data == 'object' && Object.keys(data).length === 0) // empty object
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
+const fetchPriceFromCoinGecko = async ({
+  contractAddress,
+  chainId = Network.Gnosis,
+  conversionDenomination = SupportedCurrencies.Usd,
+}: Pick<FetchCurrentPriceArgs, 'chainId' | 'contractAddress'> & {
+  conversionDenomination?: CoinGeckoSupportedCurrencies;
+}) => {
+  const url = buildCoinGeckoURL(
+    contractAddress,
+    chainId,
+    conversionDenomination,
+  );
+
+  const price = await fetchData<CoinGeckoPriceRequestResponse, number>(
+    url,
+    (data) => {
+      if (isCoinGeckoSuccessResponse(data)) {
+        return extractPriceFromCoinGeckoResponse(
+          data,
+          contractAddress,
+          conversionDenomination,
+        );
+      }
+
+      console.error(`Unable to get price for ${contractAddress}`);
+      return 0;
+    },
+    `Unable to get latest price at ${url}.`,
+  );
+
+  return price ?? 0;
+};
+
+const getCLNYPriceInUSD = async () => {
+  // Returns 1 CLNY in terms of USD, 1 CLNY : x USD
+  return fetchPriceFromCoinGecko({
+    contractAddress: Tokens.Mainnet.Mainnet,
+    chainId: Network.Mainnet,
+  });
+};
+
+/**
+ * Fetch the current price of a given token in another token or fiat denomination.
+ * @param contractAddress The contract address of the token to fetch the price of
+ * @param chainId The chain ID of the token to fetch the price of
+ * @param conversionDenomination The denomination to convert the price to
+ * @returns The current price of the token in the given denomination
+ */
+export const fetchCurrentPrice = async ({
+  contractAddress,
+  chainId = Network.Gnosis,
+  conversionDenomination = SupportedCurrencies.Usd,
+}: FetchCurrentPriceArgs): Promise<number> => {
+  if (conversionDenomination === SupportedCurrencies.Clny) {
+    const tokenPriceinUSD = await fetchPriceFromCoinGecko({
+      contractAddress,
+      chainId,
+    });
+
+    const clnyInUSD = await getCLNYPriceInUSD();
+    return convertTokenToCLNY(tokenPriceinUSD, clnyInUSD);
+  }
+
+  return fetchPriceFromCoinGecko({
+    contractAddress,
+    chainId,
+    conversionDenomination,
+  });
+};

--- a/src/utils/currency/types.ts
+++ b/src/utils/currency/types.ts
@@ -1,0 +1,24 @@
+import { SupportedCurrencies } from '~gql';
+import { coinGeckoMappings } from './config';
+
+export type CoinGeckoSupportedCurrencies =
+  keyof typeof coinGeckoMappings.currencies;
+
+export type SupportedChains = keyof typeof coinGeckoMappings.chains;
+
+export interface CoinGeckoPriceRequestSuccessResponse {
+  [contractAddress: string]: {
+    [currency: string]: number;
+  };
+}
+
+export type CoinGeckoPriceRequestResponse =
+  | CoinGeckoPriceRequestSuccessResponse
+  // A contract address without a market cap will return an empty object {}
+  | Record<string, never>;
+
+export interface FetchCurrentPriceArgs {
+  contractAddress: string;
+  chainId?: SupportedChains;
+  conversionDenomination?: SupportedCurrencies;
+}

--- a/src/utils/currency/utils.ts
+++ b/src/utils/currency/utils.ts
@@ -1,0 +1,49 @@
+export const fetchData = async <T, R = string>(
+  url: string,
+  cb: (data: T) => R,
+  error = `Fetch to ${url} failed.`,
+) => {
+  try {
+    const res = await fetch(url);
+    if (res.ok) {
+      const data: T = await res.json();
+      return cb(data);
+    }
+
+    console.error(error, res.status, ': ', res.statusText);
+  } catch (e) {
+    console.error(error, e);
+  }
+
+  return null;
+};
+
+export const convertTokenToCLNY = (
+  tokenPriceInUSD: number,
+  clnyPriceInUSD: number,
+) => {
+  const USDinCLNY = 1 / clnyPriceInUSD; // 1 USD : x CLNY
+  return tokenPriceInUSD * USDinCLNY;
+};
+
+export const mapToAPIFormat = (
+  mapping: Record<string, string>,
+  key: string,
+) => {
+  if (!(key in mapping)) {
+    console.error(`${key} is not a supported currency API input.`);
+    return key;
+  }
+
+  return mapping[key];
+};
+
+export const buildAPIEndpoint = (
+  url: URL,
+  queryParams: Record<string, string>,
+) => {
+  Object.keys(queryParams).forEach((key) =>
+    url.searchParams.append(key, queryParams[key]),
+  );
+  return url.href;
+};


### PR DESCRIPTION
## Description

This PR adds a utility for performing conversions from a given token to a given currency.

It will be used around the app to show, for example, the value of a user's balances in USD (or whatever currency they select).

It's using the [CoinGecko](https://www.coingecko.com/api/documentation) api, which does not require an api key, allows 30 calls/minute from the client, is free and supports multichain. 

It does [require attribution](https://www.coingecko.com/en/branding) though, so thoughts on where/how to add that are welcome. @arrenv 

I've made it clear in the code what does and does not make assumptions about the specific api being used, which should make code easier to change if the api gets changed.

## Testing

Mainly code review. If you want, test with #1594 by calling `useCurrency` inside `CurrencyContext` with the parameters for a token you'd like to test the conversion with (e.g CLNY on mainnet), and log out the result.

**New stuff** ✨

* Add token-to-currency conversion utility.

Contributes to #1552 
