### PR TITLE
fix: 15695351 - add missing info in token popover

### DIFF
--- a/src/components/frame/v5/pages/BalancePage/partials/TokenAvatar/TokenAvatar.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/TokenAvatar/TokenAvatar.tsx
@@ -5,16 +5,17 @@ import { LockKey } from 'phosphor-react';
 import { useMobile, useRelativePortalElement, useToggle } from '~hooks';
 import CopyableAddress from '~shared/CopyableAddress';
 import TokenIcon from '~shared/TokenIcon';
+import { formatText } from '~utils/intl';
 import Modal from '~v5/shared/Modal';
 import MenuContainer from '~v5/shared/MenuContainer';
 import Portal from '~v5/shared/Portal';
 
 import { TokenAvatarProps } from './types';
 import Tooltip from '~shared/Extensions/Tooltip';
-import { formatText } from '~utils/intl';
+import TokenInfo from '~shared/TokenInfoPopover/TokenInfo';
 
 const displayName = 'v5.pages.BalancePage.partials.TokenAvatar';
-// @TODO: implement token popover according to the design
+
 const TokenAvatar: FC<TokenAvatarProps> = ({
   token,
   tokenAddress,
@@ -84,13 +85,17 @@ const TokenAvatar: FC<TokenAvatarProps> = ({
           onClose={toggleTokenModalOff}
           isOpen={isTokenModalOpened}
         >
-          {content}
+          <TokenInfo
+            className="!p-0 w-full"
+            token={token}
+            isTokenNative={isTokenNative}
+          />
         </Modal>
       ) : (
         isTokenVisible && (
           <Portal>
             <MenuContainer
-              className="absolute p-1 z-[60]"
+              className="absolute !p-0 z-[60] min-w-80"
               hasShadow
               rounded="s"
               ref={(ref) => {
@@ -98,7 +103,7 @@ const TokenAvatar: FC<TokenAvatarProps> = ({
                 portalElementRef.current = ref;
               }}
             >
-              {content}
+              <TokenInfo token={token} isTokenNative={isTokenNative} />
             </MenuContainer>
           </Portal>
         )

--- a/src/components/shared/TokenInfoPopover/TokenInfo.tsx
+++ b/src/components/shared/TokenInfoPopover/TokenInfo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
+import clsx from 'clsx';
 
 import { Token } from '~types';
 import { DEFAULT_NETWORK_INFO } from '~constants';
@@ -15,6 +16,7 @@ const displayName = 'TokenInfoPopover.TokenInfo';
 interface Props {
   token: Token;
   isTokenNative: boolean;
+  className?: string;
 }
 
 const MSG = defineMessages({
@@ -28,12 +30,17 @@ const MSG = defineMessages({
   },
 });
 
-const TokenInfo = ({ token, isTokenNative }: Props) => {
+const TokenInfo = ({ token, isTokenNative, className }: Props) => {
   const { avatar, name, symbol, tokenAddress, thumbnail } = token;
   const { formatMessage } = useIntl();
 
   return (
-    <div className="flex flex-col items-center p-6 gap-6 w-80 text-gray-900">
+    <div
+      className={clsx(
+        className,
+        'flex flex-col items-center p-6 gap-6 w-80 text-gray-900',
+      )}
+    >
       <div className="flex flex-row items-center w-full gap-4">
         <Avatar
           size="m"


### PR DESCRIPTION
https://tw.auroracreation.com/app/tasks/15695351

<img width="641" alt="Screen Shot 2023-12-18 at 10 56 16" src="https://github.com/JoinColony/colonyCDapp/assets/119587095/a27d7dc0-937f-4875-bf20-28a78c549c31">

Changes:
- Add missing info in token popover on Balance page

Resolves:
https://github.com/JoinColony/colonyCDapp/issues/1562