### PR TITLE
Fix content alignment on colony pages

### DIFF
--- a/src/components/frame/v5/pages/ActivityPage/ActivityPage.tsx
+++ b/src/components/frame/v5/pages/ActivityPage/ActivityPage.tsx
@@ -19,7 +19,7 @@ const ActivityPage: FC = () => {
   const widgets = useActivityFeedWidgets();
 
   return (
-    <div className="flex flex-col gap-4 sm:gap-[1.125rem] w-full">
+    <div className="flex flex-col gap-4 sm:gap-6 w-full">
       <WidgetBoxList items={widgets} />
       <div>
         <ColonyActionsTable />

--- a/src/components/v5/common/TableWithActionsHeader/TableWithActionsHeader.tsx
+++ b/src/components/v5/common/TableWithActionsHeader/TableWithActionsHeader.tsx
@@ -20,7 +20,7 @@ function TableWithActionsHeader<
 }: PropsWithChildren<TableWithActionsHeaderProps<TData, TProps>>) {
   return (
     <>
-      <div className={clsx(headerClassName, 'py-3.5')}>
+      <div className={clsx(headerClassName, 'pb-3.5')}>
         <div className="flex sm:justify-between sm:items-center sm:flex-row flex-col">
           <div className="flex items-center">
             <h4 className="heading-5 mr-3">{title}</h4>


### PR DESCRIPTION
This PR addresses the colony pages (Any page other than the dashboard, landing page, profile, and onboarding pages) having different spacing between the content and the header. As far as I know, I've only observed this was the case for the incoming funds page, which had an extra padding between the subtitle and the header. Let me know if you guys find that I've missed a place in any of the other colony pages.

Basically, all pages that are accessible through the navigation of a colony, should have a gap of ONLY `32px` between the header and the start of the content.

Resolves #1507 
