### PR TITLE
feat: add token info popover for native token pill

### DIFF
--- a/src/components/common/ColonyHome/hooks.ts
+++ b/src/components/common/ColonyHome/hooks.ts
@@ -289,7 +289,7 @@ export const useDashboardHeader = (): ColonyDashboardHeaderProps => {
   return {
     colonyName: metadata?.displayName || '',
     description: truncatedText,
-    tokenName: currentToken?.token.symbol || '',
+    token: currentToken?.token,
     isTokenUnlocked: isNativeTokenUnlocked,
     colonyLinksProps: {
       items: [

--- a/src/components/frame/Extensions/pages/ColonyDetailsPage/ColonyDetailsPage.tsx
+++ b/src/components/frame/Extensions/pages/ColonyDetailsPage/ColonyDetailsPage.tsx
@@ -81,7 +81,7 @@ const ColonyDetailsPage: FC = () => {
               {nativeToken && (
                 <NativeTokenPill
                   variant="secondary"
-                  tokenName={nativeToken.symbol}
+                  token={nativeToken}
                   isLocked={isNativeTokenLocked}
                 />
               )}

--- a/src/components/frame/v5/pages/BalancePage/partials/TokenAvatar/TokenAvatar.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/TokenAvatar/TokenAvatar.tsx
@@ -37,6 +37,7 @@ const TokenAvatar: FC<TokenAvatarProps> = ({
   >([isTokenVisible], {
     top: 8,
   });
+  const isTokenInfoShown = isTokenModalOpened || isTokenVisible;
 
   const content = (
     <div className="flex gap-4 items-center">
@@ -44,9 +45,11 @@ const TokenAvatar: FC<TokenAvatarProps> = ({
       <div className="flex items-center gap-1">
         {token.name ? (
           <span
-            className={clsx('text-gray-900 font-medium', {
+            className={clsx('font-medium', {
               'truncate max-w-[6.25rem] md:max-w-full': !isTokenModalOpened,
               'md:whitespace-normal': isTokenModalOpened,
+              'text-gray-900': !isTokenInfoShown,
+              'text-blue-400': isTokenInfoShown,
             })}
           >
             {token.name}

--- a/src/components/v5/common/ColonyDashboardHeader/ColonyDashboardHeader.tsx
+++ b/src/components/v5/common/ColonyDashboardHeader/ColonyDashboardHeader.tsx
@@ -11,19 +11,13 @@ const ColonyDashboardHeader: FC<
     ColonyDashboardHeaderProps,
     'leaveColonyConfirmOpen' | 'setLeaveColonyConfirm'
   >
-> = ({
-  colonyLinksProps,
-  colonyName,
-  description,
-  tokenName,
-  isTokenUnlocked,
-}) => (
+> = ({ colonyLinksProps, colonyName, description, token, isTokenUnlocked }) => (
   <div className="flex flex-col gap-4">
     <div className="flex items-end gap-3">
       <h1 className="heading-2 text-gray-900 capitalize truncate">
         {colonyName}
       </h1>
-      <NativeTokenPill tokenName={tokenName} isLocked={!isTokenUnlocked} />
+      {token && <NativeTokenPill token={token} isLocked={!isTokenUnlocked} />}
     </div>
     <div className="flex flex-col md:flex-row gap-[1.7rem] sm:gap-4 items-start justify-between">
       <p className="text-gray-700 max-w-[52.75rem] text-md line-clamp-2">

--- a/src/components/v5/common/ColonyDashboardHeader/types.ts
+++ b/src/components/v5/common/ColonyDashboardHeader/types.ts
@@ -1,3 +1,4 @@
+import { Token } from '~types';
 import { ColonyLinksProps } from './partials/ColonyLinks/types';
 
 export interface ColonyDashboardHeaderProps {
@@ -7,5 +8,5 @@ export interface ColonyDashboardHeaderProps {
   isTokenUnlocked?: boolean;
   leaveColonyConfirmOpen: boolean;
   setLeaveColonyConfirm: (isOpen: boolean) => void;
-  tokenName: string;
+  token?: Token;
 }

--- a/src/components/v5/common/NativeTokenPill/NativeTokenPill.tsx
+++ b/src/components/v5/common/NativeTokenPill/NativeTokenPill.tsx
@@ -4,10 +4,12 @@ import clsx from 'clsx';
 
 import Tooltip from '~shared/Extensions/Tooltip';
 import { formatText } from '~utils/intl';
+import TokenInfoPopover from '~shared/TokenInfoPopover';
+import { Token } from '~types';
 
 interface NativeTokenPillProps {
   variant?: 'primary' | 'secondary';
-  tokenName: string;
+  token: Token;
   isLocked?: boolean;
 }
 
@@ -15,20 +17,22 @@ const displayName = 'v5.shared.NativeTokenPill';
 
 const NativeTokenPill = ({
   variant = 'primary',
-  tokenName,
+  token,
   isLocked = false,
 }: NativeTokenPillProps) => {
   return (
     <div
       className={clsx(
-        'h-[1.875rem] flex flex-row items-center px-1.5 rounded-lg text-gray-900',
+        'h-[1.875rem] flex flex-row items-center px-1.5 rounded-lg text-gray-900 cursor-pointer',
         {
           'bg-base-bg': variant === 'primary',
           'border border-gray-200 bg-base-white': variant === 'secondary',
         },
       )}
     >
-      <span className="text-sm font-medium">{tokenName}</span>
+      <TokenInfoPopover token={token} isTokenNative>
+        <span className="text-sm font-medium">{token.symbol}</span>
+      </TokenInfoPopover>
       {isLocked && (
         <Tooltip
           tooltipContent={


### PR DESCRIPTION
## Description

Display the token info popover by clicking on the text of `NativeTokenPill`.

Also align the balance table token name turning blue when popup is showing.

Resolves #1383
