### PR TITLE
Tweak member page filtering

### DIFF
--- a/src/hooks/members/useMemberFilters.ts
+++ b/src/hooks/members/useMemberFilters.ts
@@ -59,6 +59,10 @@ const useMemberFilters = ({
   }, [filteredByStatus, contributorTypes]);
 
   const filteredByPermissions = useMemo(() => {
+    if (!Object.keys(filterPermissions).length) {
+      return filteredByType;
+    }
+
     const databaseDomainIds = new Set(
       selectedTeam
         ? [selectedTeam.id]
@@ -70,28 +74,6 @@ const useMemberFilters = ({
       `${colonyAddress}_${Id.RootDomain}`,
       ...databaseDomainIds,
     ]);
-
-    if (!Object.keys(filterPermissions).length) {
-      return (
-        filteredByType?.filter(notNull).filter(({ roles, reputation }) => {
-          const filteredRoles = roles?.items.filter(notNull) ?? [];
-          const filteredReputation = reputation?.items.filter(notNull) ?? [];
-
-          // Filter contributors list by whether there's some rep in the selected domains
-          // or some permissions in the selected domains
-          return (
-            filteredReputation.some(({ domainId }) =>
-              databaseDomainIds.has(domainId),
-            ) ||
-            filteredRoles.some(
-              ({ domainId, ...rest }) =>
-                permissionsDomainIds.has(domainId) &&
-                hasSomeRole(rest, undefined),
-            )
-          );
-        }) ?? []
-      );
-    }
 
     return filteredByType.filter(({ roles }) => {
       const filteredRoles = roles?.items.filter(notNull) ?? [];

--- a/src/hooks/members/useMemberFilters.ts
+++ b/src/hooks/members/useMemberFilters.ts
@@ -59,7 +59,7 @@ const useMemberFilters = ({
   }, [filteredByStatus, contributorTypes]);
 
   const filteredByPermissions = useMemo(() => {
-    if (!Object.keys(filterPermissions).length) {
+    if (!Object.keys(filterPermissions).length && !selectedTeam) {
       return filteredByType;
     }
 
@@ -83,7 +83,12 @@ const useMemberFilters = ({
       return filteredRoles.some(
         ({ domainId, ...rest }) =>
           permissionsDomainIds.has(domainId) &&
-          hasSomeRole(rest, filterPermissions),
+          hasSomeRole(
+            rest,
+            Object.keys(filterPermissions).length
+              ? filterPermissions
+              : undefined,
+          ),
       );
     });
   }, [

--- a/src/hooks/members/useMemberFilters.ts
+++ b/src/hooks/members/useMemberFilters.ts
@@ -7,6 +7,7 @@ import { useColonyContext } from '~hooks';
 import { useGetSelectedTeamFilter } from '~hooks/useTeamsBreadcrumbs';
 import { ColonyContributor } from '~types';
 import { notNull } from '~utils/arrays';
+import { getDomainDatabaseId } from '~utils/databaseId';
 import { searchMembers } from '~utils/members';
 import {
   ContributorTypeFilter,
@@ -40,14 +41,18 @@ const useMemberFilters = ({
       new Set(
         selectedTeam
           ? [selectedTeam.id]
-          : nativeDomainIds.map((id) => `${colonyAddress}_${id}`),
+          : nativeDomainIds.map((id) => getDomainDatabaseId(colonyAddress, id)),
       ),
     [nativeDomainIds, colonyAddress, selectedTeam],
   );
 
   // Always include the root domain, since if the user has a permission in root, they have it in all domains
   const permissionsDomainIds = useMemo(
-    () => new Set([`${colonyAddress}_${Id.RootDomain}`, ...databaseDomainIds]),
+    () =>
+      new Set([
+        getDomainDatabaseId(colonyAddress, Id.RootDomain),
+        ...databaseDomainIds,
+      ]),
     [databaseDomainIds, colonyAddress],
   );
 

--- a/src/hooks/members/useMemberFilters.ts
+++ b/src/hooks/members/useMemberFilters.ts
@@ -113,12 +113,7 @@ const useMemberFilters = ({
       return filteredRoles.some(
         ({ domainId, ...rest }) =>
           permissionsDomainIds.has(domainId) &&
-          hasSomeRole(
-            rest,
-            Object.keys(filterPermissions).length
-              ? filterPermissions
-              : undefined,
-          ),
+          hasSomeRole(rest, filterPermissions),
       );
     });
   }, [filteredByType, filterPermissions, permissionsDomainIds]);


### PR DESCRIPTION
Fixed members without rep or roles disappearing from the `All members` tab. Now they should appear when you are not filtering by a team. The rest of the filters should work as expected (Tested various combinations, let me know if you find any that is not working as expected and I'll fix it in this PR)

Resolves #1583 
