### PR TITLE
Fallback to action metadata description when cutom title is empty

### DIFF
--- a/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
@@ -36,6 +36,10 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
     motionState || null,
   );
 
+  const actionMetadataDescription = colony
+    ? formatText({ id: 'action.title' }, getActionTitleValues(action, colony))
+    : '';
+
   return (
     <div className="flex gap-4 items-center w-full">
       <Avatar
@@ -58,7 +62,7 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
               },
             )}
           >
-            {metadata?.customTitle || '-'}
+            {metadata?.customTitle || actionMetadataDescription || '-'}
           </p>
           {colony && (
             <p
@@ -69,12 +73,7 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
                 },
               )}
             >
-              {loading
-                ? ''.padEnd(40, '-')
-                : formatText(
-                    { id: 'action.title' },
-                    getActionTitleValues(action, colony),
-                  )}
+              {loading ? ''.padEnd(40, '-') : actionMetadataDescription}
             </p>
           )}
         </div>


### PR DESCRIPTION
https://tw.auroracreation.com/app/tasks/15701598

Adds a fallback for activity feed/transaction item titles.

Before
![image](https://github.com/JoinColony/colonyCDapp/assets/38806520/76171fc9-edac-4fc8-9d61-01000d6cb3c9)
 After

![image](https://github.com/JoinColony/colonyCDapp/assets/38806520/efefcd03-6ab1-4ae8-8bdb-8d73e1379571)
