### PR TITLE
Changed useToggle event type form click to mousedown

### DIFF
--- a/src/hooks/useToggle/index.ts
+++ b/src/hooks/useToggle/index.ts
@@ -7,7 +7,7 @@ import {
   UseToggleReturnType,
 } from './types';
 
-let documentClickHandlerRegistered = false;
+let documentMousedownHandlerRegistered = false;
 let htmlElementInstance: HTMLElement | null = null;
 const refsRegistry: RefRegistryEntry[] = [];
 
@@ -21,7 +21,7 @@ const getHtmlElement = (): HTMLElement | null => {
   return htmlElementInstance;
 };
 
-const documentClickHandler = (event: MouseEvent): void => {
+const documentMousedownHandler = (event: MouseEvent): void => {
   refsRegistry.forEach(
     ({ element, toggleOff, toggleState, onBeforeCloseCallbacksRef }) => {
       if (!(event.target instanceof Element)) {
@@ -84,9 +84,9 @@ const useToggle = ({
   }, []);
 
   useEffect(() => {
-    if (!documentClickHandlerRegistered) {
-      documentClickHandlerRegistered = true;
-      document.addEventListener('click', documentClickHandler);
+    if (!documentMousedownHandlerRegistered) {
+      documentMousedownHandlerRegistered = true;
+      document.addEventListener('mousedown', documentMousedownHandler);
     }
   }, []);
 


### PR DESCRIPTION
https://tw.auroracreation.com/app/tasks/15637174

This change fixes the issue when selecting the text inside of  `container` element and releasing the mouse outside of it would trigger outside click detection.

This was mostly an issue in action sidebar as seen here:

![cancel-modal-appear-mouseup](https://github.com/JoinColony/colonyCDapp/assets/38806520/a8893a6e-1769-4ff3-a389-40a9eb35053b)

After changes:

https://github.com/JoinColony/colonyCDapp/assets/38806520/b2682a31-c5c6-4def-8e4d-198b638d7894

