### PR TITLE
block-ingestor update: increase colony metadata query max retries

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=971eaf99a4f989c3c7177eb7857a3a0a1b5f6ec4
+ENV BLOCK_INGESTOR_HASH=34cd3012168ebcfcea161d37fd5d3fd600eae365
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]


### PR DESCRIPTION
## Description

This PR updates block-ingestor hash to a commit which increases max retries for the colony metadata query in `ColonyAdded` handler. Without it, the create data script tends to fail intermittently. 

