### PR TITLE
Fix: auth-proxy block time set in wrong units

### DIFF
--- a/docker/files/auth/env.base
+++ b/docker/files/auth/env.base
@@ -11,8 +11,9 @@ ORIGIN_URL=http://localhost:9091
 
 SILENT=true
 
-DEFAULT_BLOCK_TIME=5000
+DEFAULT_BLOCK_TIME=5 # In seconds
 
 TZ='Etc/Zulu' # Only taken into account if the system doesn't have one set
 
 NODE_ENV=dev
+ 


### PR DESCRIPTION
## Description

This change fixes the action metadata and annotation mutations hanging indefinitely in the auth-proxy.

