### PR TITLE
Fix actions count not respecting selected domain filter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -166,5 +166,6 @@ module.exports = {
         warnOnUnassignedImports: true,
       },
     ],
+    'no-underscore-dangle': ['error', { allow: ['__typename'] }],
   },
 };

--- a/src/components/common/ColonyActionsTable/hooks.tsx
+++ b/src/components/common/ColonyActionsTable/hooks.tsx
@@ -12,10 +12,13 @@ import {
   SearchableColonyActionSortInput,
   SearchableSortDirection,
 } from '~gql';
-import { useActivityFeed, useColonyContext } from '~hooks';
+import {
+  useActivityFeed,
+  useColonyContext,
+  useGetSelectedDomainFilter,
+} from '~hooks';
 import { ActivityFeedColonyAction } from '~hooks/useActivityFeed/types';
 import { RefetchMotionStates } from '~hooks/useNetworkMotionStates';
-import { useGetSelectedTeamFilter } from '~hooks/useTeamsBreadcrumbs';
 import {
   COLONY_ACTIVITY_ROUTE,
   COLONY_HOME_ROUTE,
@@ -193,7 +196,7 @@ export const useGetColonyActionsTableMenuProps = (loading: boolean) => {
 };
 
 export const useActionsTableData = (pageSize: number) => {
-  const selectedTeam = useGetSelectedTeamFilter();
+  const selectedDomain = useGetSelectedDomainFilter();
   const [sorting, setSorting] = useState<SortingState>([
     {
       id: 'createdAt',
@@ -214,9 +217,9 @@ export const useActionsTableData = (pageSize: number) => {
   } = useActivityFeed(
     useMemo(
       () => ({
-        teamId: selectedTeam?.id || undefined,
+        teamId: selectedDomain?.id || undefined,
       }),
-      [selectedTeam?.id],
+      [selectedDomain?.id],
     ),
     useMemo(() => {
       const validSortValues = sorting?.reduce<

--- a/src/components/common/ColonyHome/ColonyHome.tsx
+++ b/src/components/common/ColonyHome/ColonyHome.tsx
@@ -3,11 +3,13 @@ import { defineMessages } from 'react-intl';
 
 import ColonyActionsTable from '~common/ColonyActionsTable';
 import { useSetPageBreadcrumbs } from '~context/PageHeadingContext/hooks';
-import { useColonyContext, useColonySubscription, useMobile } from '~hooks';
 import {
-  useCreateTeamBreadcrumbs,
-  useGetSelectedTeamFilter,
-} from '~hooks/useTeamsBreadcrumbs';
+  useColonyContext,
+  useColonySubscription,
+  useGetSelectedDomainFilter,
+  useMobile,
+} from '~hooks';
+import { useCreateTeamBreadcrumbs } from '~hooks/useTeamsBreadcrumbs';
 import {
   // @BETA: Disabled for now
   // COLONY_TEAMS_ROUTE,
@@ -49,7 +51,7 @@ const MSG = defineMessages({
 const ColonyHome = () => {
   const isMobile = useMobile();
   const { colony } = useColonyContext();
-  const selectedTeam = useGetSelectedTeamFilter();
+  const selectedDomain = useGetSelectedDomainFilter();
   const teamsBreadcrumbs = useCreateTeamBreadcrumbs();
 
   const { leaveColonyConfirmOpen, setLeaveColonyConfirm, ...headerProps } =
@@ -102,7 +104,7 @@ const ColonyHome = () => {
                 to={setQueryParamOnUrl(
                   COLONY_ACTIVITY_ROUTE,
                   TEAM_SEARCH_PARAM,
-                  selectedTeam?.nativeId.toString(),
+                  selectedDomain?.nativeId.toString(),
                 )}
               >
                 {formatText({ id: 'view.all' })}

--- a/src/components/common/ColonyHome/partials/Members/Members.tsx
+++ b/src/components/common/ColonyHome/partials/Members/Members.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { useMemberContext } from '~context/MemberContext';
-import { useGetSelectedTeamFilter } from '~hooks/useTeamsBreadcrumbs';
+import { useGetSelectedDomainFilter } from '~hooks';
 import { COLONY_MEMBERS_ROUTE } from '~routes';
 import { formatText } from '~utils/intl';
 import WidgetBox from '~v5/common/WidgetBox';
@@ -13,18 +13,18 @@ const displayName = 'common.ColonyHome.Members';
 const Members = () => {
   const { search } = useLocation();
 
-  const selectedTeam = useGetSelectedTeamFilter();
-  const nativeTeamId = selectedTeam?.nativeId;
+  const selectedDomain = useGetSelectedDomainFilter();
+  const nativeDomainId = selectedDomain?.nativeId;
   const { totalMembers: members, loading: membersLoading } = useMemberContext();
 
-  const domainMembers = nativeTeamId
+  const domainMembers = nativeDomainId
     ? members.filter(
         ({ roles, reputation }) =>
           roles?.items?.find(
-            (role) => role?.domain.nativeId === nativeTeamId,
+            (role) => role?.domain.nativeId === nativeDomainId,
           ) ||
           reputation?.items?.find(
-            (rep) => rep?.domain.nativeId === nativeTeamId,
+            (rep) => rep?.domain.nativeId === nativeDomainId,
           ),
       )
     : members;

--- a/src/components/common/ColonyHome/partials/Objective/Objective.tsx
+++ b/src/components/common/ColonyHome/partials/Objective/Objective.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { ACTION } from '~constants/actions';
 import { useActionSidebarContext } from '~context/ActionSidebarContext';
+import { useGetSelectedDomainFilter } from '~hooks';
 import useColonyContext from '~hooks/useColonyContext';
-import { useGetSelectedTeamFilter } from '~hooks/useTeamsBreadcrumbs';
 import { COLONY_DETAILS_ROUTE } from '~routes';
 import { formatText } from '~utils/intl';
 import { getTeamColor } from '~utils/teams';
@@ -15,8 +15,8 @@ import ProgressBar from '~v5/shared/ProgressBar';
 const displayName = 'common.ColonyHome.Objective';
 
 const Objective = () => {
-  const selectedTeam = useGetSelectedTeamFilter();
-  const nativeTeamId = selectedTeam?.nativeId ?? undefined;
+  const selectedDomain = useGetSelectedDomainFilter();
+  const nativeDomainId = selectedDomain?.nativeId ?? undefined;
 
   const {
     actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
@@ -27,7 +27,7 @@ const Objective = () => {
   const { objective } = colony?.metadata || {};
 
   const selectedTeamColor = domains?.items.find(
-    (domain) => domain?.nativeId === nativeTeamId,
+    (domain) => domain?.nativeId === nativeDomainId,
   )?.metadata?.color;
   const teamColor = getTeamColor(selectedTeamColor);
 
@@ -55,7 +55,7 @@ const Objective = () => {
               className="ml-0"
               additionalText="%"
               isTall
-              barClassName={selectedTeam ? teamColor : 'bg-blue-400'}
+              barClassName={selectedDomain ? teamColor : 'bg-blue-400'}
             />
           </>
         ) : (

--- a/src/components/common/ColonyHome/partials/TotalActions/TotalActions.tsx
+++ b/src/components/common/ColonyHome/partials/TotalActions/TotalActions.tsx
@@ -2,9 +2,7 @@ import clsx from 'clsx';
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { useGetTotalColonyActionsQuery } from '~gql';
-import { useGetSelectedDomainFilter } from '~hooks';
-import { getBaseSearchActionsFilterVariable } from '~hooks/useActivityFeed/helpers';
+import { useActionsCount, useGetSelectedDomainFilter } from '~hooks';
 import useColonyContext from '~hooks/useColonyContext';
 import { COLONY_ACTIVITY_ROUTE } from '~routes';
 import { findDomainByNativeId } from '~utils/domains';
@@ -17,19 +15,13 @@ const displayName = 'common.ColonyHome.TotalActions';
 const TotalActions = () => {
   const { search: searchParams } = useLocation();
   const { colony } = useColonyContext();
-  const { colonyAddress = '' } = colony || {};
   const selectedDomain = useGetSelectedDomainFilter();
   const nativeDomainId = selectedDomain?.nativeId;
 
-  const { data: totalActionData } = useGetTotalColonyActionsQuery({
-    variables: {
-      filter: {
-        ...getBaseSearchActionsFilterVariable(colonyAddress),
-      },
-    },
+  const { actionsCount: totalActions } = useActionsCount({
+    domainId: nativeDomainId,
   });
 
-  const totalActions = totalActionData?.searchColonyActions?.total ?? 0;
   const selectedTeamColor = findDomainByNativeId(nativeDomainId, colony)
     ?.metadata?.color;
 

--- a/src/components/common/ColonyHome/partials/TotalActions/TotalActions.tsx
+++ b/src/components/common/ColonyHome/partials/TotalActions/TotalActions.tsx
@@ -18,7 +18,7 @@ const TotalActions = () => {
   const selectedDomain = useGetSelectedDomainFilter();
   const nativeDomainId = selectedDomain?.nativeId;
 
-  const { actionsCount: totalActions } = useActionsCount({
+  const { actionsCount: totalActions, loading } = useActionsCount({
     domainId: nativeDomainId,
   });
 
@@ -30,7 +30,15 @@ const TotalActions = () => {
   return (
     <WidgetBox
       title={formatText({ id: 'widget.totalActions' })}
-      value={<h4 className="heading-4">{totalActions}</h4>}
+      value={
+        <h4 className="heading-4">
+          {loading ? (
+            <div className="skeleton opacity-25 w-[60px] h-[1.5em]" />
+          ) : (
+            totalActions
+          )}
+        </h4>
+      }
       className={clsx('text-base-white', {
         [teamColor]: selectedDomain,
         'bg-gray-900 border-gray-900': !selectedDomain,

--- a/src/components/common/ColonyHome/partials/TotalActions/TotalActions.tsx
+++ b/src/components/common/ColonyHome/partials/TotalActions/TotalActions.tsx
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom';
 
 import { useGetTotalColonyActionsQuery } from '~gql';
 import { useGetSelectedDomainFilter } from '~hooks';
-import { createBaseActionFilter } from '~hooks/useActivityFeed/helpers';
+import { getBaseSearchActionsFilterVariable } from '~hooks/useActivityFeed/helpers';
 import useColonyContext from '~hooks/useColonyContext';
 import { COLONY_ACTIVITY_ROUTE } from '~routes';
 import { findDomainByNativeId } from '~utils/domains';
@@ -24,7 +24,7 @@ const TotalActions = () => {
   const { data: totalActionData } = useGetTotalColonyActionsQuery({
     variables: {
       filter: {
-        ...createBaseActionFilter(colonyAddress),
+        ...getBaseSearchActionsFilterVariable(colonyAddress),
       },
     },
   });

--- a/src/components/common/ColonyHome/partials/TotalActions/TotalActions.tsx
+++ b/src/components/common/ColonyHome/partials/TotalActions/TotalActions.tsx
@@ -3,10 +3,11 @@ import React from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { useGetTotalColonyActionsQuery } from '~gql';
+import { useGetSelectedDomainFilter } from '~hooks';
 import { createBaseActionFilter } from '~hooks/useActivityFeed/helpers';
 import useColonyContext from '~hooks/useColonyContext';
-import { useGetSelectedTeamFilter } from '~hooks/useTeamsBreadcrumbs';
 import { COLONY_ACTIVITY_ROUTE } from '~routes';
+import { findDomainByNativeId } from '~utils/domains';
 import { formatText } from '~utils/intl';
 import { getTeamColor } from '~utils/teams';
 import WidgetBox from '~v5/common/WidgetBox';
@@ -16,9 +17,9 @@ const displayName = 'common.ColonyHome.TotalActions';
 const TotalActions = () => {
   const { search: searchParams } = useLocation();
   const { colony } = useColonyContext();
-  const { domains, colonyAddress = '' } = colony || {};
-  const selectedTeam = useGetSelectedTeamFilter();
-  const nativeTeamId = selectedTeam?.nativeId;
+  const { colonyAddress = '' } = colony || {};
+  const selectedDomain = useGetSelectedDomainFilter();
+  const nativeDomainId = selectedDomain?.nativeId;
 
   const { data: totalActionData } = useGetTotalColonyActionsQuery({
     variables: {
@@ -29,9 +30,8 @@ const TotalActions = () => {
   });
 
   const totalActions = totalActionData?.searchColonyActions?.total ?? 0;
-  const selectedTeamColor = domains?.items.find(
-    (domain) => domain?.nativeId === nativeTeamId,
-  )?.metadata?.color;
+  const selectedTeamColor = findDomainByNativeId(nativeDomainId, colony)
+    ?.metadata?.color;
 
   const teamColor = getTeamColor(selectedTeamColor);
 
@@ -40,8 +40,8 @@ const TotalActions = () => {
       title={formatText({ id: 'widget.totalActions' })}
       value={<h4 className="heading-4">{totalActions}</h4>}
       className={clsx('text-base-white', {
-        [teamColor]: selectedTeam,
-        'bg-gray-900 border-gray-900': !selectedTeam,
+        [teamColor]: selectedDomain,
+        'bg-gray-900 border-gray-900': !selectedDomain,
       })}
       href={COLONY_ACTIVITY_ROUTE}
       searchParams={searchParams}

--- a/src/components/common/ColonyHome/partials/TotalActions/TotalActions.tsx
+++ b/src/components/common/ColonyHome/partials/TotalActions/TotalActions.tsx
@@ -33,7 +33,7 @@ const TotalActions = () => {
       value={
         <h4 className="heading-4">
           {loading ? (
-            <div className="skeleton opacity-25 w-[60px] h-[1.5em]" />
+            <div className="skeleton opacity-25 w-[60px] h-[1em] my-[0.25em]" />
           ) : (
             totalActions
           )}

--- a/src/components/common/ColonyHome/types.ts
+++ b/src/components/common/ColonyHome/types.ts
@@ -12,6 +12,7 @@ export interface ChartData {
 
 export interface UseGetHomeWidgetReturnType {
   totalActions: number;
+  totalActionsLoading: boolean;
   allMembers: User[];
   teamColor: string;
   nativeToken: Token | undefined;

--- a/src/components/frame/v5/pages/ActivityPage/hooks.tsx
+++ b/src/components/frame/v5/pages/ActivityPage/hooks.tsx
@@ -7,7 +7,6 @@ import {
   useColonyContext,
   useGetSelectedDomainFilter,
 } from '~hooks';
-import { SpinnerLoader } from '~shared/Preloaders';
 import { notNull } from '~utils/arrays';
 import { formatText } from '~utils/intl';
 import { WidthBoxItem } from '~v5/common/WidgetBoxList/types';
@@ -60,17 +59,19 @@ export const useActivityFeedWidgets = (): WidthBoxItem[] => {
   const contentClassName =
     'flex flex-row-reverse items-center gap-1.5 text-right sm:text-left sm:gap-0 sm:flex-col sm:items-start';
 
+  const countSkeleton = (
+    <div className="skeleton w-[60px] h-[1em] my-[0.25em]" />
+  );
+
   return [
     {
       key: '1',
       title: formatText({ id: 'widget.totalActions' }),
       value: (
         <span className="heading-4 text-gray-900">
-          {totalActionsLoading ? (
-            <SpinnerLoader />
-          ) : (
-            getFormattedActionsCount(totalActions)
-          )}
+          {totalActionsLoading
+            ? countSkeleton
+            : getFormattedActionsCount(totalActions)}
         </span>
       ),
       className: tileClassName,
@@ -82,19 +83,17 @@ export const useActivityFeedWidgets = (): WidthBoxItem[] => {
       title: formatText({ id: 'activityPage.recentActions' }),
       value: (
         <span className="heading-4 text-gray-900">
-          {formatText(
-            { id: 'activityPage.recentActions.pastMonth' },
-            {
-              value: recentActionsLoading ? (
-                <SpinnerLoader />
-              ) : (
-                getFormattedActionsCount(recentActions)
-              ),
-              span: (chunks) => (
-                <span className="text-1 hidden sm:inline">{chunks}</span>
-              ),
-            },
-          )}
+          {recentActionsLoading
+            ? countSkeleton
+            : formatText(
+                { id: 'activityPage.recentActions.pastMonth' },
+                {
+                  value: getFormattedActionsCount(recentActions),
+                  span: (chunks) => (
+                    <span className="text-1 hidden sm:inline">{chunks}</span>
+                  ),
+                },
+              )}
         </span>
       ),
       className: tileClassName,

--- a/src/components/frame/v5/pages/ActivityPage/hooks.tsx
+++ b/src/components/frame/v5/pages/ActivityPage/hooks.tsx
@@ -7,23 +7,29 @@ import {
   useColonyContext,
   useGetSelectedDomainFilter,
 } from '~hooks';
+import { SpinnerLoader } from '~shared/Preloaders';
 import { notNull } from '~utils/arrays';
 import { formatText } from '~utils/intl';
 import { WidthBoxItem } from '~v5/common/WidgetBoxList/types';
+
+const getFormattedActionsCount = (count: number) =>
+  count > 1000 ? '999+' : count;
 
 export const useActivityFeedWidgets = (): WidthBoxItem[] => {
   const { colony } = useColonyContext();
   const { domains, colonyAddress = '' } = colony ?? {};
   const selectedDomain = useGetSelectedDomainFilter();
 
-  const { actionsCount: totalActions } = useActionsCount({
-    domainId: selectedDomain?.nativeId,
-  });
+  const { actionsCount: totalActions, loading: totalActionsLoading } =
+    useActionsCount({
+      domainId: selectedDomain?.nativeId,
+    });
 
-  const { actionsCount: recentActions } = useActionsCount({
-    domainId: selectedDomain?.nativeId,
-    onlyRecent: true,
-  });
+  const { actionsCount: recentActions, loading: recentActionsLoading } =
+    useActionsCount({
+      domainId: selectedDomain?.nativeId,
+      onlyRecent: true,
+    });
 
   const { data: domainData } = useGetTotalColonyDomainActionsQuery({
     variables: {
@@ -60,7 +66,11 @@ export const useActivityFeedWidgets = (): WidthBoxItem[] => {
       title: formatText({ id: 'widget.totalActions' }),
       value: (
         <span className="heading-4 text-gray-900">
-          {totalActions > 1000 ? '999+' : totalActions}
+          {totalActionsLoading ? (
+            <SpinnerLoader />
+          ) : (
+            getFormattedActionsCount(totalActions)
+          )}
         </span>
       ),
       className: tileClassName,
@@ -75,7 +85,11 @@ export const useActivityFeedWidgets = (): WidthBoxItem[] => {
           {formatText(
             { id: 'activityPage.recentActions.pastMonth' },
             {
-              value: recentActions > 1000 ? '999+' : recentActions,
+              value: recentActionsLoading ? (
+                <SpinnerLoader />
+              ) : (
+                getFormattedActionsCount(recentActions)
+              ),
               span: (chunks) => (
                 <span className="text-1 hidden sm:inline">{chunks}</span>
               ),

--- a/src/components/frame/v5/pages/ActivityPage/hooks.tsx
+++ b/src/components/frame/v5/pages/ActivityPage/hooks.tsx
@@ -1,54 +1,29 @@
 import clsx from 'clsx';
-import { subDays, startOfDay } from 'date-fns';
 import React from 'react';
 
+import { useGetTotalColonyDomainActionsQuery } from '~gql';
 import {
-  useGetTotalColonyActionsQuery,
-  useGetTotalColonyDomainActionsQuery,
-} from '~gql';
-import { useColonyContext, useGetSelectedDomainFilter } from '~hooks';
-import { getBaseSearchActionsFilterVariable } from '~hooks/useActivityFeed/helpers';
+  useActionsCount,
+  useColonyContext,
+  useGetSelectedDomainFilter,
+} from '~hooks';
 import { notNull } from '~utils/arrays';
 import { formatText } from '~utils/intl';
 import { WidthBoxItem } from '~v5/common/WidgetBoxList/types';
-
-const getThirtyDaysAgoIso = () => {
-  const thirtyDaysAgo = subDays(new Date(), 30);
-  const midnightThirtyDaysAgo = startOfDay(thirtyDaysAgo);
-  return midnightThirtyDaysAgo.toISOString();
-};
 
 export const useActivityFeedWidgets = (): WidthBoxItem[] => {
   const { colony } = useColonyContext();
   const { domains, colonyAddress = '' } = colony ?? {};
   const selectedDomain = useGetSelectedDomainFilter();
 
-  const { data: totalActionData } = useGetTotalColonyActionsQuery({
-    variables: {
-      filter: {
-        ...getBaseSearchActionsFilterVariable(
-          colonyAddress,
-          selectedDomain?.nativeId,
-        ),
-      },
-    },
+  const { actionsCount: totalActions } = useActionsCount({
+    domainId: selectedDomain?.nativeId,
   });
 
-  const totalActions = totalActionData?.searchColonyActions?.total ?? 0;
-
-  const { data: recentActionData } = useGetTotalColonyActionsQuery({
-    variables: {
-      filter: {
-        ...getBaseSearchActionsFilterVariable(
-          colonyAddress,
-          selectedDomain?.nativeId,
-        ),
-        createdAt: { gte: getThirtyDaysAgoIso() },
-      },
-    },
+  const { actionsCount: recentActions } = useActionsCount({
+    domainId: selectedDomain?.nativeId,
+    onlyRecent: true,
   });
-
-  const recentActions = recentActionData?.searchColonyActions?.total ?? 0;
 
   const { data: domainData } = useGetTotalColonyDomainActionsQuery({
     variables: {

--- a/src/components/frame/v5/pages/ActivityPage/hooks.tsx
+++ b/src/components/frame/v5/pages/ActivityPage/hooks.tsx
@@ -6,8 +6,8 @@ import {
   useGetTotalColonyActionsQuery,
   useGetTotalColonyDomainActionsQuery,
 } from '~gql';
-import { useColonyContext } from '~hooks';
-import { createBaseActionFilter } from '~hooks/useActivityFeed/helpers';
+import { useColonyContext, useGetSelectedDomainFilter } from '~hooks';
+import { getBaseSearchActionsFilterVariable } from '~hooks/useActivityFeed/helpers';
 import { notNull } from '~utils/arrays';
 import { formatText } from '~utils/intl';
 import { WidthBoxItem } from '~v5/common/WidgetBoxList/types';
@@ -21,11 +21,15 @@ const getThirtyDaysAgoIso = () => {
 export const useActivityFeedWidgets = (): WidthBoxItem[] => {
   const { colony } = useColonyContext();
   const { domains, colonyAddress = '' } = colony ?? {};
+  const selectedDomain = useGetSelectedDomainFilter();
 
   const { data: totalActionData } = useGetTotalColonyActionsQuery({
     variables: {
       filter: {
-        ...createBaseActionFilter(colonyAddress),
+        ...getBaseSearchActionsFilterVariable(
+          colonyAddress,
+          selectedDomain?.nativeId,
+        ),
       },
     },
   });
@@ -35,7 +39,10 @@ export const useActivityFeedWidgets = (): WidthBoxItem[] => {
   const { data: recentActionData } = useGetTotalColonyActionsQuery({
     variables: {
       filter: {
-        ...createBaseActionFilter(colonyAddress),
+        ...getBaseSearchActionsFilterVariable(
+          colonyAddress,
+          selectedDomain?.nativeId,
+        ),
         createdAt: { gte: getThirtyDaysAgoIso() },
       },
     },

--- a/src/components/frame/v5/pages/ActivityPage/hooks.tsx
+++ b/src/components/frame/v5/pages/ActivityPage/hooks.tsx
@@ -39,7 +39,6 @@ export const useActivityFeedWidgets = (): WidthBoxItem[] => {
   const domainCountsResult =
     domainData?.searchColonyActions?.aggregateItems[0]?.result || {};
   const domainsActionCount =
-    // eslint-disable-next-line no-underscore-dangle
     domainCountsResult?.__typename === 'SearchableAggregateBucketResult'
       ? domainCountsResult?.buckets?.filter(notNull) ?? []
       : [];

--- a/src/components/frame/v5/pages/BalancePage/hooks.ts
+++ b/src/components/frame/v5/pages/BalancePage/hooks.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 
-import { useColonyContext } from '~hooks';
-import { useGetSelectedTeamFilter } from '~hooks/useTeamsBreadcrumbs';
+import { useColonyContext, useGetSelectedDomainFilter } from '~hooks';
 import { getFormattedNumeralValue } from '~shared/Numeral';
 import { convertToDecimal } from '~utils/convertToDecimal';
 import {
@@ -13,7 +12,7 @@ import { UseBalancePageReturnType } from './types';
 
 export const useBalancePage = (): UseBalancePageReturnType => {
   const { colony } = useColonyContext();
-  const selectedTeam = useGetSelectedTeamFilter();
+  const selectedDomain = useGetSelectedDomainFilter();
   const { balances } = colony || {};
 
   const tokensData = useMemo(
@@ -23,7 +22,7 @@ export const useBalancePage = (): UseBalancePageReturnType => {
           getBalanceForTokenAndDomain(
             balances,
             item?.token?.tokenAddress || '',
-            selectedTeam ? Number(selectedTeam.nativeId) : undefined,
+            selectedDomain ? Number(selectedDomain.nativeId) : undefined,
           ) || 0;
         const decimals = getTokenDecimalsWithFallback(item?.token.decimals);
         const convertedValue = convertToDecimal(
@@ -41,7 +40,7 @@ export const useBalancePage = (): UseBalancePageReturnType => {
           balance: typeof formattedValue === 'string' ? formattedValue : '',
         };
       }),
-    [colony, balances, selectedTeam],
+    [colony, balances, selectedDomain],
   );
 
   const sortedTokens = useMemo(

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/BalanceTable.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/BalanceTable.tsx
@@ -7,9 +7,12 @@ import clsx from 'clsx';
 import { uniqueId } from 'lodash';
 import React, { FC, useState } from 'react';
 
-import { useColonyContext, useMobile } from '~hooks';
+import {
+  useColonyContext,
+  useGetSelectedDomainFilter,
+  useMobile,
+} from '~hooks';
 import { useCopyToClipboard } from '~hooks/useCopyToClipboard';
-import { useGetSelectedTeamFilter } from '~hooks/useTeamsBreadcrumbs';
 import useToggle from '~hooks/useToggle';
 import { formatText } from '~utils/intl';
 // import { useSearchContext } from '~context/SearchContext';
@@ -27,7 +30,7 @@ import { BalanceTableFieldModel, BalanceTableProps } from './types';
 const displayName = 'v5.pages.BalancePage.partials.BalaceTable';
 
 const BalanceTable: FC<BalanceTableProps> = ({ data }) => {
-  const selectedTeam = useGetSelectedTeamFilter();
+  const selectedDomain = useGetSelectedDomainFilter();
   const { colony } = useColonyContext();
   const { balances, nativeToken, status, colonyAddress } = colony || {};
   const { nativeToken: nativeTokenStatus } = status || {};
@@ -47,7 +50,7 @@ const BalanceTable: FC<BalanceTableProps> = ({ data }) => {
     nativeToken,
     balances,
     nativeTokenStatus,
-    Number(selectedTeam?.nativeId) || undefined,
+    Number(selectedDomain?.nativeId) || undefined,
   );
   const { getMenuProps } = useGetTableMenuProps(
     data,

--- a/src/components/frame/v5/pages/MembersPage/hooks.ts
+++ b/src/components/frame/v5/pages/MembersPage/hooks.ts
@@ -1,8 +1,7 @@
 import { useMemo } from 'react';
 
 import { useMemberContext } from '~context/MemberContext';
-import { useColonyContext } from '~hooks';
-import { useGetSelectedTeamFilter } from '~hooks/useTeamsBreadcrumbs';
+import { useColonyContext, useGetSelectedDomainFilter } from '~hooks';
 
 import { MembersTabContentListItem } from './partials/MembersTabContent/types';
 import { getMembersList } from './utils';
@@ -20,16 +19,16 @@ export const useMembersPage = () => {
     moreMembers,
   } = useMemberContext();
   const { colony } = useColonyContext();
-  const selectedTeam = useGetSelectedTeamFilter();
+  const selectedDomain = useGetSelectedDomainFilter();
 
   const contributorsList = useMemo<MembersTabContentListItem[]>(
-    () => getMembersList(pagedContributors, selectedTeam?.nativeId, colony),
-    [colony, pagedContributors, selectedTeam],
+    () => getMembersList(pagedContributors, selectedDomain?.nativeId, colony),
+    [colony, pagedContributors, selectedDomain],
   );
 
   const membersList = useMemo<MembersTabContentListItem[]>(
-    () => getMembersList(pagedMembers, selectedTeam?.nativeId, colony),
-    [colony, pagedMembers, selectedTeam],
+    () => getMembersList(pagedMembers, selectedDomain?.nativeId, colony),
+    [colony, pagedMembers, selectedDomain],
   );
 
   const sortedContributorCount = filteredContributors.length;

--- a/src/components/shared/FriendlyName/helpers.ts
+++ b/src/components/shared/FriendlyName/helpers.ts
@@ -9,7 +9,6 @@ export const getAddressFromAgent = (
     return undefined;
   }
 
-  // eslint-disable-next-line no-underscore-dangle
   switch (agent.__typename) {
     case 'Colony': {
       return agent.colonyAddress;
@@ -41,7 +40,6 @@ export const getDisplayNameFromAgent = (
     return undefined;
   }
 
-  // eslint-disable-next-line no-underscore-dangle
   switch (agent.__typename) {
     case 'Colony': {
       return agent.metadata?.displayName || agent.name;

--- a/src/context/ipfs/ipfsnode/IPFSNode.ts
+++ b/src/context/ipfs/ipfsnode/IPFSNode.ts
@@ -10,26 +10,26 @@ class IPFSNode {
     preload: { enabled: false, addresses: [] },
   });
 
-  _ipfs: IPFS;
+  ipfs: IPFS;
 
   ready: Promise<boolean>;
 
   constructor() {
     const promise = IPFS.create(IPFSNode.getIpfsConfig()).then((ipfs) => {
-      this._ipfs = ipfs;
+      this.ipfs = ipfs;
     });
     this.ready = promise.then(() => true);
   }
 
   /** Get the IPFS instance */
   getIPFS() {
-    return this._ipfs;
+    return this.ipfs;
   }
 
   /** Upload a string */
   async addString(data: string): Promise<string> {
     await this.ready;
-    const resultIterator = await this._ipfs.add(data);
+    const resultIterator = await this.ipfs.add(data);
     const {
       value: { path },
     } = await resultIterator.next();
@@ -38,12 +38,12 @@ class IPFSNode {
 
   /** Start the connection to IPFS (if not connected already) */
   start(): Promise<void> {
-    return this._ipfs.start();
+    return this.ipfs.start();
   }
 
   /** Stop the connection to IPFS */
   async stop(): Promise<void> {
-    return this._ipfs.stop();
+    return this.ipfs.stop();
   }
 }
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -66,6 +66,7 @@ export { default as useUsersByAddresses } from './useUsersByAddresses';
 export { default as useJoinedColonies } from './useJoinedColonies';
 export { default as useCurrency } from './useCurrency';
 export { default as useGetSelectedDomainFilter } from './useGetSelectedDomainFilter';
+export { default as useActionsCount } from './useActionsCount';
 
 export {
   default as useSafeTransactionStatus,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,21 +1,8 @@
 import { useEffect, useMemo, useRef } from 'react';
-import { Selector } from 'reselect';
 
 import promiseListener, { AsyncFunction } from '~redux/createPromiseListener';
-import { RootStateRecord } from '~redux/state';
 import { ActionTransformFnType } from '~utils/actions';
 import { getMainClasses } from '~utils/css';
-
-type DependantSelector = (
-  selector: Selector<RootStateRecord, any>,
-  reduxState: RootStateRecord,
-  extraArgs?: any[],
-) => boolean;
-
-export type Given = (
-  potentialSelector: Selector<RootStateRecord, any>,
-  dependantSelector?: DependantSelector,
-) => any | boolean;
 
 export {
   default as useNaiveBranchingDialogWizard,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -78,6 +78,7 @@ export { default as useTeamsOptions } from './useTeamsOptions';
 export { default as useUsersByAddresses } from './useUsersByAddresses';
 export { default as useJoinedColonies } from './useJoinedColonies';
 export { default as useCurrency } from './useCurrency';
+export { default as useGetSelectedDomainFilter } from './useGetSelectedDomainFilter';
 
 export {
   default as useSafeTransactionStatus,

--- a/src/hooks/members/useMemberFilters.ts
+++ b/src/hooks/members/useMemberFilters.ts
@@ -3,8 +3,7 @@ import { useMemo } from 'react';
 
 import { UserRole } from '~constants/permissions';
 import { useSearchContext } from '~context/SearchContext';
-import { useColonyContext } from '~hooks';
-import { useGetSelectedTeamFilter } from '~hooks/useTeamsBreadcrumbs';
+import { useColonyContext, useGetSelectedDomainFilter } from '~hooks';
 import { ColonyContributor } from '~types';
 import { notNull } from '~utils/arrays';
 import { getDomainDatabaseId } from '~utils/databaseId';
@@ -32,18 +31,18 @@ const useMemberFilters = ({
 }) => {
   const { colony } = useColonyContext();
   const { searchValue } = useSearchContext();
-  const selectedTeam = useGetSelectedTeamFilter();
+  const selectedDomain = useGetSelectedDomainFilter();
 
   const { colonyAddress = '' } = colony ?? {};
 
   const databaseDomainIds = useMemo(
     () =>
       new Set(
-        selectedTeam
-          ? [selectedTeam.id]
+        selectedDomain
+          ? [selectedDomain.id]
           : nativeDomainIds.map((id) => getDomainDatabaseId(colonyAddress, id)),
       ),
-    [nativeDomainIds, colonyAddress, selectedTeam],
+    [nativeDomainIds, colonyAddress, selectedDomain],
   );
 
   // Always include the root domain, since if the user has a permission in root, they have it in all domains
@@ -57,7 +56,7 @@ const useMemberFilters = ({
   );
 
   const filteredByTeam = useMemo(() => {
-    if (!selectedTeam) {
+    if (!selectedDomain) {
       return members;
     }
 
@@ -80,7 +79,7 @@ const useMemberFilters = ({
         );
       }) ?? []
     );
-  }, [members, databaseDomainIds, permissionsDomainIds, selectedTeam]);
+  }, [members, databaseDomainIds, permissionsDomainIds, selectedDomain]);
 
   const filteredByStatus = useMemo(() => {
     if (!filterStatus) {

--- a/src/hooks/useActionsCount.ts
+++ b/src/hooks/useActionsCount.ts
@@ -1,0 +1,61 @@
+import { startOfDay, subDays } from 'date-fns';
+
+import { useGetTotalColonyActionsQuery } from '~gql';
+import { getDomainDatabaseId } from '~utils/databaseId';
+
+import { getBaseSearchActionsFilterVariable } from './useActivityFeed/helpers';
+import useColonyContext from './useColonyContext';
+
+const getThirtyDaysAgoIso = () => {
+  const thirtyDaysAgo = subDays(new Date(), 30);
+  const midnightThirtyDaysAgo = startOfDay(thirtyDaysAgo);
+  return midnightThirtyDaysAgo.toISOString();
+};
+
+interface UseActionsCountParams {
+  domainId?: number;
+  onlyRecent?: boolean;
+}
+
+/**
+ * Hook returning the total number of actions matching the given params
+ */
+const useActionsCount = (params?: UseActionsCountParams) => {
+  const { domainId, onlyRecent } = params ?? {};
+  const { colony } = useColonyContext();
+  const { colonyAddress = '' } = colony ?? {};
+
+  const { data: totalActionData } = useGetTotalColonyActionsQuery({
+    variables: {
+      filter: {
+        ...getBaseSearchActionsFilterVariable(colonyAddress),
+        or: domainId
+          ? [
+              {
+                fromDomainId: {
+                  eq: getDomainDatabaseId(colonyAddress, domainId),
+                },
+              },
+              {
+                motionDomainId: { eq: domainId },
+              },
+            ]
+          : undefined,
+        createdAt: onlyRecent
+          ? {
+              gte: getThirtyDaysAgoIso(),
+            }
+          : undefined,
+      },
+    },
+    skip: !colony,
+  });
+
+  const actionsCount = totalActionData?.searchColonyActions?.total ?? 0;
+
+  return {
+    actionsCount,
+  };
+};
+
+export default useActionsCount;

--- a/src/hooks/useActionsCount.ts
+++ b/src/hooks/useActionsCount.ts
@@ -25,7 +25,7 @@ const useActionsCount = (params?: UseActionsCountParams) => {
   const { colony } = useColonyContext();
   const { colonyAddress = '' } = colony ?? {};
 
-  const { data: totalActionData } = useGetTotalColonyActionsQuery({
+  const { data, loading } = useGetTotalColonyActionsQuery({
     variables: {
       filter: {
         ...getBaseSearchActionsFilterVariable(colonyAddress),
@@ -51,10 +51,11 @@ const useActionsCount = (params?: UseActionsCountParams) => {
     skip: !colony,
   });
 
-  const actionsCount = totalActionData?.searchColonyActions?.total ?? 0;
+  const actionsCount = data?.searchColonyActions?.total ?? 0;
 
   return {
     actionsCount,
+    loading,
   };
 };
 

--- a/src/hooks/useActivityFeed/helpers.ts
+++ b/src/hooks/useActivityFeed/helpers.ts
@@ -1,7 +1,6 @@
 import { MotionStatesMap } from '~hooks';
 import { ColonyAction } from '~types';
 import { MotionState, getMotionState } from '~utils/colonyMotions';
-import { getDomainDatabaseId } from '~utils/databaseId';
 
 import {
   ActivityDecisionMethod,
@@ -38,9 +37,12 @@ export const filterActionByMotionState = (
     : motionStatesFilter.includes(action.motionState);
 };
 
+/**
+ * Common filtering for all action queries to ensure both listing and counting queries
+ * return the same results
+ */
 export const getBaseSearchActionsFilterVariable = (
   colonyAddress: string,
-  nativeDomainId?: number,
 ): SearchActionsFilterVariable => ({
   colonyId: {
     eq: colonyAddress,
@@ -51,11 +53,6 @@ export const getBaseSearchActionsFilterVariable = (
   colonyDecisionId: {
     exists: false,
   },
-  fromDomainId: nativeDomainId
-    ? {
-        eq: getDomainDatabaseId(colonyAddress, nativeDomainId),
-      }
-    : undefined,
 });
 
 export const getSearchActionsFilterVariable = (

--- a/src/hooks/useActivityFeed/types.ts
+++ b/src/hooks/useActivityFeed/types.ts
@@ -23,6 +23,8 @@ export interface ActivityFeedFilters {
 
 export type ActivityFeedSort = SearchActionsQueryVariables['sort'];
 
+export type SearchActionsFilterVariable = SearchActionsQueryVariables['filter'];
+
 export interface ActivityFeedOptions {
   pageSize?: number;
 }

--- a/src/hooks/useGetSelectedDomainFilter.tsx
+++ b/src/hooks/useGetSelectedDomainFilter.tsx
@@ -1,25 +1,19 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { TEAM_SEARCH_PARAM } from '~routes';
-import { notNull } from '~utils/arrays';
+import { findDomainByNativeId } from '~utils/domains';
 
 import useColonyContext from './useColonyContext';
 
 const useGetSelectedDomainFilter = () => {
   const { colony } = useColonyContext();
-  const { domains } = colony || {};
 
   const [searchParams, setSearchParams] = useSearchParams();
   const domainId = searchParams.get(TEAM_SEARCH_PARAM);
-
-  const selectedDomain = useMemo(
-    () =>
-      domains?.items
-        .filter(notNull)
-        .find((domain) => domain?.nativeId === parseInt(domainId ?? '0', 10)),
-    [domains?.items, domainId],
-  );
+  const selectedDomain = domainId
+    ? findDomainByNativeId(parseInt(domainId, 10), colony)
+    : undefined;
 
   useEffect(() => {
     if (selectedDomain && !domainId) {

--- a/src/hooks/useGetSelectedDomainFilter.tsx
+++ b/src/hooks/useGetSelectedDomainFilter.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import { TEAM_SEARCH_PARAM } from '~routes';
+import { notNull } from '~utils/arrays';
+
+import useColonyContext from './useColonyContext';
+
+const useGetSelectedDomainFilter = () => {
+  const { colony } = useColonyContext();
+  const { domains } = colony || {};
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const domainId = searchParams.get(TEAM_SEARCH_PARAM);
+
+  const selectedDomain = useMemo(
+    () =>
+      domains?.items
+        .filter(notNull)
+        .find((domain) => domain?.nativeId === parseInt(domainId ?? '0', 10)),
+    [domains?.items, domainId],
+  );
+
+  useEffect(() => {
+    if (selectedDomain && !domainId) {
+      searchParams.delete(TEAM_SEARCH_PARAM);
+      setSearchParams(searchParams);
+    }
+  }, [searchParams, setSearchParams, domainId, selectedDomain]);
+
+  return selectedDomain;
+};
+
+export default useGetSelectedDomainFilter;

--- a/src/hooks/useTeamsBreadcrumbs.ts
+++ b/src/hooks/useTeamsBreadcrumbs.ts
@@ -1,5 +1,4 @@
-import { useEffect, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useMemo } from 'react';
 
 import { TEAM_SEARCH_PARAM } from '~routes';
 import { notMaybe } from '~utils/arrays';
@@ -8,43 +7,19 @@ import { getTeamColor } from '~utils/teams';
 import { setQueryParamOnUrl } from '~utils/urls';
 
 import useColonyContext from './useColonyContext';
-
-export const useGetSelectedTeamFilter = () => {
-  const { colony } = useColonyContext();
-  const { domains } = colony || {};
-
-  const [searchParams, setSearchParams] = useSearchParams();
-  const team = searchParams.get(TEAM_SEARCH_PARAM);
-
-  const teamId = useMemo(
-    () =>
-      domains?.items.find(
-        (domain) => domain?.nativeId === parseFloat(team || '0'),
-      ),
-    [domains?.items, team],
-  );
-
-  useEffect(() => {
-    if (team && !teamId) {
-      searchParams.delete(TEAM_SEARCH_PARAM);
-      setSearchParams(searchParams);
-    }
-  }, [searchParams, team, setSearchParams, teamId]);
-
-  return teamId;
-};
+import useGetSelectedDomainFilter from './useGetSelectedDomainFilter';
 
 export const useCreateTeamBreadcrumbs = () => {
   const { colony } = useColonyContext();
-  const selectedValue = useGetSelectedTeamFilter();
+  const selectedDomain = useGetSelectedDomainFilter();
   const { domains } = colony || {};
   const navigationPathname = window.location.pathname;
 
-  const activeItem = selectedValue
+  const activeItem = selectedDomain
     ? setQueryParamOnUrl(
         navigationPathname,
         TEAM_SEARCH_PARAM,
-        `${selectedValue.nativeId}`,
+        `${selectedDomain.nativeId}`,
       )
     : navigationPathname;
 


### PR DESCRIPTION
## Description

### Colony dashboard

https://github.com/JoinColony/colonyCDapp/assets/112586815/8bd01ca4-5a6e-48b6-9a9f-dce73663dce7

### Activity feed

https://github.com/JoinColony/colonyCDapp/assets/112586815/95c7f85b-83c0-451b-bf19-df7525287e6c

Changes:
- Some renaming of `team` to `domain` for consistency
- `useActionsCount` - new shared hook for getting actions count

Resolves #1542