### PR TITLE
Wire currency conversion util

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,6 @@ PINATA_API_SECRET=<pinata-api-secret>
 
 # Only needed to be changed for on-demand environment
 WEBPACK_DISABLE_HOT_RELOAD=false
+
+# Needed for currency conversion. For testing, see: https://support.coingecko.com/hc/en-us/articles/21880397454233
+COINGECKO_API_KEY=<coingecko-api-key>

--- a/src/components/common/ColonyHome/ColonyHome.tsx
+++ b/src/components/common/ColonyHome/ColonyHome.tsx
@@ -24,7 +24,7 @@ import {
   TEAM_SEARCH_PARAM,
 } from '~routes';
 import Numeral from '~shared/Numeral';
-import { currencySymbolMap } from '~utils/currency/config';
+import { currencySymbolMap } from '~utils/currency';
 import { formatText } from '~utils/intl';
 import { setQueryParamOnUrl } from '~utils/urls';
 import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts';

--- a/src/components/common/ColonyHome/ColonyHome.tsx
+++ b/src/components/common/ColonyHome/ColonyHome.tsx
@@ -6,6 +6,7 @@ import { useLocation } from 'react-router-dom';
 import ColonyActionsTable from '~common/ColonyActionsTable';
 import { ACTION } from '~constants/actions';
 import { useActionSidebarContext } from '~context';
+import { useCurrencyContext } from '~context/CurrencyContext';
 import { useSetPageBreadcrumbs } from '~context/PageHeadingContext/hooks';
 import { useColonyContext, useColonySubscription, useMobile } from '~hooks';
 import {
@@ -23,8 +24,8 @@ import {
   TEAM_SEARCH_PARAM,
 } from '~routes';
 import Numeral from '~shared/Numeral';
+import { currencySymbolMap } from '~utils/currency/config';
 import { formatText } from '~utils/intl';
-import { getTokenDecimalsWithFallback } from '~utils/tokens';
 import { setQueryParamOnUrl } from '~utils/urls';
 import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts';
 import ColonyDashboardHeader from '~v5/common/ColonyDashboardHeader';
@@ -39,7 +40,7 @@ import ProgressBar from '~v5/shared/ProgressBar';
 import TitleWithNumber from '~v5/shared/TitleWithNumber';
 import UserAvatars from '~v5/shared/UserAvatars';
 
-import { useDashboardHeader, useGetHomeWidget } from './hooks';
+import { useDashboardHeader, useGetHomeWidget, useTotalFunds } from './hooks';
 
 // @TODO: add page components
 const displayName = 'common.ColonyHome';
@@ -70,9 +71,7 @@ const ColonyHome = () => {
     totalActions,
     allMembers,
     teamColor,
-    currentTokenBalance,
     membersLoading,
-    nativeToken,
     allTeams,
     chartData,
     otherTeamsReputation,
@@ -83,6 +82,8 @@ const ColonyHome = () => {
   const {
     actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
   } = useActionSidebarContext();
+  const { currency } = useCurrencyContext();
+  const totalFunds = useTotalFunds();
 
   const { leaveColonyConfirmOpen, setLeaveColonyConfirm, ...headerProps } =
     useDashboardHeader();
@@ -143,10 +144,10 @@ const ColonyHome = () => {
             value: (
               <div className="flex items-center gap-2 heading-4">
                 <Numeral
-                  value={currentTokenBalance}
-                  decimals={getTokenDecimalsWithFallback(nativeToken?.decimals)}
+                  value={totalFunds}
+                  prefix={currencySymbolMap[currency]}
                 />
-                <span className="text-1">{nativeToken?.symbol}</span>
+                <span className="text-1">{currency}</span>
               </div>
             ),
             href: COLONY_BALANCES_ROUTE,

--- a/src/components/common/ColonyHome/types.ts
+++ b/src/components/common/ColonyHome/types.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from 'ethers';
 import { Dispatch, SetStateAction } from 'react';
 
 import { Token, User, Domain } from '~types';
@@ -15,7 +14,6 @@ export interface UseGetHomeWidgetReturnType {
   totalActions: number;
   allMembers: User[];
   teamColor: string;
-  currentTokenBalance: BigNumber;
   nativeToken: Token | undefined;
   membersLoading: boolean;
   chartColors?: string[];

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/hooks.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/hooks.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_NETWORK_INFO } from '~constants';
 import { ACTION } from '~constants/actions';
 import { useActionSidebarContext } from '~context';
 import { NativeTokenStatus } from '~gql';
+import CurrencyConversion from '~shared/CurrencyConversion';
 import Numeral from '~shared/Numeral';
 import { Token } from '~types';
 import { getBlockExplorerLink } from '~utils/external';
@@ -120,13 +121,12 @@ export const useBalanceTableColumns = (
                 className="text-1 text-gray-900"
                 suffix={row.original.token?.symbol}
               />
-              {/* {row.original.token?.tokenAddress === ADDRESS_ZERO && (
-                <EthUsd
-                  value={currentTokenBalance}
-                  showPrefix
-                  className="text-gray-600 !text-sm"
-                />
-              )} */}
+              <CurrencyConversion
+                tokenBalance={currentTokenBalance}
+                contractAddress={row.original.token?.tokenAddress ?? ''}
+                showPrefix
+                className="text-gray-600 !text-sm"
+              />
             </div>
           );
         },

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/hooks.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/hooks.tsx
@@ -124,7 +124,6 @@ export const useBalanceTableColumns = (
               <CurrencyConversion
                 tokenBalance={currentTokenBalance}
                 contractAddress={row.original.token?.tokenAddress ?? ''}
-                showPrefix
                 className="text-gray-600 !text-sm"
               />
             </div>

--- a/src/components/shared/CurrencyConversion/CurrencyConversion.tsx
+++ b/src/components/shared/CurrencyConversion/CurrencyConversion.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import Decimal from 'decimal.js';
 import { BigNumber } from 'ethers';
+import React from 'react';
 
-import Numeral, { Props as NumeralProps } from '~shared/Numeral/Numeral';
-
-import { useCurrency } from '~hooks';
 import { useCurrencyContext } from '~context/CurrencyContext';
+import { useCurrency } from '~hooks';
+import Numeral, { Props as NumeralProps } from '~shared/Numeral/Numeral';
 import { FetchCurrentPriceArgs } from '~utils/currency/types';
 
 const displayName = 'CurrencyConversion';
@@ -28,7 +28,7 @@ interface Props extends Omit<NumeralProps, 'value'> {
   /** The network of the token being converted */
   chainId?: FetchCurrentPriceArgs['chainId'];
 
-  /** Contract address of token to be converted */
+  /** Balance of token to be converted */
   tokenBalance: BigNumber;
 }
 
@@ -54,7 +54,9 @@ const CurrencyConversion = ({
       className={className}
       prefix={showPrefix && conversionRate ? '~ ' : ''}
       suffix={showSuffix ? ` ${currency}` : ''}
-      value={tokenBalance.mul(conversionRate) || placeholder}
+      value={
+        new Decimal(tokenBalance.toString()).mul(conversionRate) || placeholder
+      }
       {...rest}
     />
   );

--- a/src/components/shared/CurrencyConversion/CurrencyConversion.tsx
+++ b/src/components/shared/CurrencyConversion/CurrencyConversion.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { BigNumber } from 'ethers';
+
+import Numeral, { Props as NumeralProps } from '~shared/Numeral/Numeral';
+
+import { useCurrency } from '~hooks';
+import { useCurrencyContext } from '~context/CurrencyContext';
+import { FetchCurrentPriceArgs } from '~utils/currency/types';
+
+const displayName = 'CurrencyConversion';
+
+interface Props extends Omit<NumeralProps, 'value'> {
+  /** Should the prefix be visible? */
+  showPrefix?: boolean;
+
+  /** Should the suffix be visible? */
+  showSuffix?: boolean;
+
+  /** A placeholder to be shown while the conversion rate is calculated */
+  placeholder?: string;
+
+  /** Ether unit the number is notated in (e.g. 'ether' = 10^18 wei) */
+  unit?: string;
+
+  /** Contract address of token to be converted */
+  contractAddress: string;
+
+  /** The network of the token being converted */
+  chainId?: FetchCurrentPriceArgs['chainId'];
+
+  /** Contract address of token to be converted */
+  tokenBalance: BigNumber;
+}
+
+const CurrencyConversion = ({
+  showPrefix = true,
+  showSuffix = true,
+  placeholder = '-',
+  tokenBalance,
+  contractAddress,
+  chainId,
+  className,
+  ...rest
+}: Props) => {
+  const { currency } = useCurrencyContext();
+  const conversionRate = useCurrency({
+    contractAddress,
+    chainId,
+    conversionDenomination: currency,
+  });
+
+  return (
+    <Numeral
+      className={className}
+      prefix={showPrefix && conversionRate ? '~ ' : ''}
+      suffix={showSuffix ? ` ${currency}` : ''}
+      value={tokenBalance.mul(conversionRate) || placeholder}
+      {...rest}
+    />
+  );
+};
+
+CurrencyConversion.displayName = displayName;
+
+export default CurrencyConversion;

--- a/src/components/shared/CurrencyConversion/CurrencyConversion.tsx
+++ b/src/components/shared/CurrencyConversion/CurrencyConversion.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { useCurrencyContext } from '~context/CurrencyContext';
 import { useCurrency } from '~hooks';
 import Numeral, { Props as NumeralProps } from '~shared/Numeral/Numeral';
-import { FetchCurrentPriceArgs } from '~utils/currency/types';
+import { FetchCurrentPriceArgs } from '~utils/currency';
 
 const displayName = 'CurrencyConversion';
 

--- a/src/components/shared/CurrencyConversion/index.ts
+++ b/src/components/shared/CurrencyConversion/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CurrencyConversion';

--- a/src/context/CurrencyContext.tsx
+++ b/src/context/CurrencyContext.tsx
@@ -7,10 +7,11 @@ import React, {
   useMemo,
   useState,
 } from 'react';
+
 import { SupportedCurrencies, useUpdateUserProfileMutation } from '~gql';
 import { useAppContext } from '~hooks';
 import { SetStateFn } from '~types';
-import { getUserCurrencyByLocation } from '~utils/currency/location';
+import { getUserCurrencyByLocation } from '~utils/currency';
 
 interface CurrencyContextValues {
   currency: SupportedCurrencies;

--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -1,8 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { Network, SupportedCurrencies } from '~gql';
-import { fetchCurrentPrice } from '~utils/currency/currency';
-import { FetchCurrentPriceArgs } from '~utils/currency/types';
+import { fetchCurrentPrice, FetchCurrentPriceArgs } from '~utils/currency';
 
 const useCurrency = ({
   contractAddress,

--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+
 import { Network, SupportedCurrencies } from '~gql';
 import { fetchCurrentPrice } from '~utils/currency/currency';
 import { FetchCurrentPriceArgs } from '~utils/currency/types';

--- a/src/utils/currency/config.ts
+++ b/src/utils/currency/config.ts
@@ -67,3 +67,15 @@ export const countryCodeToCurrencyMap = {
   ES: SupportedCurrencies.Eur, // Spain
   VA: SupportedCurrencies.Eur, // Vatican City
 };
+
+export const currencySymbolMap = {
+  [SupportedCurrencies.Usd]: '$',
+  [SupportedCurrencies.Jpy]: '¥',
+  [SupportedCurrencies.Gbp]: '£',
+  [SupportedCurrencies.Eur]: '€',
+  [SupportedCurrencies.Cad]: 'C$',
+  [SupportedCurrencies.Krw]: '₩',
+  [SupportedCurrencies.Inr]: '₹',
+  [SupportedCurrencies.Brl]: 'R$',
+  [SupportedCurrencies.Eth]: 'Ξ',
+};

--- a/src/utils/currency/config.ts
+++ b/src/utils/currency/config.ts
@@ -6,6 +6,7 @@ export const currencyApiConfig = {
   searchParams: {
     from: 'contract_addresses',
     to: 'vs_currencies',
+    api: 'x_cg_demo_api_key',
   },
 };
 export const coinGeckoMappings = {

--- a/src/utils/currency/currency.ts
+++ b/src/utils/currency/currency.ts
@@ -31,6 +31,7 @@ const buildCoinGeckoURL = (
   return buildAPIEndpoint(new URL(`${currencyApiConfig.endpoint}${chain}`), {
     [currencyApiConfig.searchParams.from]: contractAddress,
     [currencyApiConfig.searchParams.to]: denomination,
+    [currencyApiConfig.searchParams.api]: process.env.COINGECKO_API_KEY ?? '',
   });
 };
 

--- a/src/utils/currency/index.ts
+++ b/src/utils/currency/index.ts
@@ -1,0 +1,4 @@
+export * from './currency';
+export * from './config';
+export * from './types';
+export * from './location';

--- a/src/utils/currency/memo.ts
+++ b/src/utils/currency/memo.ts
@@ -1,0 +1,50 @@
+import { SupportedCurrencies } from '~gql';
+import { SupportedChains } from './types';
+
+export const savedPrices = new Map<
+  SupportedChains,
+  Map<SupportedCurrencies, Map<string, number>>
+>();
+
+export const getSavedPrice = ({
+  chainId,
+  contractAddress,
+  currency,
+}: {
+  chainId: SupportedChains;
+  contractAddress: string;
+  currency: SupportedCurrencies;
+}) => savedPrices.get(chainId)?.get(currency)?.get(contractAddress);
+
+export const savePrice = ({
+  chainId,
+  contractAddress,
+  currency,
+  price,
+}: {
+  chainId: SupportedChains;
+  contractAddress: string;
+  currency: SupportedCurrencies;
+  price: number;
+}) => {
+  const chainMap = savedPrices.get(chainId);
+  if (chainMap) {
+    const currencyMap = chainMap.get(currency);
+
+    if (currencyMap) {
+      currencyMap.set(contractAddress, price);
+    } else {
+      chainMap.set(
+        currency,
+        new Map<string, number>([[contractAddress, price]]),
+      );
+    }
+  } else {
+    savedPrices.set(
+      chainId,
+      new Map<SupportedCurrencies, Map<string, number>>([
+        [currency, new Map<string, number>([[contractAddress, price]])],
+      ]),
+    );
+  }
+};


### PR DESCRIPTION
## Description

This PR wires in the currency conversion util in all places it's needed in the app.

Using coingecko's free api key ensures you get a stable rate limit of 30 calls/minute. Create a [demo account](https://www.coingecko.com/) to get your own or add mine to your `.env` file: `CG-d4y9hVCNMRU53fFfmV7AiyKr`

Production may need higher call / rate limits (see https://www.coingecko.com/en/api/pricing). We can also use a different api if desired, we're not at all wedded to coingecko (it was just easiest for proof of concept).

## Testing

You should see the total funds conversion on ColonyHome, as well as conversions on the balances page. It's a bit tricky to test locally because it's searching for token addresses on gnosis chain, but you can mock a balance that has the same address as a token on gnosis chain (e.g xdai), to see it's working fine.

Places to add mock balances: `useTotalFunds` hook for colony home page (colonyHome/hooks), and the `CurrencyConversion` component for colony balances page.


**Changes** 🏗

* Memoize currency conversion api calls
* Wire in currency conversion util


Resolves #1623
