### PR TITLE
fix: cancel button color, nav 3rd lvl, amount sizes

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
@@ -138,7 +138,7 @@ const AmountField: FC<AmountFieldProps> = ({
                   portalElementRef.current = ref;
                 }}
               >
-                <h5 className="text-4 text-gray-400 mb-4 uppercase ml-4">
+                <h5 className="text-4 text-gray-400 mb-2 uppercase ml-4">
                   {formatText({ id: 'actionSidebar.availableTokens' })}
                 </h5>
                 <ul>
@@ -170,7 +170,7 @@ const AmountField: FC<AmountFieldProps> = ({
                             <div className="flex items-center gap-1">
                               <TokenIcon
                                 token={colonyToken}
-                                size="xs"
+                                size="xxs"
                                 className="mr-1.5"
                               />
                               <span className="text-md">

--- a/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/TransferFundsForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/TransferFundsForm.tsx
@@ -44,7 +44,7 @@ const TransferFundsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       <ActionFormRow
         icon="arrow-down-right"
         fieldName="to"
-        title={formatText({ id: 'actionSidebar.recipient' })}
+        title={formatText({ id: 'actionSidebar.to' })}
         tooltips={{
           label: {
             tooltipContent: formatText({

--- a/src/components/v5/frame/NavigationSidebar/NavigationSidebar.tsx
+++ b/src/components/v5/frame/NavigationSidebar/NavigationSidebar.tsx
@@ -39,6 +39,7 @@ const NavigationSidebarContent: FC<NavigationSidebarProps> = ({
     mobileMenuToggle,
     secondLevelMenuToggle,
     thirdLevelMenuToggle,
+    setShouldShowThirdLevel,
   } = useNavigationSidebarContext();
   const [isMenuOpen, { toggle: toggleMenu, toggleOff: toggleOffMenu }] =
     mobileMenuToggle;
@@ -46,7 +47,7 @@ const NavigationSidebarContent: FC<NavigationSidebarProps> = ({
     secondLevelMenuToggle;
   const [
     isThirdLevelMenuOpen,
-    { toggle: toggleThirdLevelMenu, toggleOff: toggleOffThirdLevelMenu },
+    { toggleOn: toggleOnThirdLevelMenu, toggleOff: toggleOffThirdLevelMenu },
   ] = thirdLevelMenuToggle;
 
   useDisableBodyScroll((isMenuOpen || openItemIndex === 0) && isTablet);
@@ -64,6 +65,16 @@ const NavigationSidebarContent: FC<NavigationSidebarProps> = ({
   const mainMenu = withMainMenu ? (
     <NavigationSidebarMainMenu mainMenuItems={mainMenuItems} />
   ) : null;
+
+  const handleArrowClick = () => {
+    if (isThirdLevelMenuOpen) {
+      toggleOffThirdLevelMenu();
+      setShouldShowThirdLevel(false);
+    } else {
+      toggleOnThirdLevelMenu();
+      setShouldShowThirdLevel(true);
+    }
+  };
 
   return (
     <nav
@@ -221,9 +232,7 @@ const NavigationSidebarContent: FC<NavigationSidebarProps> = ({
                 activeMainMenuItem?.secondLevelMenuProps ? (
                   <NavigationSidebarSecondLevel
                     {...activeMainMenuItem.secondLevelMenuProps}
-                    onArrowClick={
-                      hasThirdLevel ? toggleThirdLevelMenu : undefined
-                    }
+                    onArrowClick={hasThirdLevel ? handleArrowClick : undefined}
                     isExpanded={hasThirdLevel ? isThirdLevelMenuOpen : false}
                   />
                 ) : null}

--- a/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarContext/NavigationSidebarContext.tsx
+++ b/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarContext/NavigationSidebarContext.tsx
@@ -20,6 +20,7 @@ export const NavigationSidebarContext =
     mobileMenuToggle: DEFAULT_USE_TOGGLE_RETURN_VALUE,
     secondLevelMenuToggle: DEFAULT_USE_TOGGLE_RETURN_VALUE,
     thirdLevelMenuToggle: DEFAULT_USE_TOGGLE_RETURN_VALUE,
+    setShouldShowThirdLevel: () => {},
   });
 
 const NavigationSidebarContextProvider: FC<PropsWithChildren> = ({
@@ -28,6 +29,7 @@ const NavigationSidebarContextProvider: FC<PropsWithChildren> = ({
   const [openItemIndex, setOpenItemIndex] = useState<number | undefined>(
     undefined,
   );
+  const [shouldShowThirdLevel, setShouldShowThirdLevel] = useState(true);
   const mobileMenuToggle = useToggle({
     closeOnRouteChange: true,
   });
@@ -75,9 +77,19 @@ const NavigationSidebarContextProvider: FC<PropsWithChildren> = ({
   }, [isSecondLevelMenuOpen, toggleOffThirdLevelMenu]);
 
   useEffect(() => {
+    if (isSecondLevelMenuOpen && shouldShowThirdLevel) {
+      toggleOnThirdLevelMenu();
+    }
+  }, [
+    isSecondLevelMenuOpen,
+    shouldShowThirdLevel,
+    toggleOnThirdLevelMenu,
+    openItemIndex,
+  ]);
+
+  useEffect(() => {
     if (openItemIndex !== undefined) {
       toggleOnSecondLevelMenu();
-      toggleOnThirdLevelMenu();
     } else {
       toggleOffSecondLevelMenu();
     }
@@ -95,12 +107,14 @@ const NavigationSidebarContextProvider: FC<PropsWithChildren> = ({
       mobileMenuToggle,
       secondLevelMenuToggle,
       thirdLevelMenuToggle,
+      setShouldShowThirdLevel,
     }),
     [
       mobileMenuToggle,
       openItemIndex,
       secondLevelMenuToggle,
       thirdLevelMenuToggle,
+      setShouldShowThirdLevel,
     ],
   );
 

--- a/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarContext/types.ts
+++ b/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarContext/types.ts
@@ -1,8 +1,10 @@
+import { Dispatch, SetStateAction } from 'react';
 import { UseToggleReturnType } from '~hooks/useToggle/types';
 
 export interface NavigationSidebarContextValue {
   openItemIndex: number | undefined;
   setOpenItemIndex: (index: number | undefined) => void;
+  setShouldShowThirdLevel: Dispatch<SetStateAction<boolean>>;
   mobileMenuToggle: UseToggleReturnType;
   secondLevelMenuToggle: UseToggleReturnType;
   thirdLevelMenuToggle: UseToggleReturnType;

--- a/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarContext/types.ts
+++ b/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarContext/types.ts
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction } from 'react';
+
 import { UseToggleReturnType } from '~hooks/useToggle/types';
 
 export interface NavigationSidebarContextValue {

--- a/src/components/v5/frame/NavigationSidebar/types.ts
+++ b/src/components/v5/frame/NavigationSidebar/types.ts
@@ -20,4 +20,5 @@ export interface NavigationSidebarProps {
   mobileBottomContent?: React.ReactNode;
   hamburgerLabel?: string;
   className?: string;
+  isThirdLevelMenuOpen?: boolean;
 }

--- a/src/components/v5/shared/Modal/Modal.tsx
+++ b/src/components/v5/shared/Modal/Modal.tsx
@@ -88,7 +88,7 @@ const Modal: FC<PropsWithChildren<ModalProps>> = ({
         {(closeMessage || confirmMessage) && (
           <div className="flex flex-col-reverse gap-3 mt-8 sm:flex-row">
             {closeMessage && (
-              <Button mode="primaryOutlineFull" isFullSize onClick={onClose}>
+              <Button mode="primaryOutline" isFullSize onClick={onClose}>
                 {closeMessage}
               </Button>
             )}


### PR DESCRIPTION
https://tw.auroracreation.com/app/tasks/15637182
https://tw.auroracreation.com/app/tasks/15637067
https://tw.auroracreation.com/app/tasks/15665111
https://tw.auroracreation.com/app/tasks/15692685

**Changes** 🏗

* Changed cancel button border color
* Navigation sidebar 3rd level now `remembers` close/open state
* Sizes in amount field
* Title change in transfer funds form from `recipient` to `to`

Resolves [#1643](https://github.com/JoinColony/colonyCDapp/issues/1643) and [1642](https://github.com/JoinColony/colonyCDapp/issues/1642)
