### PR TITLE
Fix crash due to custom yup methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,9 @@ import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import ReactModal from 'react-modal';
 
-import store from '~redux/createReduxStore';
 import '~utils/yup/customMethods'; // ensures custom yup methods are available when components load
+// eslint-disable-next-line import/order
+import store from '~redux/createReduxStore';
 
 import Entry from './Entry';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,15 @@ import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import ReactModal from 'react-modal';
 
-import '~utils/yup/customMethods'; // ensures custom yup methods are available when components load
-// eslint-disable-next-line import/order
+import '~utils/yup/customMethods'; // @NOTE: This is placed here to ensure custom yup methods are available when components load
+
+import './styles/main.global.css'; // @NOTE: This is placed here to ensure it is loaded before any other styles specific to the components (like CSS modules)
+
+/* eslint-disable import/order */
 import store from '~redux/createReduxStore';
 
 import Entry from './Entry';
-
-import './styles/main.global.css';
+/* eslint-enable import/order */
 
 Decimal.set({ toExpPos: 78 });
 


### PR DESCRIPTION
Fixed CDapp crash when custom yup methods aren't available fast enough for components. This was caused due to the recent changes to the import/order.

Also fixed global styles overwriting the custom styles of some components like buttons.