### PR TITLE
Remove root/recovery permissions from selection on child domain

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/ManagePermissionsForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/ManagePermissionsForm.tsx
@@ -1,5 +1,8 @@
+import { Id } from '@colony/colony-js';
 import React, { FC, useCallback } from 'react';
+import { useWatch } from 'react-hook-form';
 
+import { USER_ROLE } from '~constants/permissions';
 import useToggle from '~hooks/useToggle';
 import Icon from '~shared/Icon';
 import { formatText } from '~utils/intl';
@@ -35,6 +38,7 @@ const ManagePermissionsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       toggleOn: togglePermissionsModalOn,
     },
   ] = useToggle();
+  const team: string | undefined = useWatch({ name: 'team' });
   const permissionSelectFooter = useCallback<
     Exclude<CardSelectProps<string>['footer'], React.ReactNode>
   >(
@@ -56,6 +60,15 @@ const ManagePermissionsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       </button>
     ),
     [togglePermissionsModalOn],
+  );
+
+  const ALLOWED_PERMISSION_OPTIONS = PERMISSIONS_OPTIONS.map(
+    ({ options, ...rest }) => ({
+      ...rest,
+      options: options.filter(({ value }) =>
+        value === USER_ROLE.Owner ? Number(team) === Id.RootDomain : true,
+      ),
+    }),
   );
 
   return (
@@ -110,7 +123,7 @@ const ManagePermissionsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
           renderSelectedValue={(option, placeholder) =>
             getRoleLabel(option?.value) || placeholder
           }
-          options={PERMISSIONS_OPTIONS}
+          options={ALLOWED_PERMISSION_OPTIONS}
           title={formatText({ id: 'actionSidebar.permissions' })}
           placeholder={formatText({
             id: 'actionSidebar.managePermissions.roleSelect.placeholder',

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/partials/PermissionsTable/PermissionsTable.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/partials/PermissionsTable/PermissionsTable.tsx
@@ -1,11 +1,12 @@
+import { ColonyRole, Id } from '@colony/colony-js';
 import clsx from 'clsx';
 import React, { FC } from 'react';
-import { useController } from 'react-hook-form';
+import { useController, useWatch } from 'react-hook-form';
 
 import { USER_ROLE } from '~constants/permissions';
 import Table from '~v5/common/Table';
 
-import { CUTOM_PERMISSION_TABLE_CONTENT } from './consts';
+import { CUSTOM_PERMISSION_TABLE_CONTENT } from './consts';
 import {
   useCustomPermissionsTableColumns,
   usePermissionsTableProps,
@@ -26,10 +27,18 @@ const PermissionsTable: FC<PermissionsTableProps> = ({
   const customPermissionsTableColumns = useCustomPermissionsTableColumns(name);
   const permissionsTableProps = usePermissionsTableProps(role);
   const { fieldState } = useController({ name });
+  const team: string | undefined = useWatch({ name: 'team' });
 
   if (!role) {
     return null;
   }
+
+  const ALLOWED_CUSTOM_PERMISSION_TABLE_CONTENT =
+    CUSTOM_PERMISSION_TABLE_CONTENT.filter(({ key }) =>
+      key === ColonyRole.Root || key === ColonyRole.Recovery
+        ? Number(team) === Id.RootDomain
+        : true,
+    );
 
   return (
     <div className={className}>
@@ -46,7 +55,7 @@ const PermissionsTable: FC<PermissionsTableProps> = ({
               '!border-negative-400': !!fieldState.error,
             },
           )}
-          data={CUTOM_PERMISSION_TABLE_CONTENT}
+          data={ALLOWED_CUSTOM_PERMISSION_TABLE_CONTENT}
           columns={customPermissionsTableColumns}
         />
       )}

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/partials/PermissionsTable/consts.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/partials/PermissionsTable/consts.tsx
@@ -69,7 +69,7 @@ export const PERMISSIONS_TABLE_CONTENT: Record<
   },
 };
 
-export const CUTOM_PERMISSION_TABLE_CONTENT: CustomPermissionTableModel[] = [
+export const CUSTOM_PERMISSION_TABLE_CONTENT: CustomPermissionTableModel[] = [
   {
     key: ColonyRole.Root,
     name: ColonyRole.Root,


### PR DESCRIPTION
Removed `Owner` set of permissions and `Root/Recovery` when the selected domain is not ROOT.

![Screenshot 2024-01-04 at 19 56 11](https://github.com/JoinColony/colonyCDapp/assets/18473896/05693285-c326-4b96-bed9-922a2db54430)
![Screenshot 2024-01-04 at 19 56 21](https://github.com/JoinColony/colonyCDapp/assets/18473896/f7a17d88-b6c8-4db9-a13b-3668996086e2)


Resolves #1655 
