### PR TITLE
Fix: Colony detail button regression

### DIFF
--- a/src/components/frame/Extensions/pages/ColonyDetailsPage/ColonyDetailsPage.tsx
+++ b/src/components/frame/Extensions/pages/ColonyDetailsPage/ColonyDetailsPage.tsx
@@ -107,6 +107,7 @@ const ColonyDetailsPage: FC = () => {
         ) : null}
         <Button
           mode="primarySolid"
+          size="small"
           text={{ id: 'button.editColonyDetails' }}
           isFullSize={isMobile}
           onClick={() => {
@@ -132,6 +133,7 @@ const ColonyDetailsPage: FC = () => {
           {!isMobile && (
             <Button
               mode="primarySolid"
+              size="small"
               text={{ id: 'button.manageObjective' }}
               textValues={{ existing: !!objective?.title }}
               onClick={() => {
@@ -152,6 +154,7 @@ const ColonyDetailsPage: FC = () => {
           // @TODO: Test functionality to create objective on mobile
           <Button
             mode="primarySolid"
+            size="small"
             text={{ id: 'button.manageObjective' }}
             textValues={{ existing: !!objective?.title }}
             isFullSize

--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+
 import { Network, SupportedCurrencies } from '~gql';
 import { fetchCurrentPrice } from '~utils/currency/currency';
 import { FetchCurrentPriceArgs } from '~utils/currency/types';

--- a/src/utils/currency/currency.ts
+++ b/src/utils/currency/currency.ts
@@ -1,5 +1,8 @@
 import { Tokens } from '@colony/colony-js';
+
 import { Network, SupportedCurrencies } from '~gql';
+
+import { currencyApiConfig, coinGeckoMappings } from './config';
 import {
   CoinGeckoPriceRequestSuccessResponse,
   FetchCurrentPriceArgs,
@@ -13,7 +16,6 @@ import {
   fetchData,
   mapToAPIFormat,
 } from './utils';
-import { currencyApiConfig, coinGeckoMappings } from './config';
 
 // The functions defined in this file assume something about the shape of the api response.
 // If that changes, or if we change the api, these functions will need to be updated.

--- a/src/utils/currency/types.ts
+++ b/src/utils/currency/types.ts
@@ -1,4 +1,5 @@
 import { SupportedCurrencies } from '~gql';
+
 import { coinGeckoMappings } from './config';
 
 export type CoinGeckoSupportedCurrencies =


### PR DESCRIPTION
## Description

Both primary buttons on the Colony detail page have been updated to match the button size as per the figma design.

**Changes** 🏗

* Added size small prop to buttons

<img width="535" alt="Screenshot 2024-01-09 at 12 11 39" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/d7896836-c4b7-4990-bc2d-9772be003204">


Resolves #1638 