### PR TITLE
Fix: User header hover state and padding

### DIFF
--- a/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
+++ b/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
@@ -92,12 +92,15 @@ const UserHubButton: FC<UserHubButtonProps> = ({
         size="large"
         isFullRounded
         ref={setTriggerRef}
-        className={clsx({
-          '!border-blue-400': visible && isMobile,
-        })}
+        className={clsx(
+          {
+            '!border-blue-400': visible,
+          },
+          'hover:!border-blue-400',
+        )}
         onClick={handleButtonClick}
       >
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2">
           {/* If there's a user, there's a wallet */}
           {walletAddress ? (
             <>

--- a/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
+++ b/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
@@ -96,7 +96,7 @@ const UserHubButton: FC<UserHubButtonProps> = ({
           {
             '!border-blue-400': visible,
           },
-          'hover:!border-blue-400',
+          'md:hover:!border-blue-400',
         )}
         onClick={handleButtonClick}
       >

--- a/src/components/common/Extensions/UserNavigation/UserNavigation.tsx
+++ b/src/components/common/Extensions/UserNavigation/UserNavigation.tsx
@@ -71,7 +71,7 @@ const UserNavigation: FC<UserNavigationProps> = ({
         </Button>
       )}
       <Hamburger
-        isOpened={visible && isMobile}
+        isOpened={visible}
         iconName={isMobile ? 'gear-six' : 'list'}
         iconSize={isMobile ? 'small' : 'extraTiny'}
         setTriggerRef={setTriggerRef}

--- a/src/components/v5/shared/Button/Hamburger.tsx
+++ b/src/components/v5/shared/Button/Hamburger.tsx
@@ -42,7 +42,7 @@ const Hamburger: FC<HamburgerProps> = ({
             'relative flex items-center justify-center border transition-all duration-normal min-w-[2.625rem] min-h-[2.5rem] p-2.5 bg-base-white rounded-full disabled:text-gray-300 z-50 text-1 text-gray-700',
             {
               'pointer-events-none': disabled,
-              'border-blue-400 md:hover:border-base-white': isOpened,
+              'border-blue-400': isOpened,
               'border-gray-200 md:hover:border-blue-400': !isOpened,
             },
           )}


### PR DESCRIPTION
## Description

User header hover state has been changed from border-gray-900 to border-blue-400.

Border colour now stays blue whilst menu is visible.

Padding between username and reputation star changed from 12px to 8px.

Hamburger menu icon now stays blue whilst menu is visible.

**Changes** 🏗

* Added hover:!border-blue-400 to override existing tertiary button style on hover
* Removed 'isMobile' from className check so that border stays blue when the menu is open on desktop as well as mobile
*  Changed outer div from gap-3 to gap-2 to fix padding size
* Removed 'isMobile' from 'isOpened' check on Hamburger element
* Removed border hover state from Hamburger is menu is open to ensure it remains solid blue when open

Hover state border colour changed
<img width="352" alt="Screenshot 2024-01-09 at 16 21 36" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/a0066904-8a44-48be-b3f1-d1515abecd2b">

Active state border colour changed
<img width="772" alt="Screenshot 2024-01-09 at 16 21 48" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/81e866db-a208-41d2-9bfa-4538dd90043d">

Hamburger icon active state border colour changed
<img width="359" alt="Screenshot 2024-01-09 at 16 21 54" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/61381beb-a7c0-4fa6-abc7-3c1e5a0ebdd0">

Resolves #1630 
