### PR TITLE
Fix: Remove tab component top padding

### DIFF
--- a/src/styles/main.global.css
+++ b/src/styles/main.global.css
@@ -199,7 +199,7 @@
 }
 
 .rts___tab {
-  @apply shadow-none border-0 relative inline-flex items-center justify-center px-0 py-2 text-md font-medium cursor-pointer border-b border-transparent transition-colors duration-normal ml-0 mr-6 last:mr-0 md:hover:text-blue-400 rounded-none gap-1;
+  @apply shadow-none border-0 relative inline-flex items-center justify-center px-0 pt-0 pb-2 text-md font-medium cursor-pointer border-b border-transparent transition-colors duration-normal ml-0 mr-6 last:mr-0 md:hover:text-blue-400 rounded-none gap-1;
 }
 
 .rts___tab___selected {


### PR DESCRIPTION
## Description

This PR removes the 8px top padding for the tab component globally.

Tabs found in members page, profile and extensions now have this top padding removed


**Changes** 🏗

Changed 'py-2' to 'pb-2 pt-0' in the main.global.css file 

<img width="141" alt="Screenshot 2024-01-09 at 17 23 09" src="https://github.com/JoinColony/colonyCDapp/assets/155957480/054347eb-0d0e-4074-ada3-ad841d1f0149">

<img width="247" alt="Screenshot 2024-01-09 at 17 29 59" src="https://github.com/JoinColony/colonyCDapp/assets/155957480/66da9161-52fe-416c-b1ba-ff3f37a813c5">



Resolves #1634  
