### PR TITLE
Feat: Add clear functionality to all search inputs

### DIFF
--- a/src/components/frame/Extensions/layouts/partials/ColonySwitcherContent/ColonySwitcherContent.tsx
+++ b/src/components/frame/Extensions/layouts/partials/ColonySwitcherContent/ColonySwitcherContent.tsx
@@ -73,7 +73,7 @@ const ColonySwitcherContent: FC<ColonySwitcherContentProps> = ({ colony }) => {
           'pt-6 border-t border-t-gray-200': colony,
         })}
       >
-        <SearchInput onChange={onSearchValueChange} />
+        <SearchInput onChange={onSearchValueChange} value={searchValue} />
         <div>
           <h3 className={titleClassName}>
             {formatText(MSG.joinedColonyTitle)}

--- a/src/components/v5/common/Filter/partials/SearchInput/SearchInput.module.css
+++ b/src/components/v5/common/Filter/partials/SearchInput/SearchInput.module.css
@@ -3,13 +3,17 @@
 }
 
 .searchInput {
-  @apply z-[1] min-h-[2.125rem] pr-3 pl-[2.125rem] py-1.5 w-full border rounded-lg border-gray-300 placeholder:text-gray-400;
+  @apply z-[1] min-h-[2.125rem] px-[2.125rem] py-1.5 w-full border rounded-lg border-gray-300 placeholder:text-gray-400;
 }
 
 .searchButton {
-  @apply text-gray-900 sm:text-gray-500 flex items-center transition-all duration-normal justify-center h-full absolute top-0 right-0 px-4 bg-blue-400 rounded-lg;
+  @apply z-[1] text-white sm:text-gray-500 flex items-center transition-all duration-normal justify-center h-full absolute top-0 right-0 px-4 bg-blue-400 rounded-lg;
 }
 
 .icon {
   @apply z-[2] absolute top-[50%] translate-y-[-50%] left-3 sm:left-[0.75rem] flex text-gray-900 sm:text-gray-500 pointer-events-none;
+}
+
+.clearSearchButton {
+  @apply z-[1] absolute top-0 right-0 flex h-[2.25rem] w-[2.25rem] justify-center items-center;
 }

--- a/src/components/v5/common/Filter/partials/SearchInput/SearchInput.tsx
+++ b/src/components/v5/common/Filter/partials/SearchInput/SearchInput.tsx
@@ -44,16 +44,26 @@ const SearchInput: FC<SearchInputProps> = ({ onSearchButtonClick }) => {
   const onInput: ChangeEventHandler<HTMLInputElement> = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       const { value: inputValue } = e.target;
+      setValue(inputValue);
 
       if (!isMobile) {
         debounced(inputValue);
-
-        return;
       }
-      setValue(inputValue);
     },
     [debounced, isMobile],
   );
+
+  const showClearButton = ref.current?.value ?? searchValue !== '';
+
+  const handleClearSearchInput = () => {
+    if (ref.current) {
+      ref.current.focus();
+      ref.current.value = '';
+    }
+
+    setValue('');
+    setSearchValue('');
+  };
 
   return (
     <div
@@ -70,12 +80,25 @@ const SearchInput: FC<SearchInputProps> = ({ onSearchButtonClick }) => {
         className={clsx(
           styles.searchInput,
           'border-gray-300 focus:outline-none group-hover:border-blue-200 group-focus-within:border-blue-200',
+          isMobile && value && '!pr-[5.375rem]',
         )}
         type="text"
         onInput={onInput}
         placeholder={formatMessage({ id: 'filter.input.placeholder' })}
         defaultValue={searchValue}
       />
+      {showClearButton && (
+        <button
+          className={clsx(
+            styles.clearSearchButton,
+            isMobile && value && '!right-[3.25rem]',
+          )}
+          onClick={handleClearSearchInput}
+          type="button"
+        >
+          <Icon name="close" appearance={{ size: 'extraExtraTiny' }} />
+        </button>
+      )}
       {isMobile && value && (
         <button
           type="button"


### PR DESCRIPTION
## Description

Added clear functionality to Colony Switcher and Members file search inputs.

**New stuff** ✨

* Added clear functionality to Colony Switcher search input by passing a value to the 'value' property which ensures the clear button prefix is shown when there is a value
* Added clear functionality to Members filter search input. This input is slightly different as it has a search submit button that only appears on mobile when the input has a value. The clear button has been added and positioned appropriately on mobile to accommodate the submit button.

All action sidebar search inputs already have the clear functionality, so does the filter on the incoming funds page. Please let me know if there are any search inputs that have been missed.

Colony Switcher search input
![Screenshot 2024-01-10 at 15 12 36](https://github.com/JoinColony/colonyCDapp/assets/34915414/21a6879e-fa78-41a2-a76b-88768c196db3)

Members filter search input desktop
![Screenshot 2024-01-12 at 09 12 02](https://github.com/JoinColony/colonyCDapp/assets/34915414/7415950e-0f99-43ea-bae9-ed3b2404399c)

Members filter search input mobile
![Screenshot 2024-01-12 at 09 12 13](https://github.com/JoinColony/colonyCDapp/assets/34915414/297ffaf6-dd6e-4a17-92e6-a568af07a929)

Resolves #1635 
