### PR TITLE
Update ColonyContext typing

### DIFF
--- a/src/components/common/ColonyActions/ActionDetailsPage/ActionDetailsPage.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/ActionDetailsPage.tsx
@@ -46,10 +46,6 @@ const ActionDetailsPage = () => {
     refetchAction,
   } = useGetColonyAction();
 
-  if (!colony) {
-    return null;
-  }
-
   const isMotion = action?.isMotion;
   const createdAt = action?.createdAt;
   const isInvalidMotion =

--- a/src/components/common/ColonyActions/ActionDetailsPage/ActionDetailsPageFeed/ActionDetailsPageEvent/ActionEventData.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/ActionDetailsPageFeed/ActionDetailsPageEvent/ActionEventData.tsx
@@ -33,8 +33,8 @@ const ActionEventData = ({
           values={getActionEventTitleValues(
             eventName,
             actionData,
-            eventId,
             colony,
+            eventId,
           )}
         />
       }

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultAction/DefaultAction.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultAction/DefaultAction.tsx
@@ -20,10 +20,6 @@ const DefaultAction = ({ actionData }: DefaultActionProps) => {
 
   const { isVotingReputationEnabled } = useEnabledExtensions();
 
-  if (!colony) {
-    return null;
-  }
-
   return (
     <div className={styles.main}>
       {/* {isMobile && <ColonyHomeInfo showNavigation isMobile />} */}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/DefaultMotion.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/DefaultMotion.tsx
@@ -37,10 +37,6 @@ const DefaultMotion = ({
   const { isVotingReputationEnabled } = useEnabledExtensions();
   const isDecision = !!actionData.decisionData;
 
-  if (!colony) {
-    return null;
-  }
-
   const { motionData, showInActionsList } = actionData;
   const motionState = getMotionState(networkMotionState, motionData);
 

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionCountdown/EscalateButton/EscalateButton.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionCountdown/EscalateButton/EscalateButton.tsx
@@ -30,16 +30,14 @@ interface EscalateButtonProps {
 }
 
 const EscalateButton = ({ motionId }: EscalateButtonProps) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { user } = useAppContext();
-
-  if (!colony) {
-    return null;
-  }
 
   const escalateTransform = mapPayload(() => {
     const payload: EscalateMotionPayload = {
-      colonyAddress: colony.colonyAddress ?? '',
+      colonyAddress,
       motionId: BigNumber.from(motionId),
       userAddress: user?.walletAddress ?? '',
     };

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/useClaimWidgetConfig.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/ClaimMotionStakes/useClaimWidgetConfig.tsx
@@ -42,9 +42,9 @@ const useClaimWidgetConfig = (
   const [isClaimed, setIsClaimed] = useState(false);
 
   const userAddress = user?.walletAddress;
-  const colonyAddress = colony?.colonyAddress;
-  const nativeTokenDecimals = colony?.nativeToken.decimals;
-  const nativeTokenSymbol = colony?.nativeToken.symbol;
+  const { colonyAddress, nativeToken, motionsWithUnclaimedStakes } = colony;
+  const { decimals: nativeTokenDecimals, symbol: nativeTokenSymbol } =
+    nativeToken;
 
   const userStake = usersStakes.find(({ address }) => address === userAddress);
   const stakerReward = stakerRewards.find(
@@ -53,8 +53,8 @@ const useClaimWidgetConfig = (
 
   // Keep isClaimed state in sync with changes to unclaimed motions on colony object
   useEffect(() => {
-    if (colony?.motionsWithUnclaimedStakes) {
-      const motionIsUnclaimed = colony.motionsWithUnclaimedStakes.some(
+    if (motionsWithUnclaimedStakes) {
+      const motionIsUnclaimed = motionsWithUnclaimedStakes.some(
         ({ motionId }) => motionId === databaseMotionId,
       );
 
@@ -65,7 +65,7 @@ const useClaimWidgetConfig = (
         setIsClaimed(false);
       }
     }
-  }, [colony?.motionsWithUnclaimedStakes, databaseMotionId, refetchAction]);
+  }, [motionsWithUnclaimedStakes, databaseMotionId, refetchAction]);
 
   // Keep isClaimed state in sync with user changes
   useEffect(() => {

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/FinalizeMotion/FinalizeButton.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/FinalizeMotion/FinalizeButton.tsx
@@ -25,12 +25,14 @@ const FinalizeButton = ({
   gasEstimate,
 }: FinalizeButtonProps) => {
   const { user } = useAppContext();
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
 
   const transform = mapPayload(
     () =>
       ({
-        colonyAddress: colony?.colonyAddress,
+        colonyAddress,
         userAddress: user?.walletAddress,
         motionId,
         gasEstimate,

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/FinalizeMotion/FinalizeMotion.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/FinalizeMotion/FinalizeMotion.tsx
@@ -53,8 +53,9 @@ const FinalizeMotion = ({
   startPollingAction,
   stopPollingAction,
 }: FinalizeMotionProps) => {
-  const { colony } = useColonyContext();
-  const { balances } = colony || {};
+  const {
+    colony: { balances },
+  } = useColonyContext();
   const [isPolling, setIsPolling] = useState(false);
 
   /* Stop polling when mounted / dismounted */

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/RevealWidget/RevealRewardItem.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/RevealWidget/RevealRewardItem.tsx
@@ -13,8 +13,9 @@ interface RevealRewardProps {
 const displayName = 'common.ColonyActions.DefaultMotion.RevealRewardItem';
 
 const RevealRewardItem = ({ voterReward }: RevealRewardProps) => {
-  const { colony } = useColonyContext();
-  const { nativeToken } = colony || {};
+  const {
+    colony: { nativeToken },
+  } = useColonyContext();
 
   return (
     <>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/RevealWidget/RevealWidget.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/RevealWidget/RevealWidget.tsx
@@ -30,14 +30,16 @@ const RevealWidget = ({
   startPollingAction,
   stopPollingAction,
 }: RevealWidgetProps) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { user } = useAppContext();
   const { hasUserVoted, vote, userVoteRevealed, setUserVoteRevealed } =
     useRevealWidgetUpdate(voterRecord, stopPollingAction);
   const transform = mapPayload(
     () =>
       ({
-        colonyAddress: colony?.colonyAddress,
+        colonyAddress,
         userAddress: user?.walletAddress ?? '',
         motionId: BigNumber.from(motionId),
       } as RevealMotionPayload),

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/GroupedTotalStake/useTotalStakeRadios.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/GroupedTotalStake/useTotalStakeRadios.tsx
@@ -39,9 +39,11 @@ const useTotalStakeRadios = () => {
       percentage: { yay: yayPercentage, nay: nayPercentage },
     },
   } = useStakingWidgetContext();
-  const { colony } = useColonyContext();
+  const {
+    colony: { nativeToken },
+  } = useColonyContext();
   const { symbol: nativeTokenSymbol, decimals: nativeTokenDecimals } =
-    colony?.nativeToken || {};
+    nativeToken;
   const { getValues } = useFormContext();
   const { stakeSide } = getValues();
   const { user } = useAppContext();

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStakeHeading.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/SingleTotalStakeHeading.tsx
@@ -55,9 +55,11 @@ const SingleTotalStakeHeading = ({
   requiredStake,
 }: SingleTotalStakeHeadingProps) => {
   const { isObjection } = useStakingWidgetContext();
-  const { colony } = useColonyContext();
+  const {
+    colony: { nativeToken },
+  } = useColonyContext();
   const { symbol: nativeTokenSymbol, decimals: nativeTokenDecimals } =
-    colony?.nativeToken || {};
+    nativeToken;
 
   return (
     <div className={styles.widgetHeading}>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/UserStakeMessage.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/SingleTotalStake/UserStakeMessage.tsx
@@ -20,9 +20,11 @@ const MSG = defineMessages({
 const UserStakeMessage = () => {
   const { usersStakes, isObjection } = useStakingWidgetContext();
   const { user } = useAppContext();
-  const { colony } = useColonyContext();
+  const {
+    colony: { nativeToken },
+  } = useColonyContext();
   const { symbol: nativeTokenSymbol, decimals: nativeTokenDecimals } =
-    colony?.nativeToken || {};
+    nativeToken;
 
   const userStakes = usersStakes.find(
     ({ address }) => address === user?.walletAddress,

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/useObjectButton.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/useObjectButton.ts
@@ -13,7 +13,9 @@ import { SLIDER_AMOUNT_KEY } from '../StakingInput';
 
 const useObjectButton = () => {
   const { user } = useAppContext();
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { pollLockedTokenBalance } = useUserTokenBalanceContext();
   const { transactionHash } = useParams();
 
@@ -33,7 +35,7 @@ const useObjectButton = () => {
     nayRemaining,
     userMinStake,
     user?.walletAddress ?? '',
-    colony?.colonyAddress ?? '',
+    colonyAddress,
     motionId,
     MotionVote.Nay,
     transactionHash,

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/useStakingControls.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingControls/useStakingControls.tsx
@@ -14,7 +14,9 @@ import {
 } from '../StakingSliderMessages/helpers';
 
 const useStakingControls = (limitExceeded: boolean) => {
-  const { colony, loading: loadingColony } = useColonyContext();
+  const {
+    colony: { nativeToken, colonyAddress },
+  } = useColonyContext();
   const { user, userLoading, walletConnecting } = useAppContext();
   const {
     motionStakes: {
@@ -31,16 +33,16 @@ const useStakingControls = (limitExceeded: boolean) => {
     hasEnoughTokens: enoughTokensToStakeMinimum,
     loadingUserTokenBalance,
   } = useEnoughTokensForStaking(
-    colony?.nativeToken.tokenAddress ?? '',
+    nativeToken.tokenAddress,
     user?.walletAddress ?? '',
-    colony?.colonyAddress ?? '',
+    colonyAddress,
     userMinStake,
   );
 
   const { data, loading: loadingReputation } = useGetUserReputationQuery({
     variables: {
       input: {
-        colonyAddress: colony?.colonyAddress ?? '',
+        colonyAddress,
         walletAddress: user?.walletAddress ?? '',
         domainId: Number(nativeMotionDomainId),
         rootHash,
@@ -83,7 +85,6 @@ const useStakingControls = (limitExceeded: boolean) => {
     userActivatedTokens,
     canStakeMore,
     isLoadingData:
-      loadingColony ||
       userLoading ||
       walletConnecting ||
       loadingUserTokenBalance ||

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/TokenErrorMessage.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/StakingSliderMessages/TokenErrorMessage.tsx
@@ -24,9 +24,11 @@ interface TokenErrorMessageProps {
 const TokenErrorMessage = ({
   tokensLeftToActivate,
 }: TokenErrorMessageProps) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { nativeToken },
+  } = useColonyContext();
   const { symbol: nativeTokenSymbol, decimals: nativeTokenDecimals } =
-    colony?.nativeToken || {};
+    nativeToken;
   const { setIsOpen: openTokenActivationPopover } = useTokenActivationContext();
   return (
     <div className={styles.activateTokens}>

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/useStakingInput.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/StakingWidget/StakingInput/useStakingInput.ts
@@ -8,7 +8,9 @@ import { getHandleStakeSuccessFn, getStakingTransformFn } from './helpers';
 
 export const useStakingInput = () => {
   const { user } = useAppContext();
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { pollLockedTokenBalance } = useUserTokenBalanceContext();
 
   const {
@@ -26,7 +28,7 @@ export const useStakingInput = () => {
     remainingToStake,
     userMinStake,
     user?.walletAddress ?? '',
-    colony?.colonyAddress ?? '',
+    colonyAddress,
     motionId,
     vote,
   );

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteRewardItem.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VoteRewardItem.tsx
@@ -15,25 +15,20 @@ interface VoteRewardItemProps {
 }
 
 const VoteRewardItem = ({ minReward, maxReward }: VoteRewardItemProps) => {
-  const { colony } = useColonyContext();
-
-  const { nativeToken } = colony || {};
+  const {
+    colony: { nativeToken },
+  } = useColonyContext();
   const showRewardRange = minReward !== maxReward;
+
   return (
     <>
-      {nativeToken && (
-        <TokenIcon
-          className={styles.tokenIcon}
-          token={nativeToken}
-          size="xxs"
-        />
-      )}
+      <TokenIcon className={styles.tokenIcon} token={nativeToken} size="xxs" />
       {minReward && (
         <Numeral
           value={minReward}
-          decimals={nativeToken?.decimals}
+          decimals={nativeToken.decimals}
           appearance={{ theme: 'dark', size: 'small' }}
-          suffix={showRewardRange ? undefined : nativeToken?.symbol}
+          suffix={showRewardRange ? undefined : nativeToken.symbol}
         />
       )}
       {showRewardRange && maxReward && (
@@ -41,9 +36,9 @@ const VoteRewardItem = ({ minReward, maxReward }: VoteRewardItemProps) => {
           <div className={styles.range} />
           <Numeral
             value={maxReward}
-            decimals={nativeToken?.decimals}
+            decimals={nativeToken.decimals}
             appearance={{ theme: 'dark', size: 'small' }}
-            suffix={nativeToken?.symbol}
+            suffix={nativeToken.symbol}
           />
         </>
       )}

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingPanel.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingPanel.tsx
@@ -17,14 +17,16 @@ interface VotingPanelProps {
 
 const VotingPanel = ({ motionDomainId }: VotingPanelProps) => {
   const { user } = useAppContext();
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const {
     formState: { isSubmitting },
     getValues,
   } = useFormContext();
 
   const { userReputation } = useUserReputation(
-    colony?.colonyAddress ?? '',
+    colonyAddress,
     user?.walletAddress ?? '',
     motionDomainId,
   );

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingWidget.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/VotingWidget.tsx
@@ -58,7 +58,9 @@ const VotingWidget = ({
   startPollingAction,
   stopPollingAction,
 }: VotingWidgetProps) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { user } = useAppContext();
   const { hasUserVoted, setHasUserVoted } = useVotingWidgetUpdate(
     voterRecord,
@@ -68,7 +70,7 @@ const VotingWidget = ({
   const transform = mapPayload(
     ({ vote }) =>
       ({
-        colonyAddress: colony?.colonyAddress ?? '',
+        colonyAddress,
         userAddress: user?.walletAddress,
         vote: Number(vote),
         motionId: BigNumber.from(motionId),

--- a/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/useVoteDetailsConfig.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/DefaultMotion/MotionPhaseWidget/VotingWidget/useVoteDetailsConfig.tsx
@@ -38,9 +38,11 @@ export const useVoteDetailsConfig = ({
   userVoteRevealed = false,
 }: VoteDetailsProps): VoteDetailsConfig[] => {
   const { user } = useAppContext();
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { userReputation, totalReputation } = useUserReputation(
-    colony?.colonyAddress ?? '',
+    colonyAddress,
     user?.walletAddress ?? '',
     Number(nativeMotionDomainId),
     rootHash,
@@ -50,13 +52,13 @@ export const useVoteDetailsConfig = ({
     variables: {
       input: {
         voterAddress: user?.walletAddress ?? '',
-        colonyAddress: colony?.colonyAddress ?? '',
+        colonyAddress,
         nativeMotionDomainId,
         motionId,
         rootHash,
       },
     },
-    skip: !user || !colony,
+    skip: !user,
     fetchPolicy: 'cache-and-network',
   });
 

--- a/src/components/common/ColonyActions/ActionDetailsPage/Layout/ActionDetailsPageLayout.tsx
+++ b/src/components/common/ColonyActions/ActionDetailsPage/Layout/ActionDetailsPageLayout.tsx
@@ -32,17 +32,13 @@ const ActionDetailsPageLayout = ({
   const { colony } = useColonyContext();
   const safeTransactionStatus = useSafeTransactionStatus(actionData);
 
-  if (!colony) {
-    return null;
-  }
-
   const hasPendingSafeTransactions = safeTransactionStatus.find(
     (transactionStatus) =>
       transactionStatus === TRANSACTION_STATUS.ACTION_NEEDED,
   );
 
   const extendedActionType = actionData
-    ? getExtendedActionType(actionData, colony?.metadata)
+    ? getExtendedActionType(actionData, colony.metadata)
     : undefined;
 
   return (

--- a/src/components/common/ColonyActions/ActionDetailsPage/useGetColonyAction.ts
+++ b/src/components/common/ColonyActions/ActionDetailsPage/useGetColonyAction.ts
@@ -27,9 +27,8 @@ export const useGetColonyAction = (transactionHash?: string) => {
   const { transactionHash: transactionId } =
     useParams<ActionDetailsPageParams>();
   const isValidTx = isTransactionFormat(transactionHash || transactionId);
-  const skipQuery = !colony || !isValidTx;
   /* Unfortunately, we need to track polling state ourselves: https://github.com/apollographql/apollo-client/issues/9081#issuecomment-975722271 */
-  const [isPolling, setIsPolling] = useState(!skipQuery);
+  const [isPolling, setIsPolling] = useState(!!isValidTx);
 
   const {
     data: actionData,
@@ -38,7 +37,7 @@ export const useGetColonyAction = (transactionHash?: string) => {
     stopPolling: stopPollingForAction,
     refetch: refetchAction,
   } = useGetColonyActionQuery({
-    skip: skipQuery,
+    skip: !isValidTx,
     variables: {
       transactionHash: (transactionHash || transactionId) ?? '',
     },
@@ -87,7 +86,7 @@ export const useGetColonyAction = (transactionHash?: string) => {
     loading: loadingMotionState,
     refetch: refetchMotionState,
   } = useGetMotionStateQuery({
-    skip: !action?.motionData || skipQuery,
+    skip: !action?.motionData || !isValidTx,
     variables: {
       input: {
         colonyAddress: colony?.colonyAddress ?? '',

--- a/src/components/common/ColonyActions/ActionsListItem/ActionsListItem.tsx
+++ b/src/components/common/ColonyActions/ActionsListItem/ActionsListItem.tsx
@@ -87,7 +87,7 @@ const ActionsListItem = ({
   const navigate = useNavigate();
 
   const handleActionRedirect = () =>
-    navigate(`/${colony?.name}?tx=${transactionHash}`);
+    navigate(`/${colony.name}?tx=${transactionHash}`);
 
   const status = ListItemStatus.Defused;
 
@@ -105,10 +105,6 @@ const ActionsListItem = ({
   const MotionTag = useMotionTag(isMotion, motionState);
   const showMotionCountdownTimer =
     useShouldDisplayMotionCountdownTime(motionState);
-
-  if (!colony) {
-    return null;
-  }
 
   const domainName = getDomainName(itemDomain, motionData?.motionDomain);
 

--- a/src/components/common/ColonyActions/ActionsListItem/helpers.ts
+++ b/src/components/common/ColonyActions/ActionsListItem/helpers.ts
@@ -8,15 +8,17 @@ export const useColonyMotionState = (
   isMotion: boolean | null | undefined,
   motionData: ColonyMotion | null | undefined,
 ) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { isVotingReputationEnabled } = useEnabledExtensions();
 
   const { data: motionStateData, refetch: refetchMotionState } =
     useGetMotionStateQuery({
-      skip: !isMotion || !motionData || !colony || !isVotingReputationEnabled,
+      skip: !isMotion || !motionData || !isVotingReputationEnabled,
       variables: {
         input: {
-          colonyAddress: colony?.colonyAddress ?? '',
+          colonyAddress,
           databaseMotionId: motionData?.databaseMotionId ?? '',
         },
       },

--- a/src/components/common/ColonyActions/ColonyActions.tsx
+++ b/src/components/common/ColonyActions/ColonyActions.tsx
@@ -5,7 +5,7 @@ import {
   SearchableColonyActionSortableFields,
   SearchableSortDirection,
 } from '~gql';
-import { useActivityFeed, useColonyContext } from '~hooks';
+import { useActivityFeed } from '~hooks';
 import {
   ActivityDecisionMethod,
   ActivityFeedFilters,
@@ -79,8 +79,6 @@ const motionStateOptions = [
 ];
 
 const ColonyActions = (/* { ethDomainId }: Props */) => {
-  const { colony } = useColonyContext();
-
   const [filters, setFilters] = useState<ActivityFeedFilters>({});
   const [sortDirection, setSortDirection] = useState<SearchableSortDirection>(
     SearchableSortDirection.Desc,
@@ -104,10 +102,6 @@ const ColonyActions = (/* { ethDomainId }: Props */) => {
       [sortDirection],
     ),
   );
-
-  if (!colony) {
-    return null;
-  }
 
   if (loadingFirstPage) {
     return (

--- a/src/components/common/ColonyActions/helpers/getColonyMetadataChanges.tsx
+++ b/src/components/common/ColonyActions/helpers/getColonyMetadataChanges.tsx
@@ -6,7 +6,7 @@ import { isEqual } from '~utils/lodash';
 
 export const getColonyMetadataChangesValue = (
   { transactionHash }: ColonyAction,
-  colony?: Colony,
+  colony: Colony,
 ) => {
   const {
     newDisplayName,
@@ -17,7 +17,7 @@ export const getColonyMetadataChangesValue = (
     newSafes,
     oldSafes,
   } =
-    colony?.metadata?.changelog?.find(
+    colony.metadata?.changelog?.find(
       (item) => item.transactionHash === transactionHash,
     ) || {};
 
@@ -31,7 +31,7 @@ export const getColonyMetadataChangesValue = (
     !haveTokensChanged &&
     !haveSafesChanged;
 
-  if (!colony || hasNoChanges) {
+  if (hasNoChanges) {
     return formatText({
       id: 'colonyMetadata.fallback',
       defaultMessage: 'metadata, but the values are the same',

--- a/src/components/common/ColonyActions/helpers/getEventTitleValues.ts
+++ b/src/components/common/ColonyActions/helpers/getEventTitleValues.ts
@@ -255,14 +255,14 @@ const getExtendedEventName = (
 export const getActionEventTitleValues = (
   eventName: ColonyAndExtensionsEvents,
   actionData: ColonyAction,
+  colony: Colony,
   eventId?: string,
-  colony?: Colony,
 ) => {
   const updatedItem = mapActionEventToExpectedFormat(
     eventName,
     actionData,
-    eventId,
     colony,
+    eventId,
   );
   const extendedEventName = getExtendedEventName(eventName, actionData);
   const keys = EVENT_TYPE_MESSAGE_KEYS_MAP[extendedEventName] ?? DEFAULT_KEYS;

--- a/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
+++ b/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
@@ -334,8 +334,8 @@ export const mapColonyActionToExpectedFormat = (
 export const mapActionEventToExpectedFormat = (
   eventName: ColonyAndExtensionsEvents,
   actionData: ColonyAction,
+  colony: Colony,
   eventId?: string,
-  colony?: Colony,
 ) => {
   const firstSafeTransaction =
     actionData?.safeTransaction?.transactions?.items[0] || undefined;
@@ -371,13 +371,13 @@ export const mapActionEventToExpectedFormat = (
       actionData.amount &&
       formatReputationChange(
         actionData.amount,
-        getTokenDecimalsWithFallback(colony?.nativeToken.decimals),
+        getTokenDecimalsWithFallback(colony.nativeToken.decimals),
       ),
     newVersion: actionData.newColonyVersion,
     reputationChangeNumeral: actionData.amount && (
       <Numeral
         value={actionData.amount}
-        decimals={getTokenDecimalsWithFallback(colony?.nativeToken.decimals)}
+        decimals={getTokenDecimalsWithFallback(colony.nativeToken.decimals)}
       />
     ),
     chainName: getAddedSafeChainName(actionData),
@@ -402,7 +402,9 @@ export const useMapMotionEventToExpectedFormat = (
 ) => {
   const { colonyAddress, motionData, pendingColonyMetadata } = actionData;
   const { nativeMotionDomainId } = motionData || {};
-  const { colony } = useColonyContext();
+  const {
+    colony: { nativeToken },
+  } = useColonyContext();
 
   const initiatorUserReputation = useUserReputation(
     colonyAddress,
@@ -421,8 +423,8 @@ export const useMapMotionEventToExpectedFormat = (
       <AmountTag>
         <Numeral
           value={motionMessageData?.amount ?? 0}
-          decimals={colony?.nativeToken.decimals ?? undefined}
-          suffix={colony?.nativeToken.symbol ?? ''}
+          decimals={nativeToken.decimals}
+          suffix={nativeToken.symbol}
         />
       </AmountTag>
     ),

--- a/src/components/common/ColonyActionsTable/hooks.tsx
+++ b/src/components/common/ColonyActionsTable/hooks.tsx
@@ -138,7 +138,7 @@ export const useColonyActionsTableColumns = (
 
 export const useGetColonyActionsTableMenuProps = (loading: boolean) => {
   const navigate = useNavigate();
-  const colonyName = useColonyContext().colony?.name || '';
+  const colonyName = useColonyContext().colony.name;
 
   return useCallback<
     TableWithMeatballMenuProps<ActivityFeedColonyAction>['getMenuProps']

--- a/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
@@ -37,9 +37,10 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
     motionState || null,
   );
 
-  const actionMetadataDescription = colony
-    ? formatText({ id: 'action.title' }, getActionTitleValues(action, colony))
-    : '';
+  const actionMetadataDescription = formatText(
+    { id: 'action.title' },
+    getActionTitleValues(action, colony),
+  );
 
   return (
     <div className="flex gap-4 items-center w-full">

--- a/src/components/common/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/components/common/ColonyDecisions/ColonyDecisions.tsx
@@ -40,7 +40,9 @@ const MSG = defineMessages({
 });
 
 const ColonyDecisions = () => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { domainIdFilter: domainId } = useColonyHomeContext();
 
   const [sortDirection, setSortDirection] = useState<ModelSortDirection>(
@@ -53,10 +55,7 @@ const ColonyDecisions = () => {
   const { user } = useAppContext();
 
   const draftDecision = useSelector(
-    getDraftDecisionFromStore(
-      user?.walletAddress || '',
-      colony?.colonyAddress ?? '',
-    ),
+    getDraftDecisionFromStore(user?.walletAddress || '', colonyAddress),
   );
 
   const filter: {
@@ -72,7 +71,7 @@ const ColonyDecisions = () => {
 
   const { data, loading: isLoadingDecisions } = useGetColonyDecisionsQuery({
     variables: {
-      colonyAddress: colony?.colonyAddress ?? '',
+      colonyAddress,
       sortDirection,
       filter,
       limit: page * ITEMS_PER_PAGE,

--- a/src/components/common/ColonyDecisions/DecisionPreview/DecisionData/DecisionNotFound.tsx
+++ b/src/components/common/ColonyDecisions/DecisionPreview/DecisionData/DecisionNotFound.tsx
@@ -51,13 +51,15 @@ const extensionLinkMsgValues = (colonyName: string) => {
 
 const DecisionNotFound = () => {
   const openDecisionDialog = useDialog(DecisionDialog);
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress, name: colonyName },
+  } = useColonyContext();
   const { isVotingReputationEnabled } = useEnabledExtensions();
 
   const handleClick = () => {
     openDecisionDialog({
       nativeDomainId: Id.RootDomain,
-      colonyAddress: colony?.colonyAddress ?? '',
+      colonyAddress,
     });
   };
 
@@ -71,7 +73,7 @@ const DecisionNotFound = () => {
       ) : (
         <FormattedMessage
           {...MSG.installExtension}
-          values={extensionLinkMsgValues(colony?.name ?? '')}
+          values={extensionLinkMsgValues(colonyName)}
         />
       )}
     </div>

--- a/src/components/common/ColonyDecisions/DecisionPreview/DecisionDetails.tsx
+++ b/src/components/common/ColonyDecisions/DecisionPreview/DecisionDetails.tsx
@@ -16,10 +16,6 @@ const DecisionDetails = ({
 }: DecisionDetailsProps) => {
   const { colony } = useColonyContext();
 
-  if (!colony) {
-    return null;
-  }
-
   const widgetValues = {
     type: ColonyActionType.CreateDecisionMotion,
     motionData: {

--- a/src/components/common/ColonyDecisions/DecisionPreview/DecisionPreview.tsx
+++ b/src/components/common/ColonyDecisions/DecisionPreview/DecisionPreview.tsx
@@ -31,12 +31,11 @@ const MSG = defineMessages({
 
 const DecisionPreview = () => {
   const { user, walletConnecting, userLoading } = useAppContext();
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const draftDecision = useSelector(
-    getDraftDecisionFromStore(
-      user?.walletAddress || '',
-      colony?.colonyAddress ?? '',
-    ),
+    getDraftDecisionFromStore(user?.walletAddress || '', colonyAddress),
   );
 
   if (walletConnecting || userLoading) {

--- a/src/components/common/ColonyDecisions/DecisionPreview/DecisionPreviewControls/DecisionPreviewControls.tsx
+++ b/src/components/common/ColonyDecisions/DecisionPreview/DecisionPreviewControls/DecisionPreviewControls.tsx
@@ -21,8 +21,9 @@ const displayName =
 const DecisionPreviewControls = ({
   draftDecision,
 }: DecisionPreviewControlsProps) => {
-  const { colony } = useColonyContext();
-  const colonyAddress = colony?.colonyAddress ?? '';
+  const {
+    colony: { colonyAddress, name: colonyName },
+  } = useColonyContext();
   const colonyHasReputation = useColonyHasReputation(colonyAddress);
   const openConfirmDeleteDialog = useDialog(DeleteDecisionDialog);
   const openDecisionDialog = useDialog(DecisionDialog);
@@ -53,7 +54,7 @@ const DecisionPreviewControls = ({
         actionType={ActionTypes.MOTION_CREATE_DECISION}
         values={{
           colonyAddress,
-          colonyName: colony?.name,
+          colonyName,
           // btn disabled if decision is undefined
           draftDecision: draftDecision as DecisionDraft,
         }}

--- a/src/components/common/ColonyDecisions/DraftDecisionItem/DraftDecisionActions.tsx
+++ b/src/components/common/ColonyDecisions/DraftDecisionItem/DraftDecisionActions.tsx
@@ -14,7 +14,9 @@ const displayName = 'common.ColonyDecisions.DraftDecisionActions';
 type DraftDecisionActionsProps = DraftDecisionItemProps;
 
 const DraftDecisionActions = ({ draftDecision }: DraftDecisionActionsProps) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const openDeleteDecisionDialog = useDialog(DeleteDecisionDialog);
   const openDecisionDialog = useDialog(DecisionDialog);
 
@@ -35,7 +37,7 @@ const DraftDecisionActions = ({ draftDecision }: DraftDecisionActionsProps) => {
           e.stopPropagation();
           openDecisionDialog({
             draftDecision,
-            colonyAddress: colony?.colonyAddress ?? '',
+            colonyAddress,
           });
         }}
       />

--- a/src/components/common/ColonyDecisions/NewDecisionButton/NewDecisionButton.tsx
+++ b/src/components/common/ColonyDecisions/NewDecisionButton/NewDecisionButton.tsx
@@ -20,16 +20,15 @@ const displayName = 'common.ColonyDecisions.NewDecisionButton';
 
 const NewDecisionButton = () => {
   const { user, walletConnecting, userLoading } = useAppContext();
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { domainIdFilter: domainId } = useColonyHomeContext();
   const { isVotingReputationEnabled, loading: isLoadingExtensions } =
     useEnabledExtensions();
   const canInteractWithNetwork = useCanInteractWithNetwork();
   const draftDecision = useSelector(
-    getDraftDecisionFromStore(
-      user?.walletAddress || '',
-      colony?.colonyAddress ?? '',
-    ),
+    getDraftDecisionFromStore(user?.walletAddress || '', colonyAddress),
   );
 
   const openDecisionDialog = useDialog(DecisionDialog);
@@ -41,15 +40,15 @@ const NewDecisionButton = () => {
         onClick: () =>
           openDecisionDialog({
             nativeDomainId: domainId,
-            colonyAddress: colony?.colonyAddress ?? '',
+            colonyAddress,
           }),
-        colonyAddress: colony?.colonyAddress ?? '',
+        colonyAddress,
       });
     } else {
       openDecisionDialog({
         nativeDomainId: domainId,
         draftDecision,
-        colonyAddress: colony?.colonyAddress ?? '',
+        colonyAddress,
       });
     }
   };

--- a/src/components/common/ColonyFundingBanner/ColonyFundingBanner.tsx
+++ b/src/components/common/ColonyFundingBanner/ColonyFundingBanner.tsx
@@ -17,8 +17,9 @@ const MSG = defineMessages({
 });
 
 const ColonyFundingBanner = () => {
-  const { colony } = useColonyContext();
-  const { colonyAddress = '' } = colony || {};
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
 
   const formattedAddress = useMemo(() => {
     const addressElements = splitAddress(colonyAddress);

--- a/src/components/common/ColonyFundingMenu/ColonyFundingMenu.tsx
+++ b/src/components/common/ColonyFundingMenu/ColonyFundingMenu.tsx
@@ -65,10 +65,6 @@ const ColonyFundingMenu = ({ filteredDomainId }: ColonyFundingMenuProps) => {
   const openMintTokenDialog = useDialog(MintTokenDialog);
   const openTransferFundsDialog = useDialog(TransferFundsDialog);
 
-  if (!colony) {
-    return null;
-  }
-
   const rootRoles = getUserRolesForDomain(
     colony,
     user?.walletAddress ?? '',

--- a/src/components/common/ColonyHome/ColonyDomainDescription/ColonyDomainDescription.tsx
+++ b/src/components/common/ColonyHome/ColonyDomainDescription/ColonyDomainDescription.tsx
@@ -13,7 +13,7 @@ const displayName = 'common.ColonyHome.ColonyDomainDescription';
 const ColonyDomainDescription = () => {
   const { colony } = useColonyContext();
   const { domainIdFilter: currentDomainId } = useColonyHomeContext();
-  if (!colony || currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID) {
+  if (currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID) {
     return null;
   }
 

--- a/src/components/common/ColonyHome/ColonyDomainSelector/ColonyDomainSelector.tsx
+++ b/src/components/common/ColonyHome/ColonyDomainSelector/ColonyDomainSelector.tsx
@@ -31,8 +31,11 @@ const ColonyDomainSelector = ({
   filteredDomainId = COLONY_TOTAL_BALANCE_DOMAIN_ID,
   onDomainChange,
 }: Props) => {
-  const { colony, canInteractWithColony } = useColonyContext();
-  const { domains } = colony || {};
+  const {
+    colony: { domains },
+    colony,
+    canInteractWithColony,
+  } = useColonyContext();
   const enabledExtensionData = useEnabledExtensions();
 
   const openEditDialog = useDialog(EditDomainDialog);

--- a/src/components/common/ColonyHome/ColonyDomainSelector/CreateDomainButton.tsx
+++ b/src/components/common/ColonyHome/ColonyDomainSelector/CreateDomainButton.tsx
@@ -23,7 +23,6 @@ const CreateDomainButton = () => {
   const openCreateDomainDialog = useDialog(CreateDomainDialog);
 
   const handleClick = () =>
-    colony &&
     openCreateDomainDialog({
       colony,
       enabledExtensionData,

--- a/src/components/common/ColonyHome/ColonyExtensionsWidget/ColonyExtensionsWidget.tsx
+++ b/src/components/common/ColonyHome/ColonyExtensionsWidget/ColonyExtensionsWidget.tsx
@@ -24,7 +24,9 @@ const MSG = defineMessages({
 });
 
 const ColonyExtensions = () => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { name: colonyName },
+  } = useColonyContext();
 
   const { installedExtensionsData, loading } = useExtensionsData();
 
@@ -60,7 +62,7 @@ const ColonyExtensions = () => {
               <li key={address} className={styles.extension}>
                 <NavLink
                   className={styles.invisibleLink}
-                  to={`/${colony?.name}/${COLONY_EXTENSIONS_ROUTE}/${extensionId}`}
+                  to={`/${colonyName}/${COLONY_EXTENSIONS_ROUTE}/${extensionId}`}
                   text={extension.name}
                 />
                 <ExtensionStatusBadge

--- a/src/components/common/ColonyHome/ColonyFundingWidget/ColonyFundingWidget.tsx
+++ b/src/components/common/ColonyHome/ColonyFundingWidget/ColonyFundingWidget.tsx
@@ -24,16 +24,11 @@ const MSG = defineMessages({
 });
 
 const ColonyFundingWidget = () => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { balances, name, tokens: colonyTokenItems, nativeToken, status },
+  } = useColonyContext();
   const { domainIdFilter: currentDomainId = COLONY_TOTAL_BALANCE_DOMAIN_ID } =
     useColonyHomeContext();
-  const {
-    balances,
-    name,
-    tokens: colonyTokenItems,
-    nativeToken,
-    status,
-  } = colony || {};
 
   const tokens = useMemo(
     () =>
@@ -97,13 +92,13 @@ const ColonyFundingWidget = () => {
           <li key={token?.tokenAddress}>
             <TokenInfoPopover
               token={token}
-              isTokenNative={token?.tokenAddress === nativeToken?.tokenAddress}
+              isTokenNative={token?.tokenAddress === nativeToken.tokenAddress}
             >
               <div className={styles.tokenBalance}>
                 <TokenBalanceItem
                   token={token}
                   isTokenNative={
-                    token?.tokenAddress === nativeToken?.tokenAddress
+                    token?.tokenAddress === nativeToken.tokenAddress
                   }
                   isNativeTokenLocked={!status?.nativeToken?.unlocked}
                   balance={domainBalances[token?.tokenAddress]}

--- a/src/components/common/ColonyHome/ColonyHome.tsx
+++ b/src/components/common/ColonyHome/ColonyHome.tsx
@@ -4,7 +4,6 @@ import { defineMessages } from 'react-intl';
 import ColonyActionsTable from '~common/ColonyActionsTable';
 import { useSetPageBreadcrumbs } from '~context/PageHeadingContext/hooks';
 import {
-  useColonyContext,
   useColonySubscription,
   useGetSelectedDomainFilter,
   useMobile,
@@ -50,7 +49,6 @@ const MSG = defineMessages({
 
 const ColonyHome = () => {
   const isMobile = useMobile();
-  const { colony } = useColonyContext();
   const selectedDomain = useGetSelectedDomainFilter();
   const teamsBreadcrumbs = useCreateTeamBreadcrumbs();
 
@@ -59,10 +57,6 @@ const ColonyHome = () => {
   const { handleUnwatch } = useColonySubscription();
 
   useSetPageBreadcrumbs(teamsBreadcrumbs);
-
-  if (!colony) {
-    return null;
-  }
 
   return (
     <div className="flex flex-col gap-10">

--- a/src/components/common/ColonyHome/ColonyHomeLayout/ColonyHomeLayout.tsx
+++ b/src/components/common/ColonyHome/ColonyHomeLayout/ColonyHomeLayout.tsx
@@ -36,10 +36,6 @@ const ColonyHomeLayout = ({ children }: ColonyHomeLayoutProps) => {
   const { colony } = useColonyContext();
   const { pathname } = useLocation();
 
-  if (!colony) {
-    return null;
-  }
-
   const isExtensions = isExtensionsRoute(pathname);
 
   return (

--- a/src/components/common/ColonyHome/ColonyMembersWidget/ColonyMembersWidget.tsx
+++ b/src/components/common/ColonyHome/ColonyMembersWidget/ColonyMembersWidget.tsx
@@ -31,7 +31,6 @@ const ColonyMembersWidget = ({ maxAvatars }: Props) => {
   const { colony } = useColonyContext();
   const { domainIdFilter: currentDomainId = COLONY_TOTAL_BALANCE_DOMAIN_ID } =
     useColonyHomeContext();
-  if (!colony) return null;
 
   const contributors = [];
   const watchers = [];

--- a/src/components/common/ColonyHome/ColonyNavigation/ColonyNavigation.tsx
+++ b/src/components/common/ColonyHome/ColonyNavigation/ColonyNavigation.tsx
@@ -8,8 +8,9 @@ import NavItem from './NavItem';
 import styles from './ColonyNavigation.css';
 
 const ColonyNavigation = () => {
-  const { colony } = useColonyContext();
-  const { name } = colony || {};
+  const {
+    colony: { name },
+  } = useColonyContext();
 
   const items = useGetNavigationItems(name);
   return (

--- a/src/components/common/ColonyHome/ColonySubscription/ColonySubscription.tsx
+++ b/src/components/common/ColonyHome/ColonySubscription/ColonySubscription.tsx
@@ -30,7 +30,10 @@ const MSG = defineMessages({
 
 const ColonySubscription = () => {
   const { wallet, user, walletConnecting, userLoading } = useAppContext();
-  const { colony, canInteractWithColony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+    canInteractWithColony,
+  } = useColonyContext();
   const { canWatch, handleWatch, handleUnwatch } = useColonySubscription();
   const noRegisteredUser = !user && !userLoading;
   const noWalletConnected = !wallet && !walletConnecting;
@@ -39,13 +42,13 @@ const ColonySubscription = () => {
   return (
     <div className={styles.main}>
       <div className={canInteractWithColony ? styles.colonySubscribed : ''}>
-        {colony?.colonyAddress && (
+        {colonyAddress && (
           <InvisibleCopyableAddress
-            address={colony?.colonyAddress}
+            address={colonyAddress}
             copyMessage={MSG.copyMessage}
           >
             <div className={styles.colonyAddress}>
-              <MaskedAddress address={colony?.colonyAddress} />
+              <MaskedAddress address={colonyAddress} />
             </div>
           </InvisibleCopyableAddress>
         )}

--- a/src/components/common/ColonyHome/ColonySubscription/ColonySubscriptionInfoPopover.tsx
+++ b/src/components/common/ColonyHome/ColonySubscription/ColonySubscriptionInfoPopover.tsx
@@ -37,11 +37,6 @@ const ColonySubscriptionInfoPopover = ({
   onUnsubscribe = () => {},
 }: Props) => {
   const { colony } = useColonyContext();
-
-  if (!colony) {
-    return null;
-  }
-
   const { colonyAddress, name, nativeToken, metadata } = colony;
   const { tokenAddress } = nativeToken;
 

--- a/src/components/common/ColonyHome/ColonyTitle/ColonyTitle.tsx
+++ b/src/components/common/ColonyHome/ColonyTitle/ColonyTitle.tsx
@@ -20,14 +20,10 @@ const MSG = defineMessages({
 });
 
 const ColonyTitle = () => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { metadata, name, colonyAddress },
+  } = useColonyContext();
   const isMobile = useMobile();
-
-  if (!colony) {
-    return null;
-  }
-
-  const { metadata, name } = colony;
 
   return (
     <div className={styles.main}>
@@ -42,7 +38,7 @@ const ColonyTitle = () => {
             text={metadata?.displayName || name || MSG.fallbackColonyName}
             data-test="colonyTitle"
           />
-          {isMobile && <ColonyAddress colonyAddress={colony.colonyAddress} />}
+          {isMobile && <ColonyAddress colonyAddress={colonyAddress} />}
         </div>
         <div>
           <ColonySubscription />

--- a/src/components/common/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.tsx
+++ b/src/components/common/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.tsx
@@ -44,8 +44,8 @@ const ColonyUnclaimedTransfers = () => {
   const {
     colony,
     canInteractWithColony,
-    startPolling: startPollingColony,
-    stopPolling: stopPollingColony,
+    startPollingColonyData,
+    stopPollingColonyData,
   } = useColonyContext();
   const claims = useColonyFundsClaims();
 
@@ -65,8 +65,8 @@ const ColonyUnclaimedTransfers = () => {
   const token = firstItem?.token;
 
   const handleClaimSuccess = () => {
-    startPollingColony(1_000);
-    setTimeout(stopPollingColony, 10_000);
+    startPollingColonyData(1_000);
+    setTimeout(stopPollingColonyData, 10_000);
   };
 
   return claimsLength ? (

--- a/src/components/common/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
+++ b/src/components/common/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
@@ -50,7 +50,6 @@ const ColonyUpgrade = () => {
   const { user, wallet } = useAppContext();
   const enabledExtensionData = useEnabledExtensions();
   const handleUpgradeColony = () =>
-    colony &&
     openUpgradeColonyDialog({
       colony,
       enabledExtensionData,

--- a/src/components/common/ColonyHome/OneTxPaymentUpgrade/OneTxPaymentUpgrade.tsx
+++ b/src/components/common/ColonyHome/OneTxPaymentUpgrade/OneTxPaymentUpgrade.tsx
@@ -25,15 +25,16 @@ const MSG = defineMessages({
 });
 
 const OneTxPaymentUpgrade = () => {
-  const { colony } = useColonyContext();
-  const { name } = colony || {};
+  const {
+    colony: { name },
+  } = useColonyContext();
   const { extensionId } = useParams<{
     extensionId: string;
   }>();
 
   const { extensionData } = useExtensionData(Extension.OneTxPayment);
 
-  if (!colony || !extensionData) {
+  if (!extensionData) {
     return null;
   }
 

--- a/src/components/common/ColonyMembers/ColonyMembers.tsx
+++ b/src/components/common/ColonyMembers/ColonyMembers.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
-import { defineMessages } from 'react-intl';
 
 import ColonyHomeInfo from '~common/ColonyHome/ColonyHomeInfo';
 import Members from '~common/Members';
-import { useColonyContext } from '~hooks';
-import NotFoundRoute from '~routes/NotFoundRoute';
-import { SpinnerLoader } from '~shared/Preloaders';
 
 import MemberControls from './MemberControls';
 import MembersFilter from './MembersFilter';
@@ -16,18 +12,10 @@ import styles from './ColonyMembers.css';
 
 const displayName = 'common.ColonyMembers';
 
-const MSG = defineMessages({
-  loadingText: {
-    id: `${displayName}.loadingText`,
-    defaultMessage: 'Loading Colony',
-  },
-});
-
 const ColonyMembers = () => {
   // const { extensionId } = useParams<{
   //   extensionId?: string;
   // }>();
-  const { colony, loading } = useColonyContext();
   const {
     filters,
     selectedDomainId,
@@ -37,21 +25,9 @@ const ColonyMembers = () => {
     isMobile,
   } = useColonyMembers();
 
-  if (loading) {
-    return (
-      <div className={styles.loadingWrapper}>
-        <SpinnerLoader loadingText={MSG.loadingText} />
-      </div>
-    );
-  }
-
   // if (!isExtensionIdValid) {
   //   return <NotFoundRoute />;
   // }
-
-  if (!colony) {
-    return <NotFoundRoute />;
-  }
 
   return (
     <div className={styles.main}>

--- a/src/components/common/ColonyMembers/MemberControls/MemberControls.tsx
+++ b/src/components/common/ColonyMembers/MemberControls/MemberControls.tsx
@@ -54,10 +54,6 @@ const MemberControls = ({ isRootOrAllDomains }: Props) => {
   const openPermissionManagementDialog = useDialog(PermissionManagementDialog);
   const openToggleManageWhitelistDialog = useDialog(ManageWhitelistDialog);
 
-  if (!colony) {
-    return null;
-  }
-
   const handlePermissionManagementDialog = () =>
     openPermissionManagementDialog({
       colony,
@@ -88,7 +84,7 @@ const MemberControls = ({ isRootOrAllDomains }: Props) => {
           {isRootOrAllDomains && (
             <li>
               <InviteLinkButton
-                colonyName={colony?.name || ''}
+                colonyName={colony.name}
                 buttonAppearance={{ theme: 'blue' }}
               />
             </li>

--- a/src/components/common/ColonyMembers/TotalReputation/TotalReputation.tsx
+++ b/src/components/common/ColonyMembers/TotalReputation/TotalReputation.tsx
@@ -3,7 +3,7 @@ import Decimal from 'decimal.js';
 import React from 'react';
 import { defineMessages } from 'react-intl';
 
-import { DEFAULT_TOKEN_DECIMALS, ADDRESS_ZERO } from '~constants';
+import { ADDRESS_ZERO } from '~constants';
 import { useGetUserReputationQuery } from '~gql';
 import { useColonyContext } from '~hooks';
 import Heading from '~shared/Heading';
@@ -25,12 +25,14 @@ type Props = {
 };
 
 const TotalReputation = ({ selectedDomainId }: Props) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress, nativeToken },
+  } = useColonyContext();
   const { data: totalReputation } = useGetUserReputationQuery({
     variables: {
       input: {
         walletAddress: ADDRESS_ZERO,
-        colonyAddress: colony?.colonyAddress || '',
+        colonyAddress,
         domainId: selectedDomainId || Id.RootDomain,
       },
     },
@@ -48,7 +50,7 @@ const TotalReputation = ({ selectedDomainId }: Props) => {
           value={new Decimal(totalReputation?.getUserReputation || '0')
             .abs()
             .toString()}
-          decimals={colony?.nativeToken?.decimals || DEFAULT_TOKEN_DECIMALS}
+          decimals={nativeToken.decimals}
           suffix="reputation points"
         />
       </p>

--- a/src/components/common/ColonyTotalFunds/ManageFundsLink/ManageFundsLink.tsx
+++ b/src/components/common/ColonyTotalFunds/ManageFundsLink/ManageFundsLink.tsx
@@ -23,7 +23,7 @@ const ManageFundsLink = () => {
   return (
     <Link
       className={styles.manageFundsLink}
-      to={`/${colony?.name}/${COLONY_INCOMING_ROUTE}`}
+      to={`/${colony.name}/${COLONY_INCOMING_ROUTE}`}
       data-test="manageFunds"
     >
       <Icon

--- a/src/components/common/ColonyTotalFunds/SelectedToken/SelectedToken.tsx
+++ b/src/components/common/ColonyTotalFunds/SelectedToken/SelectedToken.tsx
@@ -25,8 +25,9 @@ type Props = {
 };
 
 const SelectedToken = ({ children }: Props) => {
-  const { colony } = useColonyContext();
-  const { tokens, nativeToken, balances } = colony || {};
+  const {
+    colony: { tokens, nativeToken, balances },
+  } = useColonyContext();
   const { tokenAddress: nativeTokenAddress } = nativeToken || {};
   const [currentTokenAddress, setCurrentTokenAddress] = useState<Address>(
     nativeTokenAddress ?? '',

--- a/src/components/common/ColonyTotalFunds/SelectedToken/TokenSymbol.tsx
+++ b/src/components/common/ColonyTotalFunds/SelectedToken/TokenSymbol.tsx
@@ -16,8 +16,9 @@ type Props = {
 };
 
 const TokenSymbol = ({ token, tokenAddress, innerRef, onClick }: Props) => {
-  const { colony } = useColonyContext();
-  const { nativeToken, status } = colony || {};
+  const {
+    colony: { nativeToken, status },
+  } = useColonyContext();
   const { tokenAddress: nativeTokenAddress } = nativeToken || {};
 
   return (

--- a/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.tsx
+++ b/src/components/common/Expenditures/ExpenditureDetailsPage/ExpenditureDetailsPage.tsx
@@ -32,8 +32,10 @@ import styles from './ExpenditureDetailsPage.module.css';
 const ExpenditureDetailsPage = () => {
   const { expenditureId } = useParams();
 
-  const { colony } = useColonyContext();
-  const { colonyAddress = '' } = colony || {};
+  const {
+    colony: { colonyAddress },
+    colony,
+  } = useColonyContext();
   const { data, loading } = useGetExpenditureQuery({
     variables: {
       expenditureId: getExpenditureDatabaseId(
@@ -41,7 +43,7 @@ const ExpenditureDetailsPage = () => {
         Number(expenditureId),
       ),
     },
-    skip: !expenditureId || !colony,
+    skip: !expenditureId,
   });
   const expenditure = data?.getExpenditure;
 
@@ -103,10 +105,6 @@ const ExpenditureDetailsPage = () => {
   const latestCancelMotionState =
     latestCancelMotion &&
     getMotionState(networkCancelMotionState, latestCancelMotion);
-
-  if (!colony) {
-    return null;
-  }
 
   if (loading) {
     return <div>Loading expenditure...</div>;

--- a/src/components/common/Expenditures/ExpenditureForm/CreateExpenditure/AdvancedPaymentForm.tsx
+++ b/src/components/common/Expenditures/ExpenditureForm/CreateExpenditure/AdvancedPaymentForm.tsx
@@ -26,10 +26,6 @@ const AdvancedPaymentForm = () => {
 
   const [isStakeDialogOpen, setIsStakeDialogOpen] = useState(false);
 
-  if (!colony) {
-    return null;
-  }
-
   const isStakingRequired = isStakedExpenditureEnabled;
 
   const transformPayload = pipe(

--- a/src/components/common/Expenditures/ExpenditureForm/CreateExpenditure/CreateExpenditureForm.tsx
+++ b/src/components/common/Expenditures/ExpenditureForm/CreateExpenditure/CreateExpenditureForm.tsx
@@ -19,10 +19,6 @@ const CreateExpenditureForm = <T extends ExpenditureFormValues>({
 }: CreateExpenditureFormProps<T>) => {
   const { colony } = useColonyContext();
 
-  if (!colony) {
-    return null;
-  }
-
   return (
     <ActionForm<T> {...actionFormProps}>
       {(formProps) => (

--- a/src/components/common/Expenditures/ExpenditureForm/CreateExpenditure/StagedPaymentForm.tsx
+++ b/src/components/common/Expenditures/ExpenditureForm/CreateExpenditure/StagedPaymentForm.tsx
@@ -29,10 +29,6 @@ const StagedPaymentForm = () => {
 
   const [isStakeDialogOpen, setIsStakeDialogOpen] = useState(false);
 
-  if (!colony) {
-    return null;
-  }
-
   const isStakingRequired = isStakedExpenditureEnabled;
 
   const transformPayload = pipe(
@@ -40,9 +36,7 @@ const StagedPaymentForm = () => {
       return {
         ...payload,
         colony,
-        createdInDomain: colony
-          ? findDomainByNativeId(payload.createInDomainId, colony)
-          : null,
+        createdInDomain: findDomainByNativeId(payload.createInDomainId, colony),
         fundFromDomainId: payload.fundFromDomainId,
         payouts: getStagedExpenditurePayouts(payload),
         isStaged: true,

--- a/src/components/common/Expenditures/ExpenditureForm/CreateExpenditure/StreamingPaymentForm.tsx
+++ b/src/components/common/Expenditures/ExpenditureForm/CreateExpenditure/StreamingPaymentForm.tsx
@@ -21,10 +21,6 @@ import styles from '../ExpenditureForm.module.css';
 const StreamingPaymentForm = () => {
   const { colony } = useColonyContext();
 
-  if (!colony) {
-    return null;
-  }
-
   const transformPayload = pipe(
     mapPayload(
       (payload: StreamingPaymentFormValues) =>

--- a/src/components/common/Expenditures/ExpendituresPage/ExpendituresPage.tsx
+++ b/src/components/common/Expenditures/ExpendituresPage/ExpendituresPage.tsx
@@ -14,18 +14,15 @@ import styles from './ExpendituresPage.module.css';
 // import { CreateExpenditureForm } from '../ExpenditureForm';
 
 const ExpendituresPage = () => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress, name: colonyName },
+  } = useColonyContext();
 
   const { data, loading } = useGetColonyExpendituresQuery({
     variables: {
-      colonyAddress: colony?.colonyAddress ?? '',
+      colonyAddress,
     },
-    skip: !colony,
   });
-
-  if (!colony) {
-    return null;
-  }
 
   return (
     <div className={styles.pageWrapper}>
@@ -36,7 +33,7 @@ const ExpendituresPage = () => {
           .map((expenditure) => (
             <li key={expenditure.id}>
               <Link
-                to={`/${colony.name}/${COLONY_EXPENDITURES_ROUTE}/${expenditure.nativeId}`}
+                to={`/${colonyName}/${COLONY_EXPENDITURES_ROUTE}/${expenditure.nativeId}`}
               >
                 Expenditure ID: {expenditure.nativeId}
               </Link>

--- a/src/components/common/Extensions/ColonyNavigation/ColonyNavigation.tsx
+++ b/src/components/common/Extensions/ColonyNavigation/ColonyNavigation.tsx
@@ -17,8 +17,9 @@ import { getNavItems } from './partials/utils';
 const displayName = 'common.Extensions.ColonyNavigation';
 
 const ColonyNavigation = () => {
-  const { colony } = useColonyContext();
-  const { name } = colony || {};
+  const {
+    colony: { name },
+  } = useColonyContext();
   const { formatMessage } = useIntl();
   const isMobile = useMobile();
   const navItems = getNavItems(name);

--- a/src/components/common/Extensions/ExtensionActionButton/ExtensionActionButton.tsx
+++ b/src/components/common/Extensions/ExtensionActionButton/ExtensionActionButton.tsx
@@ -24,7 +24,7 @@ const ExtensionActionButton = ({
   const { colony, isSupportedColonyVersion } = useColonyContext();
   const { user, wallet } = useAppContext();
 
-  if (!colony || !user) {
+  if (!user) {
     return null;
   }
 

--- a/src/components/common/Extensions/ExtensionActionButton/ExtensionEnableButton.tsx
+++ b/src/components/common/Extensions/ExtensionActionButton/ExtensionEnableButton.tsx
@@ -26,17 +26,15 @@ interface Props {
 }
 
 const EnableButton = ({ extensionData, inputDisabled, stopPolling }: Props) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress, name: colonyName },
+  } = useColonyContext();
   const navigate = useNavigate();
   stopPolling();
 
-  if (!colony) {
-    return null;
-  }
-
   const handleEnableButtonClick = () => {
     navigate(
-      `/${colony.name}/${COLONY_EXTENSIONS_ROUTE}/${extensionData.extensionId}/${COLONY_EXTENSION_SETUP_ROUTE}`,
+      `/${colonyName}/${COLONY_EXTENSIONS_ROUTE}/${extensionData.extensionId}/${COLONY_EXTENSION_SETUP_ROUTE}`,
     );
   };
 
@@ -49,7 +47,7 @@ const EnableButton = ({ extensionData, inputDisabled, stopPolling }: Props) => {
       <ActionButton
         text={MSG.enable}
         actionType={ActionTypes.EXTENSION_ENABLE}
-        values={{ colonyAddress: colony.colonyAddress, extensionData }}
+        values={{ colonyAddress, extensionData }}
       />
     );
   }

--- a/src/components/common/Extensions/ExtensionActionButton/ExtensionInstallButton.tsx
+++ b/src/components/common/Extensions/ExtensionActionButton/ExtensionInstallButton.tsx
@@ -16,12 +16,10 @@ const InstallButton = ({
   startPolling,
   inputDisabled,
 }: Props) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const [disableInstall, setDisableInstall] = useState(inputDisabled);
-
-  if (!colony) {
-    return null;
-  }
 
   const handleInstallSuccess = () => {
     startPolling(1000);
@@ -33,7 +31,7 @@ const InstallButton = ({
       button={IconButton}
       actionType={ActionTypes.EXTENSION_INSTALL}
       values={{
-        colonyAddress: colony.colonyAddress,
+        colonyAddress,
         extensionData,
       }}
       text={{ id: 'button.install' }}

--- a/src/components/common/Extensions/ExtensionDetails/ExtensionDetails.tsx
+++ b/src/components/common/Extensions/ExtensionDetails/ExtensionDetails.tsx
@@ -38,7 +38,9 @@ const HeadingChunks = (chunks: React.ReactNode[]) => (
 
 const ExtensionDetails = () => {
   const { extensionId } = useParams();
-  const { colony } = useColonyContext();
+  const {
+    colony: { name: colonyName },
+  } = useColonyContext();
   const { user } = useAppContext();
   const { extensionData, loading, ...pollingControls } = useExtensionData(
     extensionId ?? '',
@@ -47,10 +49,6 @@ const ExtensionDetails = () => {
 
   if (loading) {
     return <SpinnerLoader appearance={{ theme: 'primary', size: 'massive' }} />;
-  }
-
-  if (!colony) {
-    return null;
   }
 
   if (!extensionData) {
@@ -62,9 +60,9 @@ const ExtensionDetails = () => {
   }
 
   const isSetupRoute = pathname.replace(/\/$/, '').endsWith('setup');
-  const extensionUrl = `/${colony.name}/${COLONY_EXTENSIONS_ROUTE}/${extensionId}`;
+  const extensionUrl = `/${colonyName}/${COLONY_EXTENSIONS_ROUTE}/${extensionId}`;
   const breadCrumbs: Crumb[] = [
-    [MSG.title, `/${colony.name}/${COLONY_EXTENSIONS_ROUTE}`],
+    [MSG.title, `/${colonyName}/${COLONY_EXTENSIONS_ROUTE}`],
     [extensionData.name, isSetupRoute ? extensionUrl : ''],
   ];
   if (isSetupRoute) {

--- a/src/components/common/Extensions/ExtensionDetails/ExtensionDetailsAside.tsx
+++ b/src/components/common/Extensions/ExtensionDetails/ExtensionDetailsAside.tsx
@@ -76,15 +76,11 @@ const ExtensionDetailsAside = ({
   canBeUninstalled,
   pollingControls,
 }: ExtensionDetailsAsideProps) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { shortPollExtensions } = useColonyHomeContext();
-
-  if (!colony) {
-    return null;
-  }
-
   const { extensionId } = extensionData;
-  const { colonyAddress } = colony;
 
   return (
     <aside>

--- a/src/components/common/Extensions/ExtensionItem/hooks.ts
+++ b/src/components/common/Extensions/ExtensionItem/hooks.ts
@@ -7,7 +7,9 @@ import { COLONY_EXTENSIONS_ROUTE } from '~routes';
 import { isInstalledExtensionData } from '~utils/extensions';
 
 export const useExtensionItem = (extensionId: string) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { name: colonyName },
+  } = useColonyContext();
   const { extensionData } = useExtensionData(extensionId);
   const navigate = useNavigate();
 
@@ -16,7 +18,7 @@ export const useExtensionItem = (extensionId: string) => {
 
   const { status, badgeMessage } = useExtensionsBadge(extensionData);
 
-  const extensionUrl = `/${colony?.name}/${COLONY_EXTENSIONS_ROUTE}/${extensionId}`;
+  const extensionUrl = `/${colonyName}/${COLONY_EXTENSIONS_ROUTE}/${extensionId}`;
 
   const handleNavigateToExtensionDetails = useCallback(() => {
     navigate(extensionUrl);

--- a/src/components/common/Extensions/ExtensionSetup/ExtensionSetup.tsx
+++ b/src/components/common/Extensions/ExtensionSetup/ExtensionSetup.tsx
@@ -49,19 +49,21 @@ const ExtensionSetup = ({
   },
 }: Props) => {
   const navigate = useNavigate();
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress, name: colonyName },
+  } = useColonyContext();
   const { shortPollExtensions } = useColonyHomeContext();
   const transform = pipe(
     mapPayload((payload) =>
       mapExtensionActionPayload(payload, initializationParams),
     ),
-    mergePayload({ colonyAddress: colony?.colonyAddress, extensionData }),
+    mergePayload({ colonyAddress, extensionData }),
   );
 
   const handleFormSuccess = useCallback(async () => {
     shortPollExtensions();
-    navigate(`/${colony?.name}/${COLONY_EXTENSIONS_ROUTE}/${extensionId}`);
-  }, [colony?.name, extensionId, navigate, shortPollExtensions]);
+    navigate(`/${colonyName}/${COLONY_EXTENSIONS_ROUTE}/${extensionId}`);
+  }, [colonyName, extensionId, navigate, shortPollExtensions]);
 
   const initialValues = useMemo(() => {
     if (!initializationParams) {
@@ -70,14 +72,10 @@ const ExtensionSetup = ({
     return createExtensionSetupInitialValues(initializationParams);
   }, [initializationParams]);
 
-  if (!colony) {
-    return null;
-  }
-
   if (isInitialized || isDeprecated || !initializationParams) {
     return (
       <Navigate
-        to={`/${colony.name}/${COLONY_EXTENSIONS_ROUTE}/${extensionId}`}
+        to={`/${colonyName}/${COLONY_EXTENSIONS_ROUTE}/${extensionId}`}
       />
     );
   }

--- a/src/components/common/Extensions/ExtensionUpgradeButton/ExtensionUpgradeButton.tsx
+++ b/src/components/common/Extensions/ExtensionUpgradeButton/ExtensionUpgradeButton.tsx
@@ -31,12 +31,12 @@ const ExtensionUpgradeButton = ({ extensionData }: Props) => {
   }
 
   const transform = mapPayload(() => ({
-    colonyAddress: colony?.colonyAddress,
+    colonyAddress: colony.colonyAddress,
     extensionId: extensionData.extensionId,
     version: extensionData.availableVersion,
   }));
 
-  if (!user?.profile || !colony) {
+  if (!user?.profile) {
     return null;
   }
 

--- a/src/components/common/Extensions/UserHub/partials/ReputationTab/ReputationTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/ReputationTab/ReputationTab.tsx
@@ -12,14 +12,14 @@ const displayName = 'common.Extensions.UserHub.partials.ReputationTab';
 
 const ReputationTab = ({ onTabChange }: ReputationTabProps) => {
   const { formatMessage } = useIntl();
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress, nativeToken },
+  } = useColonyContext();
   const { wallet } = useAppContext();
 
-  if (!colony || !wallet) {
+  if (!wallet) {
     return null;
   }
-
-  const { colonyAddress, nativeToken } = colony;
 
   // @TODO: handle empty state <EmptyContent />
   return (

--- a/src/components/common/Extensions/UserHub/partials/ReputationTab/partials/Balance.tsx
+++ b/src/components/common/Extensions/UserHub/partials/ReputationTab/partials/Balance.tsx
@@ -42,7 +42,9 @@ const ViewStakedButton: FC<ViewStakedButtonProps> = ({
 );
 
 const Balance: FC<BalanceProps> = ({ nativeToken, wallet, onTabChange }) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { formatMessage } = useIntl();
   const isMobile = useMobile();
 
@@ -51,7 +53,7 @@ const Balance: FC<BalanceProps> = ({ nativeToken, wallet, onTabChange }) => {
       input: {
         walletAddress: wallet?.address ?? '',
         tokenAddress: nativeToken?.tokenAddress ?? '',
-        colonyAddress: colony?.colonyAddress ?? '',
+        colonyAddress,
       },
     },
     skip: !wallet?.address || !nativeToken?.tokenAddress,

--- a/src/components/common/Extensions/UserHub/partials/StakesTab/StakesTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/StakesTab/StakesTab.tsx
@@ -41,10 +41,6 @@ const StakesTab = () => {
 
   const claimableStakes = stakesByFilterType.claimable;
 
-  if (!colony) {
-    return null;
-  }
-
   return (
     <div>
       <div className="flex items-center justify-between mb-4">

--- a/src/components/common/Extensions/UserHub/partials/StakesTab/useStakesByFilterType.ts
+++ b/src/components/common/Extensions/UserHub/partials/StakesTab/useStakesByFilterType.ts
@@ -14,7 +14,9 @@ import { getStakeStatus } from './helpers';
 import { StakesFilterType } from './types';
 
 export const useStakesByFilterType = () => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { user } = useAppContext();
   const { walletAddress } = user ?? {};
 
@@ -25,9 +27,9 @@ export const useStakesByFilterType = () => {
   } = useGetUserStakesQuery({
     variables: {
       userAddress: walletAddress ?? '',
-      colonyAddress: colony?.colonyAddress ?? '',
+      colonyAddress,
     },
-    skip: !walletAddress || !colony?.colonyAddress,
+    skip: !walletAddress,
     fetchPolicy: 'cache-and-network',
   });
   const userStakes = useMemo(

--- a/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
+++ b/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
@@ -30,7 +30,9 @@ const UserHubButton: FC<UserHubButtonProps> = ({
   hideUserNameOnMobile,
 }) => {
   const isMobile = useMobile();
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { wallet, user } = useAppContext();
   const [isUserHubOpen, setIsUserHubOpen] = useState(false);
 
@@ -110,7 +112,7 @@ const UserHubButton: FC<UserHubButtonProps> = ({
                 size="xxs"
               />
               <MemberReputation
-                colonyAddress={colony?.colonyAddress}
+                colonyAddress={colonyAddress}
                 hideOnMobile={hideMemberReputationOnMobile}
                 walletAddress={walletAddress}
               />

--- a/src/components/common/Extensions/UserNavigation/hooks.ts
+++ b/src/components/common/Extensions/UserNavigation/hooks.ts
@@ -122,14 +122,15 @@ export const useGroupedTransactionsAndMessages = (): {
     ApolloQueryResult<GetUserTransactionsQuery>
   >;
 } => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { user } = useAppContext();
   const [page, setPage] = useState(1);
 
   const visibleItems = TRANSACTION_LIST_PAGE_SIZE * page;
 
   const { walletAddress = '' } = user ?? {};
-  const { colonyAddress = '' } = colony ?? {};
 
   const transactionGroups = useSelector(groupedTransactionsSelector);
 

--- a/src/components/common/Extensions/UserNavigation/partials/MemberReputation/types.ts
+++ b/src/components/common/Extensions/UserNavigation/partials/MemberReputation/types.ts
@@ -1,8 +1,8 @@
 export interface MemberReputationProps {
-  colonyAddress?: string;
+  colonyAddress: string;
+  walletAddress: string;
   domainId?: number;
   hideOnMobile?: boolean;
   rootHash?: string;
   textClassName?: string;
-  walletAddress: string;
 }

--- a/src/components/common/Members/Members.tsx
+++ b/src/components/common/Members/Members.tsx
@@ -46,10 +46,10 @@ export type Member = User & {
   banned: boolean;
 };
 
-const getDomainSelectOptions = (colony?: Colony) => {
+const getDomainSelectOptions = (colony: Colony) => {
   return sortBy(
     [
-      ...(colony?.domains?.items || []),
+      ...(colony.domains?.items || []),
       {
         id: '',
         isRoot: true,
@@ -92,14 +92,14 @@ const Members = ({
 
   const filteredContributors = filterMembers(
     [],
-    colony?.metadata?.whitelistedAddresses ?? [],
+    colony.metadata?.whitelistedAddresses ?? [],
     searchValue,
     filters,
   );
 
   const filteredWatchers = filterMembers(
     [],
-    colony?.metadata?.whitelistedAddresses ?? [],
+    colony.metadata?.whitelistedAddresses ?? [],
     searchValue,
     filters,
   );

--- a/src/components/common/Members/MembersList/Actions/MemberActionsPopover.tsx
+++ b/src/components/common/Members/MembersList/Actions/MemberActionsPopover.tsx
@@ -40,10 +40,6 @@ const MemberActionsPopover = ({ closePopover, userAddress }: Props) => {
 
   const openManageWhitelistDialog = useDialog(ManageWhitelistDialog);
 
-  if (!colony) {
-    return null;
-  }
-
   const handleManageWhitelist = () => {
     openManageWhitelistDialog({
       userAddress,

--- a/src/components/common/Members/MembersList/MembersListItem.tsx
+++ b/src/components/common/Members/MembersList/MembersListItem.tsx
@@ -29,7 +29,9 @@ const MembersListItem = ({
   member,
 }: Props) => {
   const { address: walletAddress } = member;
-  const { colony } = useColonyContext();
+  const {
+    colony: { nativeToken },
+  } = useColonyContext();
   const { reputationAmount, reputationPercentage } = member as any;
 
   const renderedExtraItemContent = useMemo(
@@ -67,7 +69,7 @@ const MembersListItem = ({
           <div className={styles.reputationSection}>
             <MemberReputation
               nativeTokenDecimals={
-                colony?.nativeToken?.decimals || DEFAULT_TOKEN_DECIMALS
+                nativeToken?.decimals || DEFAULT_TOKEN_DECIMALS
               }
               userReputation={reputationAmount || ''}
               userReputationPercentage={reputationPercentage || ''}

--- a/src/components/common/NewActionButton/NewActionButton.tsx
+++ b/src/components/common/NewActionButton/NewActionButton.tsx
@@ -27,7 +27,10 @@ interface Props {
 }
 
 const NewActionButton = ({ filteredDomainId }: Props) => {
-  const { colony } = useColonyContext();
+  const {
+    colony,
+    colony: { nativeToken, colonyAddress },
+  } = useColonyContext();
   const { user, walletConnecting } = useAppContext();
 
   // const { version: networkVersion } = useNetworkContracts();
@@ -71,17 +74,13 @@ const NewActionButton = ({ filteredDomainId }: Props) => {
     variables: {
       input: {
         walletAddress: user?.walletAddress ?? '',
-        tokenAddress: colony?.nativeToken?.tokenAddress ?? '',
-        colonyAddress: colony?.colonyAddress ?? '',
+        tokenAddress: nativeToken.tokenAddress,
+        colonyAddress,
       },
     },
-    skip: !user?.walletAddress || !colony,
+    skip: !user?.walletAddress,
   });
   const tokenBalanceData = tokenBalanceQueryData?.getUserTokenBalance;
-
-  if (!colony) {
-    return null;
-  }
 
   return (
     <>
@@ -98,9 +97,9 @@ const NewActionButton = ({ filteredDomainId }: Props) => {
       />
       {/* Temporary way of activating tokens, to be deleted once the User Hub
   token activation is wired in */}
-      {tokenBalanceData && colony?.nativeToken && (
+      {tokenBalanceData && nativeToken && (
         <UserTokenActivationButton
-          nativeToken={colony?.nativeToken}
+          nativeToken={nativeToken}
           tokenBalanceData={tokenBalanceData}
         />
       )}

--- a/src/components/common/NewActionButton/wizardConfig.ts
+++ b/src/components/common/NewActionButton/wizardConfig.ts
@@ -29,7 +29,7 @@ import {
 } from '../Dialogs';
 
 export const getWizardFlowConfig = (
-  colony: Colony | undefined,
+  colony: Colony,
   filteredDomainId: number,
   enabledExtensionData: EnabledExtensionData,
 ) => [

--- a/src/components/common/TokenCard/TokenCard.tsx
+++ b/src/components/common/TokenCard/TokenCard.tsx
@@ -37,8 +37,9 @@ const MSG = defineMessages({
 });
 
 const TokenCard = ({ domainId, token }: Props) => {
-  const { colony } = useColonyContext();
-  const { balances, nativeToken, status } = colony || {};
+  const {
+    colony: { balances, nativeToken, status },
+  } = useColonyContext();
   const { nativeToken: nativeTokenStatus } = status || {};
 
   const currentTokenBalance =

--- a/src/components/common/UnclaimedTransfers/UnclaimedTransfers.tsx
+++ b/src/components/common/UnclaimedTransfers/UnclaimedTransfers.tsx
@@ -21,7 +21,9 @@ const MSG = defineMessages({
 });
 
 const UnclaimedTransfers = () => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { metadata },
+  } = useColonyContext();
   const claims = useColonyFundsClaims();
   if (!claims.length) {
     return null;
@@ -33,7 +35,7 @@ const UnclaimedTransfers = () => {
         <FormattedMessage
           {...MSG.title}
           values={{
-            colony: colony?.metadata?.displayName || 'colony',
+            colony: metadata?.displayName || 'colony',
           }}
         />
       </div>

--- a/src/components/common/UnclaimedTransfers/UnclaimedTransfersItem.tsx
+++ b/src/components/common/UnclaimedTransfers/UnclaimedTransfersItem.tsx
@@ -41,8 +41,8 @@ const UnclaimedTransfersItem = ({ claim }: Props) => {
   const {
     colony,
     canInteractWithColony,
-    startPolling: startPollingColony,
-    stopPolling: stopPollingColony,
+    startPollingColonyData,
+    stopPollingColonyData,
   } = useColonyContext();
   const [isClaimed, setIsClaimed] = useState(false);
 
@@ -55,8 +55,8 @@ const UnclaimedTransfersItem = ({ claim }: Props) => {
 
   const handleClaimSuccess = () => {
     setIsClaimed(true);
-    startPollingColony(1_000);
-    setTimeout(stopPollingColony, 10_000);
+    startPollingColonyData(1_000);
+    setTimeout(stopPollingColonyData, 10_000);
   };
 
   return (

--- a/src/components/frame/AvatarDropdown/AvatarDropdown.tsx
+++ b/src/components/frame/AvatarDropdown/AvatarDropdown.tsx
@@ -14,9 +14,9 @@ import AvatarDropdownPopoverMobile from './AvatarDropdownPopoverMobile';
 import styles from './AvatarDropdown.css';
 
 interface Props {
+  spinnerMsg: SimpleMessageValues;
   colony?: Colony;
   preventTransactions?: boolean;
-  spinnerMsg: SimpleMessageValues;
   tokenBalanceData?: UserTokenBalanceData;
 }
 
@@ -57,11 +57,9 @@ const AvatarDropdown = ({
         user?.profile?.displayName &&
         wallet?.address && (
           <AvatarDropdownPopoverMobile
-            {...{
-              colony,
-              spinnerMsg,
-              tokenBalanceData,
-            }}
+            colony={colony}
+            spinnerMsg={spinnerMsg}
+            tokenBalanceData={tokenBalanceData}
           />
         )
     : ({ close }) => (

--- a/src/components/frame/AvatarDropdown/AvatarDropdownPopoverMobile.tsx
+++ b/src/components/frame/AvatarDropdown/AvatarDropdownPopoverMobile.tsx
@@ -44,9 +44,9 @@ const MSG = defineMessages({
 });
 
 interface Props {
-  colony?: Colony;
   spinnerMsg: SimpleMessageValues;
   tokenBalanceData?: UserTokenBalanceData;
+  colony?: Colony;
 }
 
 const AvatarDropdownPopoverMobile = ({
@@ -57,7 +57,7 @@ const AvatarDropdownPopoverMobile = ({
   const { wallet } = useAppContext();
   const canInteractWithNetwork = useCanInteractWithNetwork();
 
-  const { colonyAddress, nativeToken } = colony || {};
+  const { colonyAddress = '', nativeToken } = colony || {};
 
   const { userReputation, totalReputation } = useUserReputation(
     colonyAddress,

--- a/src/components/frame/ColonyBackText/ColonyBackText.tsx
+++ b/src/components/frame/ColonyBackText/ColonyBackText.tsx
@@ -17,13 +17,10 @@ const MSG = defineMessages({
 });
 
 const ColonyBackText = () => {
-  const { colony } = useColonyContext();
-
-  if (!colony) {
-    return null;
-  }
-
-  const { displayName } = colony.metadata || {};
+  const {
+    colony: { metadata },
+  } = useColonyContext();
+  const { displayName } = metadata || {};
 
   return <FormattedMessage {...MSG.backText} values={{ displayName }} />;
 };

--- a/src/components/frame/Extensions/layouts/ColonyLayout.tsx
+++ b/src/components/frame/Extensions/layouts/ColonyLayout.tsx
@@ -7,7 +7,7 @@ import React, {
   useMemo,
   // useState,
 } from 'react';
-import { Navigate, useLocation, useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 //* Hide Initially */
 // import { defineMessages } from 'react-intl';
 // import { PaperPlaneTilt } from 'phosphor-react';
@@ -21,7 +21,7 @@ import {
   useTokensModalContext,
 } from '~context';
 import { useAppContext, useColonyContext } from '~hooks';
-import { NOT_FOUND_ROUTE, TX_SEARCH_PARAM } from '~routes';
+import { TX_SEARCH_PARAM } from '~routes';
 import ActionSidebar from '~v5/common/ActionSidebar';
 import ColonyCreatedModal from '~v5/common/Modals/ColonyCreatedModal';
 import ManageMemberModal from '~v5/common/Modals/ManageMemberModal';
@@ -49,7 +49,7 @@ const displayName = 'frame.Extensions.layouts.ColonyLayout';
 
 const ColonyLayout: FC<PropsWithChildren> = ({ children }) => {
   const { user } = useAppContext();
-  const { colony, loading } = useColonyContext();
+  const { colony } = useColonyContext();
   const { title: pageHeadingTitle, breadcrumbs = [] } = usePageHeadingContext();
   // @TODO: Eventually we want the action sidebar context to be better intergrated in the layout (maybe only used here and not in UserNavigation(Wrapper))
   const { actionSidebarToggle, actionSidebarInitialValues } =
@@ -118,15 +118,6 @@ const ColonyLayout: FC<PropsWithChildren> = ({ children }) => {
       ) : null,
     [isTokensModalOpen, txButtons, userHub],
   );
-
-  if (loading) {
-    // We have a spinner outside of this
-    return null;
-  }
-
-  if (!colony) {
-    return <Navigate to={NOT_FOUND_ROUTE} />;
-  }
 
   return (
     <>

--- a/src/components/frame/Extensions/layouts/ColonySidebar.tsx
+++ b/src/components/frame/Extensions/layouts/ColonySidebar.tsx
@@ -28,10 +28,11 @@ const ColonySidebar = ({ txButtons, userHub, transactionId }: Props) => {
   const {
     actionSidebarToggle: [, { toggle: toggleActionSideBar }],
   } = useActionSidebarContext();
-  const { colony } = useColonyContext();
-
-  const { metadata, chainMetadata, colonyAddress = '' } = colony || {};
-  const { chainId } = chainMetadata || {};
+  const {
+    colony: { metadata, chainMetadata, colonyAddress },
+    colony,
+  } = useColonyContext();
+  const { chainId } = chainMetadata;
 
   const chainIcon = getChainIconName(chainId);
 

--- a/src/components/frame/Extensions/layouts/hooks.tsx
+++ b/src/components/frame/Extensions/layouts/hooks.tsx
@@ -5,7 +5,6 @@ import { useLocation } from 'react-router-dom';
 import { ACTION } from '~constants/actions';
 import { TransactionGroupStates, useUserTransactionContext } from '~context';
 import { useActionSidebarContext } from '~context/ActionSidebarContext';
-import { ColonyFragment } from '~gql';
 import {
   useAppContext,
   useColonyContext,
@@ -42,7 +41,7 @@ export const useCalamityBannerInfo = (): UseCalamityBannerInfoReturnType => {
   const { colonyContractVersion } = useColonyContractVersion();
   const { user, wallet } = useAppContext();
   const allUserRoles = useTransformer(getAllUserRoles, [
-    colony as ColonyFragment,
+    colony,
     wallet?.address || '',
   ]);
 
@@ -89,8 +88,9 @@ export const useCalamityBannerInfo = (): UseCalamityBannerInfoReturnType => {
 };
 
 export const useMainMenuItems = (hasTransactionId: boolean) => {
-  const { colony } = useColonyContext();
-  const { metadata } = colony || {};
+  const {
+    colony: { metadata },
+  } = useColonyContext();
 
   const {
     actionSidebarToggle: [

--- a/src/components/frame/Extensions/pages/AdvancedPage/AdvancedPage.tsx
+++ b/src/components/frame/Extensions/pages/AdvancedPage/AdvancedPage.tsx
@@ -19,8 +19,10 @@ import NotificationBanner from '~v5/shared/NotificationBanner';
 const displayName = 'frame.Extensions.pages.AdvancedPage';
 
 const AdvancedPage: FC = () => {
-  const { colony } = useColonyContext();
-  const { version } = colony || {};
+  const {
+    colony: { version },
+    colony,
+  } = useColonyContext();
   const { colonyContractVersion } = useColonyContractVersion();
   // @BETA: Disabled for now
   // const isMobile = useMobile();

--- a/src/components/frame/Extensions/pages/ColonyDetailsPage/ColonyDetailsPage.tsx
+++ b/src/components/frame/Extensions/pages/ColonyDetailsPage/ColonyDetailsPage.tsx
@@ -44,13 +44,14 @@ const MSG = defineMessages({
 const ColonyDetailsPage: FC = () => {
   const { formatMessage } = useIntl();
   const isMobile = useMobile();
-  const { colony } = useColonyContext();
+  const {
+    colony: { metadata, colonyAddress, nativeToken, status },
+  } = useColonyContext();
 
   useSetPageHeadingTitle(
     formatMessage({ id: 'navigation.admin.colonyDetails' }),
   );
 
-  const { metadata, colonyAddress, nativeToken, status } = colony || {};
   const {
     avatar,
     thumbnail,

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/ExtensionDetailsPage.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/ExtensionDetailsPage.tsx
@@ -33,7 +33,10 @@ const displayName = 'frame.Extensions.pages.ExtensionDetailsPage';
 const ExtensionDetailsPage: FC = () => {
   const { extensionId } = useParams();
   const { pathname } = useLocation();
-  const { colony, refetchColony } = useColonyContext();
+  const {
+    colony: { colonyAddress, name: colonyName },
+    refetchColony,
+  } = useColonyContext();
   const navigate = useNavigate();
   const { extensionData, refetchExtensionData } = useExtensionData(
     extensionId ?? '',
@@ -43,7 +46,7 @@ const ExtensionDetailsPage: FC = () => {
 
   useSetPageHeadingTitle(formatText({ id: 'extensionsPage.title' }));
 
-  if (!colony || !extensionData) {
+  if (!extensionData) {
     return null;
   }
 
@@ -61,7 +64,7 @@ const ExtensionDetailsPage: FC = () => {
     mapPayload(({ params }) =>
       mapExtensionActionPayload(params, initializationParams),
     ),
-    mergePayload({ colonyAddress: colony?.colonyAddress, extensionData }),
+    mergePayload({ colonyAddress, extensionData }),
   );
 
   const schema = getValidationSchema({ initializationParams });
@@ -73,7 +76,7 @@ const ExtensionDetailsPage: FC = () => {
   };
 
   const handleFormSuccess = getFormSuccessFn<typeof defaultValues>({
-    colonyName: colony.name,
+    colonyName,
     extensionData,
     navigate,
     refetchColony,

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/ExtensionTopRow.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/ExtensionTopRow.tsx
@@ -28,10 +28,6 @@ const ExtensionsTopRow: FC<ExtensionsTopRowProps> = ({
 }) => {
   const { colony } = useColonyContext();
 
-  if (!colony) {
-    return null;
-  }
-
   const {
     neededColonyPermissions,
     // address will be undefined if the extension hasn't been installed / initialized yet

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/PermissionsNeededBanner.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/PermissionsNeededBanner.tsx
@@ -52,7 +52,7 @@ const PermissionsNeededBanner = ({ extensionData }: Props) => {
   const handleEnableClick = async () => {
     try {
       await asyncFunction({
-        colonyAddress: colony?.colonyAddress,
+        colonyAddress: colony.colonyAddress,
         extensionData,
       });
       setIsPermissionEnabled(true);

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetails/ExtensionDetails.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetails/ExtensionDetails.tsx
@@ -17,10 +17,6 @@ const ExtensionDetails: FC<ExtensionDetailsProps> = ({ extensionData }) => {
   const { user } = useAppContext();
   const { colony } = useColonyContext();
 
-  if (!colony) {
-    return null;
-  }
-
   const hasRootPermission =
     !!user &&
     addressHasRoles({

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetails/hooks.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetails/hooks.tsx
@@ -10,8 +10,9 @@ import Toast from '~shared/Extensions/Toast';
 import { waitForDbAfterExtensionAction } from '../../utils';
 
 export const useDeprecate = ({ extensionId }: { extensionId: Extension }) => {
-  const { colony } = useColonyContext();
-  const { colonyAddress = '' } = colony || {};
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { refetchExtensionData } = useExtensionData(extensionId);
   const deprecateExtensionValues = {
     colonyAddress,
@@ -63,9 +64,10 @@ export const useDeprecate = ({ extensionId }: { extensionId: Extension }) => {
 };
 
 export const useUninstall = ({ extensionId }: { extensionId: Extension }) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const [isLoading, setIsLoading] = useState(false);
-  const { colonyAddress = '' } = colony ?? {};
   const { refetchExtensionData } = useExtensionData(extensionId);
   const uninstallExtensionValues = {
     colonyAddress,
@@ -116,8 +118,9 @@ export const useUninstall = ({ extensionId }: { extensionId: Extension }) => {
 
 export const useReenable = ({ extensionId }: { extensionId: Extension }) => {
   const [isLoading, setIsLoading] = useState(false);
-  const { colony } = useColonyContext();
-  const { colonyAddress = '' } = colony ?? {};
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { refetchExtensionData } = useExtensionData(extensionId);
 
   const enableExtensionValues = {

--- a/src/components/frame/Extensions/pages/partials/ActionButtons.tsx
+++ b/src/components/frame/Extensions/pages/partials/ActionButtons.tsx
@@ -27,10 +27,6 @@ const ActionButtons: FC<ActionButtonProps> = ({
 
   const activeInstalls = useActiveInstalls(extensionData.extensionId);
 
-  if (!colony) {
-    return null;
-  }
-
   const userHasRoot =
     !!user &&
     addressHasRoles({

--- a/src/components/frame/Extensions/pages/partials/EnableButton.tsx
+++ b/src/components/frame/Extensions/pages/partials/EnableButton.tsx
@@ -41,10 +41,6 @@ const EnableButton = ({
     formState: { isValid, isSubmitting },
   } = useFormContext();
 
-  if (!colony) {
-    return null;
-  }
-
   const userHasArchitecture =
     !!user &&
     addressHasRoles({

--- a/src/components/frame/Extensions/pages/partials/InstallButton.tsx
+++ b/src/components/frame/Extensions/pages/partials/InstallButton.tsx
@@ -22,8 +22,10 @@ interface InstallButtonProps {
 const displayName = 'pages.ExtensionDetailsPage.InstallButton';
 
 const InstallButton = ({ extensionData }: InstallButtonProps) => {
-  const { colony, isSupportedColonyVersion } = useColonyContext();
-  const { colonyAddress = '', name: colonyName = '' } = colony ?? {};
+  const {
+    colony: { colonyAddress, name: colonyName },
+    isSupportedColonyVersion,
+  } = useColonyContext();
   const { refetchExtensionData } = useExtensionData(extensionData.extensionId);
   const [isInstallDisabled, setIsInstallDisabled] = useState(false);
   const [isPolling, setIsPolling] = useState(false);

--- a/src/components/frame/Extensions/pages/partials/UpgradeButton.tsx
+++ b/src/components/frame/Extensions/pages/partials/UpgradeButton.tsx
@@ -25,16 +25,17 @@ interface UpgradeButtonProps {
 }
 
 const UpgradeButton = ({ extensionData }: UpgradeButtonProps) => {
-  const { colony, isSupportedColonyVersion } = useColonyContext();
+  const {
+    colony: { colonyAddress, version: colonyVersion },
+    isSupportedColonyVersion,
+  } = useColonyContext();
   const isMobile = useMobile();
   const { refetchExtensionData } = useExtensionData(extensionData.extensionId);
   const [isPolling, setIsPolling] = useState(false);
   const [isUpgradeDisabled, setIsUpgradeDisabled] = useState(false);
 
-  const { colonyAddress = '' } = colony || {};
-
   const transformUpgrade = mapPayload(() => ({
-    colonyAddress: colony?.colonyAddress,
+    colonyAddress,
     extensionId: extensionData.extensionId,
     version: extensionData.availableVersion,
   }));
@@ -42,7 +43,7 @@ const UpgradeButton = ({ extensionData }: UpgradeButtonProps) => {
   const extensionCompatible = isExtensionCompatible(
     Extension[extensionData.extensionId],
     extensionData.availableVersion as ExtensionVersion,
-    colony?.version as ColonyVersion,
+    colonyVersion as ColonyVersion,
   );
   const isUpgradeButtonDisabled =
     !isSupportedColonyVersion || !extensionCompatible || isUpgradeDisabled;

--- a/src/components/frame/HamburgerDropdown/HamburgerDropdownPopover.tsx
+++ b/src/components/frame/HamburgerDropdown/HamburgerDropdownPopover.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 // import { defineMessages } from 'react-intl';
 
-import {
-  useAppContext,
-  useColonyContext,
-  useCanInteractWithNetwork,
-} from '~hooks';
+import { useAppContext, useCanInteractWithNetwork } from '~hooks';
 import DropdownMenu from '~shared/DropdownMenu';
 import {
   ColonySection,
@@ -31,14 +27,13 @@ interface Props {
 }
 
 const HamburgerDropdownPopover = ({ closePopover }: Props) => {
-  const { colony } = useColonyContext();
   const { user, wallet } = useAppContext();
   const canInteractWithNetwork = useCanInteractWithNetwork();
 
   return (
     <div className={styles.menu}>
       <DropdownMenu onClick={closePopover}>
-        {user?.profile?.displayName && colony?.name && <ColonySection />}
+        {user?.profile?.displayName && <ColonySection />}
         <UserSection />
         {canInteractWithNetwork && <CreateColonySection />}
         <HelperSection />

--- a/src/components/frame/RouteLayouts/UserNavigation/UserNavigation.tsx
+++ b/src/components/frame/RouteLayouts/UserNavigation/UserNavigation.tsx
@@ -36,14 +36,14 @@ const MSG = defineMessages({
 });
 
 const UserNavigation = () => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress, nativeToken },
+  } = useColonyContext();
   const { wallet } = useAppContext();
   const { tokenBalanceData } = useUserTokenBalanceContext();
   const { formatMessage } = useIntl();
   const isMobile = useMobile();
   const canInteractWithNetwork = useCanInteractWithNetwork();
-
-  const { colonyAddress } = colony || {};
 
   const { userReputation, totalReputation } = useUserReputation(
     colonyAddress,
@@ -52,7 +52,7 @@ const UserNavigation = () => {
 
   return (
     <div className={styles.main}>
-      {colony?.colonyAddress && wallet && !isMobile && (
+      {wallet && !isMobile && (
         <Tooltip
           content={formatMessage(MSG.userReputationTooltip)}
           placement="bottom-start"
@@ -76,10 +76,10 @@ const UserNavigation = () => {
           </div>
         </Tooltip>
       )}
-      {canInteractWithNetwork && colony?.nativeToken && tokenBalanceData && (
+      {canInteractWithNetwork && tokenBalanceData && (
         <div className={`${styles.elementWrapper} ${styles.walletWrapper}`}>
           <UserTokenActivationButton
-            nativeToken={colony.nativeToken}
+            nativeToken={nativeToken}
             tokenBalanceData={tokenBalanceData}
             dataTest="tokenActivationButton"
           />

--- a/src/components/frame/SubscribedColoniesList/SubscribedColoniesDropdown.tsx
+++ b/src/components/frame/SubscribedColoniesList/SubscribedColoniesDropdown.tsx
@@ -19,8 +19,6 @@ interface Props {
 
 const SubscribedColoniesDropdown = ({ watchlist }: Props) => {
   const { colony: activeColony } = useColonyContext();
-  const colonyToDisplay = activeColony || watchlist[0]?.colony;
-  const colonyToDisplayAddress = colonyToDisplay?.colonyAddress;
 
   return (
     <Popover
@@ -58,13 +56,13 @@ const SubscribedColoniesDropdown = ({ watchlist }: Props) => {
         className={({ isActive }) =>
           isActive ? styles.activeColony : styles.itemLink
         }
-        title={colonyToDisplay?.name}
-        to={`/${colonyToDisplay?.name}`}
+        title={activeColony.name}
+        to={`/${activeColony.name}`}
       >
         <div className={styles.itemImage}>
           <ColonyAvatar
-            colony={colonyToDisplay as Colony}
-            colonyAddress={colonyToDisplayAddress || ''}
+            colony={activeColony}
+            colonyAddress={activeColony.colonyAddress}
             size="xs"
           />
         </div>

--- a/src/components/frame/TokenActivation/StakesTab/ClaimAllButton.tsx
+++ b/src/components/frame/TokenActivation/StakesTab/ClaimAllButton.tsx
@@ -24,7 +24,7 @@ const ClaimAllButton = ({
   userAddress,
   colonyAddress,
 }: Props) => {
-  const { startPolling, stopPolling } = useColonyContext();
+  const { startPollingColonyData, stopPollingColonyData } = useColonyContext();
   const { pollLockedTokenBalance } = useUserTokenBalanceContext();
   const { setIsOpen } = useTokenActivationContext();
   const { extensionData: votingRepitationExtension } = useExtensionData(
@@ -46,8 +46,8 @@ const ClaimAllButton = ({
       dataTest="claimAllStakesButton"
       onSuccess={() => {
         setIsOpen(false);
-        startPolling(1000);
-        setTimeout(stopPolling, 10_000);
+        startPollingColonyData(1000);
+        setTimeout(stopPollingColonyData, 10_000);
         pollLockedTokenBalance();
       }}
     />

--- a/src/components/frame/TokenActivation/StakesTab/StakesTab.tsx
+++ b/src/components/frame/TokenActivation/StakesTab/StakesTab.tsx
@@ -33,13 +33,10 @@ export interface Props {
 }
 
 const StakesTab = ({ currentUserClaims }: Props) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { nativeToken, name: colonyName, colonyAddress },
+  } = useColonyContext();
   const { wallet, user } = useAppContext();
-  const { nativeToken } = colony || {};
-
-  if (!nativeToken) {
-    return null;
-  }
 
   return (
     <div className={styles.stakesContainer}>
@@ -50,7 +47,7 @@ const StakesTab = ({ currentUserClaims }: Props) => {
             <ClaimAllButton
               unclaimedStakes={currentUserClaims}
               userAddress={wallet?.address || ''}
-              colonyAddress={colony?.colonyAddress || ''}
+              colonyAddress={colonyAddress}
             />
           </div>
           <ul data-test="claimableMotionsList">
@@ -70,7 +67,7 @@ const StakesTab = ({ currentUserClaims }: Props) => {
                     nativeToken.decimals,
                   )}
                   tokenSymbol={nativeToken.symbol}
-                  colonyName={colony?.name || ''}
+                  colonyName={colonyName}
                   key={motionId}
                   motionId={motionId}
                 />

--- a/src/components/frame/TokenActivation/TokenActivationContent/TokenActivationContent.tsx
+++ b/src/components/frame/TokenActivation/TokenActivationContent/TokenActivationContent.tsx
@@ -28,7 +28,7 @@ const TokenActivationContent = ({ tokenBalanceData }: TokensTabProps) => {
   const { colony } = useColonyContext();
   const { user } = useAppContext();
 
-  const currentUserClaims = colony?.motionsWithUnclaimedStakes
+  const currentUserClaims = colony.motionsWithUnclaimedStakes
     ?.filter(notNull)
     .filter(({ unclaimedRewards }) =>
       unclaimedRewards.some(({ address }) => address === user?.walletAddress),

--- a/src/components/frame/TokenActivation/TokensTab/ChangeTokenStateForm.tsx
+++ b/src/components/frame/TokenActivation/TokensTab/ChangeTokenStateForm.tsx
@@ -71,13 +71,14 @@ const ChangeTokenStateForm = ({
   tokenBalanceData: { inactiveBalance, activeBalance, lockedBalance },
   hasLockedTokens,
 }: ChangeTokenStateFormProps) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { nativeToken, colonyAddress },
+  } = useColonyContext();
   const { pollActiveTokenBalance } = useUserTokenBalanceContext();
 
   const [isActivate, setIsActive] = useState(true);
 
-  const nativeToken = colony?.nativeToken;
-  const tokenDecimals = getTokenDecimalsWithFallback(nativeToken?.decimals);
+  const tokenDecimals = getTokenDecimalsWithFallback(nativeToken.decimals);
   const tokenBalance = isActivate ? inactiveBalance : activeBalance;
   const tokenBalanceInEthers = moveDecimal(tokenBalance, -tokenDecimals);
 
@@ -89,13 +90,13 @@ const ChangeTokenStateForm = ({
     mapPayload(({ amount }) => {
       // Convert amount string with decimals to BigInt (eth to wei)
       const formattedAmount = BigNumber.from(
-        moveDecimal(amount, nativeToken?.decimals),
+        moveDecimal(amount, nativeToken.decimals),
       );
 
       return {
         amount: formattedAmount,
-        colonyAddress: colony?.colonyAddress,
-        tokenAddress: nativeToken?.tokenAddress,
+        colonyAddress,
+        tokenAddress: nativeToken.tokenAddress,
       };
     }),
   );
@@ -145,7 +146,7 @@ const ChangeTokenStateForm = ({
                 formattingOptions={{
                   delimiter: ',',
                   numeral: true,
-                  numeralDecimalScale: nativeToken?.decimals,
+                  numeralDecimalScale: nativeToken.decimals,
                 }}
                 maxButtonParams={{
                   maxAmount: tokenBalanceInEthers,
@@ -173,7 +174,7 @@ const ChangeTokenStateForm = ({
                       <Numeral
                         value={tokenBalance ?? 0}
                         decimals={tokenDecimals}
-                        suffix={nativeToken?.symbol}
+                        suffix={nativeToken.symbol}
                         className={styles.balanceAmount}
                       />
                     ),
@@ -199,7 +200,7 @@ const ChangeTokenStateForm = ({
                         <Numeral
                           value={lockedBalance ?? 0}
                           decimals={tokenDecimals}
-                          suffix={nativeToken?.symbol}
+                          suffix={nativeToken.symbol}
                           className={styles.balanceAmount}
                         />
                       ),

--- a/src/components/frame/TokenActivation/TokensTab/TokensTab.tsx
+++ b/src/components/frame/TokenActivation/TokensTab/TokensTab.tsx
@@ -66,10 +66,11 @@ export interface TokensTabProps {
 }
 
 const TokensTab = ({ tokenBalanceData }: TokensTabProps) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { nativeToken },
+  } = useColonyContext();
   const targetRef = useRef<HTMLParagraphElement>(null);
 
-  const { nativeToken } = colony || {};
   const {
     balance,
     inactiveBalance,

--- a/src/components/frame/v5/pages/ActivityPage/hooks.tsx
+++ b/src/components/frame/v5/pages/ActivityPage/hooks.tsx
@@ -15,8 +15,9 @@ const getFormattedActionsCount = (count: number) =>
   count > 1000 ? '999+' : count;
 
 export const useActivityFeedWidgets = (): WidthBoxItem[] => {
-  const { colony } = useColonyContext();
-  const { domains, colonyAddress = '' } = colony ?? {};
+  const {
+    colony: { domains, colonyAddress },
+  } = useColonyContext();
   const selectedDomain = useGetSelectedDomainFilter();
 
   const { actionsCount: totalActions, loading: totalActionsLoading } =

--- a/src/components/frame/v5/pages/BalancePage/hooks.ts
+++ b/src/components/frame/v5/pages/BalancePage/hooks.ts
@@ -11,13 +11,14 @@ import {
 import { UseBalancePageReturnType } from './types';
 
 export const useBalancePage = (): UseBalancePageReturnType => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { tokens: colonyTokens, balances },
+  } = useColonyContext();
   const selectedDomain = useGetSelectedDomainFilter();
-  const { balances } = colony || {};
 
   const tokensData = useMemo(
     () =>
-      colony?.tokens?.items.map((item) => {
+      colonyTokens?.items.map((item) => {
         const currentTokenBalance =
           getBalanceForTokenAndDomain(
             balances,
@@ -40,7 +41,7 @@ export const useBalancePage = (): UseBalancePageReturnType => {
           balance: typeof formattedValue === 'string' ? formattedValue : '',
         };
       }),
-    [colony, balances, selectedDomain],
+    [colonyTokens, balances, selectedDomain],
   );
 
   const sortedTokens = useMemo(

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/BalanceTable.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/BalanceTable.tsx
@@ -31,8 +31,9 @@ const displayName = 'v5.pages.BalancePage.partials.BalaceTable';
 
 const BalanceTable: FC<BalanceTableProps> = ({ data }) => {
   const selectedDomain = useGetSelectedDomainFilter();
-  const { colony } = useColonyContext();
-  const { balances, nativeToken, status, colonyAddress } = colony || {};
+  const {
+    colony: { balances, nativeToken, status, colonyAddress },
+  } = useColonyContext();
   const { nativeToken: nativeTokenStatus } = status || {};
   const isMobile = useMobile();
   // const { searchValue } = useSearchContext();

--- a/src/components/frame/v5/pages/FundsPage/partials/AcceptButton/AcceptButton.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/AcceptButton/AcceptButton.tsx
@@ -18,8 +18,8 @@ const AcceptButton: FC<AcceptButtonProps> = ({
   const {
     colony,
     canInteractWithColony,
-    startPolling: startPollingColony,
-    stopPolling: stopPollingColony,
+    startPollingColonyData,
+    stopPollingColonyData,
   } = useColonyContext();
   const [isClaimed, setIsClaimed] = useState(false);
 
@@ -30,8 +30,8 @@ const AcceptButton: FC<AcceptButtonProps> = ({
 
   const handleClaimSuccess = () => {
     setIsClaimed(true);
-    startPollingColony(1_000);
-    setTimeout(stopPollingColony, 10_000);
+    startPollingColonyData(1_000);
+    setTimeout(stopPollingColonyData, 10_000);
   };
 
   return (

--- a/src/components/frame/v5/pages/FundsPage/partials/FundsTable/hooks.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/FundsTable/hooks.tsx
@@ -45,14 +45,14 @@ export const useFundsTable = (): UseFundsTableProps => {
   const claims = useColonyFundsClaims();
   const colonyTokens = useMemo(
     () =>
-      colony?.tokens?.items.filter(notNull).sort((a, b) => {
+      colony.tokens?.items.filter(notNull).sort((a, b) => {
         if (!a.token || !b.token) return 0;
 
         return a.token.name
           .toLowerCase()
           .localeCompare(b.token.name.toLowerCase());
       }) || [],
-    [colony?.tokens?.items],
+    [colony.tokens?.items],
   );
   const colonyClaims = colonyTokens.filter(({ token }) =>
     claims.some(

--- a/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
@@ -26,8 +26,9 @@ const displayName = 'v5.pages.FundsPage.partials.TokenTable';
 
 const TokenTable: FC<TokenTableProps> = ({ token }) => {
   const isMobile = useMobile();
-  const { colony } = useColonyContext();
-  const { nativeToken } = colony || {};
+  const {
+    colony: { nativeToken },
+  } = useColonyContext();
   const claims = useColonyFundsClaims();
   const currentClaims = claims.filter(
     ({ token: currentClaimToken }) => currentClaimToken?.name === token?.name,
@@ -56,7 +57,7 @@ const TokenTable: FC<TokenTableProps> = ({ token }) => {
     top: 8,
   });
 
-  const isTokenNative = token?.tokenAddress === nativeToken?.tokenAddress;
+  const isTokenNative = token?.tokenAddress === nativeToken.tokenAddress;
 
   const handleToggleToken = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -95,7 +96,7 @@ const TokenTable: FC<TokenTableProps> = ({ token }) => {
               </span>
             </button>
             <div>
-              <Numeral value={claimsAmount} decimals={nativeToken?.decimals} />{' '}
+              <Numeral value={claimsAmount} decimals={nativeToken.decimals} />{' '}
               {token?.symbol}
             </div>
           </div>

--- a/src/components/frame/v5/pages/MembersPage/AllMembersPage.tsx
+++ b/src/components/frame/v5/pages/MembersPage/AllMembersPage.tsx
@@ -15,14 +15,15 @@ const AllMembersPage: FC = () => {
   const { membersList, loading, hasMoreMembers, loadMoreMembers } =
     useMembersPage();
   const { handleClipboardCopy } = useCopyToClipboard();
-  const { colony } = useColonyContext();
+  const {
+    colony: { name: colonyName },
+  } = useColonyContext();
   const { setSearchValue } = useSearchContext();
   const { handleClearFilters } = useFilterContext();
 
   useSetPageHeadingTitle(formatText({ id: 'membersPage.title' }));
 
-  const { name } = colony || {};
-  const colonyURL = `${window.location.origin}/${name}`;
+  const colonyURL = `${window.location.origin}/${colonyName}`;
 
   // clear filters and searches when unmounting
   useEffect(

--- a/src/components/frame/v5/pages/MembersPage/ContributorsPage.tsx
+++ b/src/components/frame/v5/pages/MembersPage/ContributorsPage.tsx
@@ -17,12 +17,12 @@ const ContributorsPage: FC = () => {
     loadMoreContributors,
   } = useMembersPage();
   const { handleClipboardCopy } = useCopyToClipboard();
-  const { colony } = useColonyContext();
+  const {
+    colony: { name: colonyName },
+  } = useColonyContext();
 
   useSetPageHeadingTitle(formatText({ id: 'membersPage.title' }));
-
-  const { name } = colony || {};
-  const colonyURL = `${window.location.origin}/${name}`;
+  const colonyURL = `${window.location.origin}/${colonyName}`;
 
   return (
     <MembersTabContent

--- a/src/components/frame/v5/pages/MembersPage/partials/MembersTabContent/MembersTabContent.tsx
+++ b/src/components/frame/v5/pages/MembersPage/partials/MembersTabContent/MembersTabContent.tsx
@@ -22,15 +22,16 @@ const MembersTabContent: FC<PropsWithChildren<MembersTabContentProps>> = ({
   emptyContentProps,
 }) => {
   const items = useMembersTabContentItems(itemsProp);
-  const { colony, canInteractWithColony } = useColonyContext();
+  const {
+    colony: { name: colonyName },
+    canInteractWithColony,
+  } = useColonyContext();
   const { handleClipboardCopy, isCopied } = useCopyToClipboard();
   const { user } = useAppContext();
 
   const showPlaceholderCard =
     user && !withSimpleCards && canInteractWithColony && items.length < 12;
-
-  const { name } = colony || {};
-  const colonyURL = `${window.location.origin}/${name}`;
+  const colonyURL = `${window.location.origin}/${colonyName}`;
 
   return (
     <div

--- a/src/components/frame/v5/pages/MembersPage/utils.ts
+++ b/src/components/frame/v5/pages/MembersPage/utils.ts
@@ -9,7 +9,7 @@ import { UserStatusMode } from '~v5/common/Pills/types';
 export const getMembersList = (
   members: ColonyContributorFragment[],
   selectedTeamId: number | undefined,
-  colony: ColonyFragment | undefined,
+  colony: ColonyFragment,
 ) => {
   return members.map((contributor) => {
     const {

--- a/src/components/shared/ConfusableWarning/ConfusableWarning.tsx
+++ b/src/components/shared/ConfusableWarning/ConfusableWarning.tsx
@@ -34,7 +34,7 @@ const WarningLabel = (chunks: React.ReactNode[]) => (
   <span className={styles.warningLabel}>{chunks}</span>
 );
 
-const ConfusableWarning = ({ walletAddress, colonyAddress }: Props) => {
+const ConfusableWarning = ({ walletAddress, colonyAddress = '' }: Props) => {
   const { userReputation, totalReputation } = useUserReputation(
     colonyAddress,
     walletAddress,

--- a/src/components/shared/PopoverSection/ColonySection.tsx
+++ b/src/components/shared/PopoverSection/ColonySection.tsx
@@ -33,7 +33,7 @@ const MSG = defineMessages({
 
 const ColonySection = () => {
   const { colony } = useColonyContext();
-  const colonyHomePath = `/${colony?.name}`;
+  const colonyHomePath = `/${colony.name}`;
 
   return (
     <DropdownMenuSection>

--- a/src/components/shared/UserInfoPopover/UserInfoPopover.tsx
+++ b/src/components/shared/UserInfoPopover/UserInfoPopover.tsx
@@ -109,16 +109,14 @@ const UserInfoPopover = ({ user, banned = false, address }: Props) => {
             )}
           </div>
         )}
-        {colony && (
-          <div className={styles.section}>
-            <UserReputation
-              colony={colony}
-              userReputationForTopDomains={userReputation || []}
-              isCurrentUserReputation={wallet?.address === walletAddress}
-              isUserReputationLoading={loadingUserReputation}
-            />
-          </div>
-        )}
+        <div className={styles.section}>
+          <UserReputation
+            colony={colony}
+            userReputationForTopDomains={userReputation || []}
+            isCurrentUserReputation={wallet?.address === walletAddress}
+            isUserReputationLoading={loadingUserReputation}
+          />
+        </div>
         {/* {!totalBalance.isZero() && nativeToken && (
           <div className={styles.section}>
             <UserTokens totalBalance={totalBalance} nativeToken={nativeToken} />

--- a/src/components/v5/common/ActionSidebar/consts.tsx
+++ b/src/components/v5/common/ActionSidebar/consts.tsx
@@ -17,7 +17,7 @@ export const DECISION_METHOD_FIELD_NAME = 'decisionMethod';
 
 export const useCreateActionTypeNotification = (action: Action | undefined) => {
   const { colony } = useColonyContext();
-  const isNativeTokenUnlocked = !!colony?.status?.nativeToken?.unlocked;
+  const isNativeTokenUnlocked = !!colony.status?.nativeToken?.unlocked;
 
   if (!action) {
     return undefined;

--- a/src/components/v5/common/ActionSidebar/hooks/useActionDescriptionMetadata.tsx
+++ b/src/components/v5/common/ActionSidebar/hooks/useActionDescriptionMetadata.tsx
@@ -60,7 +60,7 @@ export const useActionDescriptionMetadata = () => {
   const { colony } = useColonyContext();
 
   return useMemo(() => {
-    if (!selectedAction || !colony || !user) {
+    if (!selectedAction || !user) {
       return undefined;
     }
 

--- a/src/components/v5/common/ActionSidebar/hooks/useActionsList.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useActionsList.ts
@@ -50,11 +50,11 @@ export const useActionsList = () => {
       isVotingReputationEnabled);
   const canMoveFunds = canFund(allUserRoles);
   const canUserMintNativeToken = isVotingReputationEnabled
-    ? colony?.status?.nativeToken?.mintable
-    : hasRoot(allUserRoles) && colony?.status?.nativeToken?.mintable;
+    ? colony.status?.nativeToken?.mintable
+    : hasRoot(allUserRoles) && colony.status?.nativeToken?.mintable;
   const canUserUnlockNativeToken = isVotingReputationEnabled
-    ? colony?.status?.nativeToken?.unlockable
-    : hasRoot(allUserRoles) && colony?.status?.nativeToken?.unlockable;
+    ? colony.status?.nativeToken?.unlockable
+    : hasRoot(allUserRoles) && colony.status?.nativeToken?.unlockable;
   const canManageTokens = hasRoot(allUserRoles);
   // @BETA: Disabled for now
   // const canSmiteReputation =

--- a/src/components/v5/common/ActionSidebar/hooks/useGetColonyAction.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useGetColonyAction.ts
@@ -28,7 +28,7 @@ export const useGetColonyAction = (transactionHash?: string) => {
   const { refetchTokenBalances } = useUserTokenBalanceContext();
   const isInvalidTx = !isTransactionFormat(transactionHash);
   /* Unfortunately, we need to track polling state ourselves: https://github.com/apollographql/apollo-client/issues/9081#issuecomment-975722271 */
-  const [isPolling, setIsPolling] = useState(isInvalidTx);
+  const [isPolling, setIsPolling] = useState(!isInvalidTx);
 
   const pollInterval = getSafePollingInterval();
 
@@ -49,7 +49,7 @@ export const useGetColonyAction = (transactionHash?: string) => {
   const action = actionData?.getColonyAction;
 
   useEffect(() => {
-    const shouldPool = isInvalidTx && !action;
+    const shouldPool = !isInvalidTx && !action;
 
     setIsPolling(shouldPool);
 

--- a/src/components/v5/common/ActionSidebar/hooks/useGetColonyAction.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useGetColonyAction.ts
@@ -21,12 +21,14 @@ export type RefetchAction = ReturnType<
 >['refetch'];
 
 export const useGetColonyAction = (transactionHash?: string) => {
-  const { colony, refetchColony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+    refetchColony,
+  } = useColonyContext();
   const { refetchTokenBalances } = useUserTokenBalanceContext();
-  const isValidTx = isTransactionFormat(transactionHash);
-  const skipQuery = !colony || !isValidTx;
+  const isInvalidTx = !isTransactionFormat(transactionHash);
   /* Unfortunately, we need to track polling state ourselves: https://github.com/apollographql/apollo-client/issues/9081#issuecomment-975722271 */
-  const [isPolling, setIsPolling] = useState(!skipQuery);
+  const [isPolling, setIsPolling] = useState(isInvalidTx);
 
   const pollInterval = getSafePollingInterval();
 
@@ -37,7 +39,7 @@ export const useGetColonyAction = (transactionHash?: string) => {
     stopPolling: stopPollingForAction,
     refetch: refetchAction,
   } = useGetColonyActionQuery({
-    skip: skipQuery,
+    skip: isInvalidTx,
     variables: {
       transactionHash: transactionHash ?? '',
     },
@@ -47,7 +49,7 @@ export const useGetColonyAction = (transactionHash?: string) => {
   const action = actionData?.getColonyAction;
 
   useEffect(() => {
-    const shouldPool = !skipQuery && !action;
+    const shouldPool = isInvalidTx && !action;
 
     setIsPolling(shouldPool);
 
@@ -79,7 +81,7 @@ export const useGetColonyAction = (transactionHash?: string) => {
     pollInterval,
     refetchColony,
     refetchTokenBalances,
-    skipQuery,
+    isInvalidTx,
     startPollingForAction,
     stopPollingForAction,
   ]);
@@ -89,10 +91,10 @@ export const useGetColonyAction = (transactionHash?: string) => {
     loading: loadingMotionState,
     refetch: refetchMotionState,
   } = useGetMotionStateQuery({
-    skip: !action?.motionData || skipQuery,
+    skip: !action?.motionData || isInvalidTx,
     variables: {
       input: {
-        colonyAddress: colony?.colonyAddress ?? '',
+        colonyAddress,
         databaseMotionId: action?.motionData?.databaseMotionId ?? '',
       },
     },
@@ -110,9 +112,9 @@ export const useGetColonyAction = (transactionHash?: string) => {
   }, [action?.motionData, refetchMotionState]);
 
   return {
-    isInvalidTransactionHash: !isValidTx,
+    isInvalidTransactionHash: isInvalidTx,
     isUnknownTransaction:
-      isValidTx && action?.colony?.colonyAddress !== colony?.colonyAddress,
+      !isInvalidTx && action?.colony?.colonyAddress !== colonyAddress,
     loadingAction: loadingAction || isPolling || loadingMotionState,
     action,
     startPollingForAction,

--- a/src/components/v5/common/ActionSidebar/hooks/useReputationValidation.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useReputationValidation.ts
@@ -23,7 +23,9 @@ export const reputationValidationSchema = object()
   .defined();
 
 export const useReputationValidation = () => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const {
     watch,
     setValue,
@@ -42,11 +44,10 @@ export const useReputationValidation = () => {
 
   const createdInDomainId = createdIn ? Number(createdIn) : Id.RootDomain;
   const { data } = useGetUserReputationQuery({
-    skip: !colony?.colonyAddress,
     variables: {
       input: {
         walletAddress: ADDRESS_ZERO,
-        colonyAddress: colony?.colonyAddress ?? '',
+        colonyAddress,
         domainId: createdInDomainId,
       },
     },

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/hooks.ts
@@ -1,5 +1,7 @@
 import { useFormContext } from 'react-hook-form';
+
 import { useFlatFormErrors } from '~hooks';
+
 import { REPUTATION_VALIDATION_FIELD_NAME } from '../../hooks/useReputationValidation';
 
 export const useGetActionErrors = () => {

--- a/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
@@ -144,7 +144,7 @@ const AmountField: FC<AmountFieldProps> = ({
                 <ul>
                   {colonyTokens.map((colonyToken) => {
                     const tokenBalance = getBalanceForTokenAndDomain(
-                      colony?.balances,
+                      colony.balances,
                       colonyToken.tokenAddress,
                       Number(teamId) || Id.RootDomain,
                     );

--- a/src/components/v5/common/ActionSidebar/partials/AmountField/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/hooks.ts
@@ -14,13 +14,11 @@ export const useAmountField = (
   const { colony } = useColonyContext();
 
   const colonyTokens =
-    colony?.tokens?.items
+    colony.tokens?.items
       .filter(notNull)
       .map((colonyToken) => colonyToken.token) || [];
 
-  const selectedToken = colony
-    ? getSelectedToken(colony, selectedTokenAddress)
-    : undefined;
+  const selectedToken = getSelectedToken(colony, selectedTokenAddress);
 
   const formattingOptions = useMemo(
     () => ({

--- a/src/components/v5/common/ActionSidebar/partials/ColonyDetailsFields/partials/ColonyAvatarField/ColonyAvatarField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ColonyDetailsFields/partials/ColonyAvatarField/ColonyAvatarField.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 import { useController } from 'react-hook-form';
 
-import { ADDRESS_ZERO } from '~constants';
 import { useAdditionalFormOptionsContext } from '~context/AdditionalFormOptionsContext/AdditionalFormOptionsContext';
 import { useColonyContext } from '~hooks';
 import useToggle from '~hooks/useToggle';
@@ -39,7 +38,9 @@ const ColonyAvatarField: FC<ColonyAvatarFieldProps> = ({
     { toggleOff: toggleAvatarModalOff, toggleOn: toggleAvatarModalOn },
   ] = useToggle();
   const uploaderText = useGetUploaderText(fileOptions);
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress, name: colonyName },
+  } = useColonyContext();
 
   return (
     <>
@@ -47,8 +48,8 @@ const ColonyAvatarField: FC<ColonyAvatarFieldProps> = ({
         <Avatar
           avatar={field.value?.image}
           placeholderIcon="at-sign-circle"
-          seed={colony?.colonyAddress && colony?.colonyAddress.toLowerCase()}
-          title={colony?.name}
+          seed={colonyAddress.toLowerCase()}
+          title={colonyName}
           size="xs"
         />
       </div>
@@ -94,7 +95,7 @@ const ColonyAvatarField: FC<ColonyAvatarFieldProps> = ({
                   colonyImageProps={{
                     src: modalValue?.image,
                   }}
-                  colonyAddress={colony?.colonyAddress || ADDRESS_ZERO}
+                  colonyAddress={colonyAddress}
                 />,
               )}
             </div>

--- a/src/components/v5/common/ActionSidebar/partials/ColonyObjectiveFields/ColonyObjectiveFields.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ColonyObjectiveFields/ColonyObjectiveFields.tsx
@@ -33,7 +33,7 @@ const MSG = defineMessages({
 
 const ColonyObjectiveFields: FC = () => {
   const { colony } = useColonyContext();
-  const { objective } = colony?.metadata || {};
+  const { objective } = colony.metadata || {};
 
   return (
     <>

--- a/src/components/v5/common/ActionSidebar/partials/ColonyVersionField/ColonyVersionField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ColonyVersionField/ColonyVersionField.tsx
@@ -7,13 +7,9 @@ import ActionFormRow from '~v5/common/ActionFormRow';
 const displayName = 'v5.common.ActionsContent.partials.ColonyVersionField';
 
 const ColonyVersionField: FC = () => {
-  const { colony } = useColonyContext();
-
-  if (!colony) {
-    return null;
-  }
-
-  const currentVersion = colony.version;
+  const {
+    colony: { version: currentVersion },
+  } = useColonyContext();
   const nextVersion = currentVersion + 1;
 
   return (

--- a/src/components/v5/common/ActionSidebar/partials/DescriptionRow/DescriptionRow.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/DescriptionRow/DescriptionRow.tsx
@@ -6,6 +6,7 @@ import { formatText } from '~utils/intl';
 import ActionFormRow from '~v5/common/ActionFormRow';
 
 import DescriptionField from '../DescriptionField';
+
 import { DescriptionRowProps } from './types';
 
 const displayName = 'v5.common.ActionSidebar.partials.DescriptionRow';

--- a/src/components/v5/common/ActionSidebar/partials/Motions/partials/MotionCountDownTimer/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/partials/MotionCountDownTimer/hooks.ts
@@ -7,7 +7,7 @@ import { MotionState } from '~utils/colonyMotions';
 
 import { getCurrentStatePeriodInMs, splitTimeLeft } from './helpers';
 
-const useMotionTimeoutPeriods = (colonyAddress = '', motionId: string) => {
+const useMotionTimeoutPeriods = (colonyAddress: string, motionId: string) => {
   const { data, loading, refetch } = useGetMotionTimeoutPeriodsQuery({
     variables: { input: { colonyAddress, motionId } },
     notifyOnNetworkStatusChange: true,
@@ -47,7 +47,7 @@ export const useMotionCountdown = (
     motionTimeoutPeriods,
     loadingMotionTimeoutPeriods,
     refetchMotionTimeoutPeriods,
-  } = useMotionTimeoutPeriods(colony?.colonyAddress, motionId);
+  } = useMotionTimeoutPeriods(colony.colonyAddress, motionId);
 
   const currentStatePeriodInMs = getCurrentStatePeriodInMs(
     state,

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/hooks.tsx
@@ -35,8 +35,9 @@ export const useFinalizeStep = (actionData: MotionAction) => {
     fromDomain,
     tokenAddress,
   } = actionData;
-  const { colony } = useColonyContext();
-  const { balances } = colony || {};
+  const {
+    colony: { colonyAddress, balances },
+  } = useColonyContext();
   const { user } = useAppContext();
 
   const domainBalance = getBalanceForTokenAndDomain(
@@ -60,7 +61,7 @@ export const useFinalizeStep = (actionData: MotionAction) => {
 
   const transform = mapPayload(
     (): MotionFinalizePayload => ({
-      colonyAddress: colony?.colonyAddress || '',
+      colonyAddress,
       userAddress: user?.walletAddress || '',
       motionId,
       gasEstimate,
@@ -89,7 +90,9 @@ export const useClaimConfig = (
     transactionHash,
   } = actionData;
   const { user } = useAppContext();
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress, nativeToken, motionsWithUnclaimedStakes },
+  } = useColonyContext();
   const extension = useExtensionData(Extension.VotingReputation);
   const { pollLockedTokenBalance } = useUserTokenBalanceContext();
 
@@ -98,9 +101,8 @@ export const useClaimConfig = (
   const extensionData = extension?.extensionData as InstalledExtensionData;
 
   const userAddress = user?.walletAddress;
-  const colonyAddress = colony?.colonyAddress;
-  const nativeTokenDecimals = colony?.nativeToken.decimals;
-  const nativeTokenSymbol = colony?.nativeToken.symbol;
+  const nativeTokenDecimals = nativeToken.decimals;
+  const nativeTokenSymbol = nativeToken.symbol;
 
   const userStake = usersStakes.find(({ address }) => address === userAddress);
   const stakerReward = stakerRewards.find(
@@ -109,8 +111,8 @@ export const useClaimConfig = (
 
   // Keep isClaimed state in sync with changes to unclaimed motions on colony object
   useEffect(() => {
-    if (colony?.motionsWithUnclaimedStakes) {
-      const motionIsUnclaimed = colony.motionsWithUnclaimedStakes.some(
+    if (motionsWithUnclaimedStakes) {
+      const motionIsUnclaimed = motionsWithUnclaimedStakes.some(
         ({ motionId }) => motionId === databaseMotionId,
       );
 
@@ -121,7 +123,7 @@ export const useClaimConfig = (
         setIsClaimed(false);
       }
     }
-  }, [colony?.motionsWithUnclaimedStakes, databaseMotionId, refetchAction]);
+  }, [motionsWithUnclaimedStakes, databaseMotionId, refetchAction]);
 
   // Keep isClaimed state in sync with user changes
   useEffect(() => {

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/RevealStep/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/RevealStep/hooks.ts
@@ -21,19 +21,20 @@ export const useRevealStep = (
   const { nativeMotionDomainId, voterRecord, rootHash, motionId } =
     motionData || {};
   const { user } = useAppContext();
-  const { colony } = useColonyContext();
-  const { nativeToken } = colony || {};
+  const {
+    colony: { colonyAddress, nativeToken },
+  } = useColonyContext();
   const { data } = useGetVoterRewardsQuery({
     variables: {
       input: {
         voterAddress: user?.walletAddress ?? '',
-        colonyAddress: colony?.colonyAddress ?? '',
+        colonyAddress,
         nativeMotionDomainId: nativeMotionDomainId || '',
         motionId: motionId || '',
         rootHash: rootHash || '',
       },
     },
-    skip: !user || !colony,
+    skip: !user,
     fetchPolicy: 'cache-and-network',
   });
 
@@ -42,7 +43,7 @@ export const useRevealStep = (
   const { vote, hasUserVoted, userVoteRevealed, setUserVoteRevealed } =
     useRevealWidgetUpdate(voterRecord || [], stopPollingAction);
   const transform = mapPayload(() => ({
-    colonyAddress: colony?.colonyAddress,
+    colonyAddress,
     userAddress: user?.walletAddress ?? '',
     motionId: BigNumber.from(motionId),
   }));

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/VotingStep/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/VotingStep/hooks.tsx
@@ -26,8 +26,9 @@ export const useVotingStep = (
   stopPollingAction: () => void,
   transactionId: string,
 ) => {
-  const { colony } = useColonyContext();
-  const { nativeToken } = colony || {};
+  const {
+    colony: { colonyAddress, nativeToken },
+  } = useColonyContext();
   const { wallet, user } = useAppContext();
   const { motionData } = actionData;
   const {
@@ -60,13 +61,13 @@ export const useVotingStep = (
     variables: {
       input: {
         voterAddress: user?.walletAddress ?? '',
-        colonyAddress: colony?.colonyAddress ?? '',
+        colonyAddress,
         nativeMotionDomainId,
         motionId,
         rootHash,
       },
     },
-    skip: !user || !colony,
+    skip: !user,
     fetchPolicy: 'cache-and-network',
   });
   const { max: maxReward, min: minReward } = data?.getVoterRewards || {};
@@ -76,7 +77,7 @@ export const useVotingStep = (
   const transform = mapPayload(
     ({ vote }) =>
       ({
-        colonyAddress: colony?.colonyAddress ?? '',
+        colonyAddress,
         userAddress: user?.walletAddress,
         vote: Number(vote),
         motionId: BigNumber.from(motionId),
@@ -112,7 +113,7 @@ export const useVotingStep = (
         label: formatText({ id: 'motion.votingStep.teamReputation' }),
         value: (
           <MemberReputation
-            colonyAddress={colony?.colonyAddress ?? ''}
+            colonyAddress={colonyAddress}
             domainId={Number(nativeMotionDomainId)}
             rootHash={rootHash}
             textClassName="text-sm"

--- a/src/components/v5/common/ActionSidebar/partials/TeamColourField/partials/TeamColourBadge.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TeamColourField/partials/TeamColourBadge.tsx
@@ -13,7 +13,7 @@ const displayName =
 const TeamColourBadge: FC<TeamColourBadgeProps> = ({ title, defaultColor }) => {
   const { colony } = useColonyContext();
 
-  const selectedTeam = colony?.domains?.items.find(
+  const selectedTeam = colony.domains?.items.find(
     (domain) => domain?.metadata?.name === title,
   );
   const color = getTeamColor(defaultColor || selectedTeam?.metadata?.color);

--- a/src/components/v5/common/ActionSidebar/partials/TokenSelect/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TokenSelect/hooks.tsx
@@ -16,7 +16,7 @@ export const useTokenSelect = (inputValue: string) => {
   const predefinedTokens = getTokenList();
   const allTokens = useGetAllTokens();
   const { colony } = useColonyContext();
-  const colonyTokens = colony?.tokens?.items || [];
+  const colonyTokens = colony.tokens?.items || [];
   const isNativeToken = colonyTokens.some(
     (token) => token?.token.tokenAddress === inputValue,
   );

--- a/src/components/v5/common/ActionSidebar/partials/forms/AdvancedPaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/AdvancedPaymentForm/hooks.ts
@@ -88,7 +88,10 @@ export const useAdvancedPayment = (
   getFormOptions: ActionFormBaseProps['getFormOptions'],
 ) => {
   const { networkInverseFee } = useNetworkInverseFee();
-  const { colony } = useColonyContext();
+  const {
+    colony: { nativeToken },
+    colony,
+  } = useColonyContext();
   const decisionMethod: DecisionMethod | undefined = useWatch({
     name: DECISION_METHOD_FIELD_NAME,
   });
@@ -104,12 +107,12 @@ export const useAdvancedPayment = (
             delay: 0,
             amount: {
               amount: 0,
-              tokenAddress: colony?.nativeToken?.tokenAddress,
+              tokenAddress: nativeToken.tokenAddress,
             },
           },
         ],
       }),
-      [colony?.nativeToken?.tokenAddress],
+      [nativeToken.tokenAddress],
     ),
     actionType:
       decisionMethod === DecisionMethod.Permissions
@@ -120,10 +123,6 @@ export const useAdvancedPayment = (
     transform: useCallback(
       pipe(
         mapPayload((payload: AdvancedPaymentFormValues) => {
-          if (!colony) {
-            return null;
-          }
-
           return getCreatePaymentDialogPayload(
             colony,
             {

--- a/src/components/v5/common/ActionSidebar/partials/forms/AdvancedPaymentForm/partials/AdvancedPaymentRecipientsField/AdvancedPaymentRecipientsField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/AdvancedPaymentForm/partials/AdvancedPaymentRecipientsField/AdvancedPaymentRecipientsField.tsx
@@ -21,7 +21,9 @@ const displayName =
 const AdvancedPaymentRecipientsField: FC<
   AdvancedPaymentRecipientsFieldProps
 > = ({ name }) => {
-  const { nativeToken } = useColonyContext().colony || {};
+  const {
+    colony: { nativeToken },
+  } = useColonyContext();
   const fieldArrayMethods = useFieldArray({
     name,
   });

--- a/src/components/v5/common/ActionSidebar/partials/forms/AdvancedPaymentForm/partials/AdvancedPaymentRecipientsField/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/AdvancedPaymentForm/partials/AdvancedPaymentRecipientsField/hooks.tsx
@@ -20,21 +20,21 @@ export const useRecipientsFieldTableColumns = (
   name: string,
   data: AdvancedPaymentRecipientsFieldModel[],
 ): ColumnDef<AdvancedPaymentRecipientsTableModel, string>[] => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { expendituresGlobalClaimDelay },
+  } = useColonyContext();
   const columnHelper = useMemo(
     () => createColumnHelper<AdvancedPaymentRecipientsTableModel>(),
     [],
   );
   const dataRef = useWrapWithRef(data);
   const expendituresGlobalClaimDelayHours = useMemo(() => {
-    if (!colony || typeof colony.expendituresGlobalClaimDelay !== 'number') {
+    if (typeof expendituresGlobalClaimDelay !== 'number') {
       return null;
     }
 
-    const { expendituresGlobalClaimDelay } = colony;
-
     return expendituresGlobalClaimDelay / (60 * 60);
-  }, [colony]);
+  }, [expendituresGlobalClaimDelay]);
   const { watch } = useFormContext();
   const selectedTeam = watch('from');
 
@@ -109,7 +109,7 @@ export const useRecipientsFieldTableColumns = (
       ],
       // eslint-disable-next-line react-hooks/exhaustive-deps
       [
-        colony?.expendituresGlobalClaimDelay,
+        expendituresGlobalClaimDelay,
         columnHelper,
         name,
         expendituresGlobalClaimDelayHours,

--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/hooks.ts
@@ -16,8 +16,9 @@ import { validationSchema, CreateDecisionFormValues } from './consts';
 export const useCreateDecision = (
   getFormOptions: ActionFormBaseProps['getFormOptions'],
 ) => {
-  const { colony } = useColonyContext();
-  const colonyAddress = colony?.colonyAddress ?? '';
+  const {
+    colony: { colonyAddress, name: colonyName },
+  } = useColonyContext();
   const { user } = useAppContext();
   const walletAddress = user?.walletAddress || '';
   const dispatch = useDispatch();
@@ -61,7 +62,7 @@ export const useCreateDecision = (
 
           return {
             colonyAddress,
-            colonyName: colony?.name,
+            colonyName,
             decisionMethod: payload.decisionMethod,
             motionParams: [],
             draftDecision: {
@@ -73,7 +74,7 @@ export const useCreateDecision = (
           };
         }),
       ),
-      [colony],
+      [],
     ),
   });
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateNewTeamForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateNewTeamForm/hooks.ts
@@ -39,10 +39,6 @@ export const useCreateNewTeam = (
     transform: useCallback(
       pipe(
         mapPayload((values: CreateNewTeamFormValues) => {
-          if (!colony) {
-            return null;
-          }
-
           return getCreateNewTeamPayload(colony, values);
         }),
       ),

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/hooks.ts
@@ -51,10 +51,6 @@ export const useEditColonyDetails = (
     transform: useCallback(
       pipe(
         mapPayload((values: EditColonyDetailsFormValues) => {
-          if (!colony) {
-            return null;
-          }
-
           return getEditColonyDetailsPayload(colony, values);
         }),
       ),

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditTeamForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditTeamForm/hooks.ts
@@ -58,7 +58,7 @@ export const useEditTeam = (
     transform: useCallback(
       pipe(
         mapPayload((values: EditTeamFormValues) => {
-          if (!colony || !selectedDomain) {
+          if (!selectedDomain) {
             return null;
           }
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/EnterRecoveryModeForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EnterRecoveryModeForm/hooks.ts
@@ -33,11 +33,7 @@ export const useEnterRecoveryMode = (
             annotation: payload.description,
           };
 
-          if (colony) {
-            return getRecoveryModeDialogPayload(colony, values, user);
-          }
-
-          return null;
+          return getRecoveryModeDialogPayload(colony, values, user);
         }),
       ),
       [colony, user],

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/hooks.ts
@@ -18,7 +18,7 @@ export const useManageColonyObjectives = (
   getFormOptions: ActionFormBaseProps['getFormOptions'],
 ) => {
   const { colony } = useColonyContext();
-  const { metadata } = colony || {};
+  const { metadata } = colony;
   const decisionMethod: DecisionMethod | undefined = useWatch({
     name: DECISION_METHOD_FIELD_NAME,
   });
@@ -45,10 +45,6 @@ export const useManageColonyObjectives = (
     transform: useCallback(
       pipe(
         mapPayload((values: ManageColonyObjectivesFormValues) => {
-          if (!colony) {
-            return null;
-          }
-
           return getManageColonyObjectivesPayload(colony, values);
         }),
       ),

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/hooks.ts
@@ -97,10 +97,6 @@ export const useManagePermissions = (
     transform: useCallback(
       pipe(
         mapPayload((values: ManagePermissionsFormValues) => {
-          if (!colony) {
-            return null;
-          }
-
           return getManagePermissionsPayload(colony, values);
         }),
       ),

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageTokensForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageTokensForm/hooks.ts
@@ -26,8 +26,8 @@ export const useManageTokens = (
   });
 
   const colonyTokens = useMemo(
-    () => colony?.tokens?.items.filter(notNull) || [],
-    [colony?.tokens?.items],
+    () => colony.tokens?.items.filter(notNull) || [],
+    [colony.tokens?.items],
   );
 
   const shouldShowMenu = useCallback(
@@ -63,10 +63,6 @@ export const useManageTokens = (
     transform: useCallback(
       pipe(
         mapPayload((values: ManageTokensFormValues) => {
-          if (!colony) {
-            return null;
-          }
-
           return getManageTokensPayload(colony, values);
         }),
       ),

--- a/src/components/v5/common/ActionSidebar/partials/forms/MintTokenForm/MintTokenForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/MintTokenForm/MintTokenForm.tsx
@@ -17,7 +17,9 @@ const displayName = 'v5.common.ActionSidebar.partials.MintTokenForm';
 
 const MintTokenForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
   const { decisionMethods } = useDecisionMethods();
-  const { colony } = useColonyContext();
+  const {
+    colony: { nativeToken },
+  } = useColonyContext();
 
   useMintToken(getFormOptions);
 
@@ -38,7 +40,7 @@ const MintTokenForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
         <AmountField
           name="amount"
           maxWidth={270}
-          tokenAddress={colony?.nativeToken.tokenAddress}
+          tokenAddress={nativeToken.tokenAddress}
         />
       </ActionFormRow>
       <ActionFormRow

--- a/src/components/v5/common/ActionSidebar/partials/forms/MintTokenForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/MintTokenForm/hooks.ts
@@ -40,10 +40,6 @@ export const useMintToken = (
     transform: useCallback(
       pipe(
         mapPayload((values: MintTokenFormValues) => {
-          if (!colony) {
-            return null;
-          }
-
           return getMintTokenPayload(colony, values);
         }),
       ),

--- a/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/hooks.ts
@@ -120,11 +120,10 @@ export const useSimplePayment = (
         createdIn: Id.RootDomain,
         payments: [],
         amount: {
-          tokenAddress:
-            selectedTokenAddress ?? colony?.nativeToken.tokenAddress,
+          tokenAddress: selectedTokenAddress ?? colony.nativeToken.tokenAddress,
         },
       }),
-      [selectedTokenAddress, colony?.nativeToken.tokenAddress],
+      [selectedTokenAddress, colony.nativeToken.tokenAddress],
     ),
     actionType:
       decisionMethod === DecisionMethod.Permissions
@@ -135,10 +134,6 @@ export const useSimplePayment = (
     transform: useCallback(
       pipe(
         mapPayload((values: SimplePaymentFormValues) => {
-          if (!colony) {
-            return null;
-          }
-
           return getSimplePaymentPayload(colony, values, networkInverseFee);
         }),
       ),

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/hooks.ts
@@ -94,10 +94,10 @@ export const useSplitPayment = (
   const { colony } = useColonyContext();
   const colonyTokens = useMemo(
     () =>
-      colony?.tokens?.items
+      colony.tokens?.items
         .filter(notNull)
         .map((colonyToken) => colonyToken.token) || [],
-    [colony?.tokens?.items],
+    [colony.tokens?.items],
   );
   const amount = useWatch({ name: 'amount' });
   const currentToken = useMemo(
@@ -115,7 +115,7 @@ export const useSplitPayment = (
     defaultValues: useMemo(
       () => ({
         amount: {
-          tokenAddress: colony?.nativeToken.tokenAddress,
+          tokenAddress: colony.nativeToken.tokenAddress,
         },
         createdIn: Id.RootDomain,
         payments: [
@@ -124,7 +124,7 @@ export const useSplitPayment = (
           },
         ],
       }),
-      [colony?.nativeToken.tokenAddress],
+      [colony.nativeToken.tokenAddress],
     ),
     actionType:
       decisionMethod === DecisionMethod.Permissions
@@ -144,15 +144,11 @@ export const useSplitPayment = (
             payments: [],
           };
 
-          if (colony) {
-            return getCreatePaymentDialogPayload(
-              colony,
-              values,
-              networkInverseFee,
-            );
-          }
-
-          return null;
+          return getCreatePaymentDialogPayload(
+            colony,
+            values,
+            networkInverseFee,
+          );
         }),
       ),
       [colony, networkInverseFee],

--- a/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/hooks.ts
@@ -101,11 +101,10 @@ export const useTransferFunds = (
         createdIn: from || Id.RootDomain,
         from: Id.RootDomain,
         amount: {
-          tokenAddress:
-            selectedTokenAddress ?? colony?.nativeToken.tokenAddress,
+          tokenAddress: selectedTokenAddress ?? colony.nativeToken.tokenAddress,
         },
       }),
-      [from, selectedTokenAddress, colony?.nativeToken.tokenAddress],
+      [from, selectedTokenAddress, colony.nativeToken.tokenAddress],
     ),
     actionType:
       decisionMethod === DecisionMethod.Permissions
@@ -116,10 +115,6 @@ export const useTransferFunds = (
     transform: useCallback(
       pipe(
         mapPayload((values: TransferFundsFormValues) => {
-          if (!colony) {
-            return null;
-          }
-
           return getTransferFundsPayload(colony, values);
         }),
       ),

--- a/src/components/v5/common/ActionSidebar/partials/forms/UnlockTokenForm/UnlockTokenForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/UnlockTokenForm/UnlockTokenForm.tsx
@@ -19,7 +19,7 @@ const displayName = 'v5.common.ActionSidebar.partials.UnlockTokenForm';
 const UnlockTokenForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
   const { decisionMethods } = useDecisionMethods();
   const { colony } = useColonyContext();
-  const isNativeTokenUnlocked = !!colony?.status?.nativeToken?.unlocked;
+  const isNativeTokenUnlocked = !!colony.status?.nativeToken?.unlocked;
   const [searchParams] = useSearchParams();
   const transactionId = searchParams?.get(TX_SEARCH_PARAM);
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/UnlockTokenForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/UnlockTokenForm/hooks.ts
@@ -37,12 +37,8 @@ export const useUnlockToken = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
     transform: useCallback(
       pipe(
-        withKey(colony?.colonyAddress || ''),
+        withKey(colony.colonyAddress),
         mapPayload((values: UnlockTokenFormValues) => {
-          if (!colony) {
-            return null;
-          }
-
           return getUnlockTokenPayload(colony, values);
         }),
       ),

--- a/src/components/v5/common/ActionSidebar/partials/forms/UpgradeColonyForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/UpgradeColonyForm/hooks.ts
@@ -32,10 +32,6 @@ export const useUpgradeColony = (
     transform: useCallback(
       pipe(
         mapPayload((values: UpgradeColonyFormValues) => {
-          if (!colony) {
-            return null;
-          }
-
           return getUpgradeColonyPayload(colony, values);
         }),
       ),

--- a/src/components/v5/common/ActionSidebar/partials/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/hooks.ts
@@ -48,7 +48,7 @@ export const useSubmitButtonText = () => {
 
 export const useSubmitButtonDisabled = () => {
   const { colony } = useColonyContext();
-  const isNativeTokenUnlocked = !!colony?.status?.nativeToken?.unlocked;
+  const isNativeTokenUnlocked = !!colony.status?.nativeToken?.unlocked;
   const selectedAction: Action | undefined = useWatch({
     name: ACTION_TYPE_FIELD_NAME,
   });

--- a/src/components/v5/common/MembersList/MembersList.tsx
+++ b/src/components/v5/common/MembersList/MembersList.tsx
@@ -37,9 +37,10 @@ const MembersList: FC<MembersListProps> = ({
 }) => {
   const { formatMessage } = useIntl();
 
-  const { colony } = useColonyContext();
-  const { name } = colony || {};
-  const colonyURL = `${window.location.origin}/${name}`;
+  const {
+    colony: { name: colonyName },
+  } = useColonyContext();
+  const colonyURL = `${window.location.origin}/${colonyName}`;
 
   const { handleClipboardCopy } = useCopyToClipboard();
 

--- a/src/components/v5/common/Modals/InviteMembersModal/InviteMemberModal.tsx
+++ b/src/components/v5/common/Modals/InviteMembersModal/InviteMemberModal.tsx
@@ -43,13 +43,15 @@ const MSG = defineMessages({
 });
 
 const InviteMembersModal = ({ isOpen, onClose }: Props) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyMemberInvite, name: colonyName },
+  } = useColonyContext();
 
   const invitesAvailable = 100;
   const inviteLink = useBaseUrl(
-    `/invite/${colony?.name}/${colony?.colonyMemberInvite?.id}`,
+    `/invite/${colonyName}/${colonyMemberInvite?.id}`,
   );
-  const invitesUsed = 100 - (colony?.colonyMemberInvite?.invitesRemaining || 0);
+  const invitesUsed = 100 - (colonyMemberInvite?.invitesRemaining || 0);
 
   const { handleClipboardCopy, isCopied } = useCopyToClipboard();
 

--- a/src/components/v5/common/ObjectiveBox/ObjectiveBox.tsx
+++ b/src/components/v5/common/ObjectiveBox/ObjectiveBox.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
+
 import { MAX_OBJECTIVE_DESCRIPTION_LENGTH } from '~constants';
 import { multiLineTextEllipsis } from '~utils/strings';
-
 import ProgressBar from '~v5/shared/ProgressBar';
 
 import { ObjectiveBoxProps } from './types';

--- a/src/components/v5/common/Pills/TeamBadge/hooks.ts
+++ b/src/components/v5/common/Pills/TeamBadge/hooks.ts
@@ -2,8 +2,9 @@ import { useColonyContext } from '~hooks';
 import { getTeamBadgeStyles } from '~utils/teams';
 
 export const useTeamBadge = (teamName: string) => {
-  const { colony } = useColonyContext();
-  const { domains } = colony || {};
+  const {
+    colony: { domains },
+  } = useColonyContext();
 
   const team = domains?.items.find((item) => {
     const { metadata } = item || {};

--- a/src/components/v5/common/TeamReputationSummary/TeamReputationSummary.tsx
+++ b/src/components/v5/common/TeamReputationSummary/TeamReputationSummary.tsx
@@ -28,11 +28,12 @@ const displayName = 'v5.common.TeamReputationSummary';
 const TeamReputationSummary: FC<TeamReputationSummaryProps> = ({
   className,
 }) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { nativeToken, domains, reputation },
+  } = useColonyContext();
   const {
     actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
   } = useActionSidebarContext();
-  const { nativeToken, domains, reputation } = colony || {};
 
   const colonyReputation = reputation ?? '0';
   const teams = domains?.items

--- a/src/components/v5/common/TeamReputationSummary/partials/hooks.ts
+++ b/src/components/v5/common/TeamReputationSummary/partials/hooks.ts
@@ -5,13 +5,15 @@ import { useGetUserReputationQuery } from '~gql';
 import { useColonyContext } from '~hooks';
 
 export const useTeamReputationSummaryRow = (id: number) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
 
   const { data: totalReputation } = useGetUserReputationQuery({
     variables: {
       input: {
         walletAddress: ADDRESS_ZERO,
-        colonyAddress: colony?.colonyAddress || '',
+        colonyAddress,
         domainId: id || Id.RootDomain,
       },
     },

--- a/src/components/v5/common/TokensModal/hooks.ts
+++ b/src/components/v5/common/TokensModal/hooks.ts
@@ -16,8 +16,9 @@ import { TokensModalType, UseTokensModalReturnType } from './types';
 export const useTokensModal = (
   type: TokensModalType,
 ): UseTokensModalReturnType => {
-  const { colony } = useColonyContext();
-  const { nativeToken } = colony || {};
+  const {
+    colony: { nativeToken, colonyAddress },
+  } = useColonyContext();
   const { symbol: tokenSymbol } = nativeToken || {};
   const {
     tokenBalanceData: tokenData,
@@ -74,7 +75,7 @@ export const useTokensModal = (
 
       return {
         amount: formattedAmount,
-        colonyAddress: colony?.colonyAddress,
+        colonyAddress,
         tokenAddress: nativeToken?.tokenAddress,
       };
     }),

--- a/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarLinksList/NavigationSidebarLinksList.tsx
+++ b/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarLinksList/NavigationSidebarLinksList.tsx
@@ -16,8 +16,9 @@ const NavigationSidebarLinksList: FC<NavigationSidebarLinksListProps> = ({
   items,
   className,
 }) => {
-  const { colony } = useColonyContext();
-  const colonyName = colony?.name || '';
+  const {
+    colony: { name: colonyName },
+  } = useColonyContext();
 
   const updatedItems = items.map((item) => {
     // Check if the 'to' field needs to be modified

--- a/src/components/v5/shared/SubNavigationItem/hooks.ts
+++ b/src/components/v5/shared/SubNavigationItem/hooks.ts
@@ -4,9 +4,10 @@ import { useColonyContext } from '~hooks';
 import { useCopyToClipboard } from '~hooks/useCopyToClipboard';
 
 export const useMembersSubNavigation = () => {
-  const { colony } = useColonyContext();
-  const { name } = colony || {};
-  const colonyURL = `${window.location.origin}/${name}`;
+  const {
+    colony: { name: colonyName },
+  } = useColonyContext();
+  const colonyURL = `${window.location.origin}/${colonyName}`;
 
   const { handleClipboardCopy, isCopied } = useCopyToClipboard();
 

--- a/src/components/v5/shared/UserAvatarPopover/UserAvatarPopover.tsx
+++ b/src/components/v5/shared/UserAvatarPopover/UserAvatarPopover.tsx
@@ -16,8 +16,9 @@ const displayName = 'v5.UserAvatarPopover';
 
 const UserAvatarPopover: FC<UserAvatarPopoverProps> = ({ size, ...props }) => {
   const { walletAddress, isContributorsList } = props;
-  const { colony } = useColonyContext();
-  const { colonyAddress = '' } = colony || {};
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { data } = useGetColonyContributorQuery({
     variables: {
       id: getColonyContributorId(colonyAddress, walletAddress),

--- a/src/components/v5/shared/UserPopover/UserPopover.tsx
+++ b/src/components/v5/shared/UserPopover/UserPopover.tsx
@@ -33,8 +33,9 @@ const UserPopover: FC<PropsWithChildren<UserPopoverProps>> = ({
   const { profile } = user || {};
   const { avatar, thumbnail } = profile || {};
 
-  const { colony } = useColonyContext();
-  const colonyAddress = colony?.colonyAddress ?? '';
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
 
   const { data: colonyContributorData } = useGetColonyContributorQuery({
     variables: {

--- a/src/context/ColonyDecisionContext.tsx
+++ b/src/context/ColonyDecisionContext.tsx
@@ -15,7 +15,9 @@ export const ColonyDecisionProvider = ({
   children,
 }: ColonyDecisionProviderProps) => {
   const { user } = useAppContext();
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
 
   /*
    * Get saved decision from local storage and, if it exists, add to the store.
@@ -23,7 +25,7 @@ export const ColonyDecisionProvider = ({
 
   const decision = getDraftDecisionFromLocalStorage(
     user?.walletAddress || '',
-    colony?.colonyAddress || '',
+    colonyAddress,
   );
 
   const dispatch = useDispatch();

--- a/src/context/MemberContext.tsx
+++ b/src/context/MemberContext.tsx
@@ -53,8 +53,9 @@ const MemberContext = createContext<
 
 const MemberContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const { colonyName } = useParams();
-  const { colony } = useColonyContext();
-  const { domains, colonyAddress = '' } = colony ?? {};
+  const {
+    colony: { domains, colonyAddress },
+  } = useColonyContext();
   const isMobile = useMobile();
   const isVerifiedPage = useMatch(`${colonyName}/${COLONY_VERIFIED_ROUTE}`);
 

--- a/src/context/UserTokenBalanceContext.tsx
+++ b/src/context/UserTokenBalanceContext.tsx
@@ -29,8 +29,9 @@ export const UserTokenBalanceProvider = ({
   children: ReactNode;
 }) => {
   const { wallet } = useAppContext();
-  const { colony } = useColonyContext();
-  const { colonyAddress, nativeToken } = colony || {};
+  const {
+    colony: { colonyAddress, nativeToken },
+  } = useColonyContext();
 
   const {
     data: tokenBalanceQueryData,
@@ -40,11 +41,11 @@ export const UserTokenBalanceProvider = ({
     variables: {
       input: {
         walletAddress: wallet?.address ?? '',
-        tokenAddress: nativeToken?.tokenAddress ?? '',
-        colonyAddress: colonyAddress ?? '',
+        tokenAddress: nativeToken.tokenAddress,
+        colonyAddress,
       },
     },
-    skip: !wallet?.address || !nativeToken?.tokenAddress,
+    skip: !wallet?.address,
   });
 
   const tokenBalanceData = tokenBalanceQueryData?.getUserTokenBalance;

--- a/src/hooks/members/useMemberFilters.ts
+++ b/src/hooks/members/useMemberFilters.ts
@@ -29,11 +29,11 @@ const useMemberFilters = ({
   contributorTypes: Set<ContributorTypeFilter>;
   filterStatus?: StatusType;
 }) => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
   const { searchValue } = useSearchContext();
   const selectedDomain = useGetSelectedDomainFilter();
-
-  const { colonyAddress = '' } = colony ?? {};
 
   const databaseDomainIds = useMemo(
     () =>

--- a/src/hooks/useActiveInstalls.ts
+++ b/src/hooks/useActiveInstalls.ts
@@ -8,8 +8,7 @@ const useActiveInstalls = (extensionId: string) => {
   const { colony } = useColonyContext();
 
   const { data } = useGetExtensionInstallationsCountQuery({
-    variables: { id: colony?.chainMetadata.chainId.toString() ?? '' },
-    skip: !colony,
+    variables: { id: colony.chainMetadata.chainId.toString() ?? '' },
   });
 
   const {

--- a/src/hooks/useActivityFeed/useActivityFeed.ts
+++ b/src/hooks/useActivityFeed/useActivityFeed.ts
@@ -30,7 +30,9 @@ const useActivityFeed = (
   sort?: ActivityFeedSort,
   { pageSize = ITEMS_PER_PAGE }: ActivityFeedOptions = {},
 ): UseActivityFeedReturn => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
 
   const [pageNumber, setPageNumber] = useState(1);
   /**
@@ -45,10 +47,7 @@ const useActivityFeed = (
 
   const { data, fetchMore, loading } = useSearchActionsQuery({
     variables: {
-      filter: getSearchActionsFilterVariable(
-        colony?.colonyAddress ?? '',
-        filters,
-      ),
+      filter: getSearchActionsFilterVariable(colonyAddress, filters),
       sort: sort || {
         field: SearchableColonyActionSortableFields.CreatedAt,
         direction: SearchableSortDirection.Desc,
@@ -56,7 +55,6 @@ const useActivityFeed = (
       limit: pageSize * 2,
     },
     fetchPolicy: 'network-only',
-    skip: !colony,
   });
 
   const { items, nextToken } = data?.searchColonyActions ?? {};

--- a/src/hooks/useColonyFundsClaims.ts
+++ b/src/hooks/useColonyFundsClaims.ts
@@ -8,8 +8,9 @@ import useColonyContext from './useColonyContext';
  *
  */
 const useColonyFundsClaims = (): ColonyClaims[] => {
-  const { colony } = useColonyContext();
-  const { fundsClaims, chainFundsClaim, tokens } = colony || {};
+  const {
+    colony: { fundsClaims, chainFundsClaim, tokens },
+  } = useColonyContext();
   const { items: claims = [] } = fundsClaims || {};
 
   /*

--- a/src/hooks/useCurrentSelectedToken.ts
+++ b/src/hooks/useCurrentSelectedToken.ts
@@ -4,9 +4,10 @@ import { useColonyContext } from '~hooks';
 import { Address } from '~types';
 
 const useCurrentSelectedToken = () => {
-  const { colony } = useColonyContext();
-  const { tokens, nativeToken } = colony || {};
-  const { tokenAddress: nativeTokenAddress } = nativeToken || {};
+  const {
+    colony: { tokens, nativeToken },
+  } = useColonyContext();
+  const { tokenAddress: nativeTokenAddress } = nativeToken;
 
   const [currentTokenAddress, setCurrentTokenAddress] = useState<Address>();
 

--- a/src/hooks/useDialogActionPermissions.ts
+++ b/src/hooks/useDialogActionPermissions.ts
@@ -6,7 +6,7 @@ import { Colony } from '~types';
 import { addressHasRoles } from '~utils/checks';
 
 const useDialogActionPermissions = (
-  colony: Colony | undefined,
+  colony: Colony,
   isVotingExtensionEnabled: boolean,
   requiredRoles: ColonyRole[],
   requiredRolesDomains: number[],

--- a/src/hooks/useExtensionData.ts
+++ b/src/hooks/useExtensionData.ts
@@ -49,10 +49,7 @@ interface UseExtensionDataReturn {
  * and mapping it into Installed or InstallableExtensionData object
  */
 const useExtensionData = (extensionId: string): UseExtensionDataReturn => {
-  const {
-    colony: { colonyAddress },
-    colony,
-  } = useColonyContext();
+  const { colony } = useColonyContext();
 
   const extensionHash = getExtensionHash(extensionId as Extension);
 
@@ -64,7 +61,7 @@ const useExtensionData = (extensionId: string): UseExtensionDataReturn => {
     refetch,
   } = useGetColonyExtensionQuery({
     variables: {
-      colonyAddress,
+      colonyAddress: colony.colonyAddress,
       extensionHash,
     },
     fetchPolicy: 'network-only',

--- a/src/hooks/useExtensionData.ts
+++ b/src/hooks/useExtensionData.ts
@@ -49,7 +49,10 @@ interface UseExtensionDataReturn {
  * and mapping it into Installed or InstallableExtensionData object
  */
 const useExtensionData = (extensionId: string): UseExtensionDataReturn => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+    colony,
+  } = useColonyContext();
 
   const extensionHash = getExtensionHash(extensionId as Extension);
 
@@ -61,10 +64,9 @@ const useExtensionData = (extensionId: string): UseExtensionDataReturn => {
     refetch,
   } = useGetColonyExtensionQuery({
     variables: {
-      colonyAddress: colony?.colonyAddress ?? '',
+      colonyAddress,
       extensionHash,
     },
-    skip: !colony,
     fetchPolicy: 'network-only',
   });
   const colonyExtension = data?.getExtensionByColonyAndHash?.items?.[0];
@@ -74,7 +76,6 @@ const useExtensionData = (extensionId: string): UseExtensionDataReturn => {
       variables: {
         extensionHash,
       },
-      skip: !colony,
       fetchPolicy: 'cache-and-network',
     });
   const { version } = versionData?.getCurrentVersionByKey?.items?.[0] || {};
@@ -84,7 +85,7 @@ const useExtensionData = (extensionId: string): UseExtensionDataReturn => {
   );
 
   const extensionData = useMemo<AnyExtensionData | null>(() => {
-    if (!version || !extensionConfig || !colony) {
+    if (!version || !extensionConfig) {
       return null;
     }
 

--- a/src/hooks/useExtensionsData.ts
+++ b/src/hooks/useExtensionsData.ts
@@ -27,16 +27,18 @@ interface UseExtensionsDataReturn {
  * and mapping it into Installed or InstallableExtensionData object
  */
 const useExtensionsData = (): UseExtensionsDataReturn => {
-  const { colony } = useColonyContext();
+  const {
+    colony,
+    colony: { colonyAddress },
+  } = useColonyContext();
   const {
     data,
     loading: extensionsLoading,
     refetch: refetchExtensions,
   } = useGetColonyExtensionsQuery({
     variables: {
-      colonyAddress: colony?.colonyAddress ?? '',
+      colonyAddress,
     },
-    skip: !colony,
     fetchPolicy: 'cache-and-network',
   });
   const colonyExtensions = data?.getColony?.extensions?.items?.filter(notNull);
@@ -64,7 +66,7 @@ const useExtensionsData = (): UseExtensionsDataReturn => {
           {};
 
         // Unsupported extension
-        if (!extensionConfig || !version || !colony) {
+        if (!extensionConfig || !version) {
           return null;
         }
 

--- a/src/hooks/useGetAllTokens.ts
+++ b/src/hooks/useGetAllTokens.ts
@@ -9,8 +9,8 @@ export const useGetAllTokens = () => {
   const { colony } = useColonyContext();
   const predefinedTokens = getTokenList();
   const colonyTokens = useMemo(
-    () => colony?.tokens?.items.filter(notNull) || [],
-    [colony?.tokens?.items],
+    () => colony.tokens?.items.filter(notNull) || [],
+    [colony.tokens?.items],
   );
 
   return useMemo(

--- a/src/hooks/usePaginatedActions.ts
+++ b/src/hooks/usePaginatedActions.ts
@@ -20,7 +20,9 @@ interface UsePaginatedActionsReturn {
 }
 
 export const usePaginatedActions = (): UsePaginatedActionsReturn => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
 
   const [sortDirection, setSortDirection] = useState<SortDirection>(
     SortDirection.Desc,
@@ -28,7 +30,7 @@ export const usePaginatedActions = (): UsePaginatedActionsReturn => {
 
   const { data, loading, fetchMore } = useGetColonyActionsQuery({
     variables: {
-      colonyAddress: colony?.colonyAddress ?? '',
+      colonyAddress,
       limit: ITEMS_PER_PAGE,
       sortDirection,
       filter: {
@@ -37,7 +39,6 @@ export const usePaginatedActions = (): UsePaginatedActionsReturn => {
         not: { colonyDecisionId: { beginsWith: '0x' } },
       },
     },
-    skip: !colony,
     fetchPolicy: 'network-only',
   });
   const { items, nextToken } = data?.getActionsByColony || {};

--- a/src/hooks/useTablePaginatedActions.ts
+++ b/src/hooks/useTablePaginatedActions.ts
@@ -22,7 +22,9 @@ export const useTablePaginatedActions = (
   page: number,
   perPage = ITEMS_PER_PAGE,
 ): UseTablePaginatedActionsReturn => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
 
   const [sortDirection, setSortDirection] = useState<SortDirection>(
     SortDirection.Desc,
@@ -30,7 +32,7 @@ export const useTablePaginatedActions = (
 
   const { data, loading, fetchMore } = useGetColonyActionsQuery({
     variables: {
-      colonyAddress: colony?.colonyAddress ?? '',
+      colonyAddress,
       limit: perPage,
       sortDirection,
       filter: {
@@ -39,7 +41,6 @@ export const useTablePaginatedActions = (
         not: { colonyDecisionId: { beginsWith: '0x' } },
       },
     },
-    skip: !colony,
     fetchPolicy: 'network-only',
   });
   const { items, nextToken } = data?.getActionsByColony || {};

--- a/src/hooks/useTeamsBreadcrumbs.ts
+++ b/src/hooks/useTeamsBreadcrumbs.ts
@@ -10,9 +10,10 @@ import useColonyContext from './useColonyContext';
 import useGetSelectedDomainFilter from './useGetSelectedDomainFilter';
 
 export const useCreateTeamBreadcrumbs = () => {
-  const { colony } = useColonyContext();
+  const {
+    colony: { domains },
+  } = useColonyContext();
   const selectedDomain = useGetSelectedDomainFilter();
-  const { domains } = colony || {};
   const navigationPathname = window.location.pathname;
 
   const activeItem = selectedDomain

--- a/src/hooks/useTeamsOptions.ts
+++ b/src/hooks/useTeamsOptions.ts
@@ -14,8 +14,9 @@ const sortByDomainId = (
 const useTeamsOptions = (
   filterOptionsFn?: (option: SearchSelectOption) => boolean,
 ): SearchSelectOptionProps['options'] => {
-  const { colony } = useColonyContext();
-  const { domains } = colony || {};
+  const {
+    colony: { domains },
+  } = useColonyContext();
 
   const teams =
     domains?.items

--- a/src/hooks/useTokenTotalBalance.ts
+++ b/src/hooks/useTokenTotalBalance.ts
@@ -4,8 +4,9 @@ import { useColonyContext } from '~hooks';
 import { Address } from '~types';
 
 const useTokenTotalBalance = (currentTokenAddress?: Address) => {
-  const { colony } = useColonyContext();
-  const { balances } = colony || {};
+  const {
+    colony: { balances },
+  } = useColonyContext();
 
   const totalTokenBalance = useMemo(() => {
     if (balances?.items && currentTokenAddress) {

--- a/src/hooks/useUserReputation.ts
+++ b/src/hooks/useUserReputation.ts
@@ -11,7 +11,7 @@ interface UseUserReputationHook {
 }
 
 const useUserReputation = (
-  colonyAddress: Address | null | undefined,
+  colonyAddress: Address,
   walletAddress: Address | null | undefined,
   domainId = Id.RootDomain,
   rootHash?: string,
@@ -20,7 +20,7 @@ const useUserReputation = (
     useGetUserReputationQuery({
       variables: {
         input: {
-          colonyAddress: colonyAddress ?? '',
+          colonyAddress,
           walletAddress: walletAddress ?? '',
           domainId,
           rootHash,
@@ -35,7 +35,7 @@ const useUserReputation = (
     useGetUserReputationQuery({
       variables: {
         input: {
-          colonyAddress: colonyAddress ?? '',
+          colonyAddress,
           walletAddress: ADDRESS_ZERO,
           domainId,
           rootHash,

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -56,22 +56,18 @@ export const convertRolesToArray = (
     .filter(notUndefined);
 
 export const getUserRolesForDomain = (
-  colony: ColonyFragment | undefined,
+  colony: ColonyFragment,
   userAddress: Address,
   domainId: number,
   excludeInherited = false,
 ): ColonyRole[] => {
-  if (!colony) {
-    return [];
-  }
-
-  const userRolesInAnyDomain = colony?.roles?.items.find(
+  const userRolesInAnyDomain = colony.roles?.items.find(
     (domainRole) =>
       domainRole?.domain?.nativeId === domainId &&
       domainRole?.targetAddress === userAddress,
   );
 
-  const userRolesInRootDomain = colony?.roles?.items.find(
+  const userRolesInRootDomain = colony.roles?.items.find(
     (domainRole) =>
       domainRole?.domain?.nativeId === Id.RootDomain &&
       domainRole?.targetAddress === userAddress,
@@ -94,10 +90,10 @@ export const getUserRolesForDomain = (
 };
 
 export const getAllUserRoles = (
-  colony: ColonyFragment | undefined,
+  colony: ColonyFragment,
   userAddress: Address | undefined,
 ): ColonyRole[] => {
-  if (!colony || !userAddress) return [];
+  if (!userAddress) return [];
 
   const userRolesInAnyDomain = colony.roles?.items.find(
     (domainRole) => domainRole?.targetAddress === userAddress,

--- a/src/utils/checks/canColonyBeUpgraded.ts
+++ b/src/utils/checks/canColonyBeUpgraded.ts
@@ -2,15 +2,9 @@ import { Colony } from '~types';
 
 const minimumRequiredColonyVersion = 4;
 
-export const canColonyBeUpgraded = (
-  colony: Colony | undefined,
-  contractVersion: number,
-) => colony && contractVersion > colony.version;
+export const canColonyBeUpgraded = (colony: Colony, contractVersion: number) =>
+  contractVersion > colony.version;
 
-export const mustColonyBeUpgraded = (
-  colony: Colony | undefined,
-  networkVersion: number,
-) =>
-  colony &&
+export const mustColonyBeUpgraded = (colony: Colony, networkVersion: number) =>
   canColonyBeUpgraded(colony, networkVersion) &&
   colony.version < minimumRequiredColonyVersion;

--- a/src/utils/checks/userHasRoles.ts
+++ b/src/utils/checks/userHasRoles.ts
@@ -13,7 +13,7 @@ export const addressHasRoles = ({
   requiredRoles,
 }: {
   requiredRolesDomains: number[];
-  colony: Colony | undefined;
+  colony: Colony;
   address: string;
   requiredRoles: ColonyRole[];
 }) => {

--- a/src/utils/colonyActions.ts
+++ b/src/utils/colonyActions.ts
@@ -575,7 +575,7 @@ const getChangelogItem = (
     transactionHash,
     pendingColonyMetadata,
   }: ColonyAction,
-  colonyMetadata?: ColonyMetadata | null,
+  colonyMetadata: ColonyMetadata | null | undefined,
 ) => {
   const metadataObject = actionIsMotion
     ? pendingColonyMetadata
@@ -591,7 +591,7 @@ const getChangelogItem = (
  */
 export const getExtendedActionType = (
   actionData: ColonyAction,
-  metadata?: ColonyMetadata | null,
+  metadata: ColonyMetadata | null | undefined,
 ): AnyActionType => {
   const { type } = actionData;
   const changelogItem = getChangelogItem(actionData, metadata);

--- a/src/utils/domains.ts
+++ b/src/utils/domains.ts
@@ -5,9 +5,9 @@ import { sortBy } from './lodash';
 
 export const findDomainByNativeId = (
   domainNativeId: number | null | undefined,
-  colony: Colony | undefined,
+  colony: Colony,
 ) => {
-  const domains = colony?.domains?.items;
+  const domains = colony.domains?.items;
   if (!domains) {
     return undefined;
   }

--- a/src/utils/validation/hasEnoughFundsValidation.ts
+++ b/src/utils/validation/hasEnoughFundsValidation.ts
@@ -14,7 +14,7 @@ export const hasEnoughFundsValidation = (
   value: number | null | undefined,
   context: TestContext<object>,
   selectedTeam: string | undefined,
-  colony: ColonyFragment | undefined,
+  colony: ColonyFragment,
   tokenAddress?: string,
 ) => {
   const { parent } = context;


### PR DESCRIPTION
### What the heck is happening?
- All of the queries that were inside `ColonyContext` have been moved to `ColonyRoute`. This way, we can type the widely used `colony` prop as defined and remove all the fluff around this object being undefined or not from the CDapp.
- Instead of redirecting the user to the loading or not found route from the context, this is done in the route component now. 
- There are many changes made in this PR but most of them are just the removal of fallbacks and optional operators.
- What we need to test with this PR is if the CDapp continues to work correctly, even if the majority of changes are mostly  "dev facing".
- What I did was search for any instances where we used the `useColonyContext` hook and updated that file. Let me know if I missed one somehow.

Resolves #1419 
