### PR TITLE
Fix skeleton loader overlapping dropdown menu

### DIFF
--- a/src/components/v5/shared/PopoverBase/PopoverBase.tsx
+++ b/src/components/v5/shared/PopoverBase/PopoverBase.tsx
@@ -19,7 +19,7 @@ const PopoverBase: FC<PropsWithChildren<PopoverBaseProps>> = ({
   <div
     ref={setTooltipRef}
     {...tooltipProps({
-      className: clsx(classNames, 'z-10', {
+      className: clsx(classNames, 'z-12', {
         'tooltip-container': withTooltipStyles,
       }),
     })}


### PR DESCRIPTION
## Description

This PR fixes the issue of the Skeleton loader in the activity feed overlapping the userMenu when it is present. 


**Changes** 🏗

Changed the Z index of the user menu pop up to 12.
![1639-skeleton-overlap](https://github.com/JoinColony/colonyCDapp/assets/155957480/f90d95e9-eca8-4bfd-b8a9-27a0f9b4d097)


Resolves #1639 
