### PR TITLE
Fix: Add interaction states to token titles

### DIFF
--- a/src/components/frame/v5/pages/BalancePage/partials/TokenAvatar/TokenAvatar.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/TokenAvatar/TokenAvatar.tsx
@@ -48,7 +48,7 @@ const TokenAvatar: FC<TokenAvatarProps> = ({
             className={clsx('font-medium', {
               'truncate max-w-[6.25rem] md:max-w-full': !isTokenModalOpened,
               'md:whitespace-normal': isTokenModalOpened,
-              'text-gray-900': !isTokenInfoShown,
+              'text-gray-900 group-hover:text-blue-400': !isTokenInfoShown,
               'text-blue-400': isTokenInfoShown,
             })}
           >
@@ -77,7 +77,7 @@ const TokenAvatar: FC<TokenAvatarProps> = ({
       <button
         type="button"
         ref={relativeElementRef}
-        className="flex gap-4 items-center"
+        className="flex gap-4 items-center group"
         onClick={isMobile ? toggleTokenModalOn : toggleToken}
       >
         {content}

--- a/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
@@ -2,12 +2,21 @@ import { getSortedRowModel, SortingState } from '@tanstack/react-table';
 import { BigNumber } from 'ethers';
 import React, { FC, useState } from 'react';
 
-import { useColonyContext, useColonyFundsClaims } from '~hooks';
-import useToggle from '~hooks/useToggle';
+import {
+  useMobile,
+  useColonyContext,
+  useRelativePortalElement,
+  useColonyFundsClaims,
+  useToggle,
+} from '~hooks';
 import Numeral from '~shared/Numeral';
 import TokenIcon from '~shared/TokenIcon';
+import TokenInfo from '~shared/TokenInfoPopover/TokenInfo';
 import Table from '~v5/common/Table';
 import AccordionItem from '~v5/shared/Accordion/partials/AccordionItem';
+import MenuContainer from '~v5/shared/MenuContainer';
+import Modal from '~v5/shared/Modal';
+import Portal from '~v5/shared/Portal';
 
 import { useTokenTableColumns } from './hooks';
 import { TokenTableProps } from './types';
@@ -15,6 +24,7 @@ import { TokenTableProps } from './types';
 const displayName = 'v5.pages.FundsPage.partials.TokenTable';
 
 const TokenTable: FC<TokenTableProps> = ({ token }) => {
+  const isMobile = useMobile();
   const { colony } = useColonyContext();
   const { nativeToken } = colony || {};
   const claims = useColonyFundsClaims();
@@ -30,35 +40,96 @@ const TokenTable: FC<TokenTableProps> = ({ token }) => {
   const columns = useTokenTableColumns();
   const [sorting, setSorting] = useState<SortingState>([]);
 
+  const [
+    isTokenModalOpened,
+    { toggleOff: toggleTokenModalOff, toggleOn: toggleTokenModalOn },
+  ] = useToggle();
+  const [isTokenVisible, { toggle: toggleToken, registerContainerRef }] =
+    useToggle();
+
+  const { portalElementRef, relativeElementRef } = useRelativePortalElement<
+    HTMLButtonElement,
+    HTMLDivElement
+  >([isTokenVisible], {
+    top: 8,
+  });
+
+  const isTokenNative = token?.tokenAddress === nativeToken?.tokenAddress;
+
+  const handleToggleToken = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    if (isMobile) {
+      toggleTokenModalOn();
+    } else {
+      toggleToken();
+    }
+  };
+
   return claimsAmount.gt(0) && token ? (
-    <AccordionItem
-      className="text-1 text-gray-900 w-full [&_.accordion-toggler]:px-[1.125rem] sm:hover:[&_.accordion-toggler]:bg-gray-25"
-      isOpen={isTableRowOpen}
-      onToggle={toggleTableRowAccordion}
-      iconName="chevron-down"
-      title={
-        <div className="flex items-center justify-between w-full py-4 text-gray-900">
-          <div className="flex items-center gap-4">
-            <TokenIcon token={token} size="xs" />
-            {token?.name}
+    <>
+      <AccordionItem
+        className="text-1 text-gray-900 w-full [&_.accordion-toggler]:px-[1.125rem] sm:hover:[&_.accordion-toggler]:bg-gray-25"
+        isOpen={isTableRowOpen}
+        onToggle={toggleTableRowAccordion}
+        iconName="chevron-down"
+        title={
+          <div className="flex items-center justify-between w-full py-4 text-gray-900">
+            <button
+              type="button"
+              className="flex items-center gap-4 hover:text-blue-400"
+              ref={relativeElementRef}
+              onClick={handleToggleToken}
+            >
+              <TokenIcon token={token} size="xs" />
+              {token?.name}
+            </button>
+            <div>
+              <Numeral value={claimsAmount} decimals={nativeToken?.decimals} />{' '}
+              {token?.symbol}
+            </div>
           </div>
-          <div>
-            <Numeral value={claimsAmount} decimals={nativeToken?.decimals} />{' '}
-            {token?.symbol}
-          </div>
-        </div>
-      }
-    >
-      <Table
-        data={currentClaims}
-        state={{ sorting }}
-        onSortingChange={setSorting}
-        getSortedRowModel={getSortedRowModel()}
-        verticalOnMobile={false}
-        columns={columns}
-        className="border-0 rounded-none -mx-[1.125rem] px-[1.125rem] !w-[calc(100%+2.25rem)] [&_td]:px-[1.125rem] [&_th]:border-y border-gray-200 [&_td]:py-4"
-      />
-    </AccordionItem>
+        }
+      >
+        <Table
+          data={currentClaims}
+          state={{ sorting }}
+          onSortingChange={setSorting}
+          getSortedRowModel={getSortedRowModel()}
+          verticalOnMobile={false}
+          columns={columns}
+          className="border-0 rounded-none -mx-[1.125rem] px-[1.125rem] !w-[calc(100%+2.25rem)] [&_td]:px-[1.125rem] [&_th]:border-y border-gray-200 [&_td]:py-4"
+        />
+      </AccordionItem>
+      {isMobile ? (
+        <Modal
+          isFullOnMobile={false}
+          onClose={toggleTokenModalOff}
+          isOpen={isTokenModalOpened}
+        >
+          <TokenInfo
+            className="!p-0 w-full"
+            token={token}
+            isTokenNative={isTokenNative}
+          />
+        </Modal>
+      ) : (
+        isTokenVisible && (
+          <Portal>
+            <MenuContainer
+              className="absolute !p-0 z-[60] min-w-80"
+              hasShadow
+              rounded="s"
+              ref={(ref) => {
+                registerContainerRef(ref);
+                portalElementRef.current = ref;
+              }}
+            >
+              <TokenInfo token={token} isTokenNative={isTokenNative} />
+            </MenuContainer>
+          </Portal>
+        )
+      )}
+    </>
   ) : null;
 };
 

--- a/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
@@ -1,4 +1,5 @@
 import { getSortedRowModel, SortingState } from '@tanstack/react-table';
+import clsx from 'clsx';
 import { BigNumber } from 'ethers';
 import React, { FC, useState } from 'react';
 
@@ -46,6 +47,7 @@ const TokenTable: FC<TokenTableProps> = ({ token }) => {
   ] = useToggle();
   const [isTokenVisible, { toggle: toggleToken, registerContainerRef }] =
     useToggle();
+  const isTokenInfoShown = isTokenModalOpened || isTokenVisible;
 
   const { portalElementRef, relativeElementRef } = useRelativePortalElement<
     HTMLButtonElement,
@@ -76,12 +78,21 @@ const TokenTable: FC<TokenTableProps> = ({ token }) => {
           <div className="flex items-center justify-between w-full py-4 text-gray-900">
             <button
               type="button"
-              className="flex items-center gap-4 hover:text-blue-400"
+              className="flex items-center gap-4 group"
               ref={relativeElementRef}
               onClick={handleToggleToken}
             >
               <TokenIcon token={token} size="xs" />
-              {token?.name}
+              <span
+                className={clsx('font-medium', {
+                  'truncate max-w-[6.25rem] md:max-w-full': !isTokenModalOpened,
+                  'md:whitespace-normal': isTokenModalOpened,
+                  'text-gray-900 group-hover:text-blue-400': !isTokenInfoShown,
+                  'text-blue-400': isTokenInfoShown,
+                })}
+              >
+                {token.name}
+              </span>
             </button>
             <div>
               <Numeral value={claimsAmount} decimals={nativeToken?.decimals} />{' '}


### PR DESCRIPTION
## Description

Added hover state to token title on balance page.

Added pop over to token title on incoming funds page - opens in portal on desktop and modal on mobile.

**New stuff** ✨

* Added group to token title button so when token icon or name is hovered, token title changes to text-blue-400
* Added portal for token pop over on desktop on incoming funds page
* Added modal for token pop over on mobile on incoming funds page
* Added active state to token title on incoming funds page

**Changes** 🏗

* On incoming funds page, converted token title / avatar div to a button to open token pop over onClick

Token title hover state on balance page
![Screenshot 2024-01-15 at 15 09 44](https://github.com/JoinColony/colonyCDapp/assets/34915414/33e8b5d4-d6d4-4fdd-94b2-a399ef0ecec8)

Token pop over on incoming funds page desktop
![Screenshot 2024-01-15 at 15 23 29](https://github.com/JoinColony/colonyCDapp/assets/34915414/bed8d63b-10fe-4d71-b768-4a63b4cca0f4)

Token pop over on incoming funds page mobile
![Screenshot 2024-01-15 at 15 23 55](https://github.com/JoinColony/colonyCDapp/assets/34915414/4bc90ca5-676f-4611-9612-440fabca5f56)

Resolves #1633 
