### PR TITLE
Fixes Chromatic build workflow and adds issue templates for Github

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,27 @@
+---
+name: Bug
+about: Something wrong? Got a nasty error?
+title: 'Example: Unable to log in with MetaMask wallet'
+labels: bug
+assignees: ''
+
+---
+
+## Steps to reproduce
+
+1. Example: log in with a MetaMask wallet
+
+
+## Expected behaviour
+
+* Example: The user is logged in without errors
+
+
+## Actual behaviour
+
+* Example: A `WALLET_CREATE_ERROR` action is dispatched and the user cannot log in
+
+
+## Suggestions (optional)
+
+* Example: A new version of MetaMask was released, maybe there are some breaking changes

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,46 @@
+---
+name: Feature
+about: For new features or enhancements.
+title: 'Example: Show activity indicator for all async activity'
+labels: feature
+assignees: ''
+
+---
+
+## Specification
+
+### Story
+
+Example: As a *user creating a colony*, I want to *see a visual indicator of activity/loading*, so that *I know I should wait for it to finish*
+
+
+### Description
+
+Example: During the colony creation wizard, there is an activity indicator for pending transactions, but there is no indicator of other async operations (e.g. for the DDB) in between these transactions. It's important that the indicator remains visible until all async activity is finished, because otherwise the user has no feedback that they're waiting for something to finish; they might leave the wizard or refresh the page, leading to frustration.
+
+
+### Design
+
+[Figma link](https://the-link-to-the-design-on-figma)
+
+[Image](!https://inline-image-from-figma-for-quick-reference-or-posterity)
+
+
+## Implementation
+
+### This issue is complete when...
+
+- [ ] The activity indicator for the `TransactionStatus` component is shown during any and all async waiting
+- [ ] The indicator is hidden when async waiting finishes (either successfully or unsuccessfully)
+
+
+### Suggestions (optional)
+
+* Example: It's probably a good idea to keep the transaction state separate from other async actions that relate to them; i.e. either adding an extra transaction status, or keeping the transaction as `PENDING` while other async activity finishes would probably lead to some confusion and unintended side effects. Perhaps component state would be a more suitable starting point.
+
+
+### Subtasks (optional)
+
+- [ ] Create a prop (e.g. with component state) which indicates either a transaction is pending, or async activity is in progress related to that transaction, in the context of the wizard
+- [ ] Pass down a prop to the `TransactionStatus` component
+- [ ] Adjust the `TransactionStatus` component such that it shows the indicator with the given prop

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -28,3 +28,4 @@ jobs:
         with:
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          exitOnceUploaded: true

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,11 +16,11 @@ jobs:
       - name: 'Setup node'
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 16.16
       - uses: actions/checkout@v1
       - name: Install dependencies
-        # 👇 Install dependencies with the same package manager used in the project (replace it as needed), e.g. yarn, npm, pnpm
-        run: yarn
+        # 👇 Install dependencies
+        run: npm install
         # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
         uses: chromaui/action@v1


### PR DESCRIPTION
## Description

This PR is intended to resolve the Chromatic Github Actions workflow failing continually.

Chromatic is still failing due to Storybook component issues, this is a feature, which I think we should use. However, for now, I have added the flag `exitOnceUploaded` to prevent it from failing the build until we can remove the Storybook components.

I have tested locally using ACT to simulate Github actions - https://github.com/nektos/act

You can see the successful build here - https://github.com/JoinColony/colonyCDapp/actions/runs/7504573403/job/20431926449

I have also taken the opportunity to add Github issue templates, pretty much copied from the Dapp repo.