### PR TITLE
Update domain ids on forms to numbers

### DIFF
--- a/src/components/common/Dialogs/TransferFundsDialog/helpers.ts
+++ b/src/components/common/Dialogs/TransferFundsDialog/helpers.ts
@@ -34,8 +34,8 @@ export const getTransferFundsDialogPayload = (
   // Convert amount string with decimals to BigInt (eth to wei)
   const amount = BigNumber.from(moveDecimal(transferAmount, decimals));
 
-  const fromDomain = findDomainByNativeId(Number(fromDomainId), colony);
-  const toDomain = findDomainByNativeId(Number(toDomainId), colony);
+  const fromDomain = findDomainByNativeId(fromDomainId, colony);
+  const toDomain = findDomainByNativeId(toDomainId, colony);
 
   return {
     colonyAddress: colony.colonyAddress,

--- a/src/components/v5/common/ActionSidebar/hooks/useGetActionData.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useGetActionData.ts
@@ -47,9 +47,7 @@ export const useGetActionData = (transactionId: string | undefined) => {
     const extendedType = getExtendedActionType(action, colony.metadata);
 
     const repeatableFields = {
-      createdIn: isMotion
-        ? motionData?.motionDomain.nativeId.toString()
-        : Id.RootDomain.toString(),
+      createdIn: isMotion ? motionData?.motionDomain.nativeId : Id.RootDomain,
       description: annotation?.message,
       title: action.metadata?.customTitle,
       decisionMethod: action.isMotion
@@ -79,7 +77,7 @@ export const useGetActionData = (transactionId: string | undefined) => {
             ),
             tokenAddress: token?.tokenAddress,
           },
-          from: fromDomain?.nativeId.toString(),
+          from: fromDomain?.nativeId,
           recipient: recipientAddress,
           ...repeatableFields,
         };
@@ -90,7 +88,7 @@ export const useGetActionData = (transactionId: string | undefined) => {
 
         return {
           [ACTION_TYPE_FIELD_NAME]: ACTION.SIMPLE_PAYMENT,
-          from: fromDomain?.nativeId.toString(),
+          from: fromDomain?.nativeId,
           amount: {
             amount: moveDecimal(
               firstPayment.amount,
@@ -118,8 +116,8 @@ export const useGetActionData = (transactionId: string | undefined) => {
       case ColonyActionType.MoveFundsMotion:
         return {
           [ACTION_TYPE_FIELD_NAME]: ACTION.TRANSFER_FUNDS,
-          from: fromDomain?.nativeId.toString(),
-          to: toDomain?.nativeId.toString(),
+          from: fromDomain?.nativeId,
+          to: toDomain?.nativeId,
           amount: {
             amount,
             tokenAddress: token?.tokenAddress,
@@ -193,7 +191,7 @@ export const useGetActionData = (transactionId: string | undefined) => {
 
         return {
           [ACTION_TYPE_FIELD_NAME]: ACTION.EDIT_EXISTING_TEAM,
-          team: fromDomain?.nativeId?.toString(),
+          team: fromDomain?.nativeId,
           teamName: isMotion ? pendingDomainMetadata?.name : changelog?.newName,
           domainColor: isMotion
             ? pendingDomainMetadata?.color
@@ -207,7 +205,7 @@ export const useGetActionData = (transactionId: string | undefined) => {
       case ColonyActionType.CreateDecisionMotion:
         return {
           [ACTION_TYPE_FIELD_NAME]: ACTION.CREATE_DECISION,
-          createdIn: decisionData?.motionDomainId.toString(),
+          createdIn: decisionData?.motionDomainId,
           title: decisionData?.title,
           description: decisionData?.description,
         };
@@ -227,7 +225,7 @@ export const useGetActionData = (transactionId: string | undefined) => {
           member: recipientAddress,
           authority: AUTHORITY.Own,
           role,
-          team: fromDomain?.nativeId.toString(),
+          team: fromDomain?.nativeId,
           permissions:
             role === USER_ROLE.Custom
               ? AVAILABLE_ROLES.reduce(

--- a/src/components/v5/common/ActionSidebar/partials/forms/AdvancedPaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/AdvancedPaymentForm/hooks.ts
@@ -31,7 +31,7 @@ export const useValidationSchema = () => {
         .shape({
           from: number().required(),
           decisionMethod: string().defined(),
-          createdIn: string().defined(),
+          createdIn: number().defined(),
           description: string().max(MAX_ANNOTATION_NUM).notRequired(),
           payments: array()
             .of(
@@ -98,7 +98,7 @@ export const useAdvancedPayment = (
     validationSchema,
     defaultValues: useMemo<DeepPartial<AdvancedPaymentFormValues>>(
       () => ({
-        createdIn: Id.RootDomain.toString(),
+        createdIn: Id.RootDomain,
         payments: [
           {
             delay: 0,

--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/consts.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/consts.ts
@@ -1,4 +1,4 @@
-import { InferType, object, string } from 'yup';
+import { InferType, object, string, number } from 'yup';
 
 import { MAX_OBJECTIVE_DESCRIPTION_LENGTH } from '~constants';
 import { ACTION_BASE_VALIDATION_SCHEMA } from '~v5/common/ActionSidebar/consts';
@@ -8,7 +8,7 @@ export const validationSchema = object()
     title: string()
       .trim()
       .required(() => 'Please enter a title.'),
-    createdIn: string().defined(),
+    createdIn: number().defined(),
     description: string().max(MAX_OBJECTIVE_DESCRIPTION_LENGTH).notRequired(),
     decisionMethod: string().defined(),
     walletAddress: string().address().required(),

--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/hooks.ts
@@ -43,7 +43,7 @@ export const useCreateDecision = (
     getFormOptions,
     defaultValues: useMemo(
       () => ({
-        createdIn: Id.RootDomain.toString(),
+        createdIn: Id.RootDomain,
         walletAddress,
       }),
       [walletAddress],

--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateNewTeamForm/consts.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateNewTeamForm/consts.ts
@@ -1,4 +1,4 @@
-import { InferType, object, string } from 'yup';
+import { InferType, object, string, number } from 'yup';
 
 import {
   MAX_ANNOTATION_LENGTH,
@@ -15,7 +15,7 @@ export const validationSchema = object()
       .required(() => 'Team name required.'),
     domainPurpose: string().trim().max(MAX_DOMAIN_PURPOSE_LENGTH).notRequired(),
     domainColor: string().defined(),
-    createdIn: string().defined(),
+    createdIn: number().defined(),
     decisionMethod: string().defined(),
     description: string().max(MAX_ANNOTATION_LENGTH).notRequired(),
   })

--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateNewTeamForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateNewTeamForm/hooks.ts
@@ -29,7 +29,7 @@ export const useCreateNewTeam = (
         : ActionTypes.ACTION_DOMAIN_CREATE,
     defaultValues: useMemo<DeepPartial<CreateNewTeamFormValues>>(
       () => ({
-        createdIn: Id.RootDomain.toString(),
+        createdIn: Id.RootDomain,
       }),
       [],
     ),

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/consts.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/consts.ts
@@ -1,4 +1,4 @@
-import { object, string, array, InferType } from 'yup';
+import { object, string, array, InferType, number } from 'yup';
 
 import {
   MAX_ANNOTATION_LENGTH,
@@ -15,7 +15,7 @@ export const validationSchema = object()
       thumbnail: string().nullable().defined(),
     }),
     colonyName: string().trim().max(MAX_COLONY_DISPLAY_NAME),
-    createdIn: string().defined(),
+    createdIn: number().defined(),
     decisionMethod: string().defined(),
     description: string().max(MAX_ANNOTATION_LENGTH).notRequired(),
     colonyDescription: string().max(MAX_OBJECTIVE_DESCRIPTION_LENGTH),

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/hooks.ts
@@ -33,7 +33,7 @@ export const useEditColonyDetails = (
           image: metadata?.avatar,
           thumbnail: metadata?.thumbnail,
         },
-        createdIn: Id.RootDomain.toString(),
+        createdIn: Id.RootDomain,
         externalLinks: metadata?.externalLinks ?? [],
       }),
       [

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditTeamForm/consts.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditTeamForm/consts.ts
@@ -1,4 +1,4 @@
-import { InferType, object, string } from 'yup';
+import { InferType, object, string, number } from 'yup';
 
 import {
   MAX_ANNOTATION_LENGTH,
@@ -9,14 +9,14 @@ import { ACTION_BASE_VALIDATION_SCHEMA } from '~v5/common/ActionSidebar/consts';
 
 export const validationSchema = object()
   .shape({
-    team: string().defined(),
+    team: number().defined(),
     teamName: string()
       .trim()
       .max(MAX_COLONY_DISPLAY_NAME)
       .required(() => 'Team name required.'),
     domainPurpose: string().trim().max(MAX_DOMAIN_PURPOSE_LENGTH).notRequired(),
     domainColor: string().notRequired(),
-    createdIn: string().defined(),
+    createdIn: number().defined(),
     decisionMethod: string().defined(),
     description: string().max(MAX_ANNOTATION_LENGTH).notRequired(),
   })

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditTeamForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditTeamForm/hooks.ts
@@ -23,11 +23,10 @@ export const useEditTeam = (
 
   const { [DECISION_METHOD_FIELD_NAME]: decisionMethod, team } = useWatch<{
     decisionMethod: DecisionMethod;
-    team: string;
+    team: number;
   }>();
 
-  const selectedDomainId = Number(team);
-  const selectedDomain = findDomainByNativeId(selectedDomainId, colony);
+  const selectedDomain = findDomainByNativeId(team, colony);
 
   useEffect(() => {
     if (!selectedDomain) {
@@ -39,7 +38,7 @@ export const useEditTeam = (
     setValue('teamName', metadata?.name);
     setValue('domainPurpose', metadata?.description);
     setValue('domainColor', metadata?.color);
-    setValue('createdIn', nativeId.toString());
+    setValue('createdIn', nativeId);
   }, [selectedDomain, setValue]);
 
   useActionFormBaseHook({
@@ -51,9 +50,9 @@ export const useEditTeam = (
         : ActionTypes.MOTION_DOMAIN_CREATE_EDIT,
     defaultValues: useMemo<DeepPartial<EditTeamFormValues>>(
       () => ({
-        createdIn: selectedDomainId.toString() || Id.RootDomain.toString(),
+        createdIn: team || Id.RootDomain,
       }),
-      [selectedDomainId],
+      [team],
     ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     transform: useCallback(

--- a/src/components/v5/common/ActionSidebar/partials/forms/EnterRecoveryModeForm/consts.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EnterRecoveryModeForm/consts.ts
@@ -1,11 +1,11 @@
-import { InferType, object, string } from 'yup';
+import { InferType, object, string, number } from 'yup';
 
 import { MAX_ANNOTATION_LENGTH } from '~constants';
 import { ACTION_BASE_VALIDATION_SCHEMA } from '~v5/common/ActionSidebar/consts';
 
 export const validationSchema = object()
   .shape({
-    createdIn: string().defined(),
+    createdIn: number().defined(),
     decisionMethod: string().defined(),
     description: string().max(MAX_ANNOTATION_LENGTH).notRequired(),
   })

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/consts.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/consts.ts
@@ -16,7 +16,7 @@ export const validationSchema = object()
     colonyObjectiveProgress: number()
       .max(100)
       .required(() => formatText({ id: 'errors.colonyObjective.progress' })),
-    createdIn: string().defined(),
+    createdIn: number().defined(),
     decisionMethod: string().defined(),
     description: string().max(MAX_ANNOTATION_LENGTH).notRequired(),
   })

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/hooks.ts
@@ -33,7 +33,7 @@ export const useManageColonyObjectives = (
           image: metadata?.avatar,
           thumbnail: metadata?.thumbnail,
         },
-        createdIn: Id.RootDomain.toString(),
+        createdIn: Id.RootDomain,
       }),
       [metadata?.avatar, metadata?.displayName, metadata?.thumbnail],
     ),

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/consts.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/consts.tsx
@@ -1,6 +1,6 @@
 import { ColonyRole } from '@colony/colony-js';
 import React from 'react';
-import { InferType, mixed, object, string } from 'yup';
+import { InferType, mixed, object, string, number } from 'yup';
 
 import { MAX_ANNOTATION_LENGTH } from '~constants';
 import {
@@ -22,8 +22,8 @@ import { UserRoleSelectMeta } from './types';
 export const validationSchema = object()
   .shape({
     member: string().required(),
-    team: string().required(),
-    createdIn: string().required(),
+    team: number().required(),
+    createdIn: number().required(),
     role: string().required(),
     authority: string().required(),
     permissions: mixed<Partial<Record<string, boolean>>>().test(

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageTokensForm/consts.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageTokensForm/consts.ts
@@ -1,11 +1,11 @@
-import { array, InferType, object, string } from 'yup';
+import { array, InferType, object, string, number } from 'yup';
 
 import { MAX_ANNOTATION_LENGTH } from '~constants';
 import { ACTION_BASE_VALIDATION_SCHEMA } from '~v5/common/ActionSidebar/consts';
 
 export const validationSchema = object()
   .shape({
-    createdIn: string().defined(),
+    createdIn: number().defined(),
     decisionMethod: string().defined(),
     description: string().max(MAX_ANNOTATION_LENGTH).notRequired(),
     selectedTokenAddresses: array()

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageTokensForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageTokensForm/hooks.ts
@@ -52,7 +52,7 @@ export const useManageTokens = (
         : ActionTypes.MOTION_EDIT_COLONY,
     defaultValues: useMemo(
       () => ({
-        createdIn: Id.RootDomain.toString(),
+        createdIn: Id.RootDomain,
         selectedTokenAddresses: colonyTokens.map(({ token }) => ({
           token: token.tokenAddress,
         })),

--- a/src/components/v5/common/ActionSidebar/partials/forms/MintTokenForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/MintTokenForm/hooks.ts
@@ -26,7 +26,7 @@ export const useMintToken = (
     validationSchema,
     defaultValues: useMemo<DeepPartial<MintTokenFormValues>>(
       () => ({
-        createdIn: Id.RootDomain.toString(),
+        createdIn: Id.RootDomain,
         amount: {},
       }),
       [],

--- a/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/hooks.ts
@@ -54,7 +54,7 @@ export const useValidationSchema = () => {
             })
             .required()
             .defined(),
-          createdIn: string().defined(),
+          createdIn: number().defined(),
           description: string().max(MAX_ANNOTATION_LENGTH).notRequired(),
           recipient: string().address().required(),
           from: number().required(),
@@ -117,7 +117,7 @@ export const useSimplePayment = (
     validationSchema,
     defaultValues: useMemo<DeepPartial<SimplePaymentFormValues>>(
       () => ({
-        createdIn: Id.RootDomain.toString(),
+        createdIn: Id.RootDomain,
         payments: [],
         amount: {
           tokenAddress:

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/hooks.ts
@@ -43,9 +43,9 @@ export const useValidationSchema = () => {
             ),
           tokenAddress: string().address().required(),
         }).required(),
-        createdIn: string().defined(),
+        createdIn: number().defined(),
         description: string().max(MAX_ANNOTATION_LENGTH).notRequired(),
-        team: string().required(),
+        team: number().required(),
         decisionMethod: string().defined(),
         distributionMethod: string().defined(),
         payments: array(
@@ -117,7 +117,7 @@ export const useSplitPayment = (
         amount: {
           tokenAddress: colony?.nativeToken.tokenAddress,
         },
-        createdIn: Id.RootDomain.toString(),
+        createdIn: Id.RootDomain,
         payments: [
           {
             percent: 0,

--- a/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/hooks.ts
@@ -52,9 +52,9 @@ export const useValidationSchema = () => {
               tokenAddress: string().address().required(),
             })
             .required(),
-          createdIn: string().defined(),
-          from: string().required(),
-          to: string()
+          createdIn: number().defined(),
+          from: number().required(),
+          to: number()
             .required()
             .when('from', (from, schema) =>
               schema.notOneOf(
@@ -94,24 +94,18 @@ export const useTransferFunds = (
   const selectedTokenAddress = amount?.tokenAddress;
   const validationSchema = useValidationSchema();
 
-  const selectedDomainId = Number(from);
-
   useActionFormBaseHook({
     validationSchema,
     defaultValues: useMemo<DeepPartial<TransferFundsFormValues>>(
       () => ({
-        createdIn: selectedDomainId.toString() || Id.RootDomain.toString(),
-        from: Id.RootDomain.toString(),
+        createdIn: from || Id.RootDomain,
+        from: Id.RootDomain,
         amount: {
           tokenAddress:
             selectedTokenAddress ?? colony?.nativeToken.tokenAddress,
         },
       }),
-      [
-        selectedDomainId,
-        selectedTokenAddress,
-        colony?.nativeToken.tokenAddress,
-      ],
+      [from, selectedTokenAddress, colony?.nativeToken.tokenAddress],
     ),
     actionType:
       decisionMethod === DecisionMethod.Permissions

--- a/src/components/v5/common/ActionSidebar/partials/forms/UnlockTokenForm/consts.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/UnlockTokenForm/consts.ts
@@ -1,11 +1,11 @@
-import { InferType, object, string } from 'yup';
+import { InferType, object, string, number } from 'yup';
 
 import { MAX_ANNOTATION_LENGTH } from '~constants';
 import { ACTION_BASE_VALIDATION_SCHEMA } from '~v5/common/ActionSidebar/consts';
 
 export const validationSchema = object()
   .shape({
-    createdIn: string().defined(),
+    createdIn: number().defined(),
     decisionMethod: string().defined(),
     description: string().max(MAX_ANNOTATION_LENGTH).notRequired(),
   })

--- a/src/components/v5/common/ActionSidebar/partials/forms/UnlockTokenForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/UnlockTokenForm/hooks.ts
@@ -30,7 +30,7 @@ export const useUnlockToken = (
         : ActionTypes.ROOT_MOTION,
     defaultValues: useMemo<DeepPartial<UnlockTokenFormValues>>(
       () => ({
-        createdIn: Id.RootDomain.toString(),
+        createdIn: Id.RootDomain,
       }),
       [],
     ),

--- a/src/components/v5/common/ActionSidebar/partials/forms/UpgradeColonyForm/consts.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/UpgradeColonyForm/consts.ts
@@ -1,11 +1,11 @@
-import { InferType, object, string } from 'yup';
+import { InferType, object, string, number } from 'yup';
 
 import { MAX_ANNOTATION_LENGTH } from '~constants';
 import { ACTION_BASE_VALIDATION_SCHEMA } from '~v5/common/ActionSidebar/consts';
 
 export const validationSchema = object()
   .shape({
-    createdIn: string().defined(),
+    createdIn: number().defined(),
     decisionMethod: string().defined(),
     description: string().max(MAX_ANNOTATION_LENGTH).notRequired(),
   })

--- a/src/components/v5/common/ActionSidebar/partials/forms/UpgradeColonyForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/UpgradeColonyForm/hooks.ts
@@ -43,7 +43,7 @@ export const useUpgradeColony = (
     ),
     defaultValues: useMemo<DeepPartial<UpgradeColonyFormValues>>(
       () => ({
-        createdIn: Id.RootDomain.toString(),
+        createdIn: Id.RootDomain,
       }),
       [],
     ),

--- a/src/components/v5/shared/SearchSelect/hooks.ts
+++ b/src/components/v5/shared/SearchSelect/hooks.ts
@@ -14,11 +14,14 @@ export const useSearchSelect = (
         ...item,
         options: item.options.filter((option) => {
           const searchQuery = searchValue.toLowerCase();
-          const optionValue = option.value.replace('-', ' ').toLowerCase();
+          const optionValue =
+            typeof option.value === 'string'
+              ? option.value.replace('-', ' ').toLowerCase()
+              : option.value;
           const optionUserName = formatText(option.label).toLowerCase();
 
           return [optionValue, optionUserName].some((value) =>
-            value.includes(searchQuery),
+            value.toString().includes(searchQuery),
           );
         }),
       })),

--- a/src/components/v5/shared/SearchSelect/partials/SearchItem/types.ts
+++ b/src/components/v5/shared/SearchSelect/partials/SearchItem/types.ts
@@ -2,6 +2,6 @@ import { SearchSelectOption } from '../../types';
 
 export interface SearchItemProps {
   options: SearchSelectOption[];
-  onChange?: (value: string) => void;
+  onChange?: (value: string | number) => void;
   isLabelVisible?: boolean;
 }

--- a/src/components/v5/shared/SearchSelect/types.ts
+++ b/src/components/v5/shared/SearchSelect/types.ts
@@ -24,7 +24,7 @@ export interface SearchSelectOptionProps {
 
 export interface SearchSelectOption {
   label: MessageDescriptor | string;
-  value: string;
+  value: string | number;
   isDisabled?: boolean;
   avatar?: string;
   showAvatar?: boolean;

--- a/src/hooks/useTeamsOptions.ts
+++ b/src/hooks/useTeamsOptions.ts
@@ -27,7 +27,7 @@ const useTeamsOptions = (
 
         return {
           label: teamName || '',
-          value: (nativeId || '').toString(),
+          value: nativeId,
           isDisabled: false,
           color: teamColor,
           isRoot,


### PR DESCRIPTION
Updated action sidebar forms to not convert domain ids to strings; instead, leave them as numbers like it is everywhere else in the codebase.

The forms should be working as they were before this change. These changes are "dev facing" only, they are made to keep the data type consistent with the rest of the CDapp.

Resolves #1426 
