### PR TITLE
resize upload colony avatar icon

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/ColonyDetailsFields/partials/ColonyAvatarField/ColonyAvatarField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ColonyDetailsFields/partials/ColonyAvatarField/ColonyAvatarField.tsx
@@ -90,7 +90,7 @@ const ColonyAvatarField: FC<ColonyAvatarFieldProps> = ({
               {getPlaceholder(
                 isLoading,
                 <ColonyAvatar
-                  size="xm"
+                  size="m"
                   colonyImageProps={{
                     src: modalValue?.image,
                   }}

--- a/src/components/v5/common/AvatarUploader/partials/FileUpload.tsx
+++ b/src/components/v5/common/AvatarUploader/partials/FileUpload.tsx
@@ -78,7 +78,7 @@ const FileUpload: FC<FileUploadProps> = ({
   return (
     <div className="w-full">
       <div
-        className="flex md:flex-col w-full"
+        className="flex md:flex-col w-full text-center"
         {...getRootProps({ 'aria-invalid': isDragReject })}
       >
         <input {...getInputProps()} />


### PR DESCRIPTION
## Description

Resized the size of the icon within ColonyAvatarField to match figma spec - this changes the avatar preview image to be larger when trying to upload a new avatar icon

**New stuff** ✨
<img width="532" alt="Screenshot 2024-01-15 at 11 00 58" src="https://github.com/JoinColony/colonyCDapp/assets/155957480/ec7b019f-aafe-48da-9438-0d5c4ea81606">


Upload text aligned to center to match figma
![Screenshot 2024-01-16 at 13 11 32](https://github.com/JoinColony/colonyCDapp/assets/155957480/72526833-bd3b-45be-afdf-49522f389797)


Resolves #1544 
