### PR TITLE
Hide about page link

### DIFF
--- a/src/components/frame/Extensions/layouts/consts.ts
+++ b/src/components/frame/Extensions/layouts/consts.ts
@@ -174,10 +174,11 @@ export const dashboardMenu: NavigationSidebarLinksListProps['items'] = [
     to: COLONY_ACTIVITY_ROUTE,
     iconName: 'presentation-chart',
   },
-  {
-    key: '2',
-    label: formatText({ id: 'navigation.dashboard.about' }),
-    to: COLONY_DETAILS_ROUTE,
-    iconName: 'book-open-text',
-  },
+  // Disabled for now
+  // {
+  //   key: '2',
+  //   label: formatText({ id: 'navigation.dashboard.about' }),
+  //   to: COLONY_DETAILS_ROUTE,
+  //   iconName: 'book-open-text',
+  // },
 ];


### PR DESCRIPTION
## Description

This PR removes (hides) the 'About' page link which shows under the dashboard tab in the navigation menu. The about link has been commented out, so it can be reused again when needed.

**Changes** 🏗
![Screenshot 2024-01-16 at 11 46 44](https://github.com/JoinColony/colonyCDapp/assets/155957480/8ea6c471-36b0-42e0-acdc-ef9ecbc18f94)

Resolves #1688 
