### PR TITLE
Update user transaction query to exclude colony address filter

### DIFF
--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -8865,7 +8865,6 @@ export type GetUserTokenBalanceQuery = { __typename?: 'Query', getUserTokenBalan
 
 export type GetUserTransactionsQueryVariables = Exact<{
   userAddress: Scalars['ID'];
-  colonyAddress?: InputMaybe<Scalars['ID']>;
   transactionsOlderThan?: InputMaybe<Scalars['String']>;
   nextToken?: InputMaybe<Scalars['String']>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -12069,11 +12068,11 @@ export type GetUserTokenBalanceQueryHookResult = ReturnType<typeof useGetUserTok
 export type GetUserTokenBalanceLazyQueryHookResult = ReturnType<typeof useGetUserTokenBalanceLazyQuery>;
 export type GetUserTokenBalanceQueryResult = Apollo.QueryResult<GetUserTokenBalanceQuery, GetUserTokenBalanceQueryVariables>;
 export const GetUserTransactionsDocument = gql`
-    query GetUserTransactions($userAddress: ID!, $colonyAddress: ID, $transactionsOlderThan: String, $nextToken: String, $limit: Int) {
+    query GetUserTransactions($userAddress: ID!, $transactionsOlderThan: String, $nextToken: String, $limit: Int) {
   getTransactionsByUser(
     from: $userAddress
     createdAt: {lt: $transactionsOlderThan}
-    filter: {colonyAddress: {eq: $colonyAddress}, deleted: {ne: true}}
+    filter: {deleted: {ne: true}}
     sortDirection: DESC
     nextToken: $nextToken
     limit: $limit
@@ -12099,7 +12098,6 @@ export const GetUserTransactionsDocument = gql`
  * const { data, loading, error } = useGetUserTransactionsQuery({
  *   variables: {
  *      userAddress: // value for 'userAddress'
- *      colonyAddress: // value for 'colonyAddress'
  *      transactionsOlderThan: // value for 'transactionsOlderThan'
  *      nextToken: // value for 'nextToken'
  *      limit: // value for 'limit'

--- a/src/graphql/queries/transactions.graphql
+++ b/src/graphql/queries/transactions.graphql
@@ -1,6 +1,5 @@
 query GetUserTransactions(
   $userAddress: ID!
-  $colonyAddress: ID
   $transactionsOlderThan: String
   $nextToken: String
   $limit: Int
@@ -8,7 +7,7 @@ query GetUserTransactions(
   getTransactionsByUser(
     from: $userAddress
     createdAt: { lt: $transactionsOlderThan }
-    filter: { colonyAddress: { eq: $colonyAddress }, deleted: { ne: true } }
+    filter: { deleted: { ne: true } }
     sortDirection: DESC
     nextToken: $nextToken
     limit: $limit


### PR DESCRIPTION
I've removed the colony address filter from the query because, for some reason, amplify/AppSync doesn't like it when the query has 2 filters and one of them is empty, in this case, that would be `colonyAddress`. 

This query is only used 1 place and that instance doesn't use the colony filter so I'm removing it from the query for this to work on prod. Of course, in the case that it is needed in the future, the idea would be to create a separate query that takes care of fetching the transactions with the colony address filter applied.

This change doesn't make a difference on the dev env, however, once this hits QA/Prod, the user hub's transactions should appear.

Resolves #1534 
