### PR TITLE
feat: add permission roles for extensions

### DIFF
--- a/src/components/common/Extensions/SpecificSidePanel/SpecificSidePanel.module.css
+++ b/src/components/common/Extensions/SpecificSidePanel/SpecificSidePanel.module.css
@@ -1,5 +1,5 @@
 .panelRow {
-  @apply flex items-start min-h-[1.25rem] gap-x-4;
+  @apply flex items-center min-h-[1.875rem] gap-x-4;
 }
 
 .panelTitle {

--- a/src/components/common/Extensions/SpecificSidePanel/SpecificSidePanel.tsx
+++ b/src/components/common/Extensions/SpecificSidePanel/SpecificSidePanel.tsx
@@ -1,13 +1,14 @@
 import React, { FC, Fragment } from 'react';
 import { useIntl } from 'react-intl';
 
+import { getRole } from '~constants/permissions';
 import { formatText } from '~utils/intl';
 import ExtensionStatusBadge from '~v5/common/Pills/ExtensionStatusBadge';
+import RolesTooltip from '~v5/shared/RolesTooltip';
 
 import { useSpecificSidePanel } from './hooks';
 import ContractAddress from './partials/ContractAddress';
 import InstalledBy from './partials/InstalledBy';
-import Permissions from './partials/Permissions';
 import SpecificSidePanelRow from './partials/SpecificSidePanelRow';
 import { SpecificSidePanelProps } from './types';
 
@@ -90,7 +91,7 @@ const SpecificSidePanel: FC<SpecificSidePanelProps> = ({ extensionData }) => {
               <div className="font-normal text-sm text-gray-600 pb-[0.875rem]">
                 {formatText({ id: 'extensionsPage.permissions' })}
               </div>
-              <Permissions roles={permissions} />
+              <RolesTooltip role={getRole(permissions)} />
             </div>
           </Fragment>
         ),

--- a/src/components/common/Extensions/SpecificSidePanel/SpecificSidePanel.tsx
+++ b/src/components/common/Extensions/SpecificSidePanel/SpecificSidePanel.tsx
@@ -87,9 +87,9 @@ const SpecificSidePanel: FC<SpecificSidePanelProps> = ({ extensionData }) => {
               title={developer.title}
               description={developer.developer}
             />
-            <div className="flex flex-col justify-between">
-              <div className="font-normal text-sm text-gray-600 pb-[0.875rem]">
-                {formatText({ id: 'extensionsPage.permissions' })}
+            <div className={styles.panelRow}>
+              <div className={styles.panelTitle}>
+                {formatText({ id: 'extensionsPage.permission' })}
               </div>
               <RolesTooltip role={getRole(permissions)} />
             </div>

--- a/src/components/v5/common/MemberCard/MemberCard.tsx
+++ b/src/components/v5/common/MemberCard/MemberCard.tsx
@@ -98,7 +98,7 @@ const MemberCard: FC<MemberCardProps> = ({
           )}
           {role && (
             <div className="ml-auto">
-              <RolesTooltip {...{ role }} />
+              <RolesTooltip role={role} />
             </div>
           )}
         </div>

--- a/src/components/v5/common/MemberCard/MemberCard.tsx
+++ b/src/components/v5/common/MemberCard/MemberCard.tsx
@@ -1,19 +1,13 @@
-import { ColonyRole } from '@colony/colony-js';
 import clsx from 'clsx';
 import React, { FC } from 'react';
 
-import { USER_ROLE, USER_ROLES } from '~constants/permissions';
-import Tooltip from '~shared/Extensions/Tooltip';
 import Icon from '~shared/Icon';
-import { formatText } from '~utils/intl';
 import { AvatarWithStatusBadge } from '~v5/shared/Avatar';
-import Link from '~v5/shared/Link';
 import MeatBallMenu from '~v5/shared/MeatBallMenu';
 import ReputationBadge from '~v5/shared/ReputationBadge';
+import RolesTooltip from '~v5/shared/RolesTooltip';
 import UserPopover from '~v5/shared/UserPopover';
 import UserPopoverAdditionalContent from '~v5/shared/UserPopoverAdditionalContent';
-
-import PermissionsBadge from '../Pills/PermissionsBadge';
 
 import { MemberCardProps } from './types';
 
@@ -104,35 +98,7 @@ const MemberCard: FC<MemberCardProps> = ({
           )}
           {role && (
             <div className="ml-auto">
-              <Tooltip
-                tooltipContent={
-                  <>
-                    {formatText(
-                      { id: 'role.description' },
-                      { role: role.name },
-                    )}
-                    <ul className="list-disc font-medium pl-4 mb-4">
-                      {role.permissions.map((permission) => (
-                        <li key={permission}>{ColonyRole[permission]}</li>
-                      ))}
-                    </ul>
-                    <Link to="https://docs.colony.io/learn/advanced-concepts/permissions">
-                      {formatText({ id: 'learn.more' })}
-                    </Link>
-                  </>
-                }
-              >
-                <PermissionsBadge
-                  text={
-                    USER_ROLES.find(
-                      ({ role: roleField }) => roleField === role.role,
-                    )?.name || formatText({ id: 'role.custom' })
-                  }
-                  iconName={
-                    role.role !== USER_ROLE.Custom ? 'user' : 'users-three'
-                  }
-                />
-              </Tooltip>
+              <RolesTooltip {...{ role }} />
             </div>
           )}
         </div>

--- a/src/components/v5/shared/RolesTooltip/RolesTooltip.tsx
+++ b/src/components/v5/shared/RolesTooltip/RolesTooltip.tsx
@@ -5,7 +5,6 @@ import { USER_ROLE, USER_ROLES } from '~constants/permissions';
 import Tooltip from '~shared/Extensions/Tooltip';
 import { formatText } from '~utils/intl';
 import PermissionsBadge from '~v5/common/Pills/PermissionsBadge';
-import Link from '~v5/shared/Link';
 
 import { RolesTooltipProps } from './types';
 
@@ -13,25 +12,18 @@ const RolesTooltip: FC<RolesTooltipProps> = ({
   role,
   roleDescription,
   tooltipProps,
-  learnMoreProps: { link, label } = {},
 }) => {
   return (
     <Tooltip
       tooltipContent={
         <>
-          {roleDescription ??
+          {roleDescription ||
             formatText({ id: 'role.description' }, { role: role.name })}
-          <ul className="list-disc font-medium pl-4 mb-4">
+          <ul className="list-disc font-medium pl-4">
             {role.permissions.map((permission) => (
               <li key={permission}>{ColonyRole[permission]}</li>
             ))}
           </ul>
-          <Link
-            to="https://docs.colony.io/learn/advanced-concepts/permissions"
-            {...link}
-          >
-            {label ?? formatText({ id: 'learn.more' })}
-          </Link>
         </>
       }
       {...tooltipProps}

--- a/src/components/v5/shared/RolesTooltip/RolesTooltip.tsx
+++ b/src/components/v5/shared/RolesTooltip/RolesTooltip.tsx
@@ -1,0 +1,50 @@
+import { ColonyRole } from '@colony/colony-js';
+import React, { FC } from 'react';
+
+import { USER_ROLE, USER_ROLES } from '~constants/permissions';
+import Tooltip from '~shared/Extensions/Tooltip';
+import { formatText } from '~utils/intl';
+import PermissionsBadge from '~v5/common/Pills/PermissionsBadge';
+import Link from '~v5/shared/Link';
+
+import { RolesTooltipProps } from './types';
+
+const RolesTooltip: FC<RolesTooltipProps> = ({
+  role,
+  roleDescription,
+  tooltipProps,
+  learnMoreProps: { link, label } = {},
+}) => {
+  return (
+    <Tooltip
+      tooltipContent={
+        <>
+          {roleDescription ??
+            formatText({ id: 'role.description' }, { role: role.name })}
+          <ul className="list-disc font-medium pl-4 mb-4">
+            {role.permissions.map((permission) => (
+              <li key={permission}>{ColonyRole[permission]}</li>
+            ))}
+          </ul>
+          <Link
+            to="https://docs.colony.io/learn/advanced-concepts/permissions"
+            {...link}
+          >
+            {label ?? formatText({ id: 'learn.more' })}
+          </Link>
+        </>
+      }
+      {...tooltipProps}
+    >
+      <PermissionsBadge
+        text={
+          USER_ROLES.find(({ role: roleField }) => roleField === role.role)
+            ?.name || formatText({ id: 'role.custom' })
+        }
+        iconName={role.role !== USER_ROLE.Custom ? 'user' : 'users-three'}
+      />
+    </Tooltip>
+  );
+};
+
+export default RolesTooltip;

--- a/src/components/v5/shared/RolesTooltip/index.tsx
+++ b/src/components/v5/shared/RolesTooltip/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './RolesTooltip';

--- a/src/components/v5/shared/RolesTooltip/types.ts
+++ b/src/components/v5/shared/RolesTooltip/types.ts
@@ -1,0 +1,14 @@
+import { UserRoleMeta } from '~constants/permissions';
+import { TooltipProps } from '~shared/Extensions/Tooltip/types';
+
+import { LinkProps } from '../Link/types';
+
+export interface RolesTooltipProps {
+  role: UserRoleMeta;
+  roleDescription?: React.ReactNode;
+  tooltipProps?: Omit<TooltipProps, 'tooltipContent'>;
+  learnMoreProps?: {
+    link?: LinkProps;
+    label?: React.ReactNode;
+  };
+}

--- a/src/components/v5/shared/RolesTooltip/types.ts
+++ b/src/components/v5/shared/RolesTooltip/types.ts
@@ -1,14 +1,8 @@
 import { UserRoleMeta } from '~constants/permissions';
 import { TooltipProps } from '~shared/Extensions/Tooltip/types';
 
-import { LinkProps } from '../Link/types';
-
 export interface RolesTooltipProps {
   role: UserRoleMeta;
   roleDescription?: React.ReactNode;
   tooltipProps?: Omit<TooltipProps, 'tooltipContent'>;
-  learnMoreProps?: {
-    link?: LinkProps;
-    label?: React.ReactNode;
-  };
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -751,7 +751,7 @@
     "extensionsPage.title": "Extensions",
     "extensionsPage.description": "Extend the functionality of your Colony",
     "extensionsPage.availableExtensions": "Available Extensions",
-    "extensionsPage.permissions": "Permissions the extension needs in the colony",
+    "extensionsPage.permission": "Permission",
     "advancedPage.title": "Advanced settings",
     "advancedPage.description": "Advanced settings of the Colony",
     "advancedPage.colony.title": "Colony version",


### PR DESCRIPTION
## Description

https://tw.auroracreation.com/app/tasks/15670058

**New stuff** ✨

* Moved Permission Roles from MemberCard as new shared component called: `RolesTooltip`
* Added `RolesTooltip` for Extension Details

Resolves https://github.com/JoinColony/colonyCDapp/issues/1694
