### PR TITLE
Fix validation of manage colony objective form

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/consts.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/consts.ts
@@ -2,6 +2,7 @@ import { InferType, number, object, string } from 'yup';
 
 import { MAX_ANNOTATION_LENGTH, MAX_COLONY_DISPLAY_NAME } from '~constants';
 import { formatText } from '~utils/intl';
+import { ACTION_BASE_VALIDATION_SCHEMA } from '~v5/common/ActionSidebar/consts';
 
 export const validationSchema = object()
   .shape({
@@ -20,7 +21,8 @@ export const validationSchema = object()
     decisionMethod: string().defined(),
     description: string().max(MAX_ANNOTATION_LENGTH).notRequired(),
   })
-  .defined();
+  .defined()
+  .concat(ACTION_BASE_VALIDATION_SCHEMA);
 
 export type ManageColonyObjectivesFormValues = InferType<
   typeof validationSchema

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/hooks.ts
@@ -34,8 +34,16 @@ export const useManageColonyObjectives = (
           thumbnail: metadata?.thumbnail,
         },
         createdIn: Id.RootDomain,
+        colonyObjectiveTitle: metadata?.objective?.title,
+        colonyObjectiveDescription: metadata?.objective?.description,
+        colonyObjectiveProgress: metadata?.objective?.progress,
       }),
-      [metadata?.avatar, metadata?.displayName, metadata?.thumbnail],
+      [
+        metadata?.avatar,
+        metadata?.displayName,
+        metadata?.thumbnail,
+        metadata?.objective,
+      ],
     ),
     actionType:
       decisionMethod === DecisionMethod.Permissions


### PR DESCRIPTION
This PR fixes the validation of the manage colony objective form. The problem was that the form didn't have default/initial values for the title, description, and progress so when you submitted the form still required you to enter a value on those fields even if you didn't want to change them but that's because for the form they were empty.

I also added validation for the action title as it was missing.

Resolves #1464
