### PR TITLE
fix permission banner showing incorrectly

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/SidebarBanner.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/SidebarBanner.tsx
@@ -51,7 +51,7 @@ export const SidebarBanner: FC = () => {
         extension.extensionId === Extension.VotingReputation;
 
       if (isOneTxPaymentExtensionAction || isVotingReputationExtensionAction) {
-        return !!extension.missingColonyPermissions;
+        return extension.missingColonyPermissions.length > 0;
       }
       return false;
     },


### PR DESCRIPTION
## Description

This PR fixes the bug where the permission banner was showing incorrectly on the 'Simple payment' action

**Changes** 🏗

![Screenshot 2024-01-18 at 13 12 28](https://github.com/JoinColony/colonyCDapp/assets/155957480/37583104-9a87-44dc-af42-babe6c25acc3)



Resolves #1691 
