### PR TITLE
fix: activity table cell height in loading state

### DIFF
--- a/src/components/common/ColonyActionsTable/hooks.tsx
+++ b/src/components/common/ColonyActionsTable/hooks.tsx
@@ -276,12 +276,14 @@ export const useActionsTableData = (pageSize: number) => {
 export const useRenderRowLink = (
   loading: boolean,
 ): RenderCellWrapper<ActivityFeedColonyAction> => {
-  return (className, content, { cell, row, renderDefault }) =>
+  const cellWrapperClassName = '!pt-[.5625rem] !pb-2';
+
+  return (className, content, { cell, row }) =>
     cell.column.columnDef.id === MEATBALL_MENU_COLUMN_ID || loading ? (
-      renderDefault()
+      <div className={clsx(className, cellWrapperClassName)}>{content}</div>
     ) : (
       <Link
-        className={clsx(className, '!py-[.5625rem]')}
+        className={clsx(className, cellWrapperClassName)}
         to={setQueryParamOnUrl(
           window.location.search,
           TX_SEARCH_PARAM,


### PR DESCRIPTION
https://tw.auroracreation.com/app/tasks/15695137
https://github.com/JoinColony/colonyCDapp/issues/1584

Replaced default table cell wrapper with custom one, with the same styles as the link to make cell the same size.