### PR TITLE
Fix `fetchTokenFromChain` lambda rpc env variables

### DIFF
--- a/amplify/backend/function/createColonyEtherealMetadata/src/index.js
+++ b/amplify/backend/function/createColonyEtherealMetadata/src/index.js
@@ -17,7 +17,7 @@ let graphqlURL = 'http://localhost:20002/graphql';
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [apiKey, graphqlURL] = await getParams([
       'appsyncApiKey',

--- a/amplify/backend/function/createPrivateBetaInvite/src/index.js
+++ b/amplify/backend/function/createPrivateBetaInvite/src/index.js
@@ -6,7 +6,7 @@ let graphqlURL = 'http://localhost:20002/graphql';
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [apiKey, graphqlURL] = await getParams(['appsyncApiKey', 'graphqlUrl']);
   }

--- a/amplify/backend/function/createUniqueColony/src/index.js
+++ b/amplify/backend/function/createUniqueColony/src/index.js
@@ -32,7 +32,7 @@ let networkAddress;
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [networkAddress, apiKey, graphqlURL, rpcURL, network] = await getParams([
       'networkContractAddress',

--- a/amplify/backend/function/createUniqueUser/src/index.js
+++ b/amplify/backend/function/createUniqueUser/src/index.js
@@ -18,7 +18,7 @@ let graphqlURL = 'http://localhost:20002/graphql';
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
 
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [apiKey, graphqlURL] = await getParams(['appsyncApiKey', 'graphqlUrl']);
   }

--- a/amplify/backend/function/fetchColonyBalances/src/index.js
+++ b/amplify/backend/function/fetchColonyBalances/src/index.js
@@ -19,7 +19,7 @@ let networkAddress;
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [networkAddress, apiKey, graphqlURL, rpcURL, network] = await getParams([
       'networkContractAddress',

--- a/amplify/backend/function/fetchColonyNativeFundsClaim/src/index.js
+++ b/amplify/backend/function/fetchColonyNativeFundsClaim/src/index.js
@@ -5,7 +5,7 @@ let rpcURL = 'http://network-contracts:8545'; // this needs to be extended to al
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [rpcURL] = await getParams(['chainRpcEndpoint']);
   }

--- a/amplify/backend/function/fetchExpenditureBalances/src/index.js
+++ b/amplify/backend/function/fetchExpenditureBalances/src/index.js
@@ -14,7 +14,7 @@ let networkAddress;
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [rpcURL, networkAddress, network] = await getParams([
       'chainRpcEndpoint',

--- a/amplify/backend/function/fetchMotionState/src/utils.js
+++ b/amplify/backend/function/fetchMotionState/src/utils.js
@@ -26,7 +26,7 @@ let network = Network.Custom;
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [
       apiKey,

--- a/amplify/backend/function/fetchMotionTimeoutPeriods/src/index.js
+++ b/amplify/backend/function/fetchMotionTimeoutPeriods/src/index.js
@@ -15,7 +15,7 @@ let reputationOracleEndpoint =
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [rpcURL, networkAddress, reputationOracleEndpoint, network] =
       await getParams([

--- a/amplify/backend/function/fetchTokenFromChain/src/index.js
+++ b/amplify/backend/function/fetchTokenFromChain/src/index.js
@@ -35,7 +35,7 @@ const setEnvVariables = async (network) => {
     rpcURL = getDevRpcUrl(network);
   }
 
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     let chainRpcParam = getRpcUrlParamName(network);
 
     const { getParams } = require('/opt/nodejs/getParams');

--- a/amplify/backend/function/fetchTokenFromChain/src/index.js
+++ b/amplify/backend/function/fetchTokenFromChain/src/index.js
@@ -42,7 +42,7 @@ const setEnvVariables = async (network) => {
     [apiKey, graphqlURL, rpcURL] = await getParams([
       'appsyncApiKey',
       'graphqlUrl',
-      'chainRpcEndpoint',
+      chainRpcParam,
     ]);
   }
 };

--- a/amplify/backend/function/fetchTokenFromChain/src/utils.js
+++ b/amplify/backend/function/fetchTokenFromChain/src/utils.js
@@ -67,8 +67,10 @@ const getRpcUrlParamName = (network) => {
       chainRpcParam = 'bnbRpcEndpoint';
       break;
     case ETHEREUM_NETWORK.shortName:
-    default:
       chainRpcParam = 'ethRpcEndpoint';
+      break;
+    default:
+      chainRpcParam = 'chainRpcEndpoint';
       break;
   }
 

--- a/amplify/backend/function/fetchVoterRewards/src/utils.js
+++ b/amplify/backend/function/fetchVoterRewards/src/utils.js
@@ -19,7 +19,7 @@ let reputationOracleEndpoint =
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [
       apiKey,

--- a/amplify/backend/function/getSafeTransactionStatus/src/index.js
+++ b/amplify/backend/function/getSafeTransactionStatus/src/index.js
@@ -14,7 +14,7 @@ let rpcURL = 'http://network-contracts:8545'; // this needs to be extended to al
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [rpcURL] = await getParams(['chainRpcEndpoint']);
   }

--- a/amplify/backend/function/getSafeTransactionStatus/src/utils.js
+++ b/amplify/backend/function/getSafeTransactionStatus/src/utils.js
@@ -42,7 +42,7 @@ const getApiKey = async (chainId) => {
   let etherscanApiKey = '';
   const ENV = process.env.ENV;
 
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [bscscanApiKey, etherscanApiKey] = await getParams([
       'bscscanApiKey',
@@ -142,7 +142,7 @@ const getHomeProvider = async () => {
   const ENV = process.env.ENV;
   let rpcURL = LOCAL_HOME_CHAIN;
 
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [rpcURL] = await getParams(['chainRpcEndpoint']);
   }

--- a/amplify/backend/function/getUserReputation/src/index.js
+++ b/amplify/backend/function/getUserReputation/src/index.js
@@ -15,7 +15,7 @@ let network = Network.Custom;
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [rpcURL, networkAddress, reputationOracleEndpoint, network] =
       await getParams([

--- a/amplify/backend/function/getUserTokenBalance/src/index.js
+++ b/amplify/backend/function/getUserTokenBalance/src/index.js
@@ -23,7 +23,7 @@ let graphqlURL = 'http://localhost:20002/graphql';
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [rpcURL, networkAddress, network, apiKey, graphqlURL] = await getParams([
       'chainRpcEndpoint',

--- a/amplify/backend/function/qaSSMtest/src/index.js
+++ b/amplify/backend/function/qaSSMtest/src/index.js
@@ -12,7 +12,7 @@ let networkAddress;
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [
       apiKey,

--- a/amplify/backend/function/setCurrentVersion/src/index.js
+++ b/amplify/backend/function/setCurrentVersion/src/index.js
@@ -10,7 +10,7 @@ let graphqlURL = 'http://localhost:20002/graphql';
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [apiKey, graphqlURL] = await getParams(['appsyncApiKey', 'graphqlUrl']);
   }

--- a/amplify/backend/function/updateContributorsWithReputation/src/index.js
+++ b/amplify/backend/function/updateContributorsWithReputation/src/index.js
@@ -41,7 +41,7 @@ let network = Network.Custom;
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
 
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [
       apiKey,

--- a/amplify/backend/function/validateUserInvite/src/index.js
+++ b/amplify/backend/function/validateUserInvite/src/index.js
@@ -13,7 +13,7 @@ let graphqlURL = 'http://localhost:20002/graphql';
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
-  if (ENV === 'qa' || ENV === 'sc' || ENV === 'prod') {
+  if (ENV === 'qa' || ENV === 'prod') {
     const { getParams } = require('/opt/nodejs/getParams');
     [apiKey, graphqlURL] = await getParams(['appsyncApiKey', 'graphqlUrl']);
   }


### PR DESCRIPTION
This quick PR fixes a value I hard-coded during the first production deployment rush, in an effort to quickly fix the "token not found in db" issue that we were having.

The error was introduced initially by the [Safe Control](https://github.com/JoinColony/colonyCDapp/pull/705) feature which didn't account for other chains besides the bridges, in a non-dev environment.

The fix was to simply add a new default case for the `getRpcUrlParamName` util, which will default to gnosis in a `qa` or `prod` environments.

While I was at it, I also removed all references to the test `sc` environment, which no longer exists in our deployment infrastructure.

**Notes on testing**
You can't really test my fix while running this locally, as it only affects `qa` and `prod` environments which all run on the `gnosis` chain.

The only thing you can test locally is to check that my fix didn't break the local dev environment for this lambda.

Alternatively you can co-opt Bogdan when doing the testing and have him deploy this to QA and testing the `fetchTokenFromChain` lambda from the AWS console manually.
 
Resolves #1501 