### PR TITLE
Fix motion timeouts query data

### DIFF
--- a/amplify/backend/function/createUniqueColony/src/package-lock.json
+++ b/amplify/backend/function/createUniqueColony/src/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@colony/colony-js": "^7.0.3",
+        "@colony/events": "^1.0.2",
         "cross-fetch": "^4.0.0",
         "ethers": "^5.7.1"
       },
@@ -49,9 +50,9 @@
       }
     },
     "node_modules/@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "dependencies": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",
@@ -2165,9 +2166,9 @@
       "requires": {}
     },
     "@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "requires": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",

--- a/amplify/backend/function/createUniqueColony/src/package.json
+++ b/amplify/backend/function/createUniqueColony/src/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@colony/colony-js": "^7.0.3",
+    "@colony/events": "^1.0.2",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.7.1"
   }

--- a/amplify/backend/function/fetchColonyBalances/src/package-lock.json
+++ b/amplify/backend/function/fetchColonyBalances/src/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@colony/colony-js": "^7.0.3",
+        "@colony/events": "^1.0.2",
         "cross-fetch": "^4.0.0",
         "ethers": "^5.7.2"
       },
@@ -49,9 +50,9 @@
       }
     },
     "node_modules/@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "dependencies": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",
@@ -2165,9 +2166,9 @@
       "requires": {}
     },
     "@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "requires": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",

--- a/amplify/backend/function/fetchColonyBalances/src/package.json
+++ b/amplify/backend/function/fetchColonyBalances/src/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@colony/colony-js": "^7.0.3",
+    "@colony/events": "^1.0.2",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.7.2"
   }

--- a/amplify/backend/function/fetchExpenditureBalances/src/package-lock.json
+++ b/amplify/backend/function/fetchExpenditureBalances/src/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@colony/colony-js": "^7.0.3",
+        "@colony/events": "^1.0.2",
         "cross-fetch": "^4.0.0",
         "ethers": "^5.7.2"
       },
@@ -49,9 +50,9 @@
       }
     },
     "node_modules/@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "dependencies": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",
@@ -2165,9 +2166,9 @@
       "requires": {}
     },
     "@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "requires": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",

--- a/amplify/backend/function/fetchExpenditureBalances/src/package.json
+++ b/amplify/backend/function/fetchExpenditureBalances/src/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@colony/colony-js": "^7.0.3",
+    "@colony/events": "^1.0.2",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.7.2"
   }

--- a/amplify/backend/function/fetchMotionState/src/package-lock.json
+++ b/amplify/backend/function/fetchMotionState/src/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@colony/colony-js": "^7.0.3",
+        "@colony/events": "^1.0.2",
         "cross-fetch": "^4.0.0",
         "ethers": "^5.1.3"
       },
@@ -49,9 +50,9 @@
       }
     },
     "node_modules/@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "dependencies": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",
@@ -2156,9 +2157,9 @@
       "requires": {}
     },
     "@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "requires": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",

--- a/amplify/backend/function/fetchMotionState/src/package.json
+++ b/amplify/backend/function/fetchMotionState/src/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@colony/colony-js": "^7.0.3",
+    "@colony/events": "^1.0.2",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.1.3"
   }

--- a/amplify/backend/function/fetchMotionTimeoutPeriods/src/index.js
+++ b/amplify/backend/function/fetchMotionTimeoutPeriods/src/index.js
@@ -54,7 +54,7 @@ exports.handler = async (event) => {
     Extension.VotingReputation,
   );
 
-  const blockTime = (await getBlockTime(networkClient.provider, 'latest')) || 0;
+  const blockTime = (await getBlockTime('latest', networkClient.provider)) || 0;
 
   const escalationPeriod = await votingReputationClient.getEscalationPeriod();
 

--- a/amplify/backend/function/fetchMotionTimeoutPeriods/src/package-lock.json
+++ b/amplify/backend/function/fetchMotionTimeoutPeriods/src/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@colony/colony-js": "^7.0.3",
+        "@colony/events": "^1.0.2",
         "cross-fetch": "^4.0.0",
         "ethers": "^5.7.2"
       },
@@ -49,9 +50,9 @@
       }
     },
     "node_modules/@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "dependencies": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",
@@ -2165,9 +2166,9 @@
       "requires": {}
     },
     "@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "requires": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",

--- a/amplify/backend/function/fetchMotionTimeoutPeriods/src/package.json
+++ b/amplify/backend/function/fetchMotionTimeoutPeriods/src/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@colony/colony-js": "^7.0.3",
+    "@colony/events": "^1.0.2",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.7.2"
   }

--- a/amplify/backend/function/fetchVoterRewards/src/package-lock.json
+++ b/amplify/backend/function/fetchVoterRewards/src/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@colony/colony-js": "^7.0.3",
+        "@colony/events": "^1.0.2",
         "cross-fetch": "^4.0.0",
         "ethers": "^5.1.3"
       },
@@ -49,9 +50,9 @@
       }
     },
     "node_modules/@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "dependencies": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",
@@ -2165,9 +2166,9 @@
       "requires": {}
     },
     "@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "requires": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",

--- a/amplify/backend/function/fetchVoterRewards/src/package.json
+++ b/amplify/backend/function/fetchVoterRewards/src/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@colony/colony-js": "^7.0.3",
+    "@colony/events": "^1.0.2",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.1.3"
   }

--- a/amplify/backend/function/getUserReputation/src/package-lock.json
+++ b/amplify/backend/function/getUserReputation/src/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@colony/colony-js": "^7.0.3",
+        "@colony/events": "^1.0.2",
         "cross-fetch": "^4.0.0",
         "ethers": "^5.7.2"
       },
@@ -49,9 +50,9 @@
       }
     },
     "node_modules/@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "dependencies": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",
@@ -2165,9 +2166,9 @@
       "requires": {}
     },
     "@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "requires": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",

--- a/amplify/backend/function/getUserReputation/src/package.json
+++ b/amplify/backend/function/getUserReputation/src/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@colony/colony-js": "^7.0.3",
+    "@colony/events": "^1.0.2",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.7.2"
   }

--- a/amplify/backend/function/getUserTokenBalance/src/package-lock.json
+++ b/amplify/backend/function/getUserTokenBalance/src/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@colony/colony-js": "^7.0.3",
+        "@colony/events": "^1.0.2",
         "cross-fetch": "^4.0.0",
         "ethers": "^5.7.2"
       },
@@ -49,9 +50,9 @@
       }
     },
     "node_modules/@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "dependencies": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",
@@ -2165,9 +2166,9 @@
       "requires": {}
     },
     "@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "requires": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",

--- a/amplify/backend/function/getUserTokenBalance/src/package.json
+++ b/amplify/backend/function/getUserTokenBalance/src/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@colony/colony-js": "^7.0.3",
+    "@colony/events": "^1.0.2",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.7.2"
   }

--- a/amplify/backend/function/qaSSMtest/src/package-lock.json
+++ b/amplify/backend/function/qaSSMtest/src/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@colony/colony-js": "^7.0.3",
+        "@colony/events": "^1.0.2",
         "cross-fetch": "^4.0.0",
         "ethers": "^5.7.2"
       },
@@ -49,9 +50,9 @@
       }
     },
     "node_modules/@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "dependencies": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",
@@ -2165,9 +2166,9 @@
       "requires": {}
     },
     "@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "requires": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",

--- a/amplify/backend/function/qaSSMtest/src/package.json
+++ b/amplify/backend/function/qaSSMtest/src/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@colony/colony-js": "^7.0.3",
+    "@colony/events": "^1.0.2",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.7.2"
   },

--- a/amplify/backend/function/updateContributorsWithReputation/src/package-lock.json
+++ b/amplify/backend/function/updateContributorsWithReputation/src/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@colony/colony-js": "^7.0.3",
+        "@colony/events": "^1.0.2",
         "cross-fetch": "^4.0.0",
         "decimal.js": "^10.2.1",
         "ethers": "^5.7.2"
@@ -50,9 +51,9 @@
       }
     },
     "node_modules/@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "dependencies": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",
@@ -2124,9 +2125,9 @@
       "requires": {}
     },
     "@colony/events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-Tb5JG95xoOFEkplvpY8vSOqmUUorGZLGbrwdL1S107B75PEBq86ksZE9P3NNJFfYppJRfrd6VeBvfmgPRHlMkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-1.0.2.tgz",
+      "integrity": "sha512-nMsy5ppFW1g/aSlMQ8dePnaM2c/sAL5E6JuO+HiA21/Xww8NeTut2+PsJdT50RuWmpO5EG5kWBfvakZzuGm02g==",
       "requires": {
         "@colony/core": "^2.0.1",
         "fetch-retry": "^5.0.4",

--- a/amplify/backend/function/updateContributorsWithReputation/src/package.json
+++ b/amplify/backend/function/updateContributorsWithReputation/src/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@colony/colony-js": "^7.0.3",
+    "@colony/events": "^1.0.2",
     "cross-fetch": "^4.0.0",
     "decimal.js": "^10.2.1",
     "ethers": "^5.7.2"

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "@apollo/client": "^3.8.8",
     "@colony/abis": "^1.2.4",
     "@colony/colony-js": "^7.0.3",
-    "@colony/events": "^1.0.1",
+    "@colony/events": "^1.0.2",
     "@colony/redux-promise-listener": "^1.2.0",
     "@colony/unicode-confusables-noascii": "^0.1.2",
     "@formatjs/intl-relativetimeformat": "^11.0.2",


### PR DESCRIPTION
Currently, once creating a motion, a spinner will show up next to the staking tab, signifying that it can't load the timeout until the staking is finished.

This is because the `fetMotionTimeoutPeriods` lambda breaks, and returns all values as `-1` which triggers a infinite loading state in the component.

The issue at fault here is that the call to `getBlockTime` has the params inversed _(`blockHash` and `provider` vs. `provider` and `blockHash`)_

This issue fixes this, making motions work once again.

~~Note that if you try to create a motion with a description _(annotation)_, it will still crash, but that is a separate issue, that was highlighted here: https://discord.com/channels/562263648173555742/998629903740182580/1198967494564646932~~

While I was at it, I also fixed the above issue, with creating a motion with an annotation. The actual fix was on the `colonyJS` side, but I brought the fix in by updating `@colony/events` in both the CDapp repo and the lambda functions

**Testing**

- Make sure to install packages both in the CDapp and in the lambdas
- Create a new motion without annotations
- Create a new motion with annotations