### PR TITLE
Fix pending colony metadata not appearing on side panel

### DIFF
--- a/docker/colony-cdapp-dev-env-auth-proxy
+++ b/docker/colony-cdapp-dev-env-auth-proxy
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV AUTH_PROXY_HASH=eb7853a22b5f8c84dd7fd85714f77378b4ecc07b
+ENV AUTH_PROXY_HASH=2c91e50052c25412dabd8fc0e7dd3604965433d2
 
 # Add dependencies from the host
 # Note: these are listed individually so that if they change, they won't affect

--- a/docker/colony-cdapp-dev-env-auth-proxy
+++ b/docker/colony-cdapp-dev-env-auth-proxy
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV AUTH_PROXY_HASH=7765a1bd46119065b49a6e9b60df97852c20ecdd
+ENV AUTH_PROXY_HASH=c31da346c6fe216795b98979ad299206923be91a
 
 # Add dependencies from the host
 # Note: these are listed individually so that if they change, they won't affect

--- a/docker/colony-cdapp-dev-env-auth-proxy
+++ b/docker/colony-cdapp-dev-env-auth-proxy
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV AUTH_PROXY_HASH=c31da346c6fe216795b98979ad299206923be91a
+ENV AUTH_PROXY_HASH=eb7853a22b5f8c84dd7fd85714f77378b4ecc07b
 
 # Add dependencies from the host
 # Note: these are listed individually so that if they change, they won't affect

--- a/src/components/v5/common/ActionSidebar/hooks/useGetActionData.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useGetActionData.ts
@@ -165,9 +165,15 @@ export const useGetActionData = (transactionId: string | undefined) => {
           colonyName: motionData
             ? pendingColonyMetadata?.displayName
             : metadata?.displayName,
-          colonyAvatar: motionData
-            ? pendingColonyMetadata?.avatar || pendingColonyMetadata?.thumbnail
-            : metadata?.avatar || metadata?.thumbnail,
+          avatar: motionData
+            ? {
+                image: pendingColonyMetadata?.avatar,
+                thumbnail: pendingColonyMetadata?.thumbnail,
+              }
+            : {
+                image: metadata?.avatar,
+                thumbnail: metadata?.thumbnail,
+              },
           colonyDescription: motionData
             ? pendingColonyMetadata?.description
             : metadata?.description,


### PR DESCRIPTION
This PR addresses the pending colony metadata not appearing on the motion side panel.

The data wasn't appearing before because the auth proxy was blocking the request: https://github.com/JoinColony/colonyCDappAuthProxy/pull/11

NOTE: This PR doesn't address the mess that is the edit colony action side panel. Only the motion version.

![Screenshot 2024-01-22 at 16 56 58](https://github.com/JoinColony/colonyCDapp/assets/18473896/f522641f-3b53-43a6-a2e6-d9e0da6818ab)

Resolves #1560 
