### PR TITLE
Fix: disconnected wallet currency conversion

### DIFF
--- a/src/components/common/Extensions/UserNavigation/partials/UserMenu/UserMenu.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserMenu/UserMenu.tsx
@@ -140,24 +140,26 @@ const UserMenu: FC<UserMenuProps> = ({
               </li>
             ))}
 
-            <li className="mb-0 hover:bg-gray-50 rounded -ml-4 w-[calc(100%+2rem)]">
-              <button
-                type="button"
-                className="navigation-link"
-                onClick={() => setActiveSubmenu(UserMenuItemName.CURRENCY)}
-                aria-expanded={activeSubmenu === UserMenuItemName.CURRENCY}
-                aria-controls="actionsWithVisibility"
-              >
-                <span className="flex items-center shrink-0 mr-2 sm:mr-0 flex-grow">
-                  <Icon
-                    name={currencyIconTitles[currency]}
-                    appearance={{ size: iconSize }}
-                  />
-                  <p className="ml-2">{currency.toUpperCase()}</p>
-                </span>
-                <Icon name={iconName} appearance={{ size: 'extraTiny' }} />
-              </button>
-            </li>
+            {wallet && (
+              <li className="mb-0 hover:bg-gray-50 rounded -ml-4 w-[calc(100%+2rem)]">
+                <button
+                  type="button"
+                  className="navigation-link"
+                  onClick={() => setActiveSubmenu(UserMenuItemName.CURRENCY)}
+                  aria-expanded={activeSubmenu === UserMenuItemName.CURRENCY}
+                  aria-controls="actionsWithVisibility"
+                >
+                  <span className="flex items-center shrink-0 mr-2 sm:mr-0 flex-grow">
+                    <Icon
+                      name={currencyIconTitles[currency]}
+                      appearance={{ size: iconSize }}
+                    />
+                    <p className="ml-2">{currency.toUpperCase()}</p>
+                  </span>
+                  <Icon name={iconName} appearance={{ size: 'extraTiny' }} />
+                </button>
+              </li>
+            )}
           </ul>
         </div>
         {wallet && (

--- a/src/context/CurrencyContext.tsx
+++ b/src/context/CurrencyContext.tsx
@@ -30,13 +30,17 @@ export const CurrencyContextProvider = ({
   const [currency, setCurrency] = useState(SupportedCurrencies.Usd);
   const [updateProfile] = useUpdateUserProfileMutation();
 
+  const STORED_CURRENCY_KEY = 'preferredCurrency';
+
   const updatePreferredCurrency = useCallback(
     async (newCurrency: SupportedCurrencies) => {
+      setCurrency(newCurrency);
+      localStorage.setItem(STORED_CURRENCY_KEY, JSON.stringify(newCurrency));
+
       if (!user?.walletAddress) {
         return;
       }
 
-      setCurrency(newCurrency);
       await updateProfile({
         variables: {
           input: {
@@ -51,8 +55,15 @@ export const CurrencyContextProvider = ({
 
   useEffect(() => {
     const setDefaultUserCurrency = async () => {
-      const defaultCurrency = await getUserCurrencyByLocation();
-      updatePreferredCurrency(defaultCurrency);
+      const storedCurrency = localStorage.getItem(STORED_CURRENCY_KEY);
+      if (storedCurrency !== null) {
+        updatePreferredCurrency(
+          JSON.parse(storedCurrency) as SupportedCurrencies,
+        );
+      } else {
+        const defaultCurrency = await getUserCurrencyByLocation();
+        updatePreferredCurrency(defaultCurrency);
+      }
     };
 
     if (user?.profile?.preferredCurrency) {


### PR DESCRIPTION
## Description

In the public version of the app, users should be able to switch currencies without having a wallet connected. Previously, when no wallet was connected, the currency switcher did not function properly. This PR makes changes to the CurrencyContext so that the preferred currency can be set even when no wallet is connected. This is saved to local storage to persist the selection and will fallback to the defaultCurrency if nothing is found in local storage. Once a wallet is connected, user.profile.preferredCurrency will take priority over the selection in local storage.

However, whilst the app is in beta, the currency switcher should be hidden unless a wallet is connected as users need a connected wallet in order to access a colony. This PR hides the currency switcher when no wallet is connected.

**New stuff** ✨

* CurrencyContext now stores preferred currency in local storage and uses this selection when no wallet is connected

**Changes** 🏗

* CurrencyContext now updates currency state even when no wallet is connected
* Currency switcher is hidden from user menu when no wallet is connected

![Screenshot 2024-01-23 at 12 54 47](https://github.com/JoinColony/colonyCDapp/assets/34915414/42ff8eb9-4d90-4eac-bffa-227b69a471c2)

Resolves #1717