### PR TITLE
fix token blockies not showing consistently

### DIFF
--- a/src/components/shared/TokenInfoPopover/TokenInfo.tsx
+++ b/src/components/shared/TokenInfoPopover/TokenInfo.tsx
@@ -4,10 +4,10 @@ import { defineMessages, useIntl } from 'react-intl';
 
 import { DEFAULT_NETWORK_INFO } from '~constants';
 import Icon from '~shared/Icon';
+import TokenIcon from '~shared/TokenIcon';
 import { Token } from '~types';
 import { getBlockExplorerLink } from '~utils/external';
 import PillsBase from '~v5/common/Pills/PillsBase';
-import Avatar from '~v5/shared/Avatar';
 import CopyableAddress from '~v5/shared/CopyableAddress';
 
 const displayName = 'TokenInfoPopover.TokenInfo';
@@ -30,7 +30,7 @@ const MSG = defineMessages({
 });
 
 const TokenInfo = ({ token, isTokenNative, className }: Props) => {
-  const { avatar, name, symbol, tokenAddress, thumbnail } = token;
+  const { name, symbol, tokenAddress } = token;
   const { formatMessage } = useIntl();
 
   return (
@@ -41,12 +41,7 @@ const TokenInfo = ({ token, isTokenNative, className }: Props) => {
       )}
     >
       <div className="flex flex-row items-center w-full gap-4">
-        <Avatar
-          size="m"
-          title={name}
-          avatar={thumbnail || avatar}
-          className="flex-shrink-0"
-        />
+        <TokenIcon size="m" token={token} className="flex-shrink-0" />
         <div className="flex flex-col flex-1 gap-1 min-w-0">
           <div className="w-full flex items-center">
             <h4 className="heading-4 truncate" title={`${name} (${symbol})`}>

--- a/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
+++ b/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
@@ -8,8 +8,8 @@ import { getEnumValueFromKey } from '~utils/getEnumValueFromKey';
 import { formatText } from '~utils/intl';
 import { getTeamColor } from '~utils/teams';
 import ExtensionsStatusBadge from '~v5/common/Pills/ExtensionStatusBadge';
-import Avatar from '~v5/shared/Avatar';
 import IconWithTooltip from '~v5/shared/IconWithTooltip';
+import UserAvatar from '~v5/shared/UserAvatar';
 
 import { sortDisabled } from '../../utils';
 
@@ -102,7 +102,11 @@ const SearchItem: FC<SearchItemProps> = ({
                 )}
                 {showAvatar && (
                   <div className="mr-2 items-center justify-center flex">
-                    <Avatar avatar={avatar} seed={walletAddress} />
+                    <UserAvatar
+                      avatar={avatar}
+                      user={walletAddress}
+                      size="xs"
+                    />
                   </div>
                 )}
                 {isLabelVisible && labelText}

--- a/src/components/v5/shared/UserAvatar/types.ts
+++ b/src/components/v5/shared/UserAvatar/types.ts
@@ -6,6 +6,7 @@ import { UserStatusMode } from '~v5/common/Pills/types';
 import { AvatarSize } from '../Avatar/types';
 
 export interface UserAvatarProps {
+  avatar?: string | null;
   avatarSize?: AvatarSize;
   className?: string;
   isContributorsList?: boolean;


### PR DESCRIPTION
## Description

This PR fixes the issue where blockies for tokens were showing inconsistently, when in the colony balance token list, each token has it's own thumbnail, if this thumbnail / image is a default blockie it'll appear as a different blockie when the user clicks on the token for more info. This is because currently a new blockie is being generated specifically for this token info image instead of using the tokens original blockie default

**New stuff** ✨
The same blockie is now shown in the token info image
![Screenshot 2024-01-24 at 12 43 40](https://github.com/JoinColony/colonyCDapp/assets/155957480/d8246ee1-5c09-4482-b58a-15e6fdae471a)

User blockies in the user drop down menu now show consistently with the user's blockie
![Screenshot 2024-01-25 at 15 31 54](https://github.com/JoinColony/colonyCDapp/assets/155957480/24055c9c-b175-4b5b-94ab-3b0491db6d97)




**Changes** 🏗

Changed <avatar> within TokenInfo.tsx to <TokenIcon> 
Removed the <Avatar> import 
Added <TokenIcon> import
Removed { avatar, thumbnail } as they are no longer used.


Resolves #1712 
