### PR TITLE
[Verified members] feat: add graphql entities for verified members

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -3409,3 +3409,14 @@ type UserStake @model {
   action: ColonyAction @hasOne(fields: ["actionId"])
   createdAt: AWSDateTime!
 }
+
+type VerifiedMember @model {
+  """
+  A colony address - user address pair that tells us if a user is verified.
+  """
+  colonyAddress: ID! @primaryKey(sortKeyFields: ["userAddress"])
+    @index(name: "verifiedMembersByColony", queryField: "getVerifiedMembersByColony")
+  userAddress: ID!
+  user: User! @hasOne(fields: ["userAddress"])
+  createdAt: AWSDateTime!
+}

--- a/scripts/create-data.js
+++ b/scripts/create-data.js
@@ -1180,7 +1180,10 @@ const createUserAndColonyData = async () => {
 
     // verify users
     await Promise.all(
-      Object.keys(availableUsers.walletUsers).map(async (userAddress) => {
+      [
+        leela.address,
+        ...Object.keys(availableUsers.randomUsers).slice(0, 5),
+      ].map(async (userAddress) => {
         await graphqlRequest(
           addVerifiedMember,
           {

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -1539,6 +1539,12 @@ export type CreateUserTokensInput = {
   userID: Scalars['ID'];
 };
 
+export type CreateVerifiedMemberInput = {
+  colonyAddress: Scalars['ID'];
+  createdAt?: InputMaybe<Scalars['AWSDateTime']>;
+  userAddress: Scalars['ID'];
+};
+
 /**
  * The current inverse of the network fee (in wei)
  * (divide 1 by it and get the actual network fee)
@@ -1716,6 +1722,11 @@ export type DeleteUserStakeInput = {
 
 export type DeleteUserTokensInput = {
   id: Scalars['ID'];
+};
+
+export type DeleteVerifiedMemberInput = {
+  colonyAddress: Scalars['ID'];
+  userAddress: Scalars['ID'];
 };
 
 /** Represents a Domain within the Colony Network */
@@ -3891,6 +3902,14 @@ export type ModelSubscriptionUserTokensFilterInput = {
   userID?: InputMaybe<ModelSubscriptionIdInput>;
 };
 
+export type ModelSubscriptionVerifiedMemberFilterInput = {
+  and?: InputMaybe<Array<InputMaybe<ModelSubscriptionVerifiedMemberFilterInput>>>;
+  colonyAddress?: InputMaybe<ModelSubscriptionIdInput>;
+  createdAt?: InputMaybe<ModelSubscriptionStringInput>;
+  or?: InputMaybe<Array<InputMaybe<ModelSubscriptionVerifiedMemberFilterInput>>>;
+  userAddress?: InputMaybe<ModelSubscriptionIdInput>;
+};
+
 export type ModelSupportedCurrenciesInput = {
   eq?: InputMaybe<SupportedCurrencies>;
   ne?: InputMaybe<SupportedCurrencies>;
@@ -4083,6 +4102,28 @@ export type ModelUserTokensFilterInput = {
   userID?: InputMaybe<ModelIdInput>;
 };
 
+export type ModelVerifiedMemberConditionInput = {
+  and?: InputMaybe<Array<InputMaybe<ModelVerifiedMemberConditionInput>>>;
+  createdAt?: InputMaybe<ModelStringInput>;
+  not?: InputMaybe<ModelVerifiedMemberConditionInput>;
+  or?: InputMaybe<Array<InputMaybe<ModelVerifiedMemberConditionInput>>>;
+};
+
+export type ModelVerifiedMemberConnection = {
+  __typename?: 'ModelVerifiedMemberConnection';
+  items: Array<Maybe<VerifiedMember>>;
+  nextToken?: Maybe<Scalars['String']>;
+};
+
+export type ModelVerifiedMemberFilterInput = {
+  and?: InputMaybe<Array<InputMaybe<ModelVerifiedMemberFilterInput>>>;
+  colonyAddress?: InputMaybe<ModelIdInput>;
+  createdAt?: InputMaybe<ModelStringInput>;
+  not?: InputMaybe<ModelVerifiedMemberFilterInput>;
+  or?: InputMaybe<Array<InputMaybe<ModelVerifiedMemberFilterInput>>>;
+  userAddress?: InputMaybe<ModelIdInput>;
+};
+
 /** A status update message for a motion (will appear in the motion's timeline) */
 export type MotionMessage = {
   __typename?: 'MotionMessage';
@@ -4236,6 +4277,7 @@ export type Mutation = {
   createUser?: Maybe<User>;
   createUserStake?: Maybe<UserStake>;
   createUserTokens?: Maybe<UserTokens>;
+  createVerifiedMember?: Maybe<VerifiedMember>;
   deleteAnnotation?: Maybe<Annotation>;
   deleteColony?: Maybe<Colony>;
   deleteColonyAction?: Maybe<ColonyAction>;
@@ -4274,6 +4316,7 @@ export type Mutation = {
   deleteUser?: Maybe<User>;
   deleteUserStake?: Maybe<UserStake>;
   deleteUserTokens?: Maybe<UserTokens>;
+  deleteVerifiedMember?: Maybe<VerifiedMember>;
   /** Updates the latest available version of a Colony or an extension */
   setCurrentVersion?: Maybe<Scalars['Boolean']>;
   updateAnnotation?: Maybe<Annotation>;
@@ -4316,6 +4359,7 @@ export type Mutation = {
   updateUser?: Maybe<User>;
   updateUserStake?: Maybe<UserStake>;
   updateUserTokens?: Maybe<UserTokens>;
+  updateVerifiedMember?: Maybe<VerifiedMember>;
   /**
    * Validates the user invite code and adds the user to the colony whitelist
    * and as a colony contributor
@@ -4609,6 +4653,13 @@ export type MutationCreateUserTokensArgs = {
 
 
 /** Root mutation type */
+export type MutationCreateVerifiedMemberArgs = {
+  condition?: InputMaybe<ModelVerifiedMemberConditionInput>;
+  input: CreateVerifiedMemberInput;
+};
+
+
+/** Root mutation type */
 export type MutationDeleteAnnotationArgs = {
   condition?: InputMaybe<ModelAnnotationConditionInput>;
   input: DeleteAnnotationInput;
@@ -4871,6 +4922,13 @@ export type MutationDeleteUserStakeArgs = {
 export type MutationDeleteUserTokensArgs = {
   condition?: InputMaybe<ModelUserTokensConditionInput>;
   input: DeleteUserTokensInput;
+};
+
+
+/** Root mutation type */
+export type MutationDeleteVerifiedMemberArgs = {
+  condition?: InputMaybe<ModelVerifiedMemberConditionInput>;
+  input: DeleteVerifiedMemberInput;
 };
 
 
@@ -5149,6 +5207,13 @@ export type MutationUpdateUserStakeArgs = {
 export type MutationUpdateUserTokensArgs = {
   condition?: InputMaybe<ModelUserTokensConditionInput>;
   input: UpdateUserTokensInput;
+};
+
+
+/** Root mutation type */
+export type MutationUpdateVerifiedMemberArgs = {
+  condition?: InputMaybe<ModelVerifiedMemberConditionInput>;
+  input: UpdateVerifiedMemberInput;
 };
 
 
@@ -5449,6 +5514,8 @@ export type Query = {
   /** Retrieve a user's token balance for a specific token */
   getUserTokenBalance?: Maybe<GetUserTokenBalanceReturn>;
   getUserTokens?: Maybe<UserTokens>;
+  getVerifiedMember?: Maybe<VerifiedMember>;
+  getVerifiedMembersByColony?: Maybe<ModelVerifiedMemberConnection>;
   /** Get the voting reward for a user and a motion */
   getVoterRewards?: Maybe<VoterRewardsReturn>;
   listAnnotations?: Maybe<ModelAnnotationConnection>;
@@ -5489,6 +5556,7 @@ export type Query = {
   listUserStakes?: Maybe<ModelUserStakeConnection>;
   listUserTokens?: Maybe<ModelUserTokensConnection>;
   listUsers?: Maybe<ModelUserConnection>;
+  listVerifiedMembers?: Maybe<ModelVerifiedMemberConnection>;
   searchColonyActions?: Maybe<SearchableColonyActionConnection>;
 };
 
@@ -6084,6 +6152,23 @@ export type QueryGetUserTokensArgs = {
 
 
 /** Root query type */
+export type QueryGetVerifiedMemberArgs = {
+  colonyAddress: Scalars['ID'];
+  userAddress: Scalars['ID'];
+};
+
+
+/** Root query type */
+export type QueryGetVerifiedMembersByColonyArgs = {
+  colonyAddress: Scalars['ID'];
+  filter?: InputMaybe<ModelVerifiedMemberFilterInput>;
+  limit?: InputMaybe<Scalars['Int']>;
+  nextToken?: InputMaybe<Scalars['String']>;
+  sortDirection?: InputMaybe<ModelSortDirection>;
+};
+
+
+/** Root query type */
 export type QueryGetVoterRewardsArgs = {
   input?: InputMaybe<GetVoterRewardsInput>;
 };
@@ -6390,6 +6475,17 @@ export type QueryListUsersArgs = {
   filter?: InputMaybe<ModelUserFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
   nextToken?: InputMaybe<Scalars['String']>;
+};
+
+
+/** Root query type */
+export type QueryListVerifiedMembersArgs = {
+  colonyAddress?: InputMaybe<Scalars['ID']>;
+  filter?: InputMaybe<ModelVerifiedMemberFilterInput>;
+  limit?: InputMaybe<Scalars['Int']>;
+  nextToken?: InputMaybe<Scalars['String']>;
+  sortDirection?: InputMaybe<ModelSortDirection>;
+  userAddress?: InputMaybe<ModelIdKeyConditionInput>;
 };
 
 
@@ -6822,6 +6918,7 @@ export type Subscription = {
   onCreateUser?: Maybe<User>;
   onCreateUserStake?: Maybe<UserStake>;
   onCreateUserTokens?: Maybe<UserTokens>;
+  onCreateVerifiedMember?: Maybe<VerifiedMember>;
   onDeleteAnnotation?: Maybe<Annotation>;
   onDeleteColony?: Maybe<Colony>;
   onDeleteColonyAction?: Maybe<ColonyAction>;
@@ -6860,6 +6957,7 @@ export type Subscription = {
   onDeleteUser?: Maybe<User>;
   onDeleteUserStake?: Maybe<UserStake>;
   onDeleteUserTokens?: Maybe<UserTokens>;
+  onDeleteVerifiedMember?: Maybe<VerifiedMember>;
   onUpdateAnnotation?: Maybe<Annotation>;
   onUpdateColony?: Maybe<Colony>;
   onUpdateColonyAction?: Maybe<ColonyAction>;
@@ -6898,6 +6996,7 @@ export type Subscription = {
   onUpdateUser?: Maybe<User>;
   onUpdateUserStake?: Maybe<UserStake>;
   onUpdateUserTokens?: Maybe<UserTokens>;
+  onUpdateVerifiedMember?: Maybe<VerifiedMember>;
 };
 
 
@@ -7091,6 +7190,11 @@ export type SubscriptionOnCreateUserTokensArgs = {
 };
 
 
+export type SubscriptionOnCreateVerifiedMemberArgs = {
+  filter?: InputMaybe<ModelSubscriptionVerifiedMemberFilterInput>;
+};
+
+
 export type SubscriptionOnDeleteAnnotationArgs = {
   filter?: InputMaybe<ModelSubscriptionAnnotationFilterInput>;
 };
@@ -7281,6 +7385,11 @@ export type SubscriptionOnDeleteUserTokensArgs = {
 };
 
 
+export type SubscriptionOnDeleteVerifiedMemberArgs = {
+  filter?: InputMaybe<ModelSubscriptionVerifiedMemberFilterInput>;
+};
+
+
 export type SubscriptionOnUpdateAnnotationArgs = {
   filter?: InputMaybe<ModelSubscriptionAnnotationFilterInput>;
 };
@@ -7468,6 +7577,11 @@ export type SubscriptionOnUpdateUserStakeArgs = {
 
 export type SubscriptionOnUpdateUserTokensArgs = {
   filter?: InputMaybe<ModelSubscriptionUserTokensFilterInput>;
+};
+
+
+export type SubscriptionOnUpdateVerifiedMemberArgs = {
+  filter?: InputMaybe<ModelSubscriptionVerifiedMemberFilterInput>;
 };
 
 /** Represents the currencies/tokens that users' balances can be converted to (for display purposes) */
@@ -8134,6 +8248,12 @@ export type UpdateUserTokensInput = {
   userID?: InputMaybe<Scalars['ID']>;
 };
 
+export type UpdateVerifiedMemberInput = {
+  colonyAddress: Scalars['ID'];
+  createdAt?: InputMaybe<Scalars['AWSDateTime']>;
+  userAddress: Scalars['ID'];
+};
+
 /** Represents a User within the Colony Network */
 export type User = {
   __typename?: 'User';
@@ -8242,6 +8362,16 @@ export type ValidateUserInviteInput = {
   /** The invite code */
   inviteCode: Scalars['ID'];
   /** The user's wallet address */
+  userAddress: Scalars['ID'];
+};
+
+export type VerifiedMember = {
+  __typename?: 'VerifiedMember';
+  /** A colony address - user address pair that tells us if a user is verified. */
+  colonyAddress: Scalars['ID'];
+  createdAt: Scalars['AWSDateTime'];
+  updatedAt: Scalars['AWSDateTime'];
+  user: User;
   userAddress: Scalars['ID'];
 };
 


### PR DESCRIPTION
## Description

I've updated the graphql schema to include the `VerifiedMember` entity, and let Amplify autogenerate all the queries for us.
I've used a combination of primary and sort key for the `VerifiedMember` entity, this is basically a compound primary key.

**New stuff** ✨

* `VerifiedMember` entity
* the 3 dev wallets get automatically added as verified members

Resolves #1721
