### PR TITLE
Fix: Verified and Non-verified users actions icon

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
@@ -57,6 +57,7 @@ const UserSelect: FC<UserSelectProps> = ({ name }) => {
       ? {
           profile: {
             displayName: selectedUserOption?.label,
+            thumbnail: selectedUserOption?.thumbnail,
           },
           walletAddress: selectedUserOption?.walletAddress,
           isVerified: selectedUserOption?.isVerified,

--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
@@ -24,7 +24,7 @@ const UserSelect: FC<UserSelectProps> = ({ name }) => {
     name,
   });
   const isError = !!error;
-  const { usersOptions, showVerifiedUsers } = useUserSelect();
+  const { usersOptions } = useUserSelect();
   const [
     isUserSelectVisible,
     {
@@ -59,6 +59,7 @@ const UserSelect: FC<UserSelectProps> = ({ name }) => {
             displayName: selectedUserOption?.label,
           },
           walletAddress: selectedUserOption?.walletAddress,
+          isVerified: selectedUserOption?.isVerified,
         }
       : undefined;
 
@@ -71,10 +72,10 @@ const UserSelect: FC<UserSelectProps> = ({ name }) => {
             size="xs"
             showUsername
             className={clsx({
-              'text-warning-400': !showVerifiedUsers,
+              'text-warning-400': !selectedUser?.isVerified,
             })}
           />
-          {showVerifiedUsers && (
+          {selectedUser?.isVerified && (
             <span className="flex ml-2 text-blue-400">
               <Icon name="verified" />
             </span>
@@ -103,11 +104,11 @@ const UserSelect: FC<UserSelectProps> = ({ name }) => {
                   size="xs"
                   showUsername
                   className={clsx({
-                    'text-warning-400': !showVerifiedUsers,
-                    'text-gray-900': showVerifiedUsers,
+                    'text-warning-400': !selectedUser?.isVerified,
+                    'text-gray-900': selectedUser?.isVerified,
                   })}
                 />
-                {showVerifiedUsers && (
+                {selectedUser?.isVerified && (
                   <span className="flex ml-2 text-blue-400">
                     <Icon name="verified" />
                   </span>
@@ -137,7 +138,7 @@ const UserSelect: FC<UserSelectProps> = ({ name }) => {
               showEmptyContent={false}
             />
           )}
-          {!showVerifiedUsers && field.value && (
+          {!selectedUser?.isVerified && field.value && (
             <UserPopover
               userName={userDisplayName}
               walletAddress={userWalletAddress}

--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/hooks.ts
@@ -24,6 +24,7 @@ export const useUserSelect = () => {
               walletAddress ||
               member.contributorAddress,
             avatar: profile?.thumbnail || profile?.avatar || '',
+            thumbnail: profile?.thumbnail || '',
             id: result.length,
             showAvatar: true,
             walletAddress,

--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/hooks.ts
@@ -27,6 +27,7 @@ export const useUserSelect = () => {
             id: result.length,
             showAvatar: true,
             walletAddress,
+            isVerified: member.isVerified,
           },
         ];
       }, []),
@@ -40,6 +41,5 @@ export const useUserSelect = () => {
       key: 'users',
       title: { id: 'actions.recipient' },
     },
-    showVerifiedUsers: false,
   };
 };

--- a/src/components/v5/shared/SearchSelect/types.ts
+++ b/src/components/v5/shared/SearchSelect/types.ts
@@ -34,4 +34,5 @@ export interface SearchSelectOption {
   missingPermissions?: string;
   token?: TokenFragment;
   isRoot?: boolean;
+  isVerified?: boolean;
 }

--- a/src/components/v5/shared/SearchSelect/types.ts
+++ b/src/components/v5/shared/SearchSelect/types.ts
@@ -27,6 +27,7 @@ export interface SearchSelectOption {
   value: string | number;
   isDisabled?: boolean;
   avatar?: string;
+  thumbnail?: string;
   showAvatar?: boolean;
   color?: string;
   walletAddress?: string;


### PR DESCRIPTION
## Description

* Show verified / non verified icon correctly for transfer recipient
* (Also fixed transfer recipient thumbnail as there was some overlap)

**Changes** 🏗

* useUserSelect hook now returns isVerified property for each member
* Conditional UI changes now depend on selectedUser?.isVerified rather than unused showVerifiedUsers property
* useUserSelect hook now returns thumbnail property for each member

Verified user:
![Screenshot 2024-01-26 at 17 04 53](https://github.com/JoinColony/colonyCDapp/assets/34915414/444ec31d-75fd-4efd-8c4e-104c450e3e7c)

Unverified user:
![Screenshot 2024-01-26 at 17 05 03](https://github.com/JoinColony/colonyCDapp/assets/34915414/b54de67b-7eae-416d-ac03-9c0494b5f323)

Resolves #1780
