### PR TITLE
[Verified members] feat: add verified members via permissions saga

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -737,11 +737,14 @@ enum ColonyActionType {
   """
   CANCEL_STAKED_EXPENDITURE_MOTION
   """
-  "
   An action related to the creation of safe transactions via Safe Control
   """
   MAKE_ARBITRARY_TRANSACTION
   MAKE_ARBITRARY_TRANSACTIONS_MOTION
+  """
+  An action related to adding verified members
+  """
+  ADD_VERIFIED_MEMBERS
 }
 
 """
@@ -2830,7 +2833,10 @@ type ColonyAction @model @searchable {
   Colony roles that are associated with the action
   """
   roles: ColonyActionRoles
-
+  """
+  Members impacted by the action (used for add/remove verified members)
+  """
+  members: [ID!]
   # Required since some actions might have multiple event entries in the list
   # which need to be iterated over and exposed individually
   #

--- a/src/components/v5/frame/ColonyHome/ColonyHome.tsx
+++ b/src/components/v5/frame/ColonyHome/ColonyHome.tsx
@@ -23,6 +23,7 @@ import Objective from './partials/Objective/index.ts';
 import ReputationChart from './partials/ReputationChart/index.ts';
 import TokenBalance from './partials/TokenBalance/index.ts';
 import TotalActions from './partials/TotalActions/index.ts';
+import { TmpAddVerifiedMembers } from './TmpAddVerifiedMembers.tsx';
 
 const displayName = 'v5.frame.ColonyHome';
 
@@ -36,6 +37,7 @@ const ColonyHome = () => {
   return (
     <div className="flex flex-col gap-10">
       <DashboardHeader />
+      <TmpAddVerifiedMembers />
       <div className="flex flex-col sm:flex-row items-center gap-[1.125rem] w-full">
         <TotalActions />
         <Members />

--- a/src/components/v5/frame/ColonyHome/TmpAddVerifiedMembers.tsx
+++ b/src/components/v5/frame/ColonyHome/TmpAddVerifiedMembers.tsx
@@ -3,10 +3,11 @@ import { pipe } from 'lodash/fp';
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { useAsyncFunction, useColonyContext } from '~hooks';
-import { ActionTypes } from '~redux/actionTypes';
-import { mapPayload, withMeta } from '~utils/actions';
-import { setQueryParamOnUrl } from '~utils/urls';
+import { useColonyContext } from '~context/ColonyContext.tsx';
+import useAsyncFunction from '~hooks/useAsyncFunction.ts';
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { mapPayload, withMeta } from '~utils/actions.ts';
+import { setQueryParamOnUrl } from '~utils/urls.ts';
 
 export const TmpAddVerifiedMembers = () => {
   const {

--- a/src/components/v5/frame/ColonyHome/TmpAddVerifiedMembers.tsx
+++ b/src/components/v5/frame/ColonyHome/TmpAddVerifiedMembers.tsx
@@ -1,29 +1,46 @@
 import { Id } from '@colony/colony-js';
+import { pipe } from 'lodash/fp';
 import React, { useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 
-import { useColonyContext } from '~hooks';
+import { useAsyncFunction, useColonyContext } from '~hooks';
 import { ActionTypes } from '~redux/actionTypes';
+import { mapPayload, withMeta } from '~utils/actions';
+import { setQueryParamOnUrl } from '~utils/urls';
 
 export const TmpAddVerifiedMembers = () => {
   const {
     colony: { colonyAddress, name },
   } = useColonyContext();
-  const dispatch = useDispatch();
+  const navigate = useNavigate();
   const [members, setMembers] = useState('');
 
+  const verifyMembers = useAsyncFunction({
+    submit: ActionTypes.ACTION_ADD_VERIFIED_MEMBERS,
+    error: ActionTypes.ACTION_ADD_VERIFIED_MEMBERS_ERROR,
+    success: ActionTypes.ACTION_ADD_VERIFIED_MEMBERS_SUCCESS,
+    transform: pipe(
+      mapPayload((payload) => {
+        return payload;
+      }),
+      withMeta({
+        setTxHash: (txHash: string) => {
+          navigate(setQueryParamOnUrl(window.location.pathname, 'tx', txHash), {
+            replace: true,
+          });
+        },
+      }),
+    ),
+  });
+
   const handleSubmit = () => {
-    // console.log('sabamito!');
-    dispatch({
-      type: ActionTypes.ACTION_ADD_VERIFIED_MEMBERS,
-      payload: {
-        colonyAddress,
-        colonyName: name,
-        members: members.split(','),
-        customActionTitle: 'Verifying members!',
-        domainId: Id.RootDomain,
-        annotationMessage: 'Annotated bruh',
-      },
+    verifyMembers({
+      colonyAddress,
+      colonyName: name,
+      members: members.split(','),
+      customActionTitle: 'Verifying members!',
+      domainId: Id.RootDomain,
+      annotationMessage: 'Annotated bruh',
     });
   };
 

--- a/src/components/v5/frame/ColonyHome/TmpAddVerifiedMembers.tsx
+++ b/src/components/v5/frame/ColonyHome/TmpAddVerifiedMembers.tsx
@@ -1,0 +1,44 @@
+import { Id } from '@colony/colony-js';
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { useColonyContext } from '~hooks';
+import { ActionTypes } from '~redux/actionTypes';
+
+export const TmpAddVerifiedMembers = () => {
+  const {
+    colony: { colonyAddress, name },
+  } = useColonyContext();
+  const dispatch = useDispatch();
+  const [members, setMembers] = useState('');
+
+  const handleSubmit = () => {
+    // console.log('sabamito!');
+    dispatch({
+      type: ActionTypes.ACTION_ADD_VERIFIED_MEMBERS,
+      payload: {
+        colonyAddress,
+        colonyName: name,
+        members: members.split(','),
+        customActionTitle: 'Verifying members!',
+        domainId: Id.RootDomain,
+        annotationMessage: 'Annotated bruh',
+      },
+    });
+  };
+
+  return (
+    <>
+      <input
+        style={{ border: '1px solid salmon' }}
+        value={members}
+        onChange={(e) => {
+          setMembers(e.target.value);
+        }}
+      />
+      <button type="button" onClick={handleSubmit}>
+        Verify
+      </button>
+    </>
+  );
+};

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -269,6 +269,8 @@ export type ColonyAction = {
   initiatorUser?: Maybe<User>;
   /** Will be true if the action is a motion */
   isMotion?: Maybe<Scalars['Boolean']>;
+  /** Members impacted by the action (used for add/remove verified members) */
+  members?: Maybe<Array<Scalars['ID']>>;
   /** Metadata associated with the action (Eg. Custom action title) */
   metadata?: Maybe<ColonyActionMetadata>;
   /** Expanded `ColonyMotion` for the corresponding `motionId` */
@@ -365,6 +367,8 @@ export type ColonyActionRolesInput = {
  * These can all happen in a Colony and will be interpreted by the dApp according to their types
  */
 export enum ColonyActionType {
+  /** An action related to adding verified members */
+  AddVerifiedMembers = 'ADD_VERIFIED_MEMBERS',
   /** An action related to a motion to cancel a staked expenditure */
   CancelStakedExpenditureMotion = 'CANCEL_STAKED_EXPENDITURE_MOTION',
   /** An action related to editing a Colony's details */
@@ -393,10 +397,7 @@ export enum ColonyActionType {
   FundExpenditureMotion = 'FUND_EXPENDITURE_MOTION',
   /** A generic or unspecified Colony action */
   Generic = 'GENERIC',
-  /**
-   * "
-   * An action related to the creation of safe transactions via Safe Control
-   */
+  /** An action related to the creation of safe transactions via Safe Control */
   MakeArbitraryTransaction = 'MAKE_ARBITRARY_TRANSACTION',
   MakeArbitraryTransactionsMotion = 'MAKE_ARBITRARY_TRANSACTIONS_MOTION',
   /** An action related to minting tokens within a Colony */
@@ -1084,6 +1085,7 @@ export type CreateColonyActionInput = {
   individualEvents?: InputMaybe<Scalars['String']>;
   initiatorAddress: Scalars['ID'];
   isMotion?: InputMaybe<Scalars['Boolean']>;
+  members?: InputMaybe<Array<Scalars['ID']>>;
   motionDomainId?: InputMaybe<Scalars['Int']>;
   motionId?: InputMaybe<Scalars['ID']>;
   networkFee?: InputMaybe<Scalars['String']>;
@@ -2241,6 +2243,7 @@ export type ModelColonyActionConditionInput = {
   individualEvents?: InputMaybe<ModelStringInput>;
   initiatorAddress?: InputMaybe<ModelIdInput>;
   isMotion?: InputMaybe<ModelBooleanInput>;
+  members?: InputMaybe<ModelIdInput>;
   motionDomainId?: InputMaybe<ModelIntInput>;
   motionId?: InputMaybe<ModelIdInput>;
   networkFee?: InputMaybe<ModelStringInput>;
@@ -2277,6 +2280,7 @@ export type ModelColonyActionFilterInput = {
   individualEvents?: InputMaybe<ModelStringInput>;
   initiatorAddress?: InputMaybe<ModelIdInput>;
   isMotion?: InputMaybe<ModelBooleanInput>;
+  members?: InputMaybe<ModelIdInput>;
   motionDomainId?: InputMaybe<ModelIntInput>;
   motionId?: InputMaybe<ModelIdInput>;
   networkFee?: InputMaybe<ModelStringInput>;
@@ -3409,6 +3413,7 @@ export type ModelSubscriptionColonyActionFilterInput = {
   individualEvents?: InputMaybe<ModelSubscriptionStringInput>;
   initiatorAddress?: InputMaybe<ModelSubscriptionIdInput>;
   isMotion?: InputMaybe<ModelSubscriptionBooleanInput>;
+  members?: InputMaybe<ModelSubscriptionIdInput>;
   motionDomainId?: InputMaybe<ModelSubscriptionIntInput>;
   motionId?: InputMaybe<ModelSubscriptionIdInput>;
   networkFee?: InputMaybe<ModelSubscriptionStringInput>;
@@ -6619,6 +6624,7 @@ export enum SearchableColonyActionAggregateField {
   IndividualEvents = 'individualEvents',
   InitiatorAddress = 'initiatorAddress',
   IsMotion = 'isMotion',
+  Members = 'members',
   MotionDomainId = 'motionDomainId',
   MotionId = 'motionId',
   NetworkFee = 'networkFee',
@@ -6662,6 +6668,7 @@ export type SearchableColonyActionFilterInput = {
   individualEvents?: InputMaybe<SearchableStringFilterInput>;
   initiatorAddress?: InputMaybe<SearchableIdFilterInput>;
   isMotion?: InputMaybe<SearchableBooleanFilterInput>;
+  members?: InputMaybe<SearchableIdFilterInput>;
   motionDomainId?: InputMaybe<SearchableIntFilterInput>;
   motionId?: InputMaybe<SearchableIdFilterInput>;
   networkFee?: InputMaybe<SearchableStringFilterInput>;
@@ -6697,6 +6704,7 @@ export enum SearchableColonyActionSortableFields {
   IndividualEvents = 'individualEvents',
   InitiatorAddress = 'initiatorAddress',
   IsMotion = 'isMotion',
+  Members = 'members',
   MotionDomainId = 'motionDomainId',
   MotionId = 'motionId',
   NetworkFee = 'networkFee',
@@ -7809,6 +7817,7 @@ export type UpdateColonyActionInput = {
   individualEvents?: InputMaybe<Scalars['String']>;
   initiatorAddress?: InputMaybe<Scalars['ID']>;
   isMotion?: InputMaybe<Scalars['Boolean']>;
+  members?: InputMaybe<Array<Scalars['ID']>>;
   motionDomainId?: InputMaybe<Scalars['Int']>;
   motionId?: InputMaybe<Scalars['ID']>;
   networkFee?: InputMaybe<Scalars['String']>;

--- a/src/redux/sagas/actions/addVerifiedMembers.ts
+++ b/src/redux/sagas/actions/addVerifiedMembers.ts
@@ -1,22 +1,24 @@
 import { ClientType } from '@colony/colony-js';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
-import { Action, AllActions, ActionTypes } from '~redux';
-import { transactionAddParams } from '~redux/actionCreators';
+import { ActionTypes } from '~redux';
+import type { Action, AllActions } from '~redux';
+import { transactionAddParams } from '~redux/actionCreators/transactions.ts';
 
 import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
-} from '../transactions';
+  waitForTxResult,
+} from '../transactions/index.ts';
 import {
   createActionMetadataInDB,
   initiateTransaction,
   putError,
   takeFrom,
   uploadAnnotation,
-} from '../utils';
-import { getAddVerifiedMembersOperation } from '../utils/verifiedMembers';
+} from '../utils/index.ts';
+import { getAddVerifiedMembersOperation } from '../utils/verifiedMembers.ts';
 
 function* addVerifiedMembersAction({
   payload: {
@@ -106,10 +108,7 @@ function* addVerifiedMembersAction({
 
     setTxHash?.(txHash);
 
-    yield takeFrom(
-      addVerifiedMembers.channel,
-      ActionTypes.TRANSACTION_SUCCEEDED,
-    );
+    waitForTxResult(addVerifiedMembers.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 

--- a/src/redux/sagas/actions/addVerifiedMembers.ts
+++ b/src/redux/sagas/actions/addVerifiedMembers.ts
@@ -1,27 +1,170 @@
-import { put, takeEvery } from 'redux-saga/effects';
+import { ClientType, ColonyRole, getPermissionProofs } from '@colony/colony-js';
+import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
+import ColonyManager from '~context/ColonyManager';
 import { Action, AllActions, ActionTypes } from '~redux';
+import { transactionAddParams } from '~redux/actionCreators';
 
-function* addVerifiedMembers({
-  /*
+import {
+  createTransaction,
+  createTransactionChannels,
+  getTxChannel,
+} from '../transactions';
+import {
+  createActionMetadataInDB,
+  getColonyManager,
+  initiateTransaction,
+  putError,
+  takeFrom,
+  uploadAnnotation,
+} from '../utils';
+import { getAddVerifiedMembersOperation } from '../utils/verifiedMembers';
+
+function* addVerifiedMembersAction({
   payload: {
     colonyAddress,
     colonyName,
     members,
     customActionTitle,
+    domainId,
     annotationMessage,
   },
-    */
-  // meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, navigate, setTxHash },
   meta,
 }: Action<ActionTypes.ACTION_ADD_VERIFIED_MEMBERS>) {
-  yield put<AllActions>({
-    type: ActionTypes.ACTION_ADD_VERIFIED_MEMBERS_SUCCESS,
-    payload: {},
-    meta,
-  });
+  let txChannel;
+
+  try {
+    if (!domainId) {
+      throw new Error('Domain not set for addVerifiedMembers transaction');
+    }
+    if (!colonyAddress) {
+      throw new Error(
+        'No colony address set for addVerifiedMembers transaction',
+      );
+    }
+    if (!Array.isArray(members) || members.length === 0) {
+      throw new Error('No members set for addVerifiedMembers transaction');
+    }
+
+    txChannel = yield call(getTxChannel, metaId);
+    const colonyManager: ColonyManager = yield getColonyManager();
+
+    // setup batch ids and channels
+    const batchKey = 'addVerifiedMembers';
+
+    const { addVerifiedMembers, annotateAddVerifiedMembers } =
+      yield createTransactionChannels(metaId, [
+        'addVerifiedMembers',
+        'annotateAddVerifiedMembersAction',
+      ]);
+
+    yield fork(createTransaction, addVerifiedMembers.id, {
+      context: ClientType.ColonyClient,
+      methodName: 'metadataDelta',
+      identifier: colonyAddress,
+      params: [],
+      group: {
+        key: batchKey,
+        id: metaId,
+        index: 0,
+      },
+      ready: false,
+    });
+
+    if (annotationMessage) {
+      yield fork(createTransaction, annotateAddVerifiedMembers.id, {
+        context: ClientType.ColonyClient,
+        methodName: 'annotateTransaction',
+        identifier: colonyAddress,
+        params: [],
+        group: {
+          key: batchKey,
+          id: metaId,
+          index: 1,
+        },
+        ready: false,
+      });
+    }
+
+    yield takeFrom(addVerifiedMembers.channel, ActionTypes.TRANSACTION_CREATED);
+    if (annotationMessage) {
+      yield takeFrom(
+        annotateAddVerifiedMembers.channel,
+        ActionTypes.TRANSACTION_CREATED,
+      );
+    }
+
+    const colonyClient = yield colonyManager.getClient(
+      ClientType.ColonyClient,
+      colonyAddress,
+    );
+
+    const [permissionDomainId, childSkillIndex] = yield getPermissionProofs(
+      colonyClient.networkClient,
+      colonyClient,
+      domainId,
+      ColonyRole.Architecture,
+    );
+
+    // add params, how to blobify the last JSON??
+    yield put(
+      transactionAddParams(addVerifiedMembers.id, [
+        permissionDomainId,
+        childSkillIndex,
+        domainId,
+        getAddVerifiedMembersOperation(colonyAddress, members),
+      ]),
+    );
+
+    yield initiateTransaction({ id: addVerifiedMembers.id });
+
+    const {
+      payload: { hash: txHash },
+    } = yield takeFrom(
+      addVerifiedMembers.channel,
+      ActionTypes.TRANSACTION_HASH_RECEIVED,
+    );
+
+    setTxHash?.(txHash);
+
+    yield takeFrom(
+      addVerifiedMembers.channel,
+      ActionTypes.TRANSACTION_SUCCEEDED,
+    );
+
+    yield createActionMetadataInDB(txHash, customActionTitle);
+
+    if (annotationMessage) {
+      yield uploadAnnotation({
+        txChannel: annotateAddVerifiedMembers,
+        message: annotationMessage,
+        txHash,
+      });
+    }
+
+    yield put<AllActions>({
+      type: ActionTypes.ACTION_ADD_VERIFIED_MEMBERS_SUCCESS,
+      payload: {},
+      meta,
+    });
+
+    if (colonyName && navigate) {
+      navigate(`/${colonyName}?tx=${txHash}`, {
+        state: { isRedirect: true },
+      });
+    }
+  } catch (error) {
+    return yield putError(ActionTypes.ACTION_DOMAIN_CREATE_ERROR, error, meta);
+  } finally {
+    txChannel.close();
+  }
+  return null;
 }
 
-export default function* addVerifiedMembersSaga() {
-  yield takeEvery(ActionTypes.ACTION_ADD_VERIFIED_MEMBERS, addVerifiedMembers);
+export default function* addVerifiedMembersActionSaga() {
+  yield takeEvery(
+    ActionTypes.ACTION_ADD_VERIFIED_MEMBERS,
+    addVerifiedMembersAction,
+  );
 }

--- a/src/redux/sagas/actions/index.ts
+++ b/src/redux/sagas/actions/index.ts
@@ -1,5 +1,6 @@
 import { all, call } from 'redux-saga/effects';
 
+import addVerifiedMembersActionSaga from './addVerifiedMembers.ts';
 import createDomainActionSaga from './createDomain.ts';
 import editColonyActionSaga from './editColony.ts';
 import editDomainActionSaga from './editDomain.ts';
@@ -31,5 +32,6 @@ export default function* actionsSagas() {
     call(manageVerifiedRecipientsSaga),
     call(manageExistingSafesActionSaga),
     call(initiateSafeTransactionSaga),
+    call(addVerifiedMembersActionSaga),
   ]);
 }

--- a/src/redux/sagas/utils/verifiedMembers.ts
+++ b/src/redux/sagas/utils/verifiedMembers.ts
@@ -1,0 +1,25 @@
+enum ActionType {
+  ADD = 'ADD',
+  REMOVE = 'REMOVE',
+}
+
+type AddVerifiedMembersOperation = {
+  type: ActionType.ADD;
+  entity: 'verifiedMembers';
+  colonyAddress: string;
+  members: string[];
+};
+
+export type VerifiedMembersOperation = AddVerifiedMembersOperation;
+
+export const getAddVerifiedMembersOperation = (
+  colonyAddress: string,
+  members: string[],
+): AddVerifiedMembersOperation => {
+  return {
+    type: ActionType.ADD,
+    entity: 'verifiedMembers',
+    colonyAddress,
+    members,
+  };
+};

--- a/src/redux/types/actions/colonyActions.ts
+++ b/src/redux/types/actions/colonyActions.ts
@@ -304,8 +304,9 @@ export type ColonyActionsActionTypes =
         colonyAddress: Address;
         colonyName: string;
         members: string[];
+        domainId: number;
         annotationMessage?: string;
-        customActionTitle?: string;
+        customActionTitle: string;
       },
       MetaWithSetter<object>
     >


### PR DESCRIPTION
## Description

This PR adds a saga to add verified members, construct the JSON object for the block ingestor, and call the saga from a very dumb component for testing purposes (will remove once we merge the form).

**New stuff** ✨

* `addVerifiedMembers` saga
* `TmpVerifiedMembers` component

Resolves  #1729
