### PR TITLE
Fix: Teams UI optimisations

### DIFF
--- a/src/components/v5/common/TeamCard/TeamCard.tsx
+++ b/src/components/v5/common/TeamCard/TeamCard.tsx
@@ -40,17 +40,17 @@ const TeamCard: FC<TeamCardProps> = ({
     <Card
       className={clsx(
         className,
-        'bg-gray-25 border-gray-200 pt-6 px-5 pb-5 h-full w-full flex flex-col min-h-[12.25rem] text-gray-600 relative',
+        'bg-gray-25 border-gray-200 pt-6 px-5 pb-5 h-full w-full flex flex-col min-h-[12.5rem] text-gray-600 relative',
       )}
       withPadding={false}
     >
       <div className="w-full flex-grow flex flex-col gap-3">
-        <div className="text-gray-900 flex justify-between items-start gap-2">
+        <div className="flex justify-between items-start gap-2">
           <div className="truncate">
-            <h3 className="text-lg font-medium mb-1 truncate w-full">
+            <h3 className="text-lg font-medium mb-1 truncate w-full text-gray-900">
               {title || teamProps.name}
             </h3>
-            <div className="flex items-center gap-x-4 gap-y-1 flex-shrink-0 flex-wrap">
+            <div className="flex items-center gap-x-4 gap-y-1 flex-shrink-0 flex-wrap text-gray-600">
               <Tooltip
                 placement={isMobile ? 'auto' : 'right'}
                 tooltipContent="Team balance"
@@ -81,9 +81,9 @@ const TeamCard: FC<TeamCardProps> = ({
               {!!members?.length && (
                 <div className="flex-shrink-0 ml-auto">
                   <UserAvatars
-                    maxAvatarsToShow={5}
+                    maxAvatarsToShow={4}
                     className="[&_.placeholder]:bg-gray-200 [&_.placeholder]:text-gray-900"
-                    size="xms"
+                    size="sm"
                     items={members}
                   />
                 </div>

--- a/src/components/v5/common/TeamCardList/TeamCardList.tsx
+++ b/src/components/v5/common/TeamCardList/TeamCardList.tsx
@@ -7,14 +7,13 @@ import TeamCard from '../TeamCard/index.ts';
 import { type TeamCardListProps } from './types.ts';
 
 const TeamCardList: FC<TeamCardListProps> = ({ items, className }) => (
-  <ul className={clsx(className, 'flex flex-wrap gap-6')}>
+  <ul className={clsx(className, 'grid sm:grid-cols-2 lg:grid-cols-3 gap-6')}>
     {items.map(({ key, ...item }) => (
       <motion.li
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
         key={key}
-        className="w-full sm:w-[calc(50%-.75rem)]"
       >
         <TeamCard {...item} />
       </motion.li>

--- a/src/components/v5/shared/ReputationBadge/ReputationBadge.tsx
+++ b/src/components/v5/shared/ReputationBadge/ReputationBadge.tsx
@@ -11,9 +11,7 @@ const ReputationBadge: FC<ReputationBadgeProps> = ({
   fractionDigits,
   className,
 }) => (
-  <div
-    className={clsx(className, 'flex items-center gap-1 text-gray-900 text-sm')}
-  >
+  <div className={clsx(className, 'flex items-center gap-1 text-sm')}>
     <Star size={14} className="flex-shrink-0" />
     <span className="inline-block">
       {reputation.toFixed(fractionDigits !== undefined ? fractionDigits : 2)}%


### PR DESCRIPTION
## Description

- Increased the number of cards shown per row on the teams page from 2 to 3 on desktop. Remains at 2 on tablet and 1 on mobile.
- Changed the colour of the team funds and reputation to text-gray-600
- Reduced the max number of avatars shown to 4
- Reduced the size of the avatars to 30 x 30px
- Set the min-height of the card to ensure the content block is 94px high regardless of content

3 cards on desktop
![Screenshot 2024-01-30 at 16 13 13](https://github.com/JoinColony/colonyCDapp/assets/34915414/1611342f-ebeb-4a39-b020-5e3c2c6bd8cf)

2 cards on tablet
![Screenshot 2024-01-30 at 16 13 27](https://github.com/JoinColony/colonyCDapp/assets/34915414/c849aaab-f3bc-4623-ae04-3fc49943f7b4)

1 card on mobile
![Screenshot 2024-01-30 at 16 13 34](https://github.com/JoinColony/colonyCDapp/assets/34915414/70f52907-fe91-4613-8467-6192af28ae5c)

Card example showing changed text colour and max avatars
![Screenshot 2024-01-30 at 16 13 54](https://github.com/JoinColony/colonyCDapp/assets/34915414/e5357837-fc2f-4df8-b55c-5cd52c9de243)

Avatar size
![Screenshot 2024-01-30 at 16 19 17](https://github.com/JoinColony/colonyCDapp/assets/34915414/156b3abd-6837-4ed6-9737-1937ec4c588b)

Card content size with no description
![Screenshot 2024-01-30 at 16 10 13](https://github.com/JoinColony/colonyCDapp/assets/34915414/dae4d34d-5b46-4dbd-8231-dbacd80368eb)

Card content size with description
![Screenshot 2024-01-30 at 16 10 24](https://github.com/JoinColony/colonyCDapp/assets/34915414/707d7927-503f-4eff-86b9-4b100d765427)


Resolves #1796
