### PR TITLE
Fix incoming transfers: ingestor hash update

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -1263,9 +1263,9 @@ type Colony @model {
   # If you have a better idea, on how to merged them, I'll all ears..
   fundsClaims: [ColonyFundsClaim] @hasMany
   """
-  List of native chain token claims (e.g., Token 0x0000...0000: ETH, xDAI, etc.)
+  Native chain token claim (e.g., Token 0x0000...0000: ETH, xDAI, etc.)
+  This is not an array since only a single token type can be returned
   """
-  # This is not an array since only a single token type can be returned
   chainFundsClaim: ColonyChainFundsClaim
     @function(name: "fetchColonyNativeFundsClaim-${env}")
   """

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=8c49224e8b7553c13910c3db9acda3f294df875a
+ENV BLOCK_INGESTOR_HASH=53227363e3b768a48d65029b3c0f4eef9cb04dde
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=ccb2bf24ab47a0d6baabecd17597936264315669
+ENV BLOCK_INGESTOR_HASH=8c49224e8b7553c13910c3db9acda3f294df875a
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -109,7 +109,10 @@ export type Colony = {
   actions?: Maybe<ModelColonyActionConnection>;
   /** Returns a list token balances for each domain and each token that the colony has */
   balances?: Maybe<ColonyBalances>;
-  /** List of native chain token claims (e.g., Token 0x0000...0000: ETH, xDAI, etc.) */
+  /**
+   * Native chain token claim (e.g., Token 0x0000...0000: ETH, xDAI, etc.)
+   * This is not an array since only a single token type can be returned
+   */
   chainFundsClaim?: Maybe<ColonyChainFundsClaim>;
   /** Metadata related to the chain of the Colony */
   chainMetadata: ChainMetadata;


### PR DESCRIPTION
## Description

This PR fixes a couple of issues discovered while investigating the incoming funds bug. For context, sending tokens to a colony triggers a `Transfer` event, which block-ingestor is supposed to pick up and process.

1. block-ingestor was not able to match the `Transfer` events with any of the existing event listeners and it was simply ignoring it.
2. We had a bug in setting up the listeners anyway, and it would only ever set up a single listener (presumably for the first colony it starts tracking).
3. When it finally made it to the correct handler, we failed to ensure the transferred token is in the DB, and it would make entire CDapp crash (BTW. This is another good arguments to break down the massive `GetFullColonyByName` query into smaller queries, since a single field failure will lead to a consistent 404). 

All the magic happens in [block-ingestor](https://github.com/JoinColony/block-ingestor/pull/165), this PR simply updates the docker image hash.

## Testing
You need a brand new token that you will transfer to a colony. To create a token, run `npm run truffle console` with the following commands line-by-line: 
```ts
// create new token (name, symbol, decimals)
t = await Token.new('Token name', 'TKN', 18)
t.unlock()
// mint some tokens (10 ether)
t.mint('10000000000000000000')
// transfer some tokens to your colony (0.5 ether)
t.transfer('<COLONY_ADDRESS>', '500000000000000000')
```

Head to the incoming funds page of your colony (make sure to refresh) and check "Unapproved" option in the filters:
<img width="761" alt="image" src="https://github.com/JoinColony/colonyCDapp/assets/112586815/3ffe08a3-dd58-40c9-80b2-8e1850ecc9f9">

The transfer should appear in the list.

Resolves #1797 
