### PR TITLE
fix: switch all sagas to use waitForTxResult

### DIFF
--- a/src/redux/sagas/actions/createDomain.ts
+++ b/src/redux/sagas/actions/createDomain.ts
@@ -28,6 +28,7 @@ import {
   createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   initiateTransaction,
@@ -129,7 +130,7 @@ function* createDomainAction({
         receipt: { transactionHash: txHash },
         eventData,
       },
-    } = yield takeFrom(createDomain.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    } = yield waitForTxResult(createDomain.channel);
 
     setTxHash?.(txHash);
 

--- a/src/redux/sagas/actions/editColony.ts
+++ b/src/redux/sagas/actions/editColony.ts
@@ -19,6 +19,7 @@ import {
   createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   createActionMetadataInDB,
@@ -143,7 +144,7 @@ function* editColonyAction({
       ActionTypes.TRANSACTION_HASH_RECEIVED,
     );
 
-    yield takeFrom(editColony.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(editColony.channel);
 
     const existingTokenAddresses = getExistingTokenAddresses(colony);
     const modifiedTokenAddresses = getModifiedTokenAddresses(

--- a/src/redux/sagas/actions/editDomain.ts
+++ b/src/redux/sagas/actions/editDomain.ts
@@ -23,6 +23,7 @@ import {
   createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   putError,
@@ -133,7 +134,7 @@ function* editDomainAction({
 
     setTxHash?.(txHash);
 
-    yield takeFrom(editDomain.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(editDomain.channel);
 
     /**
      * Save the updated metadata in the database

--- a/src/redux/sagas/actions/initiateSafeTransaction.ts
+++ b/src/redux/sagas/actions/initiateSafeTransaction.ts
@@ -20,6 +20,7 @@ import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import { createActionMetadataInDB, uploadAnnotation } from '../utils/index.ts';
 import {
@@ -118,10 +119,7 @@ function* initiateSafeTransactionAction({
       ActionTypes.TRANSACTION_HASH_RECEIVED,
     );
 
-    yield takeFrom(
-      initiateSafeTransaction.channel,
-      ActionTypes.TRANSACTION_SUCCEEDED,
-    );
+    yield waitForTxResult(initiateSafeTransaction.channel);
 
     /**
      * Create parent safe transaction in the database

--- a/src/redux/sagas/actions/manageExistingSafes.ts
+++ b/src/redux/sagas/actions/manageExistingSafes.ts
@@ -22,6 +22,7 @@ import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   createActionMetadataInDB,
@@ -136,10 +137,7 @@ function* manageExistingSafesAction({
       });
     }
 
-    yield takeFrom(
-      manageExistingSafes.channel,
-      ActionTypes.TRANSACTION_SUCCEEDED,
-    );
+    yield waitForTxResult(manageExistingSafes.channel);
 
     /**
      * Update colony metadata in the db

--- a/src/redux/sagas/actions/managePermissions.ts
+++ b/src/redux/sagas/actions/managePermissions.ts
@@ -19,6 +19,7 @@ import {
   createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   initiateTransaction,
@@ -146,7 +147,7 @@ function* managePermissionsAction({
 
     setTxHash?.(txHash);
 
-    yield takeFrom(setUserRoles.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(setUserRoles.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 

--- a/src/redux/sagas/actions/manageReputation.ts
+++ b/src/redux/sagas/actions/manageReputation.ts
@@ -12,6 +12,7 @@ import {
   createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   initiateTransaction,
@@ -138,7 +139,7 @@ function* manageReputationAction({
 
     setTxHash?.(txHash);
 
-    yield takeFrom(manageReputation.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(manageReputation.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 

--- a/src/redux/sagas/actions/manageVerifiedRecipients.ts
+++ b/src/redux/sagas/actions/manageVerifiedRecipients.ts
@@ -24,6 +24,7 @@ import {
   createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   createActionMetadataInDB,
@@ -139,7 +140,7 @@ function* manageVerifiedRecipients({
 
     setTxHash?.(txHash);
 
-    yield takeFrom(editColony.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(editColony.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 

--- a/src/redux/sagas/actions/mintTokens.ts
+++ b/src/redux/sagas/actions/mintTokens.ts
@@ -7,6 +7,7 @@ import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   createActionMetadataInDB,
@@ -107,11 +108,11 @@ function* createMintTokensAction({
       ActionTypes.TRANSACTION_HASH_RECEIVED,
     );
 
-    yield takeFrom(mintTokens.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(mintTokens.channel);
 
     yield initiateTransaction({ id: claimColonyFunds.id });
 
-    yield takeFrom(claimColonyFunds.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(claimColonyFunds.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 

--- a/src/redux/sagas/actions/moveFunds.ts
+++ b/src/redux/sagas/actions/moveFunds.ts
@@ -11,6 +11,7 @@ import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   putError,
@@ -140,7 +141,7 @@ function* createMoveFundsAction({
 
     setTxHash?.(txHash);
 
-    yield takeFrom(moveFunds.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(moveFunds.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 

--- a/src/redux/sagas/actions/payment.ts
+++ b/src/redux/sagas/actions/payment.ts
@@ -15,6 +15,7 @@ import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   initiateTransaction,
@@ -175,7 +176,7 @@ function* createPaymentAction({
       ActionTypes.TRANSACTION_HASH_RECEIVED,
     );
 
-    yield takeFrom(paymentAction.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(paymentAction.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 

--- a/src/redux/sagas/actions/unlockToken.ts
+++ b/src/redux/sagas/actions/unlockToken.ts
@@ -7,6 +7,7 @@ import {
   createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   createActionMetadataInDB,
@@ -81,7 +82,7 @@ function* tokenUnlockAction({
       ActionTypes.TRANSACTION_HASH_RECEIVED,
     );
 
-    yield takeFrom(tokenUnlock.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(tokenUnlock.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 

--- a/src/redux/sagas/actions/versionUpgrade.ts
+++ b/src/redux/sagas/actions/versionUpgrade.ts
@@ -8,6 +8,7 @@ import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   createActionMetadataInDB,
@@ -94,7 +95,7 @@ function* createVersionUpgradeAction({
 
     setTxHash?.(txHash);
 
-    yield takeFrom(upgrade.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(upgrade.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 

--- a/src/redux/sagas/colony/colonyCreate.ts
+++ b/src/redux/sagas/colony/colonyCreate.ts
@@ -44,6 +44,7 @@ import {
   type ChannelDefinition,
   createGroupTransaction,
   createTransactionChannels,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import { updateTransaction } from '../transactions/transactionsToDb.ts';
 import { getOneTxPaymentVersion } from '../utils/extensionVersion.ts';
@@ -221,7 +222,7 @@ function* colonyCreate({
 
     const {
       payload: { eventData },
-    } = yield takeFrom(createColony.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    } = yield waitForTxResult(createColony.channel);
 
     const colonyAddress = eventData.ColonyAdded?.colonyAddress;
     const tokenAddress =
@@ -293,7 +294,7 @@ function* colonyCreate({
     if (setOwner) {
       yield put(transactionAddParams(setOwner.id, [colonyAddress]));
       yield initiateTransaction({ id: setOwner.id });
-      yield takeFrom(setOwner.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+      yield waitForTxResult(setOwner.channel);
     }
 
     if (deployOneTx) {
@@ -307,7 +308,7 @@ function* colonyCreate({
       );
       yield initiateTransaction({ id: deployOneTx.id });
 
-      yield takeFrom(deployOneTx.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+      yield waitForTxResult(deployOneTx.channel);
 
       /*
        * Set OneTx administration role
@@ -361,7 +362,7 @@ function* colonyCreate({
       );
       yield initiateTransaction({ id: setOneTxRoles.id });
 
-      yield takeFrom(setOneTxRoles.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+      yield waitForTxResult(setOneTxRoles.channel);
     }
 
     /*

--- a/src/redux/sagas/motions/claimAllMotionRewards.ts
+++ b/src/redux/sagas/motions/claimAllMotionRewards.ts
@@ -27,6 +27,7 @@ import {
   createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   initiateTransaction,
@@ -152,9 +153,7 @@ function* claimAllMotionRewards({
     );
 
     yield all(
-      Object.keys(channels).map((id) =>
-        takeFrom(channels[id].channel, ActionTypes.TRANSACTION_SUCCEEDED),
-      ),
+      Object.keys(channels).map((id) => waitForTxResult(channels[id].channel)),
     );
 
     yield put<AllActions>({

--- a/src/redux/sagas/motions/claimMotionRewards.ts
+++ b/src/redux/sagas/motions/claimMotionRewards.ts
@@ -20,6 +20,7 @@ import {
   type ChannelDefinition,
   createGroupTransaction,
   createTransactionChannels,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   initiateTransaction,
@@ -130,9 +131,7 @@ function* claimMotionRewards({
     );
 
     yield all(
-      Object.keys(channels).map((id) =>
-        takeFrom(channels[id].channel, ActionTypes.TRANSACTION_SUCCEEDED),
-      ),
+      Object.keys(channels).map((id) => waitForTxResult(channels[id].channel)),
     );
 
     yield put<AllActions>({

--- a/src/redux/sagas/motions/createDecisionMotion.ts
+++ b/src/redux/sagas/motions/createDecisionMotion.ts
@@ -164,7 +164,7 @@ function* createDecisionMotion({
 
     // yield put(transactionReady(annotateMotion.id));
 
-    // yield takeFrom(annotateMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    // yield waitForTxResult(annotateMotion.channel);
 
     yield put<AllActions>({
       type: ActionTypes.MOTION_CREATE_DECISION_SUCCESS,

--- a/src/redux/sagas/motions/createEditDomainMotion.ts
+++ b/src/redux/sagas/motions/createEditDomainMotion.ts
@@ -23,6 +23,7 @@ import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   putError,
@@ -195,7 +196,7 @@ function* createEditDomainMotion({
 
     setTxHash?.(txHash);
 
-    yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(createMotion.channel);
 
     if (isCreateDomain) {
       /**

--- a/src/redux/sagas/motions/editColonyMotion.ts
+++ b/src/redux/sagas/motions/editColonyMotion.ts
@@ -17,6 +17,7 @@ import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   createActionMetadataInDB,
@@ -184,7 +185,7 @@ function* editColonyMotion({
     );
 
     setTxHash?.(txHash);
-    yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(createMotion.channel);
 
     const modifiedTokenAddresses = getPendingModifiedTokenAddresses(
       colony,

--- a/src/redux/sagas/motions/escalateMotion.ts
+++ b/src/redux/sagas/motions/escalateMotion.ts
@@ -19,6 +19,7 @@ import {
   createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   putError,
@@ -121,10 +122,7 @@ function* escalateMotion({
 
     yield initiateTransaction({ id: escalateMotionTransaction.id });
 
-    yield takeFrom(
-      escalateMotionTransaction.channel,
-      ActionTypes.TRANSACTION_SUCCEEDED,
-    );
+    yield waitForTxResult(escalateMotionTransaction.channel);
 
     yield put<AllActions>({
       type: ActionTypes.MOTION_ESCALATE_SUCCESS,

--- a/src/redux/sagas/motions/initiateSafeTransactionMotion.ts
+++ b/src/redux/sagas/motions/initiateSafeTransactionMotion.ts
@@ -21,6 +21,7 @@ import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   getColonyManager,
@@ -171,7 +172,7 @@ function* initiateSafeTransactionMotion({
       ActionTypes.TRANSACTION_HASH_RECEIVED,
     );
 
-    yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(createMotion.channel);
 
     /**
      * Create parent safe transaction in the database

--- a/src/redux/sagas/motions/managePermissionsMotion.ts
+++ b/src/redux/sagas/motions/managePermissionsMotion.ts
@@ -16,6 +16,7 @@ import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   getColonyManager,
@@ -169,7 +170,7 @@ function* managePermissionsMotion({
     );
 
     setTxHash?.(txHash);
-    yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(createMotion.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 

--- a/src/redux/sagas/motions/manageReputationMotion.ts
+++ b/src/redux/sagas/motions/manageReputationMotion.ts
@@ -14,6 +14,7 @@ import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   putError,
@@ -185,7 +186,7 @@ function* manageReputationMotion({
 
     setTxHash?.(txHash);
 
-    yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(createMotion.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 

--- a/src/redux/sagas/motions/moveFundsMotion.ts
+++ b/src/redux/sagas/motions/moveFundsMotion.ts
@@ -16,6 +16,7 @@ import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   putError,
@@ -203,7 +204,7 @@ function* moveFundsMotion({
 
     setTxHash?.(txHash);
 
-    yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(createMotion.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 

--- a/src/redux/sagas/motions/paymentMotion.ts
+++ b/src/redux/sagas/motions/paymentMotion.ts
@@ -14,6 +14,7 @@ import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   putError,
@@ -222,7 +223,7 @@ function* createPaymentMotion({
 
     setTxHash?.(txHash);
 
-    yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(createMotion.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 

--- a/src/redux/sagas/motions/revealVoteMotion.ts
+++ b/src/redux/sagas/motions/revealVoteMotion.ts
@@ -9,6 +9,7 @@ import {
   createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   putError,
@@ -128,10 +129,7 @@ function* revealVoteMotion({
       );
 
       yield initiateTransaction({ id: revealVoteMotionTransaction.id });
-      yield takeFrom(
-        revealVoteMotionTransaction.channel,
-        ActionTypes.TRANSACTION_SUCCEEDED,
-      );
+      yield waitForTxResult(revealVoteMotionTransaction.channel);
 
       return yield put<AllActions>({
         type: ActionTypes.MOTION_REVEAL_VOTE_SUCCESS,

--- a/src/redux/sagas/motions/rootMotion.ts
+++ b/src/redux/sagas/motions/rootMotion.ts
@@ -10,6 +10,7 @@ import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   putError,
@@ -135,7 +136,7 @@ function* createRootMotionSaga({
       ActionTypes.TRANSACTION_HASH_RECEIVED,
     );
 
-    yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(createMotion.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 

--- a/src/redux/sagas/motions/stakeMotion.ts
+++ b/src/redux/sagas/motions/stakeMotion.ts
@@ -19,6 +19,7 @@ import {
   createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   putError,
@@ -161,16 +162,16 @@ function* stakeMotion({
     if (activateTokens) {
       yield initiateTransaction({ id: approve.id });
 
-      yield takeFrom(approve.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+      yield waitForTxResult(approve.channel);
 
       yield initiateTransaction({ id: deposit.id });
 
-      yield takeFrom(deposit.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+      yield waitForTxResult(deposit.channel);
     }
 
     yield initiateTransaction({ id: approveStake.id });
 
-    yield takeFrom(approveStake.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(approveStake.channel);
 
     yield put(transactionPending(stakeMotionTransaction.id));
 
@@ -219,10 +220,7 @@ function* stakeMotion({
       ActionTypes.TRANSACTION_HASH_RECEIVED,
     );
 
-    yield takeFrom(
-      stakeMotionTransaction.channel,
-      ActionTypes.TRANSACTION_SUCCEEDED,
-    );
+    yield waitForTxResult(stakeMotionTransaction.channel);
 
     if (annotationMessage) {
       yield uploadAnnotation({

--- a/src/redux/sagas/motions/voteMotion.ts
+++ b/src/redux/sagas/motions/voteMotion.ts
@@ -9,6 +9,7 @@ import {
   createGroupTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   putError,
@@ -85,10 +86,7 @@ function* voteMotion({
 
     yield initiateTransaction({ id: voteMotionTransaction.id });
 
-    yield takeFrom(
-      voteMotionTransaction.channel,
-      ActionTypes.TRANSACTION_SUCCEEDED,
-    );
+    yield waitForTxResult(voteMotionTransaction.channel);
 
     yield put<AllActions>({
       type: ActionTypes.MOTION_VOTE_SUCCESS,

--- a/src/redux/sagas/users/index.ts
+++ b/src/redux/sagas/users/index.ts
@@ -23,6 +23,7 @@ import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
+  waitForTxResult,
 } from '../transactions/index.ts';
 import {
   getColonyManager,
@@ -223,13 +224,13 @@ function* userDepositToken({
 
     yield initiateTransaction({ id: approve.id });
 
-    yield takeFrom(approve.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(approve.channel);
 
     yield takeFrom(deposit.channel, ActionTypes.TRANSACTION_CREATED);
 
     yield initiateTransaction({ id: deposit.id });
 
-    yield takeFrom(deposit.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(deposit.channel);
 
     yield put({
       type: ActionTypes.USER_DEPOSIT_TOKEN_SUCCESS,
@@ -268,7 +269,7 @@ function* userWithdrawToken({
 
     yield initiateTransaction({ id: withdraw.id });
 
-    yield takeFrom(withdraw.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+    yield waitForTxResult(withdraw.channel);
 
     yield put<AllActions>({
       type: ActionTypes.USER_WITHDRAW_TOKEN_SUCCESS,

--- a/src/redux/sagas/utils/annotations.ts
+++ b/src/redux/sagas/utils/annotations.ts
@@ -10,11 +10,13 @@ import {
   transactionAddParams,
   transactionPending,
 } from '~redux/actionCreators/index.ts';
-import { ActionTypes } from '~redux/actionTypes.ts';
 
-import { type TransactionChannel } from '../transactions/index.ts';
+import {
+  waitForTxResult,
+  type TransactionChannel,
+} from '../transactions/index.ts';
 
-import { initiateTransaction, takeFrom } from './effects.ts';
+import { initiateTransaction } from './effects.ts';
 import { ipfsUploadAnnotation } from './ipfs.ts';
 
 export const uploadAnnotationToDb = async ({
@@ -78,5 +80,5 @@ export function* uploadAnnotation({
 
   yield initiateTransaction({ id: txChannel.id });
 
-  yield takeFrom(txChannel.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+  yield waitForTxResult(txChannel.channel);
 }


### PR DESCRIPTION
## Description

Switched all sagas from: `yield takeFrom(channel, ActionTypes.TRANSACTION_SUCCEEDED);` to: `yield waitForTxResult(channel);`

Previously, if there was an error or the transaction was cancelled, no error action was created so the UI would continually show a loading state. Now the waitForTxResult should properly throw an error in the event of an error or a cancelled transaction which should trigger an error state on the front end.

Resolves #1018