### PR TITLE
Fix: change the label "recipient" to "to" for TransferFunds

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/TransferFunds/TransferFunds.tsx
+++ b/src/components/v5/common/CompletedAction/partials/TransferFunds/TransferFunds.tsx
@@ -88,7 +88,7 @@ const TransferFunds = ({ action }: TransferFundsProps) => {
           >
             <div className="flex items-center gap-2">
               <ArrowDownRight size={ICON_SIZE} />
-              <span>{formatText({ id: 'actionSidebar.recipient' })}</span>
+              <span>{formatText({ id: 'actionSidebar.to' })}</span>
             </div>
           </Tooltip>
         </div>


### PR DESCRIPTION
TeamWork: https://tw.auroracreation.com/app/tasks/15637182

## Description

This is a small text correction for created "Transfer funds" actions.

**Changes** 🏗

before:

![image](https://github.com/JoinColony/colonyCDapp/assets/90605528/b9c35f23-d95f-451d-8593-31eb863f4d59)


after:

![image](https://github.com/JoinColony/colonyCDapp/assets/90605528/b395ded0-6176-4849-9a67-3f998d7a4d33)
