### PR TITLE
Fix: Members pop over UI equal padding when no team or reputation

### DIFF
--- a/src/components/v5/shared/UserPopover/partials/UserInfo.tsx
+++ b/src/components/v5/shared/UserPopover/partials/UserInfo.tsx
@@ -46,7 +46,7 @@ const UserInfo: FC<UserInfoProps> = ({
         <div
           className={clsx({
             'mb-[2.4375rem]': userStatus && userStatus !== 'general',
-            'mb-6': !userStatus || userStatus === 'general',
+            'mb-6': userStatus === 'general',
           })}
         >
           <UserAvatarDetails


### PR DESCRIPTION
## Description

Users who have not joined a team or have no reputation should have equal padding above and below on their members pop over. Previously there was too much bottom padding.

## Testing

On the all members page, click on a user who is not in a team and has no reputation.

## Diffs

**Changes** 🏗

* Remove margin bottom when no userStatus

![Screenshot 2024-02-02 at 13 59 44](https://github.com/JoinColony/colonyCDapp/assets/34915414/7479002e-7a98-4eca-ae9d-b6584cca1de4)

Resolves #1450