### PR TITLE
Fix: prefilling recipient for non members

### DIFF
--- a/src/components/frame/v5/pages/MembersPage/partials/MembersTabContent/hooks.tsx
+++ b/src/components/frame/v5/pages/MembersPage/partials/MembersTabContent/hooks.tsx
@@ -29,8 +29,7 @@ export const useMembersTabContentItems = (
   return useMemo(
     () =>
       items.map(({ userAvatarProps, ...item }) => {
-        const { user } = userAvatarProps;
-        const { walletAddress } = user || {};
+        const { walletAddress } = userAvatarProps;
 
         return {
           ...item,


### PR DESCRIPTION
## Description

Implement the fix, where selecting the "Make Payment" option from the user's kebab menu automatically fills in the "Recipient" field, ensuring this functionality works for both colony members and non-members.

## Testing

Automatic filling of the "Recipient" field for users who are not colony members

Instructions for testing this branch:

* Step 1. Award permissions to an address in a Colony that is not a member.
* Step 2. Navigate to the members page where that member should appear as a contributor.
* Step 3. From the kebab menu, select the option to "Make payment".
* Step 4. Take note of the "Recipient" field, which will not have an address pre-filled.

## Diffs

**Changes** 🏗

https://github.com/JoinColony/colonyCDapp/assets/90605528/6a285d37-7f9d-4347-9599-49a198dccfb6

Resolves: https://github.com/JoinColony/colonyCDapp/issues/1836
