### PR TITLE
fix: richtext bold heading font-size

### DIFF
--- a/src/components/v5/shared/RichText/hooks.ts
+++ b/src/components/v5/shared/RichText/hooks.ts
@@ -1,6 +1,5 @@
 import { mergeAttributes } from '@tiptap/core';
 import Blockquote from '@tiptap/extension-blockquote';
-import Bold from '@tiptap/extension-bold';
 import CharacterCount from '@tiptap/extension-character-count';
 import Document from '@tiptap/extension-document';
 import Heading from '@tiptap/extension-heading';
@@ -69,14 +68,9 @@ export const useRichText = (
             ];
           },
         }),
-        Bold.configure({
-          HTMLAttributes: {
-            class: 'text-md',
-          },
-        }),
         Blockquote.configure({
           HTMLAttributes: {
-            class: 'border-l border-gray-300 pl-2 ml-4',
+            class: 'border-l border-gray-300 pl-2 ml-8',
           },
         }),
         CharacterCount.configure({

--- a/src/components/v5/shared/RichText/partials/RichTextContent/RichTextContent.module.css
+++ b/src/components/v5/shared/RichText/partials/RichTextContent/RichTextContent.module.css
@@ -6,10 +6,6 @@
   @apply mb-2.5;
 }
 
-.rich-text-content :global(.tiptap) > blockquote {
-  @apply ml-8;
-}
-
 .rich-text-content :global(.tiptap) > ul {
   @apply pl-8;
 


### PR DESCRIPTION
## Description

https://tw.auroracreation.com/app/tasks/15771891

## Testing

* Step 1. Open create action side panel and choose any action type.
* Step 2. Add some text into description.
* Step 3. Wrap selected line as heading and bold - it shouldn't change font-size
* Step 4. Add blockquote - it should have 32px of margin left.

**IMPORTANT NOTE**: Setting bold for heading has no visual effect. It's simply because headings font-weight is set for 600 (SemiBold) which is highest possible weight for Inter font in the app. If we want the bold to have an effect on headings we need to install additional font-weight for 900 Black (Heavy). I will need a feedback if we want to install this extra font weight.

## Diffs

**Changes** 🏗

* Removed `text-md` class for bold wrapper in richtext. It wasn't necessary and it caused an issue that changed font-size for headings
* Moved blockquote `margin-left` into `useRichText` hook. It should be styled here not in css module.

Resolves #1844
