### PR TITLE
Fix: Team pill colour now correct in completed state

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/TransferFunds/TransferFunds.tsx
+++ b/src/components/v5/common/CompletedAction/partials/TransferFunds/TransferFunds.tsx
@@ -94,7 +94,10 @@ const TransferFunds = ({ action }: TransferFundsProps) => {
         </div>
         {action.toDomain?.metadata?.name ? (
           <div>
-            <TeamBadge name={action.toDomain?.metadata?.name} />
+            <TeamBadge
+              name={action.toDomain?.metadata?.name}
+              color={action.toDomain?.metadata?.color}
+            />
           </div>
         ) : null}
 

--- a/src/components/v5/common/CompletedAction/partials/rows/TeamFrom.tsx
+++ b/src/components/v5/common/CompletedAction/partials/rows/TeamFrom.tsx
@@ -31,7 +31,7 @@ const TeamFromRow = ({ teamMetadata }: TeamFromRowProps) => {
         </Tooltip>
       </div>
       <div>
-        <TeamBadge name={teamMetadata.name} />
+        <TeamBadge name={teamMetadata.name} color={teamMetadata.color} />
       </div>
     </>
   );


### PR DESCRIPTION
## Description

When using the "transfer funds" action, the team colours should show the correct colour in the completed state.

## Testing

* Transfer funds from one team to another - team colours should be correct in the completed state

## Diffs

**Changes** 🏗

* Added color prop to TeamBadge component in the completedAction rows

![Screenshot 2024-02-02 at 15 59 01](https://github.com/JoinColony/colonyCDapp/assets/34915414/392efabe-5f68-473c-b237-8039a22b309f)

Resolves #1819
