### PR TITLE
fix: Currency flag icon cropping

### DIFF
--- a/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Currency/Currency.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Currency/Currency.tsx
@@ -22,7 +22,7 @@ interface CurrencyProps {
 const Currency = ({ closeSubmenu }: CurrencyProps) => {
   const { updatePreferredCurrency } = useCurrencyContext();
   const isMobile = useMobile();
-  const iconSize = isMobile ? 'small' : 'tiny';
+  const iconSize = isMobile ? 'small' : 'small';
 
   const handleCurrencyClick = (currency: SupportedCurrencies) => {
     updatePreferredCurrency(currency);


### PR DESCRIPTION
## Description

This PR fixes the currency flag cropping issue on some screen dimensions. When testing I found that it was only possible to see the cropping on 2560x1440 when the icons were 'tiny'.

## Testing

* Load up the currency menu
* Test with different size viewports to try replicate and look for any cropping

**Changes** 🏗

Changed the icon size from 'tiny' to 'small' as per figma designs and it seems to have solved the cropping issue on the dimensions I originally replicated this issue with (and others). because of this, I've made no other changes due to it matching figma and the issue not being replicated.

Resolves #1662 
