### PR TITLE
Fix: Blockies placeholder during colony creation onboarding flow

### DIFF
--- a/amplify/backend/function/fetchTokenFromChain/src/graphql.js
+++ b/amplify/backend/function/fetchTokenFromChain/src/graphql.js
@@ -22,6 +22,7 @@ module.exports = {
           type
           createdAt
           updatedAt
+          avatar
         }
         nextToken
       }

--- a/src/components/common/Onboarding/wizardSteps/CreateColony/CreateColonyCardRow.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/CreateColonyCardRow.tsx
@@ -21,10 +21,6 @@ const MSG = defineMessages({
     id: `${displayName}.nativeToken`,
     defaultMessage: 'Native token',
   },
-  existingToken: {
-    id: `${displayName}.existingToken`,
-    defaultMessage: 'Existing token',
-  },
   blockchain: {
     id: `${displayName}.blockchain`,
     defaultMessage: 'Blockchain',
@@ -49,7 +45,7 @@ const CardRow = ({ updatedWizardValues, setStep }: CardRowProps) => {
       step: 0,
     },
     {
-      title: existingToken ? MSG.existingToken : MSG.nativeToken,
+      title: MSG.nativeToken,
       text: existingToken ? existingToken.name : tokenName,
       subText: existingToken ? existingToken.symbol : tokenSymbol,
       step: 2,

--- a/src/components/common/Onboarding/wizardSteps/CreateColony/CreateColonyCardRow.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/CreateColonyCardRow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
 
+import Icon from '~shared/Icon/index.ts';
 import { type WizardStepProps } from '~shared/Wizard/index.ts';
 import { formatText } from '~utils/intl.ts';
 import Avatar from '~v5/shared/Avatar/index.ts';
@@ -48,13 +49,19 @@ const CardRow = ({ updatedWizardValues, setStep }: CardRowProps) => {
       text: tokenName,
       subText: tokenSymbol,
       step: 2,
-      icon: (
-        <Avatar
-          avatar={tokenAvatar}
-          seed={tokenAddress || tokenName}
-          size="s"
-        />
-      ),
+      icon:
+        tokenAvatar || tokenAddress ? (
+          <Avatar avatar={tokenAvatar} seed={tokenAddress} size="s" />
+        ) : (
+          <div className="bg-gray-200 text-gray-600 p-2.5 rounded-full flex">
+            <Icon
+              name="image"
+              appearance={{
+                size: 'extraSmall',
+              }}
+            />
+          </div>
+        ),
     },
     /* Not yet implemented
      * {

--- a/src/components/common/Onboarding/wizardSteps/CreateColony/CreateColonyCardRow.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/CreateColonyCardRow.tsx
@@ -21,6 +21,10 @@ const MSG = defineMessages({
     id: `${displayName}.nativeToken`,
     defaultMessage: 'Native token',
   },
+  existingToken: {
+    id: `${displayName}.existingToken`,
+    defaultMessage: 'Existing token',
+  },
   blockchain: {
     id: `${displayName}.blockchain`,
     defaultMessage: 'Blockchain',
@@ -30,10 +34,10 @@ const MSG = defineMessages({
 const CardRow = ({ updatedWizardValues, setStep }: CardRowProps) => {
   const {
     displayName: colonyDisplayName,
+    token: existingToken,
     tokenName,
     tokenSymbol,
     tokenAvatar,
-    tokenAddress,
     colonyName,
   } = updatedWizardValues;
 
@@ -45,13 +49,17 @@ const CardRow = ({ updatedWizardValues, setStep }: CardRowProps) => {
       step: 0,
     },
     {
-      title: MSG.nativeToken,
-      text: tokenName,
-      subText: tokenSymbol,
+      title: existingToken ? MSG.existingToken : MSG.nativeToken,
+      text: existingToken ? existingToken.name : tokenName,
+      subText: existingToken ? existingToken.symbol : tokenSymbol,
       step: 2,
       icon:
-        tokenAvatar || tokenAddress ? (
-          <Avatar avatar={tokenAvatar} seed={tokenAddress} size="s" />
+        tokenAvatar || existingToken ? (
+          <Avatar
+            avatar={tokenAvatar || existingToken?.avatar}
+            seed={existingToken?.tokenAddress}
+            size="s"
+          />
         ) : (
           <div className="bg-gray-200 text-gray-600 p-2.5 rounded-full flex">
             <Icon

--- a/src/components/common/Onboarding/wizardSteps/CreateColony/StepCreateTokenInputs.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/StepCreateTokenInputs.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { defineMessages, useIntl } from 'react-intl';
 
+import Icon from '~shared/Icon/index.ts';
 import { type UseAvatarUploaderProps } from '~v5/common/AvatarUploader/hooks.tsx';
 import AvatarUploader from '~v5/common/AvatarUploader/index.ts';
 import Input from '~v5/common/Fields/Input/index.ts';
@@ -35,7 +36,7 @@ const MSG = defineMessages({
   tokenDescription: {
     id: `${displayName}.tokenDescription`,
     defaultMessage:
-      'The token logo will only exist on Colony and can be changed at anytime.',
+      'The logo will only exist on Colony. A blockie will be generated if no logo is added in this step.',
   },
 });
 
@@ -113,7 +114,20 @@ const StepCreateTokenInputs = ({
         {formatMessage(MSG.tokenDescription)}
       </p>
       <AvatarUploader
-        avatarPlaceholder={<Avatar size="xm" avatar={tokenAvatarUrl} />}
+        avatarPlaceholder={
+          tokenAvatarUrl ? (
+            <Avatar size="m" avatar={tokenAvatarUrl} />
+          ) : (
+            <div className="bg-gray-200 text-gray-600 p-4 rounded-full flex">
+              <Icon
+                name="image"
+                appearance={{
+                  size: 'medium',
+                }}
+              />
+            </div>
+          )
+        }
         fileOptions={{
           fileFormat: ['.PNG', '.JPG', '.SVG'],
           fileDimension: '250x250px',

--- a/src/components/v5/common/AvatarUploader/partials/DefaultContent.tsx
+++ b/src/components/v5/common/AvatarUploader/partials/DefaultContent.tsx
@@ -49,7 +49,7 @@ const DefaultContent: FC<DefaultContentProps> = ({
         <>
           <div className="w-9 h-9 mb-2">
             <div className="bg-gray-50 p-[0.25rem] rounded-full flex items-start justify-center">
-              <div className="bg-gray-200 p-[0.25rem] rounded-full flex items-start justify-center">
+              <div className="bg-gray-200 text-gray-600 p-[0.25rem] rounded-full flex items-start justify-center">
                 <Icon name="cloud-arrow-up" appearance={{ size: 'small' }} />
               </div>
             </div>


### PR DESCRIPTION
## Description

Previously when creating a colony, you would get shown two different blockies when creating the native token. This PR replaces the temporary blockie with a placeholder graphic.

## Testing

1. Generate a new beta invite code.
```
mutation MyMutation {
  createPrivateBetaInviteCode(input: {}) {
    id
  }
}
```
2. Go to: http://localhost:9091/create-colony/{beta-invite-code}
3. Follow the onboarding flow, when creating the token there should be a placeholder image (unless you upload your own image).
4. When completing the onboarding flow a new blockie will be generated for the colony as before.

## Diffs

**Changes** 🏗

* Temporary blockie replaced with placeholder
* (I also noticed the icon on the AvatarUploader was the wrong colour, so have snuck that fix into this PR too)

![Screenshot 2024-02-07 at 12 41 03](https://github.com/JoinColony/colonyCDapp/assets/34915414/45625a45-1359-49b0-a79e-3cd8b143f455)

![Screenshot 2024-02-07 at 12 41 09](https://github.com/JoinColony/colonyCDapp/assets/34915414/b685e13f-4143-4403-95c1-c9dec6ae9bee)

Resolves #1532