### PR TITLE
Fix: colors of member and funds widgets

### DIFF
--- a/src/components/v5/common/WidgetBox/WidgetBox.tsx
+++ b/src/components/v5/common/WidgetBox/WidgetBox.tsx
@@ -51,16 +51,12 @@ const WidgetBox: FC<WidgetBoxProps> = ({
     </>
   );
 
-  const hoverStyles = 'transition-all sm:hover:border-gray-900';
+  const hoverStyles =
+    'transition-all sm:hover:border-gray-900 sm:hover:text-gray-900 sm:hover:bg-base-white';
 
   return href ? (
     <Link
-      className={clsx(
-        className,
-        wrapperClassName,
-        hoverStyles,
-        'sm:hover:text-gray-900 sm:hover:bg-base-white',
-      )}
+      className={clsx(className, wrapperClassName, hoverStyles)}
       to={{ pathname: href, search: searchParams || '' }}
     >
       {content}

--- a/src/components/v5/frame/ColonyHome/partials/Members/Members.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/Members/Members.tsx
@@ -62,6 +62,7 @@ const Members = () => {
         />
       }
       searchParams={search}
+      className="bg-base-bg border-base-bg"
     />
   );
 };

--- a/src/components/v5/frame/ColonyHome/partials/TokenBalance/TokenBalance.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/TokenBalance/TokenBalance.tsx
@@ -31,6 +31,7 @@ const TokenBalance = () => {
       }
       href={COLONY_BALANCES_ROUTE}
       searchParams={search}
+      className="bg-base-bg border-base-bg"
     />
   );
 };


### PR DESCRIPTION
## Description

Changed base colors for member and funds widgets

## Testing

Colors for member and funds widgets match the designs on [Figma](https://www.figma.com/file/l1dOM5qiQYwF0ElvKDqqjg/Design-System---Colony-v3?type=design&node-id=1781-5904&mode=design&t=sV3pM07H74aLrg8m-0).

Instructions for testing this branch:

* Step 1. Go to the dashboard
* Step 2. Compare widget colors with designs

## Diffs

**Changes** 🏗

https://github.com/JoinColony/colonyCDapp/assets/90605528/17a87d19-8328-4fee-bd39-376f7dfcfa4b


Resolves: https://github.com/JoinColony/colonyCDapp/issues/1832
