### PR TITLE
Fix: dynamic height for colony details input

### DIFF
--- a/src/components/v5/common/Fields/TextareaBase/hooks.ts
+++ b/src/components/v5/common/Fields/TextareaBase/hooks.ts
@@ -1,4 +1,4 @@
-import noop from 'lodash/noop';
+import { noop } from 'lodash';
 import { useEffect, useImperativeHandle, useRef } from 'react';
 
 const useAutosizeTextArea = (
@@ -21,9 +21,11 @@ const useAutosizeTextArea = (
     }
 
     const textArea = textAreaRef.current;
-    textArea.style.height = '0px';
-    const { scrollHeight } = textArea;
 
+    // Reset the height to auto to get the correct scrollHeight for content
+    textArea.style.height = 'auto';
+
+    const { scrollHeight } = textArea;
     textArea.style.height = `${scrollHeight}px`;
 
     return () => {


### PR DESCRIPTION
## Description

dynamic TextArea height for colony description was not working properly on large screens in Firefox.
(I managed to reproduce this problem only on the Firefox browser and on a 24-inch (2k) screen.)

## Testing

The height of the TextArea in the "Edit Colony details" action for the "Colony description" field. Scrollbar in TextArea should not show up

Instructions for testing this branch:

* Step 1. Create the "Edit Colony details" action
* Step 2. Enter some several-line text into the "Colony details" field
* Step 3. Make sure TextArea does not have its own Scrollbar

## Diffs

**Changes** 🏗

Before:

![image](https://github.com/JoinColony/colonyCDapp/assets/90605528/8179332a-e705-4b2a-ac9e-217760505d8f)

After:

![image](https://github.com/JoinColony/colonyCDapp/assets/90605528/18f4b62b-571d-4ad3-a025-1f638ed3dbbd)


Resolves: https://github.com/JoinColony/colonyCDapp/issues/1855
