### PR TITLE
Fix[1875]: extension ui issues

### DIFF
--- a/src/components/common/Extensions/SpecificSidePanel/SpecificSidePanel.module.css
+++ b/src/components/common/Extensions/SpecificSidePanel/SpecificSidePanel.module.css
@@ -1,5 +1,5 @@
 .panelRow {
-  @apply flex items-center min-h-[1.875rem] gap-x-4;
+  @apply flex items-center min-h-[1.875rem] gap-x-2;
 }
 
 .panelTitle {

--- a/src/components/common/Extensions/SpecificSidePanel/SpecificSidePanel.tsx
+++ b/src/components/common/Extensions/SpecificSidePanel/SpecificSidePanel.tsx
@@ -42,11 +42,15 @@ const SpecificSidePanel: FC<SpecificSidePanelProps> = ({ extensionData }) => {
             <div className={styles.panelRow}>
               <div className={styles.panelTitle}>{statusType.title}</div>
               <div className="flex justify-start flex-col gap-y-2 md:flex-row md:flex-wrap">
-                {statuses.map((status) => (
-                  <div key={status} className="flex flex-wrap gap-2">
-                    <ExtensionStatusBadge mode={status} text={status} />
-                  </div>
-                ))}
+                <div className="flex flex-wrap gap-1">
+                  {statuses.map((status) => (
+                    <ExtensionStatusBadge
+                      key={status}
+                      mode={status}
+                      text={status}
+                    />
+                  ))}
+                </div>
               </div>
             </div>
             {!statuses?.includes('not-installed') && (

--- a/src/components/common/Extensions/SpecificSidePanel/SpecificSidePanel.tsx
+++ b/src/components/common/Extensions/SpecificSidePanel/SpecificSidePanel.tsx
@@ -21,7 +21,7 @@ const SpecificSidePanel: FC<SpecificSidePanelProps> = ({ extensionData }) => {
   const { statuses, sidePanelData } = useSpecificSidePanel(extensionData);
 
   return (
-    <div className="flex gap-4 flex-col">
+    <div className="flex gap-2 flex-col">
       <h3 className="heading-5 -mb-0.5">
         {formatMessage({ id: 'specific.side.panel.title' })}
       </h3>

--- a/src/components/v5/common/Pills/ExtensionStatusBadge/ExtensionStatusBadge.tsx
+++ b/src/components/v5/common/Pills/ExtensionStatusBadge/ExtensionStatusBadge.tsx
@@ -20,7 +20,7 @@ const ExtensionStatusBadge: FC<PropsWithChildren<PillsProps>> = ({
         mode === 'not-installed' ||
         mode === 'finalizable' ||
         mode === 'extension',
-      'text-negative-400 bg-red-100': mode === 'disabled',
+      'text-negative-400 bg-negative-100': mode === 'disabled',
       'text-purple-400 bg-purple-100': mode === 'deprecated',
       'text-gray-900 bg-base-white border border-gray-200':
         mode === 'governance' || mode === 'payments',


### PR DESCRIPTION
## Description

Fixed issues with extension details UI:
- corrected color for "disabled" status
- changed columns gap

## Testing

The tests consist of checking whether the extension details section is compatible with Figma.

Instructions for testing this branch:

* Step 1. Go to extensions screen
* Step 2. Click "Manage" button for some extension 
* Step 3. Check if the "Extension details" section is compatible with Figma

## Diffs

**Changes** 🏗

Before:
![image](https://github.com/JoinColony/colonyCDapp/assets/90605528/489cb81d-5406-476a-9708-52e657b87dfc)

After:
![image](https://github.com/JoinColony/colonyCDapp/assets/90605528/ce71b977-db9e-4a0d-8d8e-190ab5e674f3)


Resolves: https://github.com/JoinColony/colonyCDapp/issues/1869
