### PR TITLE
fix: spacing between title and content, decision method field, comple…

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -61,12 +61,7 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
         <FormTextareaBase
           name="title"
           placeholder={formatText({ id: 'placeholder.title' })}
-          className={`
-            heading-3 mb-2
-            text-gray-900
-            transition-colors
-            leading-tight
-          `}
+          className="heading-3 text-gray-900 transition-colors leading-tight"
           message={false}
           shouldFocus
           onKeyDown={(e) => {
@@ -78,13 +73,25 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
           onChange={(e) => {
             e.target.value = e.target.value.replace(/[\r\n\v]+/g, '');
           }}
+          wrapperClassName={clsx('flex flex-col', {
+            'mb-2': selectedAction,
+          })}
         />
-        <div className="text-gray-900 text-md flex gap-1 break-all">
-          <ActionSidebarDescription />
-        </div>
+        {selectedAction && (
+          <div className="text-gray-900 text-md flex gap-1 break-all">
+            <ActionSidebarDescription />
+          </div>
+        )}
         <SidebarBanner />
         {!readonly && <NoPermissionsError />}
-        <ActionTypeSelect className="mt-7 mb-3 min-h-[1.875rem] flex flex-col justify-center" />
+        <ActionTypeSelect
+          className={clsx(
+            'mt-7 min-h-[1.875rem] flex flex-col justify-center',
+            {
+              'mb-3': FormComponent,
+            },
+          )}
+        />
         {FormComponent && <FormComponent getFormOptions={getFormOptions} />}
 
         <NoReputationError />

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/SidebarBanner.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/SidebarBanner.tsx
@@ -64,10 +64,12 @@ export const SidebarBanner: FC = () => {
 
   return (
     <>
-      <ActionTypeNotification
-        selectedAction={selectedAction}
-        className="mt-7"
-      />
+      {selectedAction && (
+        <ActionTypeNotification
+          selectedAction={selectedAction}
+          className="mt-7"
+        />
+      )}
       {requiredExtensionsWithoutPermission.map((extension) => (
         <div className="mt-6" key={extension.extensionId}>
           <NotificationBanner status="warning" icon={WarningCircle}>

--- a/src/components/v5/common/ActionSidebar/partials/CreatedIn/CreatedIn.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/CreatedIn/CreatedIn.tsx
@@ -10,11 +10,11 @@ import { DECISION_METHOD_FIELD_NAME } from '../../consts.tsx';
 import { useHasNoDecisionMethods } from '../../hooks/index.ts';
 import TeamsSelect from '../TeamsSelect/index.ts';
 
-import { type CreatedInRowProps } from './types.ts';
+import { type CreatedInProps } from './types.ts';
 
-const displayName = 'v5.common.ActionSidebar.partials.CreatedInRow';
+const displayName = 'v5.common.ActionSidebar.partials.CreatedIn';
 
-const CreatedInRow: FC<CreatedInRowProps> = ({ filterOptionsFn, readonly }) => {
+const CreatedIn: FC<CreatedInProps> = ({ filterOptionsFn, readonly }) => {
   const hasNoDecisionMethods = useHasNoDecisionMethods();
   const decisionMethod: DecisionMethod | undefined = useWatch({
     name: DECISION_METHOD_FIELD_NAME,
@@ -43,6 +43,6 @@ const CreatedInRow: FC<CreatedInRowProps> = ({ filterOptionsFn, readonly }) => {
   ) : null;
 };
 
-CreatedInRow.displayName = displayName;
+CreatedIn.displayName = displayName;
 
-export default CreatedInRow;
+export default CreatedIn;

--- a/src/components/v5/common/ActionSidebar/partials/CreatedIn/index.ts
+++ b/src/components/v5/common/ActionSidebar/partials/CreatedIn/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CreatedIn.tsx';

--- a/src/components/v5/common/ActionSidebar/partials/CreatedIn/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/CreatedIn/types.ts
@@ -1,3 +1,3 @@
 import { type TeamSelectProps } from '../TeamsSelect/types.ts';
 
-export type CreatedInRowProps = Omit<TeamSelectProps, 'name'>;
+export type CreatedInProps = Omit<TeamSelectProps, 'name'>;

--- a/src/components/v5/common/ActionSidebar/partials/CreatedInRow/index.ts
+++ b/src/components/v5/common/ActionSidebar/partials/CreatedInRow/index.ts
@@ -1,1 +1,0 @@
-export { default } from './CreatedInRow.tsx';

--- a/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx
@@ -71,6 +71,7 @@ const DecisionMethodField = ({
           id: 'actionSidebar.decisionMethod.placeholder',
         })}
         disabled={disabled || hasNoDecisionMethods}
+        cardClassName="sm:min-w-[12.875rem]"
       />
     </ActionFormRow>
   );

--- a/src/components/v5/common/ActionSidebar/partials/Description/Description.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Description/Description.tsx
@@ -9,11 +9,11 @@ import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
 import { useHasNoDecisionMethods } from '../../hooks/index.ts';
 import DescriptionField from '../DescriptionField/index.ts';
 
-import { type DescriptionRowProps } from './types.ts';
+import { type DescriptionProps } from './types.ts';
 
-const displayName = 'v5.common.ActionSidebar.partials.DescriptionRow';
+const displayName = 'v5.common.ActionSidebar.partials.Description';
 
-const DescriptionRow: FC<DescriptionRowProps> = ({
+const Description: FC<DescriptionProps> = ({
   disabled,
   maxDescriptionLength,
 }) => {
@@ -58,6 +58,6 @@ const DescriptionRow: FC<DescriptionRowProps> = ({
   ) : null;
 };
 
-DescriptionRow.displayName = displayName;
+Description.displayName = displayName;
 
-export default DescriptionRow;
+export default Description;

--- a/src/components/v5/common/ActionSidebar/partials/Description/index.ts
+++ b/src/components/v5/common/ActionSidebar/partials/Description/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Description.tsx';

--- a/src/components/v5/common/ActionSidebar/partials/Description/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/Description/types.ts
@@ -1,4 +1,4 @@
-export interface DescriptionRowProps {
+export interface DescriptionProps {
   maxDescriptionLength?: number;
   disabled?: boolean;
 }

--- a/src/components/v5/common/ActionSidebar/partials/DescriptionRow/index.ts
+++ b/src/components/v5/common/ActionSidebar/partials/DescriptionRow/index.ts
@@ -1,1 +1,0 @@
-export { default } from './DescriptionRow.tsx';

--- a/src/components/v5/common/ActionSidebar/partials/forms/AdvancedPaymentForm/AdvancedPaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/AdvancedPaymentForm/AdvancedPaymentForm.tsx
@@ -6,9 +6,9 @@ import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
 import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/index.ts';
 
 import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedInRow from '../../CreatedInRow/CreatedInRow.tsx';
+import CreatedIn from '../../CreatedIn/index.ts';
 import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import DescriptionRow from '../../DescriptionRow/index.ts';
+import Description from '../../Description/index.ts';
 
 import { useAdvancedPayment } from './hooks.ts';
 import AdvancedPaymentRecipientsField from './partials/AdvancedPaymentRecipientsField/index.ts';
@@ -35,8 +35,8 @@ const AdvancedPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
         <TeamsSelect name="from" />
       </ActionFormRow>
       <DecisionMethodField />
-      <CreatedInRow />
-      <DescriptionRow />
+      <CreatedIn />
+      <Description />
       <AdvancedPaymentRecipientsField name="payments" />
     </>
   );

--- a/src/components/v5/common/ActionSidebar/partials/forms/BatchPaymentForm/BatchPaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/BatchPaymentForm/BatchPaymentForm.tsx
@@ -8,7 +8,7 @@ import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/index.ts'
 
 import { type ActionFormBaseProps } from '../../../types.ts';
 import BatchPaymentsTable from '../../BatchPaymentsTable/index.ts';
-import CreatedInRow from '../../CreatedInRow/CreatedInRow.tsx';
+import CreatedIn from '../../CreatedIn/index.ts';
 import DecisionMethodField from '../../DecisionMethodField/index.ts';
 
 const displayName = 'v5.common.ActionSidebar.partials.BatchPaymentForm';
@@ -31,7 +31,7 @@ const BatchPaymentForm: FC<ActionFormBaseProps> = () => {
         <TeamsSelect name="from" />
       </ActionFormRow>
       <DecisionMethodField />
-      <CreatedInRow />
+      <CreatedIn />
       <ActionFormRow
         icon={Pencil}
         fieldName="description"

--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/CreateDecisionForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/CreateDecisionForm.tsx
@@ -1,9 +1,9 @@
 import React, { type FC } from 'react';
 
 import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedInRow from '../../CreatedInRow/CreatedInRow.tsx';
+import CreatedIn from '../../CreatedIn/index.ts';
 import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import DescriptionRow from '../../DescriptionRow/index.ts';
+import Description from '../../Description/index.ts';
 import { useIsFieldDisabled } from '../../hooks.ts';
 
 import { useCreateDecision } from './hooks.ts';
@@ -18,8 +18,8 @@ const CreateDecisionForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
   return (
     <>
       <DecisionMethodField disabled={isFieldDisabled} reputationOnly />
-      <CreatedInRow disabled={isFieldDisabled} />
-      <DescriptionRow disabled={isFieldDisabled} />
+      <CreatedIn />
+      <Description />
     </>
   );
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateNewTeamForm/CreateNewTeamForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateNewTeamForm/CreateNewTeamForm.tsx
@@ -14,9 +14,9 @@ import FormInputBase from '~v5/common/Fields/InputBase/FormInputBase.tsx';
 import FormTextareaBase from '~v5/common/Fields/TextareaBase/FormTextareaBase.tsx';
 
 import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedInRow from '../../CreatedInRow/CreatedInRow.tsx';
+import CreatedIn from '../../CreatedIn/index.ts';
 import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import DescriptionRow from '../../DescriptionRow/index.ts';
+import Description from '../../Description/index.ts';
 
 import { useCreateNewTeam } from './hooks.ts';
 
@@ -97,8 +97,8 @@ const CreateNewTeamForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
         <TeamColorField name="domainColor" disabled={hasNoDecisionMethods} />
       </ActionFormRow>
       <DecisionMethodField />
-      <CreatedInRow />
-      <DescriptionRow />
+      <CreatedIn />
+      <Description />
     </>
   );
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/EditColonyDetailsForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/EditColonyDetailsForm.tsx
@@ -3,9 +3,9 @@ import React, { type FC } from 'react';
 import ColonyDetailsFields from '~v5/common/ActionSidebar/partials/ColonyDetailsFields/index.ts';
 
 import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedInRow from '../../CreatedInRow/CreatedInRow.tsx';
+import CreatedIn from '../../CreatedIn/index.ts';
 import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import DescriptionRow from '../../DescriptionRow/index.ts';
+import Description from '../../Description/index.ts';
 
 import { useEditColonyDetails } from './hooks.ts';
 import SocialLinksTable from './partials/SocialLinksTable/index.ts';
@@ -19,8 +19,8 @@ const EditColonyDetailsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
     <>
       <ColonyDetailsFields />
       <DecisionMethodField />
-      <CreatedInRow />
-      <DescriptionRow />
+      <CreatedIn />
+      <Description />
       <SocialLinksTable name="externalLinks" />
     </>
   );

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditTeamForm/EditTeamForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditTeamForm/EditTeamForm.tsx
@@ -22,8 +22,9 @@ import FormInputBase from '~v5/common/Fields/InputBase/FormInputBase.tsx';
 import FormTextareaBase from '~v5/common/Fields/TextareaBase/FormTextareaBase.tsx';
 
 import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedInRow from '../../CreatedInRow/CreatedInRow.tsx';
+import CreatedIn from '../../CreatedIn/index.ts';
 import DecisionMethodField from '../../DecisionMethodField/index.ts';
+import Description from '../../Description/index.ts';
 
 import { useEditTeam } from './hooks.ts';
 
@@ -125,15 +126,14 @@ const EditTeamForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       >
         <TeamColorField name="domainColor" disabled={hasNoDecisionMethods} />
       </ActionFormRow>
-
       <DecisionMethodField />
-
-      <CreatedInRow
+      <CreatedIn
         filterOptionsFn={(option) =>
           option.value === Id.RootDomain.toString() ||
           option.value === selectedTeam
         }
       />
+      <Description />
     </>
   );
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/ManageColonyObjectivesForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/ManageColonyObjectivesForm.tsx
@@ -4,9 +4,9 @@ import { MAX_OBJECTIVE_DESCRIPTION_LENGTH } from '~constants/index.ts';
 import ColonyObjectiveFields from '~v5/common/ActionSidebar/partials/ColonyObjectiveFields/index.ts';
 
 import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedInRow from '../../CreatedInRow/CreatedInRow.tsx';
+import CreatedIn from '../../CreatedIn/index.ts';
 import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import DescriptionRow from '../../DescriptionRow/index.ts';
+import Description from '../../Description/index.ts';
 
 import { useManageColonyObjectives } from './hooks.ts';
 
@@ -22,8 +22,8 @@ const ManageColonyObjectivesForm: FC<ActionFormBaseProps> = ({
     <>
       <ColonyObjectiveFields />
       <DecisionMethodField />
-      <CreatedInRow />
-      <DescriptionRow maxDescriptionLength={MAX_OBJECTIVE_DESCRIPTION_LENGTH} />
+      <CreatedIn />
+      <Description maxDescriptionLength={MAX_OBJECTIVE_DESCRIPTION_LENGTH} />
     </>
   );
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/ManagePermissionsForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/ManagePermissionsForm.tsx
@@ -18,9 +18,9 @@ import { FormCardSelect } from '~v5/common/Fields/CardSelect/index.ts';
 import { type CardSelectProps } from '~v5/common/Fields/CardSelect/types.ts';
 
 import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedInRow from '../../CreatedInRow/CreatedInRow.tsx';
+import CreatedIn from '../../CreatedIn/index.ts';
 import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import DescriptionRow from '../../DescriptionRow/index.ts';
+import Description from '../../Description/index.ts';
 import TeamsSelect from '../../TeamsSelect/index.ts';
 import UserSelect from '../../UserSelect/index.ts';
 
@@ -186,8 +186,8 @@ const ManagePermissionsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
         />
       </ActionFormRow>
       <DecisionMethodField />
-      <CreatedInRow />
-      <DescriptionRow />
+      <CreatedIn />
+      <Description />
       {role !== RemoveRoleOptionValue.remove && (
         <PermissionsTable name="permissions" role={role} className="mt-7" />
       )}

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageTokensForm/ManageTokensForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageTokensForm/ManageTokensForm.tsx
@@ -3,9 +3,9 @@ import React, { type FC } from 'react';
 import { useHasNoDecisionMethods } from '~v5/common/ActionSidebar/hooks/index.ts';
 
 import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedInRow from '../../CreatedInRow/CreatedInRow.tsx';
+import CreatedIn from '../../CreatedIn/index.ts';
 import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import DescriptionRow from '../../DescriptionRow/index.ts';
+import Description from '../../Description/index.ts';
 import TokensTable from '../../TokensTable/index.ts';
 
 import { useManageTokens } from './hooks.ts';
@@ -20,8 +20,8 @@ const ManageTokensForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
   return (
     <>
       <DecisionMethodField />
-      <CreatedInRow />
-      <DescriptionRow />
+      <CreatedIn />
+      <Description />
       <TokensTable
         name="selectedTokenAddresses"
         shouldShowMenu={shouldShowMenu}

--- a/src/components/v5/common/ActionSidebar/partials/forms/MintTokenForm/MintTokenForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/MintTokenForm/MintTokenForm.tsx
@@ -5,9 +5,9 @@ import { formatText } from '~utils/intl.ts';
 
 import { type ActionFormBaseProps } from '../../../types.ts';
 import AmountRow from '../../AmountRow/AmountRow.tsx';
-import CreatedInRow from '../../CreatedInRow/CreatedInRow.tsx';
+import CreatedIn from '../../CreatedIn/index.ts';
 import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import DescriptionRow from '../../DescriptionRow/index.ts';
+import Description from '../../Description/index.ts';
 
 import { useMintToken } from './hooks.ts';
 
@@ -34,8 +34,8 @@ const MintTokenForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
         }}
       />
       <DecisionMethodField />
-      <CreatedInRow readonly />
-      <DescriptionRow />
+      <CreatedIn readonly />
+      <Description />
     </>
   );
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/SimplePaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/SimplePaymentForm.tsx
@@ -10,9 +10,9 @@ import UserSelect from '~v5/common/ActionSidebar/partials/UserSelect/index.ts';
 
 import { type ActionFormBaseProps } from '../../../types.ts';
 import AmountRow from '../../AmountRow/AmountRow.tsx';
-import CreatedInRow from '../../CreatedInRow/CreatedInRow.tsx';
+import CreatedIn from '../../CreatedIn/CreatedIn.tsx';
 import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import DescriptionRow from '../../DescriptionRow/index.ts';
+import Description from '../../Description/index.ts';
 
 import { useSimplePayment } from './hooks.ts';
 
@@ -69,8 +69,8 @@ const SimplePaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
         }}
       />
       <DecisionMethodField />
-      <CreatedInRow />
-      <DescriptionRow />
+      <CreatedIn />
+      <Description />
       {/* Disabled for now */}
       {/* <TransactionTable name="payments" tokenAddress={tokenAddress} /> */}
     </>

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/SplitPaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/SplitPaymentForm.tsx
@@ -9,9 +9,9 @@ import { FormCardSelect } from '~v5/common/Fields/CardSelect/index.ts';
 
 import { type ActionFormBaseProps } from '../../../types.ts';
 import AmountRow from '../../AmountRow/AmountRow.tsx';
-import CreatedInRow from '../../CreatedInRow/CreatedInRow.tsx';
+import CreatedIn from '../../CreatedIn/index.ts';
 import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import DescriptionRow from '../../DescriptionRow/index.ts';
+import Description from '../../Description/index.ts';
 
 import { useSplitPayment } from './hooks.ts';
 import SplitPaymentRecipientsField from './partials/SplitPaymentRecipientsField/index.ts';
@@ -73,8 +73,8 @@ const SplitPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
         <TeamsSelect name="team" />
       </ActionFormRow>
       <DecisionMethodField />
-      <CreatedInRow />
-      <DescriptionRow />
+      <CreatedIn />
+      <Description />
       {currentToken && (
         <SplitPaymentRecipientsField
           amount={amount}

--- a/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/TransferFundsForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/TransferFundsForm.tsx
@@ -10,9 +10,9 @@ import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/index.ts'
 
 import { type ActionFormBaseProps } from '../../../types.ts';
 import AmountRow from '../../AmountRow/AmountRow.tsx';
-import CreatedInRow from '../../CreatedInRow/CreatedInRow.tsx';
+import CreatedIn from '../../CreatedIn/index.ts';
 import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import DescriptionRow from '../../DescriptionRow/index.ts';
+import Description from '../../Description/index.ts';
 
 import { useTransferFunds } from './hooks.ts';
 
@@ -70,14 +70,14 @@ const TransferFundsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       />
 
       <DecisionMethodField />
-      <CreatedInRow
+      <CreatedIn
         filterOptionsFn={(option) =>
           (option.value === Id.RootDomain.toString() ||
             option.value === selectedTeam) &&
           !!option.isRoot
         }
       />
-      <DescriptionRow />
+      <Description />
     </>
   );
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/UnlockTokenForm/UnlockTokenForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/UnlockTokenForm/UnlockTokenForm.tsx
@@ -5,9 +5,9 @@ import { useColonyContext } from '~context/ColonyContext.tsx';
 import { TX_SEARCH_PARAM } from '~routes/index.ts';
 
 import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedInRow from '../../CreatedInRow/CreatedInRow.tsx';
+import CreatedIn from '../../CreatedIn/index.ts';
 import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import DescriptionRow from '../../DescriptionRow/index.ts';
+import Description from '../../Description/index.ts';
 
 import { useUnlockToken } from './hooks.ts';
 
@@ -24,8 +24,8 @@ const UnlockTokenForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
   return isNativeTokenUnlocked && !transactionId ? null : (
     <>
       <DecisionMethodField />
-      <CreatedInRow readonly />
-      <DescriptionRow />
+      <CreatedIn readonly />
+      <Description />
     </>
   );
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/UpgradeColonyForm/UpgradeColonyForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/UpgradeColonyForm/UpgradeColonyForm.tsx
@@ -3,9 +3,9 @@ import React, { type FC } from 'react';
 import ColonyVersionField from '~v5/common/ActionSidebar/partials/ColonyVersionField/index.ts';
 
 import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedInRow from '../../CreatedInRow/CreatedInRow.tsx';
+import CreatedIn from '../../CreatedIn/index.ts';
 import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import DescriptionRow from '../../DescriptionRow/index.ts';
+import Description from '../../Description/index.ts';
 
 import { useUpgradeColony } from './hooks.ts';
 
@@ -18,8 +18,8 @@ const UpgradeColonyForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
     <>
       <ColonyVersionField />
       <DecisionMethodField />
-      <CreatedInRow />
-      <DescriptionRow />
+      <CreatedIn />
+      <Description />
     </>
   );
 };

--- a/src/components/v5/common/CompletedAction/partials/CreateDecision/CreateDecision.tsx
+++ b/src/components/v5/common/CompletedAction/partials/CreateDecision/CreateDecision.tsx
@@ -35,12 +35,12 @@ const MSG = defineMessages({
 });
 
 const CreateDecision = ({ action }: CreateDecisionProps) => {
-  const { customTitle = formatText(MSG.defaultTitle) } = action?.metadata || {};
+  const { title = formatText(MSG.defaultTitle) } = action?.decisionData || {};
   const { initiatorUser } = action;
 
   return (
     <>
-      <ActionTitle>{customTitle}</ActionTitle>
+      <ActionTitle>{title}</ActionTitle>
       <ActionSubtitle>
         {formatText(MSG.subtitle, {
           user: initiatorUser ? (

--- a/src/components/v5/common/Fields/TextareaBase/hooks.ts
+++ b/src/components/v5/common/Fields/TextareaBase/hooks.ts
@@ -24,9 +24,11 @@ const useAutosizeTextArea = (
 
     // Reset the height to auto to get the correct scrollHeight for content
     textArea.style.height = 'auto';
+    textArea.style.overflow = 'scroll';
 
     const { scrollHeight } = textArea;
     textArea.style.height = `${scrollHeight}px`;
+    textArea.style.overflow = 'hidden';
 
     return () => {
       textArea.style.height = '';


### PR DESCRIPTION
https://github.com/JoinColony/colonyCDapp/issues/1873

- DecisionMethodRow component to make all of the decision method fields consistent
- spacing between the title and form content is 28px now, I've removed redundant margins
- completed agreement action title is correct now - I've replaced action.metadata with action.decisionData