### PR TITLE
Fix: Completed action rich text description formatting

### DIFF
--- a/src/components/v5/common/ActionSidebar/consts.tsx
+++ b/src/components/v5/common/ActionSidebar/consts.tsx
@@ -42,15 +42,10 @@ export const ACTION_BASE_VALIDATION_SCHEMA = object()
     description: string()
       .test(
         'isValidDescriptionLength',
-        ({ value }) =>
-          formatText(
-            { id: 'errors.title.maxLength' },
-            {
-              maxLength: MAX_ANNOTATION_LENGTH,
-              currentLength:
-                value !== undefined ? stripHTMLFromText(value).length : 0,
-            },
-          ),
+        formatText(
+          { id: 'errors.description.maxLength' },
+          { maxLength: MAX_ANNOTATION_LENGTH },
+        ),
         isValidDescriptionLength,
       )
       .notRequired(),

--- a/src/components/v5/common/ActionSidebar/consts.tsx
+++ b/src/components/v5/common/ActionSidebar/consts.tsx
@@ -22,6 +22,11 @@ export const actionSidebarAnimation: Variants = {
   },
 };
 
+function isValidDescriptionLength(description: string) {
+  const strippedDescription = stripHTMLFromText(description);
+  return strippedDescription.length <= MAX_ANNOTATION_LENGTH;
+}
+
 export const ACTION_BASE_VALIDATION_SCHEMA = object()
   .shape({
     title: string()
@@ -35,12 +40,19 @@ export const ACTION_BASE_VALIDATION_SCHEMA = object()
         ),
       ),
     description: string()
-      .transform((description: string | undefined) =>
-        typeof description === 'string'
-          ? stripHTMLFromText(description)
-          : description,
+      .test(
+        'isValidDescriptionLength',
+        ({ value }) =>
+          formatText(
+            { id: 'errors.title.maxLength' },
+            {
+              maxLength: MAX_ANNOTATION_LENGTH,
+              currentLength:
+                value !== undefined ? stripHTMLFromText(value).length : 0,
+            },
+          ),
+        isValidDescriptionLength,
       )
-      .max(MAX_ANNOTATION_LENGTH)
       .notRequired(),
   })
   .defined()

--- a/src/components/v5/shared/RichTextDisplay/RichTextDisplay.module.css
+++ b/src/components/v5/shared/RichTextDisplay/RichTextDisplay.module.css
@@ -2,6 +2,10 @@
   @apply mb-1;
 }
 
+.rich-text-content > p {
+  @apply min-h-[1.25rem];
+}
+
 .rich-text-content > :is(h1, h2, h3) {
   @apply mb-2.5;
 }

--- a/src/components/v5/shared/RichTextDisplay/RichTextDisplay.module.css
+++ b/src/components/v5/shared/RichTextDisplay/RichTextDisplay.module.css
@@ -1,0 +1,26 @@
+.rich-text-content > * {
+  @apply mb-1;
+}
+
+.rich-text-content > :is(h1, h2, h3) {
+  @apply mb-2.5;
+}
+
+.rich-text-content > ul {
+  @apply pl-8;
+
+  list-style: disc;
+}
+
+.rich-text-content > ol {
+  @apply pl-8;
+
+  list-style: decimal;
+}
+
+@media screen(md) {
+  .rich-text-content > ul,
+  .rich-text-content > ol {
+    @apply pl-4;
+  }
+}

--- a/src/components/v5/shared/RichTextDisplay/RichTextDisplay.tsx
+++ b/src/components/v5/shared/RichTextDisplay/RichTextDisplay.tsx
@@ -2,6 +2,8 @@ import clsx from 'clsx';
 import DOMPurify from 'dompurify';
 import React from 'react';
 
+import styles from './RichTextDisplay.module.css';
+
 const displayName = 'v5.RichTextDisplay';
 
 interface RichTextDisplayProps {
@@ -23,7 +25,7 @@ const RichTextDisplay = ({
 
   return (
     <div
-      className={clsx('prose text-gray-900 text-md', className)}
+      className={clsx(styles.richTextContent, className)}
       dangerouslySetInnerHTML={{ __html: cleanContent }}
     />
   );

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1432,6 +1432,7 @@
     "colonyAvatar.chainImage.alt": "Chain logo",
     "colonyName": "Colony name",
     "errors.title.maxLength": "Title must not exceed {maxLength} characters",
+    "errors.description.maxLength": "Description must not exceed {maxLength} characters",
     "errors.colonyObjective.title": "Colony objective title is required",
     "errors.colonyObjective.description": "Colony objective description is required",
     "errors.colonyObjective.progress": "Colony objective progress is required",


### PR DESCRIPTION
## Description

Rich text should be formatted correctly in both the creation and completed state.

Previously the HTML from the description input field was being stripped out as part of the error validation, as such it was not being properly submitted. This has been replaced with a custom yup test.

Formatted the completed action description to match the action description input.

## Testing

1. Write a rich text description in an action.
2. Create a Simple payment action with a description.
3. Complete the action and view the description in the completed state.

## Diffs

**Changes** 🏗

* `ACTION_BASE_VALIDATION_SCHEMA` description max length validation replaced with custom yup test.
* Applied the same styles from the action description input to the completed action description

![Screenshot 2024-02-09 at 16 25 58](https://github.com/JoinColony/colonyCDapp/assets/34915414/22f2650a-b407-40cc-8682-dc3d16c0d523)

Resolves #1776