### PR TITLE
Fix[1884]: styles for main cta button in pending state

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/ActionButtons.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionButtons.tsx
@@ -65,10 +65,11 @@ const ActionButtons: FC<ActionButtonsProps> = ({ isActionDisabled }) => {
           isFullSize={isMobile}
           text={{ id: 'button.pending' }}
           icon={
-            <span className="flex shrink-0 ml-1.5">
+            <span className="flex shrink-0 ml-2">
               <SpinnerGap size={14} className="animate-spin" />
             </span>
           }
+          className="!px-4 !text-md"
         />
       ) : (
         <Button

--- a/src/components/v5/common/ActionSidebar/partials/ActionButtons.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionButtons.tsx
@@ -66,7 +66,7 @@ const ActionButtons: FC<ActionButtonsProps> = ({ isActionDisabled }) => {
           text={{ id: 'button.pending' }}
           icon={
             <span className="flex shrink-0 ml-2">
-              <SpinnerGap size={14} className="animate-spin" />
+              <SpinnerGap size={18} className="animate-spin" />
             </span>
           }
           className="!px-4 !text-md"

--- a/src/components/v5/shared/Button/IconButton.tsx
+++ b/src/components/v5/shared/Button/IconButton.tsx
@@ -38,7 +38,6 @@ const IconButton: FC<PropsWithChildren<IconButtonProps>> = ({
       ) : (
         <button
           className={clsx(
-            className,
             styles.pending,
             'flex items-center justify-center font-medium transition-all duration-normal',
             {


### PR DESCRIPTION
## Description

Main CTA button was not compatible with styles in Figma

## Testing

The tests consist in verifying whether the main CTA button in the pending state is compatible with Figma

Instructions for testing this branch:

* Step 1. Create some action
* Step 2. Create a situation in which the button confirming adding an action is in the "pending" state
* Step 3. Compare button styles with Figma

## Diffs

**Changes** 🏗

Before:

![image](https://github.com/JoinColony/colonyCDapp/assets/90605528/728af573-059d-40d2-b176-ef87a6edf8f5)

After:

![image](https://github.com/JoinColony/colonyCDapp/assets/90605528/f20d9b0d-afb7-4528-9584-08830ab5ea41)


Resolves: https://github.com/JoinColony/colonyCDapp/issues/1884
