### PR TITLE
Fix: Calamity banner learn more link styling

### DIFF
--- a/src/components/v5/shared/CalamityBanner/partials/CalamityBannerContent.tsx
+++ b/src/components/v5/shared/CalamityBanner/partials/CalamityBannerContent.tsx
@@ -55,7 +55,7 @@ const CalamityBannerContent: FC<CalamityBannerContentProps> = ({
           <div className="flex items-center">
             <Link
               {...linkProps}
-              className="text-2 text-gray-900 underline !hover:text-base-white sm:hover:no-underline"
+              className="text-sm font-semibold text-gray-900 underline !hover:text-base-white sm:hover:no-underline"
             />
             <Button
               {...buttonProps}


### PR DESCRIPTION
## Description

Calamity banner 'learn more' text link should match the figma styling.

## Testing

Get the calamity banner to show and verify the 'learn more' text has the correct styling. The easiest way to do this is to change 'canUpgrade' to true on line 125 in `/src/components/frame/Extensions/layouts/ColonyLayout.tsx`

## Diffs

**Changes** 🏗

* Changed link styling to `text-sm font-semibold` to set the font-size to 12px, line-height to 18px and font-weight to 600 as per the figma design.

![Screenshot 2024-02-13 at 15 03 40](https://github.com/JoinColony/colonyCDapp/assets/34915414/30d16dda-2eef-47a6-9122-6f3114920fd7)

Resolves #1868
