### PR TITLE
Fix: Redirect to 404 when using an invalid extension name

### DIFF
--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/ExtensionDetailsPage.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/ExtensionDetailsPage.tsx
@@ -48,7 +48,7 @@ const ExtensionDetailsPage: FC = () => {
   useSetPageHeadingTitle(formatText({ id: 'extensionsPage.title' }));
 
   if (!extensionData) {
-    return null;
+    return <NotFoundRoute />;
   }
 
   if (!extensionData) {


### PR DESCRIPTION
## Description

This PR fixes the bug where a blank extension page is shown when an invalid extension name is used in the web address. The expected behaviour is to redirect any invalid extension names to a 404 page.

## Testing

1. Go to extensions
2. Try use an invalid extension name in the link like 'http://localhost:9091/wayne/extensions/VotingReputati' 


## Diffs

**Changes** 🏗

Changed code so the page redirects to 404 instead of displaying an empty page when extension name is invalid.

![Blank-extension-page](https://github.com/JoinColony/colonyCDapp/assets/155957480/e02a20f3-b20d-4d25-940e-7cea6b4c29e4)

Resolves #1841 
