### PR TITLE
Fix: Show joined colonies in the joined colonies list

### DIFF
--- a/src/components/frame/Extensions/layouts/partials/ColonySwitcherContent/hooks.ts
+++ b/src/components/frame/Extensions/layouts/partials/ColonySwitcherContent/hooks.ts
@@ -40,11 +40,9 @@ export const useColonySwitcherContent = (
 
   const currentColonyItem = colony && getColonySwitcherListItem(colony);
 
-  const listItems: ColonySwitcherListItem[] = joinedColonies
-    .filter(
-      (joinedColony) => joinedColony?.colonyAddress !== colony?.colonyAddress,
-    )
-    .map(getColonySwitcherListItem);
+  const listItems: ColonySwitcherListItem[] = joinedColonies.map(
+    getColonySwitcherListItem,
+  );
 
   const filteredListItems = listItems.filter(
     (item) =>

--- a/src/components/frame/Extensions/layouts/partials/ColonySwitcherItem/ColonySwitcherItem.tsx
+++ b/src/components/frame/Extensions/layouts/partials/ColonySwitcherItem/ColonySwitcherItem.tsx
@@ -3,6 +3,7 @@ import React, { type FC } from 'react';
 import { NavLink } from 'react-router-dom';
 
 import { ADDRESS_ZERO } from '~constants/index.ts';
+import useNavigationSidebarContext from '~v5/frame/NavigationSidebar/partials/NavigationSidebarContext/hooks.ts';
 import ColonyAvatar from '~v5/shared/ColonyAvatar/index.ts';
 
 import { type ColonySwitcherItemProps } from './types.ts';
@@ -14,6 +15,8 @@ const ColonySwitcherItem: FC<ColonySwitcherItemProps> = ({
   avatarProps,
   ...rest
 }) => {
+  const { setOpenItemIndex } = useNavigationSidebarContext();
+
   const { chainIcon: Icon, ...restAvatarProps } = avatarProps || {
     colonyAddress: ADDRESS_ZERO,
   };
@@ -27,6 +30,11 @@ const ColonySwitcherItem: FC<ColonySwitcherItemProps> = ({
           'justify-between': !!Icon,
         },
       )}
+      onClick={
+        rest.to === window.location.pathname
+          ? () => setOpenItemIndex(undefined)
+          : undefined
+      }
       {...rest}
     >
       <div className="flex items-center gap-2 truncate">


### PR DESCRIPTION
## Description

The Joined Colonies list in the Colony Switcher should show all joined colonies, including the currently selected colony.

In selecting the current colony from the colony switcher, the navigation sidebar should close.

## Testing

1. Switch to a colony
2. Ensure the colony still shows in the joined colonies list
3. Click the current colony and the navigation sidebar should close.

## Diffs

**Changes**

* Navigation sidebar now closes when selecting the current colony from the colony switcher (in both the current colony section at the top, and the joined colonies section) - Achieved this by adding an onClick handler to setOpenItemIndex to undefined only if the link matches the current pathname.
* Removed the filter from the joinedColonies list which previously removed the current colony

Member in multiple colonies:
![Screenshot 2024-02-14 at 16 38 13](https://github.com/JoinColony/colonyCDapp/assets/34915414/807cc9da-d137-41b8-b7fa-1d7dddfabe44)

Member in only one colony:
![Screenshot 2024-02-14 at 16 41 17](https://github.com/JoinColony/colonyCDapp/assets/34915414/4320775e-9e98-4cb7-a8be-5021de9765fb)


Resolves #1901
