### PR TITLE
Include network fee when setting advanced payments payouts

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -3212,7 +3212,15 @@ type ExpenditureSlot {
 
 type ExpenditurePayout {
   tokenAddress: ID!
+  """
+  Payout amount, excluding network fee
+  """
   amount: String!
+  """
+  Network fee amount
+  @TODO: Make this a non-nullable field once existing data is updated
+  """
+  networkFee: String
   isClaimed: Boolean!
 }
 

--- a/docker/colony-cdapp-dev-env-auth-proxy
+++ b/docker/colony-cdapp-dev-env-auth-proxy
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV AUTH_PROXY_HASH=7765a1bd46119065b49a6e9b60df97852c20ecdd
+ENV AUTH_PROXY_HASH=2c91e50052c25412dabd8fc0e7dd3604965433d2
 
 # Add dependencies from the host
 # Note: these are listed individually so that if they change, they won't affect

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=d348ae26a472b8654b21747713817c183bba1ec5
+ENV BLOCK_INGESTOR_HASH=2ae19ca480979913712f239268cf5796e321d925
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/utils.tsx
@@ -36,7 +36,6 @@ const getPaymentPayload = ({
     recipient: recipientAddress,
     tokenAddress,
     amount: amountWithFees, // @NOTE: Only the contract sees this amount
-    decimals,
   };
 };
 

--- a/src/components/v5/frame/ColonyHome/ColonyHome.tsx
+++ b/src/components/v5/frame/ColonyHome/ColonyHome.tsx
@@ -13,6 +13,7 @@ import {
 } from '~routes/index.ts';
 import { formatText } from '~utils/intl.ts';
 import { setQueryParamOnUrl } from '~utils/urls.ts';
+import TmpAdvancedPayments from '~v5/payments/TmpAdvancedPayments.tsx';
 import Link from '~v5/shared/Link/index.ts';
 
 import Agreements from './partials/Agreements/index.ts';
@@ -40,6 +41,9 @@ const ColonyHome = () => {
         <TotalActions />
         <Members />
         <TokenBalance />
+      </div>
+      <div className="mx-auto">
+        <TmpAdvancedPayments />
       </div>
       <div className="flex flex-col md:grid md:grid-cols-[39%_1fr] gap-6 w-full">
         <div className="flex flex-col items-center gap-6 md:gap-[1.125rem] w-full">

--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -1,0 +1,45 @@
+import { Id } from '@colony/colony-js';
+import React from 'react';
+
+import { useAppContext } from '~context/AppContext.tsx';
+import { useColonyContext } from '~context/ColonyContext.tsx';
+import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
+import { ActionTypes } from '~redux';
+import { type CreateExpenditurePayload } from '~redux/sagas/expenditures/createExpenditure.ts';
+import { findDomainByNativeId } from '~utils/domains.ts';
+import { ActionButton } from '~v5/shared/Button/index.ts';
+
+const TmpAdvancedPayments = () => {
+  const { colony } = useColonyContext();
+  const { user } = useAppContext();
+
+  const { networkInverseFee } = useNetworkInverseFee();
+
+  const rootDomain = findDomainByNativeId(Id.RootDomain, colony);
+  if (!rootDomain) {
+    return null;
+  }
+
+  const payload: CreateExpenditurePayload = {
+    payouts: [
+      {
+        amount: '10',
+        tokenAddress: colony.nativeToken.tokenAddress,
+        recipientAddress: user?.walletAddress ?? '',
+        claimDelay: 0,
+      },
+    ],
+    colony,
+    createdInDomain: rootDomain,
+    fundFromDomainId: 1,
+    networkInverseFee: networkInverseFee ?? '0',
+  };
+
+  return (
+    <ActionButton actionType={ActionTypes.EXPENDITURE_CREATE} values={payload}>
+      Create expenditure
+    </ActionButton>
+  );
+};
+
+export default TmpAdvancedPayments;

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -1929,14 +1929,21 @@ export type ExpenditureMetadata = {
 
 export type ExpenditurePayout = {
   __typename?: 'ExpenditurePayout';
+  /** Payout amount, excluding network fee */
   amount: Scalars['String'];
   isClaimed: Scalars['Boolean'];
+  /**
+   * Network fee amount
+   * @TODO: Make this a non-nullable field once existing data is updated
+   */
+  networkFee?: Maybe<Scalars['String']>;
   tokenAddress: Scalars['ID'];
 };
 
 export type ExpenditurePayoutInput = {
   amount: Scalars['String'];
   isClaimed: Scalars['Boolean'];
+  networkFee?: InputMaybe<Scalars['String']>;
   tokenAddress: Scalars['ID'];
 };
 

--- a/src/redux/sagas/actions/payment.ts
+++ b/src/redux/sagas/actions/payment.ts
@@ -1,6 +1,5 @@
 import { ClientType, ColonyRole } from '@colony/colony-js';
 import { BigNumber } from 'ethers';
-import moveDecimal from 'move-decimal-point';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context/index.ts';
@@ -58,11 +57,6 @@ function* createPaymentAction({
       }
       if (!payments.every(({ tokenAddress }) => !!tokenAddress)) {
         throw new Error('Payment token not set for OneTxPayment transaction');
-      }
-      if (!payments.every(({ decimals }) => !!decimals)) {
-        throw new Error(
-          'Payment token decimals not set for OneTxPayment transaction',
-        );
       }
       if (!payments.every(({ recipient }) => !!recipient)) {
         throw new Error('Recipient not assigned for OneTxPayment transaction');
@@ -248,12 +242,11 @@ export function sortAndCombinePayments(
   recipient: string;
   amount: BigNumber;
   tokenAddress: string;
-  decimals: number;
 }[] {
   return payments.sort(sortPayments).reduce(
     (acc, payment) => {
-      const { recipient, tokenAddress, amount, decimals } = payment;
-      const convertedAmount = BigNumber.from(moveDecimal(amount, decimals));
+      const { recipient, tokenAddress, amount } = payment;
+      const convertedAmount = BigNumber.from(amount);
 
       const {
         recipient: prevRecipient,

--- a/src/redux/sagas/expenditures/createExpenditure.ts
+++ b/src/redux/sagas/expenditures/createExpenditure.ts
@@ -33,6 +33,7 @@ function* createExpenditure({
     fundFromDomainId,
     isStaged,
     stages,
+    networkInverseFee,
   },
 }: Action<ActionTypes.EXPENDITURE_CREATE>) {
   const colonyManager: ColonyManager = yield getColonyManager();
@@ -129,6 +130,7 @@ function* createExpenditure({
         getSetExpenditureValuesFunctionParams(
           expenditureId,
           payoutsWithSlotIds,
+          networkInverseFee,
         ),
       ),
     );

--- a/src/redux/sagas/expenditures/createStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/createStakedExpenditure.ts
@@ -33,6 +33,7 @@ function* createStakedExpenditure({
     stakedExpenditureAddress,
     isStaged,
     stages,
+    networkInverseFee,
   },
 }: Action<ActionTypes.STAKED_EXPENDITURE_CREATE>) {
   const colonyManager: ColonyManager = yield getColonyManager();
@@ -174,6 +175,7 @@ function* createStakedExpenditure({
         getSetExpenditureValuesFunctionParams(
           expenditureId,
           payoutsWithSlotIds,
+          networkInverseFee,
         ),
       ),
     );

--- a/src/redux/sagas/expenditures/editExpenditure.ts
+++ b/src/redux/sagas/expenditures/editExpenditure.ts
@@ -17,7 +17,7 @@ import {
 } from '../utils/index.ts';
 
 function* editExpenditure({
-  payload: { colonyAddress, expenditure, payouts },
+  payload: { colonyAddress, expenditure, payouts, networkInverseFee },
   meta,
 }: Action<ActionTypes.EXPENDITURE_EDIT>) {
   const txChannel = yield call(getTxChannel, meta.id);
@@ -81,6 +81,7 @@ function* editExpenditure({
       params: getSetExpenditureValuesFunctionParams(
         expenditure.nativeId,
         resolvedPayouts,
+        networkInverseFee,
       ),
     });
 

--- a/src/redux/sagas/motions/paymentMotion.ts
+++ b/src/redux/sagas/motions/paymentMotion.ts
@@ -60,11 +60,6 @@ function* createPaymentMotion({
       if (!payments.every(({ tokenAddress }) => !!tokenAddress)) {
         throw new Error('Payment token not set for OneTxPayment transaction');
       }
-      if (!payments.every(({ decimals }) => !!decimals)) {
-        throw new Error(
-          'Payment token decimals not set for OneTxPayment transaction',
-        );
-      }
       if (!payments.every(({ recipient }) => !!recipient)) {
         throw new Error('Recipient not assigned for OneTxPayment transaction');
       }

--- a/src/redux/types/actions/colonyActions.ts
+++ b/src/redux/types/actions/colonyActions.ts
@@ -30,7 +30,6 @@ export type OneTxPaymentPayload = {
     recipient: string;
     amount: string;
     tokenAddress: Address;
-    decimals: number;
   }[];
   annotationMessage?: string;
   motionDomainId?: number;

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -43,6 +43,7 @@ export type ExpendituresActionTypes =
         fundFromDomainId: number;
         isStaged?: boolean;
         stages?: ExpenditureStageFieldValue[];
+        networkInverseFee: string;
       },
       MetaWithSetter<object>
     >
@@ -83,6 +84,7 @@ export type ExpendituresActionTypes =
         colonyAddress: Address;
         expenditure: Expenditure;
         payouts: ExpenditurePayoutFieldValue[];
+        networkInverseFee: string;
       },
       object
     >
@@ -127,6 +129,7 @@ export type ExpendituresActionTypes =
         stakedExpenditureAddress: Address;
         isStaged?: boolean;
         stages?: ExpenditureStageFieldValue[];
+        networkInverseFee: string;
       },
       MetaWithSetter<object>
     >

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -88,7 +88,7 @@ export const calculateFee = (
   const feesInWei = totalToPayInWei.sub(amountInWei);
   return {
     feesInWei: feesInWei.toString(),
-    totalToPay: moveDecimal(totalToPayInWei, -1 * decimals),
+    totalToPay: totalToPayInWei.toString(),
   }; // NOTE: seems like moveDecimal does not have strict typing
 };
 

--- a/src/utils/yup/tests/index.ts
+++ b/src/utils/yup/tests/index.ts
@@ -1,7 +1,6 @@
 import { type OperationVariables } from '@apollo/client';
 import { BigNumber } from 'ethers';
 import { type DocumentNode, type OperationDefinitionNode } from 'graphql';
-import moveDecimal from 'move-decimal-point';
 import { type TestContext, ValidationError, type TestFunction } from 'yup';
 
 import { ContextModule, getContext } from '~context/index.ts';
@@ -281,10 +280,8 @@ export const getHasEnoughBalanceTestFn = (
           .totalToPay
       : value;
 
-    const convertedAmount = BigNumber.from(
-      moveDecimal(amountWithFeesIncluded, tokenDecimals),
+    return BigNumber.from(amountWithFeesIncluded).lte(
+      selectedDomainBalance.balance,
     );
-
-    return convertedAmount.lte(selectedDomainBalance.balance);
   };
 };


### PR DESCRIPTION
## Description

This PR ensures the network fee is included in every payout amount set by the sagas.

## Testing

There is a temporary button to create an expenditure from root domain to the currently logged in user with one payout of 10 ETH in colony's native token.

You can then run the following query to confirm the network fee has been saved correctly:
```gql
query ListExpenditures {
  listExpenditures {
    items {
      slots {
        recipientAddress
        payouts {
          amount
          tokenAddress
          networkFee
        }
      }
    }
  }
}
```
There is gonna be quite a few if you ran `create-data` script, however only the one created from the UI will have a single slot with non-null `networkFee`. **Note:** The list is not sorted chronologically so you might find the new payments get added somewhere in the middle. I find it easiest to locate them by searching the response for `"networkFee": "`.
 
The network fee in local dev is set at 1% but due to the way it's calculated (https://github.com/JoinColony/colonyNetwork/blob/806e4d5750dc3a6b9fa80f6e007773b28327c90f/contracts/colony/ColonyFunding.sol#L656) it actually works out as around `0.101010...` for 10 ETH payout.

The refactoring bit touched the Simple Payment action so it might be worth checking there's no regression.

block-ingestor PR: https://github.com/JoinColony/block-ingestor/pull/174
colonyCDappAuthProxy PR: https://github.com/JoinColony/colonyCDappAuthProxy/pull/11

## Diffs

**Changes** 🏗

* Updated expenditure sagas
* Refactored `calculateFee` util
* Modified schema to add `networkFee` field to `ExpenditurePayout`

Resolves #947 
