### PR TITLE
Fix: Unable to leave a colony

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/LeaveColonyModal/LeaveColonyModal.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/LeaveColonyModal/LeaveColonyModal.tsx
@@ -2,7 +2,6 @@ import { WarningCircle } from '@phosphor-icons/react';
 import React from 'react';
 import { defineMessages } from 'react-intl';
 
-import { apolloClient } from '~apollo';
 import { useColonyContext } from '~context/ColonyContext.tsx';
 import { useColonyDashboardContext } from '~context/ColonyDashboardContext.tsx';
 import useColonySubscription from '~hooks/useColonySubscription.ts';
@@ -40,7 +39,6 @@ const LeaveColonyModal = () => {
       onConfirm={() => {
         closeLeaveColonyModal();
         handleUnwatch();
-        apolloClient.cache.evict({ fieldName: 'getContributorsByAddress' });
       }}
       icon={WarningCircle}
       buttonMode="primarySolid"

--- a/src/components/v5/frame/ColonyHome/partials/LeaveColonyModal/LeaveColonyModal.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/LeaveColonyModal/LeaveColonyModal.tsx
@@ -2,6 +2,7 @@ import { WarningCircle } from '@phosphor-icons/react';
 import React from 'react';
 import { defineMessages } from 'react-intl';
 
+import { apolloClient } from '~apollo';
 import { useColonyContext } from '~context/ColonyContext.tsx';
 import { useColonyDashboardContext } from '~context/ColonyDashboardContext.tsx';
 import useColonySubscription from '~hooks/useColonySubscription.ts';
@@ -39,6 +40,7 @@ const LeaveColonyModal = () => {
       onConfirm={() => {
         closeLeaveColonyModal();
         handleUnwatch();
+        apolloClient.cache.evict({ fieldName: 'getContributorsByAddress' });
       }}
       icon={WarningCircle}
       buttonMode="primarySolid"

--- a/src/components/v5/frame/ColonyHome/partials/LeaveColonyModal/LeaveColonyModal.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/LeaveColonyModal/LeaveColonyModal.tsx
@@ -2,6 +2,7 @@ import { WarningCircle } from '@phosphor-icons/react';
 import React from 'react';
 import { defineMessages } from 'react-intl';
 
+import { useColonyContext } from '~context/ColonyContext.tsx';
 import { useColonyDashboardContext } from '~context/ColonyDashboardContext.tsx';
 import useColonySubscription from '~hooks/useColonySubscription.ts';
 import { formatText } from '~utils/intl.ts';
@@ -24,7 +25,8 @@ const MSG = defineMessages({
 });
 
 const LeaveColonyModal = () => {
-  const { handleUnwatch } = useColonySubscription();
+  const { colony } = useColonyContext();
+  const { handleUnwatch } = useColonySubscription(colony);
   const { isLeaveColonyModalOpen, closeLeaveColonyModal } =
     useColonyDashboardContext();
 

--- a/src/components/v5/shared/Button/JoinButton/JoinButton.tsx
+++ b/src/components/v5/shared/Button/JoinButton/JoinButton.tsx
@@ -1,6 +1,7 @@
 import Lottie from 'lottie-react';
 import React, { type FC, useState } from 'react';
 
+import { apolloClient } from '~apollo';
 import { useAppContext } from '~context/AppContext.tsx';
 import { useColonyContext } from '~context/ColonyContext.tsx';
 import joinButtonAnimation from '~utils/animations/joinButtonAnimation.json';
@@ -23,6 +24,7 @@ const JoinButton: FC = () => {
 
   const onClick = () => {
     handleWatch();
+    apolloClient.cache.evict({ fieldName: 'getContributorsByAddress' });
 
     if (!showJoinButton) {
       return;

--- a/src/components/v5/shared/Button/JoinButton/JoinButton.tsx
+++ b/src/components/v5/shared/Button/JoinButton/JoinButton.tsx
@@ -1,7 +1,6 @@
 import Lottie from 'lottie-react';
 import React, { type FC, useState } from 'react';
 
-import { apolloClient } from '~apollo';
 import { useAppContext } from '~context/AppContext.tsx';
 import { useColonyContext } from '~context/ColonyContext.tsx';
 import joinButtonAnimation from '~utils/animations/joinButtonAnimation.json';
@@ -24,7 +23,6 @@ const JoinButton: FC = () => {
 
   const onClick = () => {
     handleWatch();
-    apolloClient.cache.evict({ fieldName: 'getContributorsByAddress' });
 
     if (!showJoinButton) {
       return;

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -8748,6 +8748,7 @@ export type GetContributorsByAddressQueryVariables = Exact<{
   sortDirection?: InputMaybe<ModelSortDirection>;
   limit?: InputMaybe<Scalars['Int']>;
   nextToken?: InputMaybe<Scalars['String']>;
+  isWatching?: InputMaybe<Scalars['Boolean']>;
 }>;
 
 
@@ -11421,12 +11422,13 @@ export type GetVerifiedMembersQueryHookResult = ReturnType<typeof useGetVerified
 export type GetVerifiedMembersLazyQueryHookResult = ReturnType<typeof useGetVerifiedMembersLazyQuery>;
 export type GetVerifiedMembersQueryResult = Apollo.QueryResult<GetVerifiedMembersQuery, GetVerifiedMembersQueryVariables>;
 export const GetContributorsByAddressDocument = gql`
-    query GetContributorsByAddress($contributorAddress: ID!, $sortDirection: ModelSortDirection = ASC, $limit: Int, $nextToken: String) {
+    query GetContributorsByAddress($contributorAddress: ID!, $sortDirection: ModelSortDirection = ASC, $limit: Int, $nextToken: String, $isWatching: Boolean) {
   getContributorsByAddress(
     contributorAddress: $contributorAddress
     sortDirection: $sortDirection
     limit: $limit
     nextToken: $nextToken
+    filter: {isWatching: {eq: $isWatching}}
   ) {
     items {
       id
@@ -11456,6 +11458,7 @@ export const GetContributorsByAddressDocument = gql`
  *      sortDirection: // value for 'sortDirection'
  *      limit: // value for 'limit'
  *      nextToken: // value for 'nextToken'
+ *      isWatching: // value for 'isWatching'
  *   },
  * });
  */

--- a/src/graphql/queries/contributors.graphql
+++ b/src/graphql/queries/contributors.graphql
@@ -41,12 +41,14 @@ query GetContributorsByAddress(
   $sortDirection: ModelSortDirection = ASC
   $limit: Int
   $nextToken: String
+  $isWatching: Boolean
 ) {
   getContributorsByAddress(
     contributorAddress: $contributorAddress
     sortDirection: $sortDirection
     limit: $limit
     nextToken: $nextToken
+    filter: { isWatching: { eq: $isWatching } }
   ) {
     items {
       id

--- a/src/hooks/useColonySubscription.ts
+++ b/src/hooks/useColonySubscription.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { apolloClient } from '~apollo';
 import { useAppContext } from '~context/AppContext.tsx';
 import {
   useCreateColonyContributorMutation,
@@ -56,6 +57,11 @@ const useColonySubscription = (colony?: Colony) => {
   /* Update a Colony Contributor */
   const [updateContributor] = useUpdateColonyContributorMutation();
 
+  const clearContributorCaches = () => {
+    apolloClient.cache.evict({ fieldName: 'getContributorsByAddress' });
+    apolloClient.cache.evict({ fieldName: 'getColonyContributor' });
+  };
+
   const handleWatch = () => {
     if (user) {
       if (!isAlreadyContributor) {
@@ -75,6 +81,7 @@ const useColonySubscription = (colony?: Colony) => {
     } else {
       connectWallet();
     }
+    clearContributorCaches();
   };
 
   const handleUnwatch = () => {
@@ -84,6 +91,7 @@ const useColonySubscription = (colony?: Colony) => {
         setIsWatching(Boolean(data?.updateColonyContributor?.isWatching));
       },
     });
+    clearContributorCaches();
   };
 
   const canWatch = useCanJoinColony(isWatching, colony) && !loading;

--- a/src/hooks/useJoinedColonies.ts
+++ b/src/hooks/useJoinedColonies.ts
@@ -9,6 +9,7 @@ const useJoinedColonies = (userAddress?: string) => {
   const { data, loading } = useGetContributorsByAddressQuery({
     variables: {
       contributorAddress: userAddress ?? ADDRESS_ZERO,
+      isWatching: true,
     },
     skip: !userAddress,
   });


### PR DESCRIPTION
## Description

Leave this colony button results in a 400 error.

Leaving a colony should also remove it from the 'joined colonies' list in the colony switcher and the 'join' button in the top right should also reappear.

## Testing

1. Join a Colony.
2. Try to leave the colony.
3. 'Joined colonies' list in the colony switcher should show correct list of colonies
4. 'Join' button should show after leaving the colony.

![image](https://github.com/JoinColony/colonyCDapp/assets/33682027/0b7a3845-8d57-4b30-906d-48dfafb0a330)

## Diffs

**Changes** 🏗

* 'Leave this colony' button no longer results in a 400 error (caused by not passing ColonyFragment to useColonySubscription)
* `GetContributorsByAddress` query now accepts an `isWatching` filter to ensure the joined colonies list only shows colonies a user is watching
* `getContributorsByAddress` and `getColonyContributor` caches are now cleared when watching / unwatching a colony. This ensures the 'joined colonies' list updates correctly and the 'join' button shows correctly.

https://github.com/JoinColony/colonyCDapp/assets/34915414/4f245c0d-6385-4177-8058-9fc539d09846

Resolves #1902
