### PR TITLE
Advanced Payments: Store selected decision method for an expenditure

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -3224,12 +3224,17 @@ type ExpenditurePayout {
   isClaimed: Boolean!
 }
 
+enum DecisionMethod {
+  PERMISSIONS
+  REPUPTATION
+}
+
 type ExpenditureMetadata @model {
   id: ID! # Self-managed, formatted as colonyId_nativeId
   fundFromDomainNativeId: Int!
   stages: [ExpenditureStage!]
   stakeAmount: String
-  decisionMethod: String
+  decisionMethod: DecisionMethod!
 }
 
 type ExpenditureBalance {

--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -3229,6 +3229,7 @@ type ExpenditureMetadata @model {
   fundFromDomainNativeId: Int!
   stages: [ExpenditureStage!]
   stakeAmount: String
+  decisionMethod: String
 }
 
 type ExpenditureBalance {

--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -3224,9 +3224,9 @@ type ExpenditurePayout {
   isClaimed: Boolean!
 }
 
-enum DecisionMethod {
+enum ExpenditureDecisionMethod {
   PERMISSIONS
-  REPUPTATION
+  REPUTATION
 }
 
 type ExpenditureMetadata @model {
@@ -3234,7 +3234,7 @@ type ExpenditureMetadata @model {
   fundFromDomainNativeId: Int!
   stages: [ExpenditureStage!]
   stakeAmount: String
-  decisionMethod: DecisionMethod!
+  decisionMethod: ExpenditureDecisionMethod!
 }
 
 type ExpenditureBalance {

--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 
 import { useAppContext } from '~context/AppContext.tsx';
 import { useColonyContext } from '~context/ColonyContext.tsx';
+import { DecisionMethod } from '~gql';
 import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
 import { ActionTypes } from '~redux';
 import { type CreateExpenditurePayload } from '~redux/sagas/expenditures/createExpenditure.ts';
 import { findDomainByNativeId } from '~utils/domains.ts';
-import { DecisionMethod } from '~v5/common/ActionSidebar/hooks/index.ts';
 import { ActionButton } from '~v5/shared/Button/index.ts';
 
 const TmpAdvancedPayments = () => {

--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -7,6 +7,7 @@ import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
 import { ActionTypes } from '~redux';
 import { type CreateExpenditurePayload } from '~redux/sagas/expenditures/createExpenditure.ts';
 import { findDomainByNativeId } from '~utils/domains.ts';
+import { DecisionMethod } from '~v5/common/ActionSidebar/hooks/index.ts';
 import { ActionButton } from '~v5/shared/Button/index.ts';
 
 const TmpAdvancedPayments = () => {
@@ -33,6 +34,7 @@ const TmpAdvancedPayments = () => {
     createdInDomain: rootDomain,
     fundFromDomainId: 1,
     networkInverseFee: networkInverseFee ?? '0',
+    decisionMethod: DecisionMethod.Permissions,
   };
 
   return (

--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { useAppContext } from '~context/AppContext.tsx';
 import { useColonyContext } from '~context/ColonyContext.tsx';
-import { DecisionMethod } from '~gql';
+import { ExpenditureDecisionMethod } from '~gql';
 import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
 import { ActionTypes } from '~redux';
 import { type CreateExpenditurePayload } from '~redux/sagas/expenditures/createExpenditure.ts';
@@ -34,7 +34,7 @@ const TmpAdvancedPayments = () => {
     createdInDomain: rootDomain,
     fundFromDomainId: 1,
     networkInverseFee: networkInverseFee ?? '0',
-    decisionMethod: DecisionMethod.Permissions,
+    decisionMethod: ExpenditureDecisionMethod.Permissions,
   };
 
   return (

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -1360,7 +1360,7 @@ export type CreateExpenditureInput = {
 };
 
 export type CreateExpenditureMetadataInput = {
-  decisionMethod: DecisionMethod;
+  decisionMethod: ExpenditureDecisionMethod;
   fundFromDomainNativeId: Scalars['Int'];
   id?: InputMaybe<Scalars['ID']>;
   stages?: InputMaybe<Array<ExpenditureStageInput>>;
@@ -1569,11 +1569,6 @@ export type CurrentVersion = {
   /** The current version number */
   version: Scalars['Int'];
 };
-
-export enum DecisionMethod {
-  Permissions = 'PERMISSIONS',
-  Repuptation = 'REPUPTATION'
-}
 
 export type DeleteAnnotationInput = {
   id: Scalars['ID'];
@@ -1923,10 +1918,15 @@ export type ExpenditureBalanceInput = {
   tokenAddress: Scalars['ID'];
 };
 
+export enum ExpenditureDecisionMethod {
+  Permissions = 'PERMISSIONS',
+  Reputation = 'REPUTATION'
+}
+
 export type ExpenditureMetadata = {
   __typename?: 'ExpenditureMetadata';
   createdAt: Scalars['AWSDateTime'];
-  decisionMethod: DecisionMethod;
+  decisionMethod: ExpenditureDecisionMethod;
   fundFromDomainNativeId: Scalars['Int'];
   id: Scalars['ID'];
   stages?: Maybe<Array<ExpenditureStage>>;
@@ -2857,11 +2857,6 @@ export type ModelCurrentVersionFilterInput = {
   version?: InputMaybe<ModelIntInput>;
 };
 
-export type ModelDecisionMethodInput = {
-  eq?: InputMaybe<DecisionMethod>;
-  ne?: InputMaybe<DecisionMethod>;
-};
-
 export type ModelDomainColorInput = {
   eq?: InputMaybe<DomainColor>;
   ne?: InputMaybe<DomainColor>;
@@ -2949,6 +2944,11 @@ export type ModelExpenditureConnection = {
   nextToken?: Maybe<Scalars['String']>;
 };
 
+export type ModelExpenditureDecisionMethodInput = {
+  eq?: InputMaybe<ExpenditureDecisionMethod>;
+  ne?: InputMaybe<ExpenditureDecisionMethod>;
+};
+
 export type ModelExpenditureFilterInput = {
   and?: InputMaybe<Array<InputMaybe<ModelExpenditureFilterInput>>>;
   colonyId?: InputMaybe<ModelIdInput>;
@@ -2970,7 +2970,7 @@ export type ModelExpenditureFilterInput = {
 
 export type ModelExpenditureMetadataConditionInput = {
   and?: InputMaybe<Array<InputMaybe<ModelExpenditureMetadataConditionInput>>>;
-  decisionMethod?: InputMaybe<ModelDecisionMethodInput>;
+  decisionMethod?: InputMaybe<ModelExpenditureDecisionMethodInput>;
   fundFromDomainNativeId?: InputMaybe<ModelIntInput>;
   not?: InputMaybe<ModelExpenditureMetadataConditionInput>;
   or?: InputMaybe<Array<InputMaybe<ModelExpenditureMetadataConditionInput>>>;
@@ -2985,7 +2985,7 @@ export type ModelExpenditureMetadataConnection = {
 
 export type ModelExpenditureMetadataFilterInput = {
   and?: InputMaybe<Array<InputMaybe<ModelExpenditureMetadataFilterInput>>>;
-  decisionMethod?: InputMaybe<ModelDecisionMethodInput>;
+  decisionMethod?: InputMaybe<ModelExpenditureDecisionMethodInput>;
   fundFromDomainNativeId?: InputMaybe<ModelIntInput>;
   id?: InputMaybe<ModelIdInput>;
   not?: InputMaybe<ModelExpenditureMetadataFilterInput>;
@@ -7976,7 +7976,7 @@ export type UpdateExpenditureInput = {
 };
 
 export type UpdateExpenditureMetadataInput = {
-  decisionMethod?: InputMaybe<DecisionMethod>;
+  decisionMethod?: InputMaybe<ExpenditureDecisionMethod>;
   fundFromDomainNativeId?: InputMaybe<Scalars['Int']>;
   id: Scalars['ID'];
   stages?: InputMaybe<Array<ExpenditureStageInput>>;

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -1360,6 +1360,7 @@ export type CreateExpenditureInput = {
 };
 
 export type CreateExpenditureMetadataInput = {
+  decisionMethod?: InputMaybe<Scalars['String']>;
   fundFromDomainNativeId: Scalars['Int'];
   id?: InputMaybe<Scalars['ID']>;
   stages?: InputMaybe<Array<ExpenditureStageInput>>;
@@ -1920,6 +1921,7 @@ export type ExpenditureBalanceInput = {
 export type ExpenditureMetadata = {
   __typename?: 'ExpenditureMetadata';
   createdAt: Scalars['AWSDateTime'];
+  decisionMethod?: Maybe<Scalars['String']>;
   fundFromDomainNativeId: Scalars['Int'];
   id: Scalars['ID'];
   stages?: Maybe<Array<ExpenditureStage>>;
@@ -2958,6 +2960,7 @@ export type ModelExpenditureFilterInput = {
 
 export type ModelExpenditureMetadataConditionInput = {
   and?: InputMaybe<Array<InputMaybe<ModelExpenditureMetadataConditionInput>>>;
+  decisionMethod?: InputMaybe<ModelStringInput>;
   fundFromDomainNativeId?: InputMaybe<ModelIntInput>;
   not?: InputMaybe<ModelExpenditureMetadataConditionInput>;
   or?: InputMaybe<Array<InputMaybe<ModelExpenditureMetadataConditionInput>>>;
@@ -2972,6 +2975,7 @@ export type ModelExpenditureMetadataConnection = {
 
 export type ModelExpenditureMetadataFilterInput = {
   and?: InputMaybe<Array<InputMaybe<ModelExpenditureMetadataFilterInput>>>;
+  decisionMethod?: InputMaybe<ModelStringInput>;
   fundFromDomainNativeId?: InputMaybe<ModelIntInput>;
   id?: InputMaybe<ModelIdInput>;
   not?: InputMaybe<ModelExpenditureMetadataFilterInput>;
@@ -3670,6 +3674,7 @@ export type ModelSubscriptionExpenditureFilterInput = {
 
 export type ModelSubscriptionExpenditureMetadataFilterInput = {
   and?: InputMaybe<Array<InputMaybe<ModelSubscriptionExpenditureMetadataFilterInput>>>;
+  decisionMethod?: InputMaybe<ModelSubscriptionStringInput>;
   fundFromDomainNativeId?: InputMaybe<ModelSubscriptionIntInput>;
   id?: InputMaybe<ModelSubscriptionIdInput>;
   or?: InputMaybe<Array<InputMaybe<ModelSubscriptionExpenditureMetadataFilterInput>>>;
@@ -7961,6 +7966,7 @@ export type UpdateExpenditureInput = {
 };
 
 export type UpdateExpenditureMetadataInput = {
+  decisionMethod?: InputMaybe<Scalars['String']>;
   fundFromDomainNativeId?: InputMaybe<Scalars['Int']>;
   id: Scalars['ID'];
   stages?: InputMaybe<Array<ExpenditureStageInput>>;

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -1360,7 +1360,7 @@ export type CreateExpenditureInput = {
 };
 
 export type CreateExpenditureMetadataInput = {
-  decisionMethod?: InputMaybe<Scalars['String']>;
+  decisionMethod: DecisionMethod;
   fundFromDomainNativeId: Scalars['Int'];
   id?: InputMaybe<Scalars['ID']>;
   stages?: InputMaybe<Array<ExpenditureStageInput>>;
@@ -1569,6 +1569,11 @@ export type CurrentVersion = {
   /** The current version number */
   version: Scalars['Int'];
 };
+
+export enum DecisionMethod {
+  Permissions = 'PERMISSIONS',
+  Repuptation = 'REPUPTATION'
+}
 
 export type DeleteAnnotationInput = {
   id: Scalars['ID'];
@@ -1921,7 +1926,7 @@ export type ExpenditureBalanceInput = {
 export type ExpenditureMetadata = {
   __typename?: 'ExpenditureMetadata';
   createdAt: Scalars['AWSDateTime'];
-  decisionMethod?: Maybe<Scalars['String']>;
+  decisionMethod: DecisionMethod;
   fundFromDomainNativeId: Scalars['Int'];
   id: Scalars['ID'];
   stages?: Maybe<Array<ExpenditureStage>>;
@@ -2852,6 +2857,11 @@ export type ModelCurrentVersionFilterInput = {
   version?: InputMaybe<ModelIntInput>;
 };
 
+export type ModelDecisionMethodInput = {
+  eq?: InputMaybe<DecisionMethod>;
+  ne?: InputMaybe<DecisionMethod>;
+};
+
 export type ModelDomainColorInput = {
   eq?: InputMaybe<DomainColor>;
   ne?: InputMaybe<DomainColor>;
@@ -2960,7 +2970,7 @@ export type ModelExpenditureFilterInput = {
 
 export type ModelExpenditureMetadataConditionInput = {
   and?: InputMaybe<Array<InputMaybe<ModelExpenditureMetadataConditionInput>>>;
-  decisionMethod?: InputMaybe<ModelStringInput>;
+  decisionMethod?: InputMaybe<ModelDecisionMethodInput>;
   fundFromDomainNativeId?: InputMaybe<ModelIntInput>;
   not?: InputMaybe<ModelExpenditureMetadataConditionInput>;
   or?: InputMaybe<Array<InputMaybe<ModelExpenditureMetadataConditionInput>>>;
@@ -2975,7 +2985,7 @@ export type ModelExpenditureMetadataConnection = {
 
 export type ModelExpenditureMetadataFilterInput = {
   and?: InputMaybe<Array<InputMaybe<ModelExpenditureMetadataFilterInput>>>;
-  decisionMethod?: InputMaybe<ModelStringInput>;
+  decisionMethod?: InputMaybe<ModelDecisionMethodInput>;
   fundFromDomainNativeId?: InputMaybe<ModelIntInput>;
   id?: InputMaybe<ModelIdInput>;
   not?: InputMaybe<ModelExpenditureMetadataFilterInput>;
@@ -7966,7 +7976,7 @@ export type UpdateExpenditureInput = {
 };
 
 export type UpdateExpenditureMetadataInput = {
-  decisionMethod?: InputMaybe<Scalars['String']>;
+  decisionMethod?: InputMaybe<DecisionMethod>;
   fundFromDomainNativeId?: InputMaybe<Scalars['Int']>;
   id: Scalars['ID'];
   stages?: InputMaybe<Array<ExpenditureStageInput>>;

--- a/src/redux/sagas/expenditures/createExpenditure.ts
+++ b/src/redux/sagas/expenditures/createExpenditure.ts
@@ -34,6 +34,7 @@ function* createExpenditure({
     isStaged,
     stages,
     networkInverseFee,
+    decisionMethod,
   },
 }: Action<ActionTypes.EXPENDITURE_CREATE>) {
   const colonyManager: ColonyManager = yield getColonyManager();
@@ -153,6 +154,7 @@ function* createExpenditure({
       colonyAddress,
       expenditureId,
       fundFromDomainId,
+      decisionMethod,
       stages: isStaged ? stages : undefined,
     });
 

--- a/src/redux/sagas/expenditures/createStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/createStakedExpenditure.ts
@@ -34,6 +34,7 @@ function* createStakedExpenditure({
     isStaged,
     stages,
     networkInverseFee,
+    decisionMethod,
   },
 }: Action<ActionTypes.STAKED_EXPENDITURE_CREATE>) {
   const colonyManager: ColonyManager = yield getColonyManager();
@@ -198,6 +199,7 @@ function* createStakedExpenditure({
       colonyAddress,
       expenditureId,
       fundFromDomainId,
+      decisionMethod,
       stages: isStaged ? stages : undefined,
       stakeAmount,
     });

--- a/src/redux/sagas/utils/expenditures.ts
+++ b/src/redux/sagas/utils/expenditures.ts
@@ -15,6 +15,7 @@ import { type Expenditure } from '~types/graphql.ts';
 import { type MethodParams } from '~types/transactions.ts';
 import { getExpenditureDatabaseId } from '~utils/databaseId.ts';
 import { calculateFee } from '~utils/tokens.ts';
+import { type DecisionMethod } from '~v5/common/ActionSidebar/hooks/index.ts';
 
 /**
  * Util returning a map between token addresses and arrays of payouts field values
@@ -121,6 +122,7 @@ interface SaveExpenditureMetadataParams {
   colonyAddress: string;
   expenditureId: number;
   fundFromDomainId: number;
+  decisionMethod: DecisionMethod;
   stages?: ExpenditureStageFieldValue[];
   stakeAmount?: string;
 }
@@ -129,6 +131,7 @@ export function* saveExpenditureMetadata({
   colonyAddress,
   expenditureId,
   fundFromDomainId,
+  decisionMethod,
   stages,
   stakeAmount,
 }: SaveExpenditureMetadataParams) {
@@ -143,6 +146,7 @@ export function* saveExpenditureMetadata({
       input: {
         id: getExpenditureDatabaseId(colonyAddress, expenditureId),
         fundFromDomainNativeId: fundFromDomainId,
+        decisionMethod,
         stages: stages?.map((stage, index) => ({
           name: stage.name,
           slotId: index + 1,

--- a/src/redux/sagas/utils/expenditures.ts
+++ b/src/redux/sagas/utils/expenditures.ts
@@ -4,7 +4,7 @@ import { DEFAULT_TOKEN_DECIMALS } from '~constants/index.ts';
 import { ContextModule, getContext } from '~context/index.ts';
 import {
   CreateExpenditureMetadataDocument,
-  type DecisionMethod,
+  type ExpenditureDecisionMethod,
   type CreateExpenditureMetadataMutation,
   type CreateExpenditureMetadataMutationVariables,
 } from '~gql';
@@ -122,7 +122,7 @@ interface SaveExpenditureMetadataParams {
   colonyAddress: string;
   expenditureId: number;
   fundFromDomainId: number;
-  decisionMethod: DecisionMethod;
+  decisionMethod: ExpenditureDecisionMethod;
   stages?: ExpenditureStageFieldValue[];
   stakeAmount?: string;
 }

--- a/src/redux/sagas/utils/expenditures.ts
+++ b/src/redux/sagas/utils/expenditures.ts
@@ -4,6 +4,7 @@ import { DEFAULT_TOKEN_DECIMALS } from '~constants/index.ts';
 import { ContextModule, getContext } from '~context/index.ts';
 import {
   CreateExpenditureMetadataDocument,
+  type DecisionMethod,
   type CreateExpenditureMetadataMutation,
   type CreateExpenditureMetadataMutationVariables,
 } from '~gql';
@@ -15,7 +16,6 @@ import { type Expenditure } from '~types/graphql.ts';
 import { type MethodParams } from '~types/transactions.ts';
 import { getExpenditureDatabaseId } from '~utils/databaseId.ts';
 import { calculateFee } from '~utils/tokens.ts';
-import { type DecisionMethod } from '~v5/common/ActionSidebar/hooks/index.ts';
 
 /**
  * Util returning a map between token addresses and arrays of payouts field values

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -1,4 +1,4 @@
-import { type StreamingPaymentEndCondition } from '~gql';
+import { type DecisionMethod, type StreamingPaymentEndCondition } from '~gql';
 import { type ActionTypes } from '~redux/actionTypes.ts';
 import {
   type ExpenditurePayoutFieldValue,
@@ -11,7 +11,6 @@ import {
   type ExpenditureSlot,
 } from '~types/graphql.ts';
 import { type Address } from '~types/index.ts';
-import { type DecisionMethod } from '~v5/common/ActionSidebar/hooks/useDecisionMethods.ts';
 
 import {
   type UniqueActionType,

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -11,6 +11,7 @@ import {
   type ExpenditureSlot,
 } from '~types/graphql.ts';
 import { type Address } from '~types/index.ts';
+import { type DecisionMethod } from '~v5/common/ActionSidebar/hooks/useDecisionMethods.ts';
 
 import {
   type UniqueActionType,
@@ -44,6 +45,7 @@ export type ExpendituresActionTypes =
         isStaged?: boolean;
         stages?: ExpenditureStageFieldValue[];
         networkInverseFee: string;
+        decisionMethod: DecisionMethod;
       },
       MetaWithSetter<object>
     >
@@ -130,6 +132,7 @@ export type ExpendituresActionTypes =
         isStaged?: boolean;
         stages?: ExpenditureStageFieldValue[];
         networkInverseFee: string;
+        decisionMethod: DecisionMethod;
       },
       MetaWithSetter<object>
     >

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -1,4 +1,7 @@
-import { type DecisionMethod, type StreamingPaymentEndCondition } from '~gql';
+import {
+  type ExpenditureDecisionMethod,
+  type StreamingPaymentEndCondition,
+} from '~gql';
 import { type ActionTypes } from '~redux/actionTypes.ts';
 import {
   type ExpenditurePayoutFieldValue,
@@ -44,7 +47,7 @@ export type ExpendituresActionTypes =
         isStaged?: boolean;
         stages?: ExpenditureStageFieldValue[];
         networkInverseFee: string;
-        decisionMethod: DecisionMethod;
+        decisionMethod: ExpenditureDecisionMethod;
       },
       MetaWithSetter<object>
     >
@@ -131,7 +134,7 @@ export type ExpendituresActionTypes =
         isStaged?: boolean;
         stages?: ExpenditureStageFieldValue[];
         networkInverseFee: string;
-        decisionMethod: DecisionMethod;
+        decisionMethod: ExpenditureDecisionMethod;
       },
       MetaWithSetter<object>
     >


### PR DESCRIPTION
## Description

The UI requires storing the selected decision method for an expenditure for later reference.

This PR:
- Modifies the `createExpenditure`, `createStakedExpenditure` sagas to accept a decision method parameter
- Modifies the schema (`ExpenditureMetadata` model) to add a field storing the selected method 

## Testing

There is a temporary button to create an expenditure from root domain to the currently logged in user with one payout of 10 ETH in colony's native token with the 'Permissions' decision method.

You can then run the following query to confirm the decision method has been saved correctly: (If you have previously ran the create-data script there will be a bunch of expenditures without metadata, but the newly created expenditure should be correct)

```
query ListExpenditures {
  listExpenditures {
    items {
      metadata {
        decisionMethod
      }
    }
  }
}
```

## Diffs

**Changes** 🏗

* `createExpenditure`, `createStakedExpenditure` sagas now accept a decision method parameter
- `ExpenditureMetadata` model now has a decisionMethod field 


Resolves #1878
