### PR TITLE
fix: Update create colony step description

### DIFF
--- a/src/components/common/Onboarding/wizardSteps/CreateColony/StepColonyName.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/StepColonyName.tsx
@@ -26,8 +26,7 @@ const MSG = defineMessages({
   },
   description: {
     id: `${displayName}.description`,
-    defaultMessage:
-      'Let’s set up your Colony. Enter a name for your Colony and a short description about your Colony’s mission and purpose.',
+    defaultMessage: 'Let’s set up your Colony. Enter a name and custom URL.',
   },
 });
 


### PR DESCRIPTION
## Description

This PR changes the description step found in the create colony page from 

"set up your Colony. Enter a name for your Colony and a short description about your Colony’s mission and purpose." 

to 

"Let’s set up your Colony. Enter a name and custom URL."

This is a small change

## Testing

* Step 1. go to create colony page
* Step 2. Look at the description found under the 'Welcome' heading

## Diffs

**New stuff** ✨
![Screenshot 2024-02-16 at 13 52 06](https://github.com/JoinColony/colonyCDapp/assets/155957480/c2f2f2cc-7c20-4164-8664-d8dd3c2ad3b2)



Resolves #1915 
