### PR TITLE
[Advanced payments] feat: add annotation support to all expenditure sagas

### DIFF
--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -95,7 +95,7 @@ const TmpAdvancedPayments = () => {
 
   const createExpenditurePayload: CreateExpenditurePayload = {
     payouts,
-    colony,
+    colonyAddress: colony.colonyAddress,
     createdInDomain: rootDomain,
     fundFromDomainId: 1,
     networkInverseFee,
@@ -107,7 +107,6 @@ const TmpAdvancedPayments = () => {
   const handleLockExpenditure = async () => {
     const payload: LockExpenditurePayload = {
       colonyAddress: colony.colonyAddress,
-      colonyName: colony.name,
       nativeExpenditureId: Number(expenditureId),
     };
 
@@ -131,7 +130,6 @@ const TmpAdvancedPayments = () => {
   const handleFinalizeExpenditure = async () => {
     const finalizePayload: FinalizeExpenditurePayload = {
       colonyAddress: colony.colonyAddress,
-      colonyName: colony.name,
       nativeExpenditureId: Number(expenditureId),
     };
 
@@ -156,7 +154,7 @@ const TmpAdvancedPayments = () => {
 
     const payload: CreateStakedExpenditurePayload = {
       payouts,
-      colony,
+      colonyAddress: colony.colonyAddress,
       createdInDomain: rootDomain,
       fundFromDomainId: 1,
       stakeAmount,

--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -100,7 +100,6 @@ const TmpAdvancedPayments = () => {
     fundFromDomainId: 1,
     networkInverseFee,
     decisionMethod: ExpenditureDecisionMethod.Permissions,
-    customActionTitle: 'Custom create expenditure title!',
     annotationMessage: 'expenditure annotation',
   };
 

--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -100,6 +100,8 @@ const TmpAdvancedPayments = () => {
     fundFromDomainId: 1,
     networkInverseFee,
     decisionMethod: ExpenditureDecisionMethod.Permissions,
+    customActionTitle: 'Custom advanced payments title!',
+    annotationMessage: 'my custom annotation',
   };
 
   const handleLockExpenditure = async () => {

--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -100,8 +100,8 @@ const TmpAdvancedPayments = () => {
     fundFromDomainId: 1,
     networkInverseFee,
     decisionMethod: ExpenditureDecisionMethod.Permissions,
-    customActionTitle: 'Custom advanced payments title!',
-    annotationMessage: 'my custom annotation',
+    customActionTitle: 'Custom create expenditure title!',
+    annotationMessage: 'expenditure annotation',
   };
 
   const handleLockExpenditure = async () => {

--- a/src/redux/sagas/expenditures/cancelDraftExpenditure.ts
+++ b/src/redux/sagas/expenditures/cancelDraftExpenditure.ts
@@ -175,6 +175,9 @@ function* cancelDraftExpenditure({
       meta,
     );
   }
+  [cancelExpenditure, cancelAndReclaimStake, annotateCancelExpenditure].forEach(
+    (channel) => channel.channel.close(),
+  );
 
   return null;
 }

--- a/src/redux/sagas/expenditures/cancelDraftExpenditure.ts
+++ b/src/redux/sagas/expenditures/cancelDraftExpenditure.ts
@@ -11,7 +11,6 @@ import {
   waitForTxResult,
 } from '../transactions/index.ts';
 import {
-  createActionMetadataInDB,
   getColonyManager,
   initiateTransaction,
   putError,
@@ -26,7 +25,6 @@ function* cancelDraftExpenditure({
     expenditure,
     stakedExpenditureAddress,
     annotationMessage,
-    customActionTitle,
   },
 }: Action<ActionTypes.EXPENDITURE_DRAFT_CANCEL>) {
   const colonyManager: ColonyManager = yield getColonyManager();
@@ -109,10 +107,6 @@ function* cancelDraftExpenditure({
           txHash,
         });
       }
-
-      if (customActionTitle) {
-        yield createActionMetadataInDB(txHash, customActionTitle);
-      }
     } else {
       yield fork(createTransaction, cancelExpenditure.id, {
         context: ClientType.ColonyClient,
@@ -166,10 +160,6 @@ function* cancelDraftExpenditure({
           message: annotationMessage,
           txHash,
         });
-      }
-
-      if (customActionTitle) {
-        yield createActionMetadataInDB(txHash, customActionTitle);
       }
     }
 

--- a/src/redux/sagas/expenditures/cancelDraftExpenditure.ts
+++ b/src/redux/sagas/expenditures/cancelDraftExpenditure.ts
@@ -1,23 +1,33 @@
 import { ClientType, ColonyRole, getPermissionProofs } from '@colony/colony-js';
-import { call, fork, put, takeEvery } from 'redux-saga/effects';
+import { fork, put, takeEvery } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context/index.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 
 import {
+  type ChannelDefinition,
   createTransaction,
-  getTxChannel,
+  createTransactionChannels,
   waitForTxResult,
 } from '../transactions/index.ts';
 import {
+  createActionMetadataInDB,
   getColonyManager,
   initiateTransaction,
   putError,
+  takeFrom,
+  uploadAnnotation,
 } from '../utils/index.ts';
 
 function* cancelDraftExpenditure({
   meta,
-  payload: { colonyAddress, expenditure, stakedExpenditureAddress },
+  payload: {
+    colonyAddress,
+    expenditure,
+    stakedExpenditureAddress,
+    annotationMessage,
+    customActionTitle,
+  },
 }: Action<ActionTypes.EXPENDITURE_DRAFT_CANCEL>) {
   const colonyManager: ColonyManager = yield getColonyManager();
   const colonyClient = yield colonyManager.getClient(
@@ -25,7 +35,15 @@ function* cancelDraftExpenditure({
     colonyAddress,
   );
 
-  const txChannel = yield call(getTxChannel, meta.id);
+  const batchKey = 'cancelDraftExpenditure';
+  const {
+    cancelExpenditure,
+    cancelAndReclaimStake,
+    annotateCancelExpenditure,
+  }: Record<string, ChannelDefinition> = yield createTransactionChannels(
+    meta.id,
+    ['cancelExpenditure', 'cancelAndReclaimStake', 'annotateCancelExpenditure'],
+  );
 
   try {
     if (expenditure.isStaked && stakedExpenditureAddress) {
@@ -37,31 +55,129 @@ function* cancelDraftExpenditure({
         stakedExpenditureAddress,
       );
 
-      yield fork(createTransaction, meta.id, {
+      yield fork(createTransaction, cancelAndReclaimStake.id, {
         context: ClientType.StakedExpenditureClient,
         methodName: 'cancelAndReclaimStake',
         identifier: colonyAddress,
+        group: {
+          key: batchKey,
+          id: meta.id,
+          index: 0,
+        },
         params: [permissionDomainId, childSkillIndex, expenditure.nativeId],
       });
-      yield initiateTransaction({ id: meta.id });
+
+      if (annotationMessage) {
+        yield fork(createTransaction, annotateCancelExpenditure.id, {
+          context: ClientType.ColonyClient,
+          methodName: 'annotateTransaction',
+          identifier: colonyAddress,
+          group: {
+            key: batchKey,
+            id: meta.id,
+            index: 1,
+          },
+          ready: false,
+        });
+      }
+
+      yield takeFrom(
+        cancelAndReclaimStake.channel,
+        ActionTypes.TRANSACTION_CREATED,
+      );
+      if (annotationMessage) {
+        yield takeFrom(
+          annotateCancelExpenditure.channel,
+          ActionTypes.TRANSACTION_CREATED,
+        );
+      }
+
+      const {
+        payload: { hash: txHash },
+      } = yield takeFrom(
+        cancelAndReclaimStake.channel,
+        ActionTypes.TRANSACTION_HASH_RECEIVED,
+      );
+      yield initiateTransaction({ id: cancelAndReclaimStake.id });
+
+      yield waitForTxResult(cancelAndReclaimStake.channel);
+
+      if (annotationMessage) {
+        yield uploadAnnotation({
+          txChannel: annotateCancelExpenditure,
+          message: annotationMessage,
+          txHash,
+        });
+      }
+
+      if (customActionTitle) {
+        yield createActionMetadataInDB(txHash, customActionTitle);
+      }
     } else {
-      yield fork(createTransaction, meta.id, {
+      yield fork(createTransaction, cancelExpenditure.id, {
         context: ClientType.ColonyClient,
         methodName: 'cancelExpenditure',
         identifier: colonyAddress,
+        group: {
+          key: batchKey,
+          id: meta.id,
+          index: 0,
+        },
         params: [expenditure.nativeId],
       });
-      yield initiateTransaction({ id: meta.id });
-    }
-    const { type } = yield waitForTxResult(txChannel);
+      if (annotationMessage) {
+        yield fork(createTransaction, annotateCancelExpenditure.id, {
+          context: ClientType.ColonyClient,
+          methodName: 'annotateTransaction',
+          identifier: colonyAddress,
+          group: {
+            key: batchKey,
+            id: meta.id,
+            index: 1,
+          },
+          ready: false,
+        });
+      }
 
-    if (type === ActionTypes.TRANSACTION_SUCCEEDED) {
-      yield put<AllActions>({
-        type: ActionTypes.EXPENDITURE_DRAFT_CANCEL_SUCCESS,
-        payload: {},
-        meta,
-      });
+      yield takeFrom(
+        cancelExpenditure.channel,
+        ActionTypes.TRANSACTION_CREATED,
+      );
+      if (annotationMessage) {
+        yield takeFrom(
+          annotateCancelExpenditure.channel,
+          ActionTypes.TRANSACTION_CREATED,
+        );
+      }
+
+      const {
+        payload: { hash: txHash },
+      } = yield takeFrom(
+        cancelExpenditure.channel,
+        ActionTypes.TRANSACTION_HASH_RECEIVED,
+      );
+      yield initiateTransaction({ id: cancelExpenditure.id });
+
+      yield waitForTxResult(cancelExpenditure.channel);
+
+      if (annotationMessage) {
+        yield uploadAnnotation({
+          txChannel: annotateCancelExpenditure,
+          message: annotationMessage,
+          txHash,
+        });
+      }
+
+      if (customActionTitle) {
+        yield createActionMetadataInDB(txHash, customActionTitle);
+      }
     }
+
+    yield put<AllActions>({
+      type: ActionTypes.EXPENDITURE_DRAFT_CANCEL_SUCCESS,
+      payload: {},
+      meta,
+    });
   } catch (error) {
     return yield putError(
       ActionTypes.EXPENDITURE_DRAFT_CANCEL_ERROR,
@@ -69,8 +185,6 @@ function* cancelDraftExpenditure({
       meta,
     );
   }
-
-  txChannel.close();
 
   return null;
 }

--- a/src/redux/sagas/expenditures/cancelStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/cancelStakedExpenditure.ts
@@ -137,6 +137,9 @@ function* cancelStakedExpenditureAction({
       meta,
     );
   }
+  [cancelStakedExpenditure, annotateCancelStakedExpenditure].forEach(
+    (channel) => channel.channel.close(),
+  );
 
   return null;
 }

--- a/src/redux/sagas/expenditures/cancelStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/cancelStakedExpenditure.ts
@@ -11,7 +11,6 @@ import {
   waitForTxResult,
 } from '../transactions/index.ts';
 import {
-  createActionMetadataInDB,
   getColonyManager,
   initiateTransaction,
   putError,
@@ -27,7 +26,6 @@ function* cancelStakedExpenditureAction({
     shouldPunish,
     expenditure,
     annotationMessage,
-    customActionTitle,
   },
 }: Action<ActionTypes.STAKED_EXPENDITURE_CANCEL>) {
   const batchKey = 'cancelStakedExpenditure';
@@ -125,10 +123,6 @@ function* cancelStakedExpenditureAction({
         message: annotationMessage,
         txHash,
       });
-    }
-
-    if (customActionTitle) {
-      yield createActionMetadataInDB(txHash, customActionTitle);
     }
 
     yield put<AllActions>({

--- a/src/redux/sagas/expenditures/cancelStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/cancelStakedExpenditure.ts
@@ -1,36 +1,50 @@
 import { ClientType, ColonyRole, getPermissionProofs } from '@colony/colony-js';
-import { call, fork, put, takeEvery } from 'redux-saga/effects';
+import { fork, put, takeEvery } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context/index.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 
 import {
+  type ChannelDefinition,
   createTransaction,
-  getTxChannel,
+  createTransactionChannels,
   waitForTxResult,
 } from '../transactions/index.ts';
 import {
+  createActionMetadataInDB,
   getColonyManager,
   initiateTransaction,
   putError,
+  takeFrom,
+  uploadAnnotation,
 } from '../utils/index.ts';
 
-function* cancelStakedExpenditure({
+function* cancelStakedExpenditureAction({
   meta,
   payload: {
     colonyAddress,
     stakedExpenditureAddress,
     shouldPunish,
     expenditure,
+    annotationMessage,
+    customActionTitle,
   },
 }: Action<ActionTypes.STAKED_EXPENDITURE_CANCEL>) {
+  const batchKey = 'cancelStakedExpenditure';
+
   const colonyManager: ColonyManager = yield getColonyManager();
   const colonyClient = yield colonyManager.getClient(
     ClientType.ColonyClient,
     colonyAddress,
   );
 
-  const txChannel = yield call(getTxChannel, meta.id);
+  const {
+    cancelStakedExpenditure,
+    annotateCancelStakedExpenditure,
+  }: Record<string, ChannelDefinition> = yield createTransactionChannels(
+    meta.id,
+    ['cancelStakedExpenditure', 'annotateCancelStakedExpenditure'],
+  );
 
   try {
     const [extensionPermissionDomainId, extensionChildSkillIndex] =
@@ -50,10 +64,15 @@ function* cancelStakedExpenditure({
         ColonyRole.Arbitration,
       );
 
-    yield fork(createTransaction, meta.id, {
+    yield fork(createTransaction, cancelStakedExpenditure.id, {
       context: ClientType.StakedExpenditureClient,
       methodName: 'cancelAndPunish',
       identifier: colonyAddress,
+      group: {
+        key: batchKey,
+        id: meta.id,
+        index: 0,
+      },
       params: [
         extensionPermissionDomainId,
         extensionChildSkillIndex,
@@ -64,17 +83,59 @@ function* cancelStakedExpenditure({
       ],
     });
 
-    yield initiateTransaction({ id: meta.id });
-
-    const { type } = yield waitForTxResult(txChannel);
-
-    if (type === ActionTypes.TRANSACTION_SUCCEEDED) {
-      yield put<AllActions>({
-        type: ActionTypes.STAKED_EXPENDITURE_CANCEL_SUCCESS,
-        payload: {},
-        meta,
+    if (annotationMessage) {
+      yield fork(createTransaction, annotateCancelStakedExpenditure.id, {
+        context: ClientType.ColonyClient,
+        methodName: 'annotateTransaction',
+        identifier: colonyAddress,
+        group: {
+          key: batchKey,
+          id: meta.id,
+          index: 1,
+        },
+        ready: false,
       });
     }
+
+    yield takeFrom(
+      cancelStakedExpenditure.channel,
+      ActionTypes.TRANSACTION_CREATED,
+    );
+    if (annotationMessage) {
+      yield takeFrom(
+        annotateCancelStakedExpenditure.channel,
+        ActionTypes.TRANSACTION_CREATED,
+      );
+    }
+
+    const {
+      payload: { hash: txHash },
+    } = yield takeFrom(
+      cancelStakedExpenditure.channel,
+      ActionTypes.TRANSACTION_HASH_RECEIVED,
+    );
+
+    yield initiateTransaction({ id: cancelStakedExpenditure.id });
+
+    yield waitForTxResult(cancelStakedExpenditure.channel);
+
+    if (annotationMessage) {
+      yield uploadAnnotation({
+        txChannel: annotateCancelStakedExpenditure,
+        message: annotationMessage,
+        txHash,
+      });
+    }
+
+    if (customActionTitle) {
+      yield createActionMetadataInDB(txHash, customActionTitle);
+    }
+
+    yield put<AllActions>({
+      type: ActionTypes.STAKED_EXPENDITURE_CANCEL_SUCCESS,
+      payload: {},
+      meta,
+    });
   } catch (error) {
     return yield putError(
       ActionTypes.STAKED_EXPENDITURE_CANCEL_ERROR,
@@ -83,14 +144,12 @@ function* cancelStakedExpenditure({
     );
   }
 
-  txChannel.close();
-
   return null;
 }
 
 export default function* cancelStakedExpenditureSaga() {
   yield takeEvery(
     ActionTypes.STAKED_EXPENDITURE_CANCEL,
-    cancelStakedExpenditure,
+    cancelStakedExpenditureAction,
   );
 }

--- a/src/redux/sagas/expenditures/claimExpenditure.ts
+++ b/src/redux/sagas/expenditures/claimExpenditure.ts
@@ -10,7 +10,6 @@ import {
   waitForTxResult,
 } from '../transactions/index.ts';
 import {
-  createActionMetadataInDB,
   initiateTransaction,
   putError,
   takeFrom,
@@ -34,7 +33,6 @@ function* claimExpenditure({
     nativeExpenditureId,
     claimableSlots,
     annotationMessage,
-    customActionTitle,
   },
 }: Action<ActionTypes.EXPENDITURE_CLAIM>) {
   const batchKey = 'claimExpenditure';
@@ -117,10 +115,6 @@ function* claimExpenditure({
           message: annotationMessage,
           txHash,
         });
-      }
-
-      if (customActionTitle) {
-        yield createActionMetadataInDB(txHash, customActionTitle);
       }
     }
 

--- a/src/redux/sagas/expenditures/claimExpenditure.ts
+++ b/src/redux/sagas/expenditures/claimExpenditure.ts
@@ -81,7 +81,7 @@ function* claimExpenditure({
         group: {
           key: batchKey,
           id: meta.id,
-          index: payoutsWithSlotIds.length - 1,
+          index: payoutsWithSlotIds.length,
         },
         ready: false,
       });

--- a/src/redux/sagas/expenditures/claimExpenditure.ts
+++ b/src/redux/sagas/expenditures/claimExpenditure.ts
@@ -130,6 +130,7 @@ function* claimExpenditure({
       const payoutChannelId = getPayoutChannelId(payout);
       channels[payoutChannelId].channel.close();
     }
+    annotatePayoutChannel.channel.close();
   }
 
   return null;

--- a/src/redux/sagas/expenditures/createExpenditure.ts
+++ b/src/redux/sagas/expenditures/createExpenditure.ts
@@ -77,6 +77,7 @@ function* createExpenditure({
       ColonyRole.Administration,
     );
 
+    // Move these to createGroupTransaction
     yield fork(createTransaction, makeExpenditure.id, {
       context: ClientType.ColonyClient,
       methodName: 'makeExpenditure',
@@ -117,7 +118,7 @@ function* createExpenditure({
     }
 
     if (annotationMessage) {
-      yield createTransaction(annotateMakeExpenditure.id, {
+      yield fork(createTransaction, annotateMakeExpenditure.id, {
         context: ClientType.ColonyClient,
         methodName: 'annotateTransaction',
         identifier: colonyAddress,

--- a/src/redux/sagas/expenditures/createExpenditure.ts
+++ b/src/redux/sagas/expenditures/createExpenditure.ts
@@ -77,7 +77,6 @@ function* createExpenditure({
       ColonyRole.Administration,
     );
 
-    // Move these to createGroupTransaction
     yield fork(createTransaction, makeExpenditure.id, {
       context: ClientType.ColonyClient,
       methodName: 'makeExpenditure',
@@ -198,7 +197,9 @@ function* createExpenditure({
       stages: isStaged ? stages : undefined,
     });
 
-    yield createActionMetadataInDB(txHash, customActionTitle);
+    if (customActionTitle) {
+      yield createActionMetadataInDB(txHash, customActionTitle);
+    }
 
     yield put<AllActions>({
       type: ActionTypes.EXPENDITURE_CREATE_SUCCESS,

--- a/src/redux/sagas/expenditures/createExpenditure.ts
+++ b/src/redux/sagas/expenditures/createExpenditure.ts
@@ -18,7 +18,6 @@ import {
   getSetExpenditureValuesFunctionParams,
   saveExpenditureMetadata,
   initiateTransaction,
-  createActionMetadataInDB,
   uploadAnnotation,
 } from '../utils/index.ts';
 
@@ -37,7 +36,6 @@ function* createExpenditure({
     networkInverseFee,
     decisionMethod,
     annotationMessage,
-    customActionTitle,
   },
 }: Action<ActionTypes.EXPENDITURE_CREATE>) {
   const colonyManager: ColonyManager = yield getColonyManager();
@@ -193,10 +191,6 @@ function* createExpenditure({
       decisionMethod,
       stages: isStaged ? stages : undefined,
     });
-
-    if (customActionTitle) {
-      yield createActionMetadataInDB(txHash, customActionTitle);
-    }
 
     yield put<AllActions>({
       type: ActionTypes.EXPENDITURE_CREATE_SUCCESS,

--- a/src/redux/sagas/expenditures/createExpenditure.ts
+++ b/src/redux/sagas/expenditures/createExpenditure.ts
@@ -26,10 +26,9 @@ export type CreateExpenditurePayload =
   Action<ActionTypes.EXPENDITURE_CREATE>['payload'];
 
 function* createExpenditure({
-  meta: { navigate, setTxHash },
   meta,
   payload: {
-    colony: { name: colonyName, colonyAddress },
+    colonyAddress,
     payouts,
     createdInDomain,
     fundFromDomainId,
@@ -146,8 +145,6 @@ function* createExpenditure({
       ActionTypes.TRANSACTION_HASH_RECEIVED,
     );
 
-    setTxHash?.(txHash);
-
     yield waitForTxResult(makeExpenditure.channel);
 
     const expenditureId = yield call(colonyClient.getExpenditureCount);
@@ -210,12 +207,6 @@ function* createExpenditure({
     // @TODO: Remove during advanced payments UI wiring
     // eslint-disable-next-line no-console
     console.log('Created expenditure ID:', expenditureId.toString());
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (error) {
     return yield putError(ActionTypes.EXPENDITURE_CREATE_ERROR, error, meta);
   }

--- a/src/redux/sagas/expenditures/createExpenditure.ts
+++ b/src/redux/sagas/expenditures/createExpenditure.ts
@@ -205,9 +205,12 @@ function* createExpenditure({
     return yield putError(ActionTypes.EXPENDITURE_CREATE_ERROR, error, meta);
   }
 
-  [makeExpenditure, setExpenditureValues, setExpenditureStaged].forEach(
-    (channel) => channel.channel.close(),
-  );
+  [
+    makeExpenditure,
+    setExpenditureValues,
+    setExpenditureStaged,
+    annotateMakeExpenditure,
+  ].forEach((channel) => channel.channel.close());
 
   return null;
 }

--- a/src/redux/sagas/expenditures/createExpenditure.ts
+++ b/src/redux/sagas/expenditures/createExpenditure.ts
@@ -123,7 +123,7 @@ function* createExpenditure({
         group: {
           key: batchKey,
           id: meta.id,
-          index: 3,
+          index: isStaged ? 3 : 2,
         },
         ready: false,
       });

--- a/src/redux/sagas/expenditures/createStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/createStakedExpenditure.ts
@@ -242,7 +242,9 @@ function* createStakedExpenditure({
       stakeAmount,
     });
 
-    yield createActionMetadataInDB(txHash, customActionTitle);
+    if (customActionTitle) {
+      yield createActionMetadataInDB(txHash, customActionTitle);
+    }
 
     yield put<AllActions>({
       type: ActionTypes.EXPENDITURE_CREATE_SUCCESS,

--- a/src/redux/sagas/expenditures/createStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/createStakedExpenditure.ts
@@ -27,10 +27,9 @@ export type CreateStakedExpenditurePayload =
   Action<ActionTypes.STAKED_EXPENDITURE_CREATE>['payload'];
 
 function* createStakedExpenditure({
-  meta: { navigate, setTxHash },
   meta,
   payload: {
-    colony: { name: colonyName, colonyAddress },
+    colonyAddress,
     payouts,
     createdInDomain,
     fundFromDomainId,
@@ -191,7 +190,6 @@ function* createStakedExpenditure({
       ActionTypes.TRANSACTION_HASH_RECEIVED,
     );
 
-    setTxHash?.(txHash);
     yield waitForTxResult(makeExpenditure.channel);
 
     const expenditureId = yield call(colonyClient.getExpenditureCount);
@@ -255,12 +253,6 @@ function* createStakedExpenditure({
     // @TODO: Remove during advanced payments UI wiring
     // eslint-disable-next-line no-console
     console.log('Created expenditure ID:', expenditureId.toString());
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (error) {
     return yield putError(ActionTypes.EXPENDITURE_CREATE_ERROR, error, meta);
   } finally {

--- a/src/redux/sagas/expenditures/createStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/createStakedExpenditure.ts
@@ -133,7 +133,7 @@ function* createStakedExpenditure({
         group: {
           key: batchKey,
           id: meta.id,
-          index: 3,
+          index: isStaged ? 4 : 3,
         },
         ready: false,
       });

--- a/src/redux/sagas/expenditures/createStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/createStakedExpenditure.ts
@@ -20,7 +20,6 @@ import {
   saveExpenditureMetadata,
   initiateTransaction,
   uploadAnnotation,
-  createActionMetadataInDB,
 } from '../utils/index.ts';
 
 export type CreateStakedExpenditurePayload =
@@ -39,7 +38,6 @@ function* createStakedExpenditure({
     stages,
     networkInverseFee,
     decisionMethod,
-    customActionTitle,
     annotationMessage,
   },
 }: Action<ActionTypes.STAKED_EXPENDITURE_CREATE>) {
@@ -239,10 +237,6 @@ function* createStakedExpenditure({
       stages: isStaged ? stages : undefined,
       stakeAmount,
     });
-
-    if (customActionTitle) {
-      yield createActionMetadataInDB(txHash, customActionTitle);
-    }
 
     yield put<AllActions>({
       type: ActionTypes.EXPENDITURE_CREATE_SUCCESS,

--- a/src/redux/sagas/expenditures/createStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/createStakedExpenditure.ts
@@ -255,6 +255,7 @@ function* createStakedExpenditure({
       makeExpenditure,
       setExpenditureValues,
       setExpenditureStaged,
+      annotateMakeStagedExpenditure,
     ].forEach(({ channel }) => channel.close());
   }
   return null;

--- a/src/redux/sagas/expenditures/createStreamingPayment.ts
+++ b/src/redux/sagas/expenditures/createStreamingPayment.ts
@@ -40,7 +40,7 @@ const TIMESTAMP_IN_FUTURE = 2_000_000_000;
 
 function* createStreamingPaymentAction({
   payload: {
-    colony: { name: colonyName, colonyAddress },
+    colonyAddress,
     createdInDomain,
     recipientAddress,
     tokenAddress,
@@ -54,7 +54,6 @@ function* createStreamingPaymentAction({
     customActionTitle,
   },
   meta,
-  meta: { navigate, setTxHash },
 }: Action<ActionTypes.STREAMING_PAYMENT_CREATE>) {
   const apolloClient = getContext(ContextModule.ApolloClient);
 
@@ -155,8 +154,6 @@ function* createStreamingPaymentAction({
       ActionTypes.TRANSACTION_HASH_RECEIVED,
     );
 
-    setTxHash?.(txHash);
-
     yield waitForTxResult(createStreamingPayment.channel);
 
     if (annotationMessage) {
@@ -197,12 +194,6 @@ function* createStreamingPaymentAction({
       payload: {},
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (error) {
     return yield putError(
       ActionTypes.STREAMING_PAYMENT_CREATE_ERROR,

--- a/src/redux/sagas/expenditures/createStreamingPayment.ts
+++ b/src/redux/sagas/expenditures/createStreamingPayment.ts
@@ -147,7 +147,7 @@ function* createStreamingPaymentAction({
       );
     }
 
-    yield initiateTransaction({ id: meta.id });
+    yield initiateTransaction({ id: createStreamingPayment.id });
     const {
       payload: { hash: txHash },
     } = yield takeFrom(

--- a/src/redux/sagas/expenditures/createStreamingPayment.ts
+++ b/src/redux/sagas/expenditures/createStreamingPayment.ts
@@ -195,6 +195,10 @@ function* createStreamingPaymentAction({
       meta,
     );
   }
+  [createStreamingPayment, annotateCreateStreamingPayment].forEach((channel) =>
+    channel.channel.close(),
+  );
+
   return null;
 }
 

--- a/src/redux/sagas/expenditures/createStreamingPayment.ts
+++ b/src/redux/sagas/expenditures/createStreamingPayment.ts
@@ -4,7 +4,7 @@ import {
   ColonyRole,
   getPermissionProofs,
 } from '@colony/colony-js';
-import { call, fork, takeEvery } from 'redux-saga/effects';
+import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
 import { ContextModule, getContext } from '~context/index.ts';
 import {
@@ -13,20 +13,23 @@ import {
   type CreateStreamingPaymentMetadataMutationVariables,
 } from '~gql';
 import { ActionTypes } from '~redux/actionTypes.ts';
-import { type Action } from '~redux/types/index.ts';
+import { type AllActions, type Action } from '~redux/types/index.ts';
 import { getExpenditureDatabaseId } from '~utils/databaseId.ts';
 import { toNumber } from '~utils/numbers.ts';
 
 import {
+  type ChannelDefinition,
   createTransaction,
-  getTxChannel,
+  createTransactionChannels,
   waitForTxResult,
 } from '../transactions/index.ts';
 import {
+  createActionMetadataInDB,
   getColonyManager,
   initiateTransaction,
   putError,
   takeFrom,
+  uploadAnnotation,
 } from '../utils/index.ts';
 
 export type CreateStreamingPaymentPayload =
@@ -35,9 +38,9 @@ export type CreateStreamingPaymentPayload =
 // @TODO: Figure out a more appropriate way of getting this
 const TIMESTAMP_IN_FUTURE = 2_000_000_000;
 
-function* createStreamingPayment({
+function* createStreamingPaymentAction({
   payload: {
-    colonyAddress,
+    colony: { name: colonyName, colonyAddress },
     createdInDomain,
     recipientAddress,
     tokenAddress,
@@ -47,13 +50,23 @@ function* createStreamingPayment({
     interval,
     endCondition,
     limitAmount,
+    annotationMessage,
+    customActionTitle,
   },
   meta,
-  meta: { setTxHash },
+  meta: { navigate, setTxHash },
 }: Action<ActionTypes.STREAMING_PAYMENT_CREATE>) {
   const apolloClient = getContext(ContextModule.ApolloClient);
 
-  const txChannel = yield getTxChannel(meta.id);
+  const batchKey = 'createStreamingPayment';
+
+  const {
+    createStreamingPayment,
+    annotateCreateStreamingPayment,
+  }: Record<string, ChannelDefinition> = yield createTransactionChannels(
+    meta.id,
+    ['createStreamingPayment', 'annotateCreateStreamingPayment'],
+  );
 
   try {
     const colonyManager = yield getColonyManager();
@@ -85,10 +98,15 @@ function* createStreamingPayment({
         ColonyRole.Arbitration,
       );
 
-    yield fork(createTransaction, meta.id, {
+    yield fork(createTransaction, createStreamingPayment.id, {
       context: ClientType.StreamingPaymentsClient,
       methodName: 'create',
       identifier: colonyAddress,
+      group: {
+        key: batchKey,
+        id: meta.id,
+        index: 0,
+      },
       params: [
         fundingPermissionDomainId,
         fundingChildSkillIndex,
@@ -104,15 +122,50 @@ function* createStreamingPayment({
       ],
     });
 
-    yield takeFrom(txChannel, ActionTypes.TRANSACTION_CREATED);
+    if (annotationMessage) {
+      yield fork(createTransaction, annotateCreateStreamingPayment.id, {
+        context: ClientType.ColonyClient,
+        methodName: 'annotateTransaction',
+        identifier: colonyAddress,
+        group: {
+          key: batchKey,
+          id: meta.id,
+          index: 1,
+        },
+        ready: false,
+      });
+    }
+
+    yield takeFrom(
+      createStreamingPayment.channel,
+      ActionTypes.TRANSACTION_CREATED,
+    );
+    if (annotationMessage) {
+      yield takeFrom(
+        annotateCreateStreamingPayment.channel,
+        ActionTypes.TRANSACTION_CREATED,
+      );
+    }
+
     yield initiateTransaction({ id: meta.id });
     const {
       payload: { hash: txHash },
-    } = yield takeFrom(txChannel, ActionTypes.TRANSACTION_HASH_RECEIVED);
+    } = yield takeFrom(
+      createStreamingPayment.channel,
+      ActionTypes.TRANSACTION_HASH_RECEIVED,
+    );
 
     setTxHash?.(txHash);
 
-    yield waitForTxResult(txChannel);
+    yield waitForTxResult(createStreamingPayment.channel);
+
+    if (annotationMessage) {
+      yield uploadAnnotation({
+        txChannel: annotateCreateStreamingPayment,
+        message: annotationMessage,
+        txHash,
+      });
+    }
 
     const streamingPaymentId = yield call(
       streamingPaymentsClient.getNumStreamingPayments,
@@ -134,6 +187,22 @@ function* createStreamingPayment({
         },
       },
     });
+
+    if (customActionTitle) {
+      yield createActionMetadataInDB(txHash, customActionTitle);
+    }
+
+    yield put<AllActions>({
+      type: ActionTypes.STREAMING_PAYMENT_CREATE_SUCCESS,
+      payload: {},
+      meta,
+    });
+
+    if (colonyName && navigate) {
+      navigate(`/${colonyName}?tx=${txHash}`, {
+        state: { isRedirect: true },
+      });
+    }
   } catch (error) {
     return yield putError(
       ActionTypes.STREAMING_PAYMENT_CREATE_ERROR,
@@ -145,5 +214,8 @@ function* createStreamingPayment({
 }
 
 export default function* createStreamingPaymentSaga() {
-  yield takeEvery(ActionTypes.STREAMING_PAYMENT_CREATE, createStreamingPayment);
+  yield takeEvery(
+    ActionTypes.STREAMING_PAYMENT_CREATE,
+    createStreamingPaymentAction,
+  );
 }

--- a/src/redux/sagas/expenditures/createStreamingPayment.ts
+++ b/src/redux/sagas/expenditures/createStreamingPayment.ts
@@ -24,7 +24,6 @@ import {
   waitForTxResult,
 } from '../transactions/index.ts';
 import {
-  createActionMetadataInDB,
   getColonyManager,
   initiateTransaction,
   putError,
@@ -51,7 +50,6 @@ function* createStreamingPaymentAction({
     endCondition,
     limitAmount,
     annotationMessage,
-    customActionTitle,
   },
   meta,
 }: Action<ActionTypes.STREAMING_PAYMENT_CREATE>) {
@@ -184,10 +182,6 @@ function* createStreamingPaymentAction({
         },
       },
     });
-
-    if (customActionTitle) {
-      yield createActionMetadataInDB(txHash, customActionTitle);
-    }
 
     yield put<AllActions>({
       type: ActionTypes.STREAMING_PAYMENT_CREATE_SUCCESS,

--- a/src/redux/sagas/expenditures/editExpenditure.ts
+++ b/src/redux/sagas/expenditures/editExpenditure.ts
@@ -17,7 +17,6 @@ import {
   initiateTransaction,
   takeFrom,
   uploadAnnotation,
-  createActionMetadataInDB,
 } from '../utils/index.ts';
 
 function* editExpenditureAction({
@@ -26,7 +25,6 @@ function* editExpenditureAction({
     expenditure,
     payouts,
     networkInverseFee,
-    customActionTitle,
     annotationMessage,
   },
   meta,
@@ -139,7 +137,7 @@ function* editExpenditureAction({
       ActionTypes.TRANSACTION_HASH_RECEIVED,
     );
 
-    const { type } = yield waitForTxResult(editExpenditure.channel);
+    yield waitForTxResult(editExpenditure.channel);
 
     if (annotationMessage) {
       yield uploadAnnotation({
@@ -149,17 +147,11 @@ function* editExpenditureAction({
       });
     }
 
-    if (type === ActionTypes.TRANSACTION_SUCCEEDED) {
-      if (customActionTitle) {
-        yield createActionMetadataInDB(txHash, customActionTitle);
-      }
-
-      yield put<AllActions>({
-        type: ActionTypes.EXPENDITURE_EDIT_SUCCESS,
-        payload: {},
-        meta,
-      });
-    }
+    yield put<AllActions>({
+      type: ActionTypes.EXPENDITURE_EDIT_SUCCESS,
+      payload: {},
+      meta,
+    });
   } catch (error) {
     return yield putError(ActionTypes.EXPENDITURE_EDIT_ERROR, error, meta);
   }

--- a/src/redux/sagas/expenditures/editExpenditure.ts
+++ b/src/redux/sagas/expenditures/editExpenditure.ts
@@ -22,7 +22,7 @@ import {
 
 function* editExpenditureAction({
   payload: {
-    colony: { colonyAddress, name: colonyName },
+    colonyAddress,
     expenditure,
     payouts,
     networkInverseFee,
@@ -30,7 +30,6 @@ function* editExpenditureAction({
     annotationMessage,
   },
   meta,
-  meta: { navigate, setTxHash },
 }: Action<ActionTypes.EXPENDITURE_EDIT>) {
   const batchKey = 'createExpenditure';
 
@@ -140,8 +139,6 @@ function* editExpenditureAction({
       ActionTypes.TRANSACTION_HASH_RECEIVED,
     );
 
-    setTxHash?.(txHash);
-
     const { type } = yield waitForTxResult(editExpenditure.channel);
 
     if (annotationMessage) {
@@ -162,12 +159,6 @@ function* editExpenditureAction({
         payload: {},
         meta,
       });
-
-      if (colonyName && navigate) {
-        navigate(`/${colonyName}?tx=${txHash}`, {
-          state: { isRedirect: true },
-        });
-      }
     }
   } catch (error) {
     return yield putError(ActionTypes.EXPENDITURE_EDIT_ERROR, error, meta);

--- a/src/redux/sagas/expenditures/editExpenditure.ts
+++ b/src/redux/sagas/expenditures/editExpenditure.ts
@@ -155,6 +155,9 @@ function* editExpenditureAction({
   } catch (error) {
     return yield putError(ActionTypes.EXPENDITURE_EDIT_ERROR, error, meta);
   }
+  [editExpenditure, annotateEditExpenditure].forEach((channel) =>
+    channel.channel.close(),
+  );
 
   return null;
 }

--- a/src/redux/sagas/expenditures/finalizeExpenditure.ts
+++ b/src/redux/sagas/expenditures/finalizeExpenditure.ts
@@ -10,7 +10,6 @@ import {
   waitForTxResult,
 } from '../transactions/index.ts';
 import {
-  createActionMetadataInDB,
   initiateTransaction,
   putError,
   takeFrom,
@@ -21,12 +20,7 @@ export type FinalizeExpenditurePayload =
   Action<ActionTypes.EXPENDITURE_FINALIZE>['payload'];
 
 function* finalizeExpenditureAction({
-  payload: {
-    colonyAddress,
-    nativeExpenditureId,
-    customActionTitle,
-    annotationMessage,
-  },
+  payload: { colonyAddress, nativeExpenditureId, annotationMessage },
   meta,
 }: Action<ActionTypes.EXPENDITURE_FINALIZE>) {
   const batchKey = 'finalizeExpenditure';
@@ -93,10 +87,6 @@ function* finalizeExpenditureAction({
         message: annotationMessage,
         txHash,
       });
-    }
-
-    if (customActionTitle) {
-      yield createActionMetadataInDB(txHash, customActionTitle);
     }
 
     yield put<AllActions>({

--- a/src/redux/sagas/expenditures/finalizeExpenditure.ts
+++ b/src/redux/sagas/expenditures/finalizeExpenditure.ts
@@ -22,13 +22,12 @@ export type FinalizeExpenditurePayload =
 
 function* finalizeExpenditureAction({
   payload: {
-    colony: { colonyAddress, name: colonyName },
+    colonyAddress,
     nativeExpenditureId,
     customActionTitle,
     annotationMessage,
   },
   meta,
-  meta: { navigate, setTxHash },
 }: Action<ActionTypes.EXPENDITURE_FINALIZE>) {
   const batchKey = 'finalizeExpenditure';
 
@@ -86,8 +85,6 @@ function* finalizeExpenditureAction({
       ActionTypes.TRANSACTION_HASH_RECEIVED,
     );
 
-    setTxHash?.(txHash);
-
     yield waitForTxResult(finalizeExpenditure.channel);
 
     if (annotationMessage) {
@@ -107,12 +104,6 @@ function* finalizeExpenditureAction({
       payload: {},
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (error) {
     return yield putError(ActionTypes.EXPENDITURE_FINALIZE_ERROR, error, meta);
   }

--- a/src/redux/sagas/expenditures/finalizeExpenditure.ts
+++ b/src/redux/sagas/expenditures/finalizeExpenditure.ts
@@ -97,6 +97,9 @@ function* finalizeExpenditureAction({
   } catch (error) {
     return yield putError(ActionTypes.EXPENDITURE_FINALIZE_ERROR, error, meta);
   }
+  [finalizeExpenditure, annotateFinalizeExpenditure].forEach((channel) =>
+    channel.channel.close(),
+  );
 
   return null;
 }

--- a/src/redux/sagas/expenditures/finalizeExpenditure.ts
+++ b/src/redux/sagas/expenditures/finalizeExpenditure.ts
@@ -37,7 +37,7 @@ function* finalizeExpenditureAction({
     annotateFinalizeExpenditure,
   }: Record<string, ChannelDefinition> = yield createTransactionChannels(
     meta.id,
-    ['makeExpenditure', 'annotateFinalizeExpenditure'],
+    ['finalizeExpenditure', 'annotateFinalizeExpenditure'],
   );
 
   try {

--- a/src/redux/sagas/expenditures/fundExpenditure.ts
+++ b/src/redux/sagas/expenditures/fundExpenditure.ts
@@ -15,7 +15,6 @@ import {
 } from '../transactions/index.ts';
 import { getExpenditureBalancesByTokenAddress } from '../utils/expenditures.ts';
 import {
-  createActionMetadataInDB,
   initiateTransaction,
   putError,
   takeFrom,
@@ -31,7 +30,6 @@ function* fundExpenditure({
     expenditure,
     fromDomainFundingPotId,
     annotationMessage,
-    customActionTitle,
   },
   meta,
 }: Action<ActionTypes.EXPENDITURE_FUND>) {
@@ -124,10 +122,6 @@ function* fundExpenditure({
           message: annotationMessage,
           txHash,
         });
-      }
-
-      if (customActionTitle) {
-        yield createActionMetadataInDB(txHash, customActionTitle);
       }
     }
 

--- a/src/redux/sagas/expenditures/fundExpenditure.ts
+++ b/src/redux/sagas/expenditures/fundExpenditure.ts
@@ -136,6 +136,7 @@ function* fundExpenditure({
     [...balancesByTokenAddresses.keys()].forEach((tokenAddress) =>
       channels[tokenAddress].channel.close(),
     );
+    annotateFundExpenditure.channel.close();
   }
 
   return null;

--- a/src/redux/sagas/expenditures/lockExpenditure.ts
+++ b/src/redux/sagas/expenditures/lockExpenditure.ts
@@ -10,7 +10,6 @@ import {
   waitForTxResult,
 } from '../transactions/index.ts';
 import {
-  createActionMetadataInDB,
   initiateTransaction,
   putError,
   takeFrom,
@@ -21,12 +20,7 @@ export type LockExpenditurePayload =
   Action<ActionTypes.EXPENDITURE_LOCK>['payload'];
 
 function* lockExpenditureAction({
-  payload: {
-    colonyAddress,
-    nativeExpenditureId,
-    annotationMessage,
-    customActionTitle,
-  },
+  payload: { colonyAddress, nativeExpenditureId, annotationMessage },
   meta,
 }: Action<ActionTypes.EXPENDITURE_LOCK>) {
   const batchKey = 'lockExpenditure';
@@ -76,10 +70,6 @@ function* lockExpenditureAction({
         message: annotationMessage,
         txHash,
       });
-    }
-
-    if (customActionTitle) {
-      yield createActionMetadataInDB(txHash, customActionTitle);
     }
 
     yield put<AllActions>({

--- a/src/redux/sagas/expenditures/lockExpenditure.ts
+++ b/src/redux/sagas/expenditures/lockExpenditure.ts
@@ -80,6 +80,9 @@ function* lockExpenditureAction({
   } catch (error) {
     return yield putError(ActionTypes.EXPENDITURE_LOCK_ERROR, error, meta);
   }
+  [lockExpenditure, annotateLockExpenditure].forEach((channel) =>
+    channel.channel.close(),
+  );
 
   return null;
 }

--- a/src/redux/sagas/expenditures/lockExpenditure.ts
+++ b/src/redux/sagas/expenditures/lockExpenditure.ts
@@ -1,52 +1,99 @@
 import { ClientType } from '@colony/colony-js';
-import { call, fork, put, takeEvery } from 'redux-saga/effects';
+import { fork, put, takeEvery } from 'redux-saga/effects';
 
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 
 import {
+  type ChannelDefinition,
   createTransaction,
-  getTxChannel,
+  createTransactionChannels,
   waitForTxResult,
 } from '../transactions/index.ts';
-import { initiateTransaction, putError } from '../utils/index.ts';
+import {
+  createActionMetadataInDB,
+  initiateTransaction,
+  putError,
+  takeFrom,
+  uploadAnnotation,
+} from '../utils/index.ts';
 
 export type LockExpenditurePayload =
   Action<ActionTypes.EXPENDITURE_LOCK>['payload'];
 
-function* lockExpenditure({
-  payload: { colonyAddress, nativeExpenditureId },
+function* lockExpenditureAction({
+  payload: {
+    colonyAddress,
+    nativeExpenditureId,
+    annotationMessage,
+    customActionTitle,
+  },
   meta,
 }: Action<ActionTypes.EXPENDITURE_LOCK>) {
-  const txChannel = yield call(getTxChannel, meta.id);
+  const batchKey = 'lockExpenditure';
+
+  const {
+    lockExpenditure,
+    annotateLockExpenditure,
+  }: Record<string, ChannelDefinition> = yield createTransactionChannels(
+    meta.id,
+    ['lockExpenditure', 'annotateLockExpenditure'],
+  );
 
   try {
-    yield fork(createTransaction, meta.id, {
+    yield fork(createTransaction, lockExpenditure.id, {
       context: ClientType.ColonyClient,
       methodName: 'lockExpenditure',
       identifier: colonyAddress,
       params: [nativeExpenditureId],
     });
-
-    yield initiateTransaction({ id: meta.id });
-
-    const { type } = yield waitForTxResult(txChannel);
-
-    if (type === ActionTypes.TRANSACTION_SUCCEEDED) {
-      yield put<AllActions>({
-        type: ActionTypes.EXPENDITURE_LOCK_SUCCESS,
-        payload: {},
-        meta,
+    if (annotationMessage) {
+      yield fork(createTransaction, annotateLockExpenditure.id, {
+        context: ClientType.ColonyClient,
+        methodName: 'annotateTransaction',
+        identifier: colonyAddress,
+        group: {
+          key: batchKey,
+          id: meta.id,
+          index: 1,
+        },
+        ready: false,
       });
     }
+
+    yield initiateTransaction({ id: lockExpenditure.id });
+    const {
+      payload: { hash: txHash },
+    } = yield takeFrom(
+      lockExpenditure.channel,
+      ActionTypes.TRANSACTION_HASH_RECEIVED,
+    );
+
+    yield waitForTxResult(lockExpenditure.channel);
+
+    if (annotationMessage) {
+      yield uploadAnnotation({
+        txChannel: annotateLockExpenditure,
+        message: annotationMessage,
+        txHash,
+      });
+    }
+
+    if (customActionTitle) {
+      yield createActionMetadataInDB(txHash, customActionTitle);
+    }
+
+    yield put<AllActions>({
+      type: ActionTypes.EXPENDITURE_LOCK_SUCCESS,
+      payload: {},
+      meta,
+    });
   } catch (error) {
     return yield putError(ActionTypes.EXPENDITURE_LOCK_ERROR, error, meta);
   }
-
-  txChannel.close();
 
   return null;
 }
 
 export default function* lockExpenditureSaga() {
-  yield takeEvery(ActionTypes.EXPENDITURE_LOCK, lockExpenditure);
+  yield takeEvery(ActionTypes.EXPENDITURE_LOCK, lockExpenditureAction);
 }

--- a/src/redux/sagas/expenditures/releaseExpenditureStage.ts
+++ b/src/redux/sagas/expenditures/releaseExpenditureStage.ts
@@ -11,7 +11,6 @@ import {
   waitForTxResult,
 } from '../transactions/index.ts';
 import {
-  createActionMetadataInDB,
   getColonyManager,
   initiateTransaction,
   putError,
@@ -27,7 +26,6 @@ function* releaseExpenditureStage({
     tokenAddresses,
     stagedExpenditureAddress,
     annotationMessage,
-    customActionTitle,
   },
   meta,
 }: Action<ActionTypes.RELEASE_EXPENDITURE_STAGE>) {
@@ -112,10 +110,6 @@ function* releaseExpenditureStage({
         message: annotationMessage,
         txHash,
       });
-    }
-
-    if (customActionTitle) {
-      yield createActionMetadataInDB(txHash, customActionTitle);
     }
 
     yield put<AllActions>({

--- a/src/redux/sagas/expenditures/releaseExpenditureStage.ts
+++ b/src/redux/sagas/expenditures/releaseExpenditureStage.ts
@@ -1,18 +1,22 @@
 import { ClientType, ColonyRole, getPermissionProofs } from '@colony/colony-js';
-import { call, fork, put, takeEvery } from 'redux-saga/effects';
+import { fork, put, takeEvery } from 'redux-saga/effects';
 
 import { ActionTypes } from '~redux/actionTypes.ts';
 import { type Action, type AllActions } from '~redux/types/index.ts';
 
 import {
+  type ChannelDefinition,
   createTransaction,
-  getTxChannel,
+  createTransactionChannels,
   waitForTxResult,
 } from '../transactions/index.ts';
 import {
+  createActionMetadataInDB,
   getColonyManager,
   initiateTransaction,
   putError,
+  takeFrom,
+  uploadAnnotation,
 } from '../utils/index.ts';
 
 function* releaseExpenditureStage({
@@ -22,10 +26,20 @@ function* releaseExpenditureStage({
     slotId,
     tokenAddresses,
     stagedExpenditureAddress,
+    annotationMessage,
+    customActionTitle,
   },
   meta,
 }: Action<ActionTypes.RELEASE_EXPENDITURE_STAGE>) {
-  const txChannel = yield call(getTxChannel, meta.id);
+  const batchKey = 'releaseExpenditure';
+
+  const {
+    releaseExpenditure,
+    annotateReleaseExpenditure,
+  }: Record<string, ChannelDefinition> = yield createTransactionChannels(
+    meta.id,
+    ['releaseExpenditure', 'annotateReleaseExpenditure'],
+  );
 
   const colonyManager = yield getColonyManager();
   const colonyClient = yield colonyManager.getClient(
@@ -42,10 +56,15 @@ function* releaseExpenditureStage({
       stagedExpenditureAddress,
     );
 
-    yield fork(createTransaction, meta.id, {
+    yield fork(createTransaction, releaseExpenditure.id, {
       context: ClientType.StagedExpenditureClient,
       methodName: 'releaseStagedPayment',
       identifier: colonyAddress,
+      group: {
+        key: batchKey,
+        id: meta.id,
+        index: 0,
+      },
       params: [
         permissionDomainId,
         childSkillIndex,
@@ -55,8 +74,49 @@ function* releaseExpenditureStage({
       ],
     });
 
-    yield initiateTransaction({ id: meta.id });
-    yield waitForTxResult(txChannel);
+    if (annotationMessage) {
+      yield fork(createTransaction, annotateReleaseExpenditure.id, {
+        context: ClientType.ColonyClient,
+        methodName: 'annotateTransaction',
+        identifier: colonyAddress,
+        group: {
+          key: batchKey,
+          id: meta.id,
+          index: 1,
+        },
+        ready: false,
+      });
+    }
+
+    yield takeFrom(releaseExpenditure.channel, ActionTypes.TRANSACTION_CREATED);
+    if (annotationMessage) {
+      yield takeFrom(
+        annotateReleaseExpenditure.channel,
+        ActionTypes.TRANSACTION_CREATED,
+      );
+    }
+
+    yield initiateTransaction({ id: releaseExpenditure.id });
+    const {
+      payload: { hash: txHash },
+    } = yield takeFrom(
+      releaseExpenditure.channel,
+      ActionTypes.TRANSACTION_HASH_RECEIVED,
+    );
+
+    yield waitForTxResult(releaseExpenditure.channel);
+
+    if (annotationMessage) {
+      yield uploadAnnotation({
+        txChannel: annotateReleaseExpenditure,
+        message: annotationMessage,
+        txHash,
+      });
+    }
+
+    if (customActionTitle) {
+      yield createActionMetadataInDB(txHash, customActionTitle);
+    }
 
     yield put<AllActions>({
       type: ActionTypes.RELEASE_EXPENDITURE_STAGE_SUCCESS,
@@ -70,8 +130,6 @@ function* releaseExpenditureStage({
       meta,
     );
   }
-
-  txChannel.close();
 
   return null;
 }

--- a/src/redux/sagas/expenditures/releaseExpenditureStage.ts
+++ b/src/redux/sagas/expenditures/releaseExpenditureStage.ts
@@ -124,6 +124,9 @@ function* releaseExpenditureStage({
       meta,
     );
   }
+  [releaseExpenditure, annotateReleaseExpenditure].forEach((channel) =>
+    channel.channel.close(),
+  );
 
   return null;
 }

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -138,6 +138,8 @@ export type ExpendituresActionTypes =
         isStaged?: boolean;
         stages?: ExpenditureStageFieldValue[];
         networkInverseFee: string;
+        customActionTitle: string;
+        annotationMessage?: string;
         decisionMethod: ExpenditureDecisionMethod;
       },
       MetaWithSetter<object>

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -176,6 +176,8 @@ export type ExpendituresActionTypes =
         slotId: number;
         tokenAddresses: Address[];
         stagedExpenditureAddress: Address;
+        customActionTitle?: string;
+        annotationMessage?: string;
       },
       MetaWithSetter<object>
     >

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -108,6 +108,8 @@ export type ExpendituresActionTypes =
         colonyAddress: Address;
         expenditure: Expenditure;
         stakedExpenditureAddress?: Address;
+        customActionTitle?: string;
+        annotationMessage?: string;
       },
       object
     >

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -48,7 +48,7 @@ export type ExpendituresActionTypes =
         stages?: ExpenditureStageFieldValue[];
         networkInverseFee: string;
         decisionMethod: ExpenditureDecisionMethod;
-        customActionTitle: string;
+        customActionTitle?: string;
         annotationMessage?: string;
       },
       MetaWithSetter<object>
@@ -117,7 +117,7 @@ export type ExpendituresActionTypes =
         colonyAddress: Address;
         nativeExpenditureId: number;
         claimableSlots: ExpenditureSlot[];
-        customActionTitle: string;
+        customActionTitle?: string;
         annotationMessage?: string;
       },
       object
@@ -138,7 +138,7 @@ export type ExpendituresActionTypes =
         isStaged?: boolean;
         stages?: ExpenditureStageFieldValue[];
         networkInverseFee: string;
-        customActionTitle: string;
+        customActionTitle?: string;
         annotationMessage?: string;
         decisionMethod: ExpenditureDecisionMethod;
       },
@@ -195,7 +195,7 @@ export type ExpendituresActionTypes =
   | UniqueActionType<
       ActionTypes.STREAMING_PAYMENT_CREATE,
       {
-        colonyAddress: Address;
+        colony: Colony;
         createdInDomain: Domain;
         recipientAddress: Address;
         tokenAddress: Address;
@@ -205,6 +205,8 @@ export type ExpendituresActionTypes =
         interval: number;
         endCondition: StreamingPaymentEndCondition;
         limitAmount?: string;
+        customActionTitle?: string;
+        annotationMessage?: string;
       },
       MetaWithSetter<object>
     >

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -8,7 +8,6 @@ import {
   type ExpenditureStageFieldValue,
 } from '~types/expenditures.ts';
 import {
-  type Colony,
   type Domain,
   type Expenditure,
   type ExpenditureSlot,
@@ -42,7 +41,7 @@ export type ExpendituresActionTypes =
   | UniqueActionType<
       ActionTypes.EXPENDITURE_CREATE,
       {
-        colony: Colony;
+        colonyAddress: Address;
         payouts: ExpenditurePayoutFieldValue[];
         // the domain to create the expenditure in
         createdInDomain: Domain;
@@ -74,7 +73,7 @@ export type ExpendituresActionTypes =
   | UniqueActionType<
       ActionTypes.EXPENDITURE_FINALIZE,
       {
-        colony: Colony;
+        colonyAddress: Address;
         nativeExpenditureId: number;
         customActionTitle?: string;
         annotationMessage?: string;
@@ -93,7 +92,7 @@ export type ExpendituresActionTypes =
   | UniqueActionType<
       ActionTypes.EXPENDITURE_EDIT,
       {
-        colony: Colony;
+        colonyAddress: Address;
         expenditure: Expenditure;
         payouts: ExpenditurePayoutFieldValue[];
         networkInverseFee: string;
@@ -137,7 +136,7 @@ export type ExpendituresActionTypes =
   | UniqueActionType<
       ActionTypes.STAKED_EXPENDITURE_CREATE,
       {
-        colony: Colony;
+        colonyAddress: Address;
         payouts: ExpenditurePayoutFieldValue[];
         // the domain to create the expenditure in
         createdInDomain: Domain;
@@ -207,7 +206,7 @@ export type ExpendituresActionTypes =
   | UniqueActionType<
       ActionTypes.STREAMING_PAYMENT_CREATE,
       {
-        colony: Colony;
+        colonyAddress: Address;
         createdInDomain: Domain;
         recipientAddress: Address;
         tokenAddress: Address;

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -58,9 +58,10 @@ export type ExpendituresActionTypes =
   | UniqueActionType<
       ActionTypes.EXPENDITURE_LOCK,
       {
-        colonyName: string;
         colonyAddress: Address;
         nativeExpenditureId: number;
+        customActionTitle?: string;
+        annotationMessage?: string;
       },
       object
     >

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -87,12 +87,14 @@ export type ExpendituresActionTypes =
   | UniqueActionType<
       ActionTypes.EXPENDITURE_EDIT,
       {
-        colonyAddress: Address;
+        colony: Colony;
         expenditure: Expenditure;
         payouts: ExpenditurePayoutFieldValue[];
         networkInverseFee: string;
+        customActionTitle?: string;
+        annotationMessage?: string;
       },
-      object
+      MetaWithSetter<object>
     >
   | ErrorActionType<ActionTypes.EXPENDITURE_EDIT_ERROR, object>
   | UniqueActionType<ActionTypes.EXPENDITURE_EDIT_SUCCESS, object, object>

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -48,6 +48,8 @@ export type ExpendituresActionTypes =
         stages?: ExpenditureStageFieldValue[];
         networkInverseFee: string;
         decisionMethod: ExpenditureDecisionMethod;
+        customActionTitle: string;
+        annotationMessage?: string;
       },
       MetaWithSetter<object>
     >
@@ -115,6 +117,8 @@ export type ExpendituresActionTypes =
         colonyAddress: Address;
         nativeExpenditureId: number;
         claimableSlots: ExpenditureSlot[];
+        customActionTitle: string;
+        annotationMessage?: string;
       },
       object
     >

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -24,7 +24,6 @@ export type ExpenditureFundPayload = {
   colonyAddress: Address;
   fromDomainFundingPotId: number;
   expenditure: Expenditure;
-  customActionTitle?: string;
   annotationMessage?: string;
 };
 
@@ -33,7 +32,6 @@ export type CancelStakedExpenditurePayload = {
   stakedExpenditureAddress: string;
   shouldPunish: boolean;
   expenditure: Expenditure;
-  customActionTitle?: string;
   annotationMessage?: string;
 };
 
@@ -51,7 +49,6 @@ export type ExpendituresActionTypes =
         stages?: ExpenditureStageFieldValue[];
         networkInverseFee: string;
         decisionMethod: ExpenditureDecisionMethod;
-        customActionTitle?: string;
         annotationMessage?: string;
       },
       MetaWithSetter<object>
@@ -63,7 +60,6 @@ export type ExpendituresActionTypes =
       {
         colonyAddress: Address;
         nativeExpenditureId: number;
-        customActionTitle?: string;
         annotationMessage?: string;
       },
       object
@@ -75,7 +71,6 @@ export type ExpendituresActionTypes =
       {
         colonyAddress: Address;
         nativeExpenditureId: number;
-        customActionTitle?: string;
         annotationMessage?: string;
       },
       MetaWithSetter<object>
@@ -96,7 +91,7 @@ export type ExpendituresActionTypes =
         expenditure: Expenditure;
         payouts: ExpenditurePayoutFieldValue[];
         networkInverseFee: string;
-        customActionTitle?: string;
+
         annotationMessage?: string;
       },
       MetaWithSetter<object>
@@ -109,7 +104,6 @@ export type ExpendituresActionTypes =
         colonyAddress: Address;
         expenditure: Expenditure;
         stakedExpenditureAddress?: Address;
-        customActionTitle?: string;
         annotationMessage?: string;
       },
       object
@@ -126,7 +120,6 @@ export type ExpendituresActionTypes =
         colonyAddress: Address;
         nativeExpenditureId: number;
         claimableSlots: ExpenditureSlot[];
-        customActionTitle?: string;
         annotationMessage?: string;
       },
       object
@@ -147,7 +140,6 @@ export type ExpendituresActionTypes =
         isStaged?: boolean;
         stages?: ExpenditureStageFieldValue[];
         networkInverseFee: string;
-        customActionTitle?: string;
         annotationMessage?: string;
         decisionMethod: ExpenditureDecisionMethod;
       },
@@ -181,7 +173,6 @@ export type ExpendituresActionTypes =
         slotId: number;
         tokenAddresses: Address[];
         stagedExpenditureAddress: Address;
-        customActionTitle?: string;
         annotationMessage?: string;
       },
       MetaWithSetter<object>
@@ -216,7 +207,6 @@ export type ExpendituresActionTypes =
         interval: number;
         endCondition: StreamingPaymentEndCondition;
         limitAmount?: string;
-        customActionTitle?: string;
         annotationMessage?: string;
       },
       MetaWithSetter<object>

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -69,11 +69,12 @@ export type ExpendituresActionTypes =
   | UniqueActionType<
       ActionTypes.EXPENDITURE_FINALIZE,
       {
-        colonyName: string;
-        colonyAddress: Address;
+        colony: Colony;
         nativeExpenditureId: number;
+        customActionTitle?: string;
+        annotationMessage?: string;
       },
-      object
+      MetaWithSetter<object>
     >
   | ErrorActionType<ActionTypes.EXPENDITURE_FINALIZE_ERROR, object>
   | UniqueActionType<ActionTypes.EXPENDITURE_FINALIZE_SUCCESS, object, object>

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -25,6 +25,8 @@ export type ExpenditureFundPayload = {
   colonyAddress: Address;
   fromDomainFundingPotId: number;
   expenditure: Expenditure;
+  customActionTitle?: string;
+  annotationMessage?: string;
 };
 
 export type CancelStakedExpenditurePayload = {

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -32,6 +32,8 @@ export type CancelStakedExpenditurePayload = {
   stakedExpenditureAddress: string;
   shouldPunish: boolean;
   expenditure: Expenditure;
+  customActionTitle?: string;
+  annotationMessage?: string;
 };
 
 export type ExpendituresActionTypes =


### PR DESCRIPTION
## Description

Add annotation and custom title support to all expenditure sagas.

## How to test

Spin up a fresh environment/create a new colony.
You can also go to "Wayne enterprises" and click `Create expenditure`
![image](https://github.com/JoinColony/colonyCDapp/assets/23449297/b6f2ee38-6993-40b0-925b-9c7c6f217d9e)
Check that the transaction is pending and the last step should be `Annotating transaction`
![image](https://github.com/JoinColony/colonyCDapp/assets/23449297/3f63651e-6f66-4447-a39d-8fe2ddf0c147)

It should pass, check it by going to GraphiQL and running 
```
query MyQuery {
  listAnnotations {
    items {
      actionId
      message
    }
  }
}
```
And you should see annotations there!
![image](https://github.com/JoinColony/colonyCDapp/assets/23449297/6b00df19-cff5-477c-8089-872e55ce2dc1)


## Diffs

**New stuff** ✨

* Support for sending annotations and custom titles in all expenditure sagas

Resolves #1043 
