### PR TITLE
Fix non-members address not appearing on payment side pannel

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/SimplePayment/SimplePayment.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SimplePayment/SimplePayment.tsx
@@ -2,9 +2,11 @@ import { UserFocus } from '@phosphor-icons/react';
 import React from 'react';
 import { defineMessages } from 'react-intl';
 
+import { ADDRESS_ZERO } from '~constants';
 import Tooltip from '~shared/Extensions/Tooltip/index.ts';
 import { type ColonyAction } from '~types/graphql.ts';
 import { formatText } from '~utils/intl.ts';
+import { splitWalletAddress } from '~utils/splitWalletAddress.ts';
 import UserAvatar from '~v5/shared/UserAvatar/index.ts';
 import UserPopover from '~v5/shared/UserPopover/index.ts';
 
@@ -43,7 +45,8 @@ const MSG = defineMessages({
 
 const SimplePayment = ({ action }: SimplePaymentProps) => {
   const { customTitle = formatText(MSG.defaultTitle) } = action?.metadata || {};
-  const { amount, initiatorUser, recipientUser, token } = action;
+  const { amount, initiatorUser, recipientAddress, recipientUser, token } =
+    action;
 
   const formattedAmount = getFormattedTokenAmount(
     amount || '1',
@@ -57,14 +60,15 @@ const SimplePayment = ({ action }: SimplePaymentProps) => {
         {formatText(MSG.subtitle, {
           amount: formattedAmount,
           token: action.token?.symbol,
-          recipient: recipientUser ? (
+          recipient: recipientAddress ? (
             <UserPopover
-              userName={recipientUser.profile?.displayName}
-              walletAddress={recipientUser.walletAddress}
+              userName={recipientUser?.profile?.displayName}
+              walletAddress={recipientAddress}
               user={recipientUser}
               withVerifiedBadge={false}
             >
-              {recipientUser.profile?.displayName}
+              {recipientUser?.profile?.displayName ||
+                splitWalletAddress(recipientAddress)}
             </UserPopover>
           ) : null,
           user: initiatorUser ? (
@@ -101,10 +105,9 @@ const SimplePayment = ({ action }: SimplePaymentProps) => {
         </div>
         <div>
           <UserAvatar
-            user={{
-              profile: action.recipientUser?.profile,
-              walletAddress: action.recipientAddress || '',
-            }}
+            user={
+              action.recipientUser || action.recipientAddress || ADDRESS_ZERO
+            }
             size="xs"
             showUsername
           />

--- a/src/components/v5/common/CompletedAction/partials/SimplePayment/SimplePayment.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SimplePayment/SimplePayment.tsx
@@ -7,7 +7,7 @@ import Tooltip from '~shared/Extensions/Tooltip/index.ts';
 import { type ColonyAction } from '~types/graphql.ts';
 import { formatText } from '~utils/intl.ts';
 import { splitWalletAddress } from '~utils/splitWalletAddress.ts';
-import UserAvatar from '~v5/shared/UserAvatar/index.ts';
+import UserAvatarPopover from '~v5/shared/UserAvatarPopover/index.ts';
 import UserPopover from '~v5/shared/UserPopover/index.ts';
 
 import { DEFAULT_TOOLTIP_POSITION, ICON_SIZE } from '../../consts.ts';
@@ -104,12 +104,9 @@ const SimplePayment = ({ action }: SimplePaymentProps) => {
           </Tooltip>
         </div>
         <div>
-          <UserAvatar
-            user={
-              action.recipientUser || action.recipientAddress || ADDRESS_ZERO
-            }
+          <UserAvatarPopover
+            walletAddress={action.recipientAddress || ADDRESS_ZERO}
             size="xs"
-            showUsername
           />
         </div>
 

--- a/src/components/v5/shared/UserAvatarPopover/UserAvatarPopover.tsx
+++ b/src/components/v5/shared/UserAvatarPopover/UserAvatarPopover.tsx
@@ -4,7 +4,6 @@ import React, { type FC } from 'react';
 import { useColonyContext } from '~context/ColonyContext.tsx';
 import { useGetColonyContributorQuery } from '~gql';
 import { getColonyContributorId } from '~utils/members.ts';
-import { splitWalletAddress } from '~utils/splitWalletAddress.ts';
 import { type ContributorTypeFilter } from '~v5/common/TableFiltering/types.ts';
 import UserAvatar from '~v5/shared/UserAvatar/index.ts';
 
@@ -23,7 +22,7 @@ const UserAvatarPopover: FC<UserAvatarPopoverProps> = ({
   const {
     colony: { colonyAddress },
   } = useColonyContext();
-  const { data } = useGetColonyContributorQuery({
+  const { data, loading } = useGetColonyContributorQuery({
     variables: {
       id: getColonyContributorId(colonyAddress, walletAddress),
       colonyAddress,
@@ -34,16 +33,15 @@ const UserAvatarPopover: FC<UserAvatarPopoverProps> = ({
   const { user } = contributor ?? {};
   const { displayName: userDisplayName } = user?.profile || {};
 
-  const splitAddress = splitWalletAddress(user?.walletAddress || '');
   const userStatus = (contributor?.type?.toLowerCase() ??
     null) as ContributorTypeFilter | null;
 
   return (
     <UserPopover
-      userName={userDisplayName ?? splitAddress}
+      userName={userDisplayName}
       user={user}
       className={clsx({
-        skeleton: !user,
+        skeleton: loading,
       })}
       additionalContent={additionalContent}
       {...props}


### PR DESCRIPTION
## Description

- This PR fixes the complete action side pannel not showing the address of a user with no profile. With the changes, now the shortened address should appear on the description and the recipient row.

![Screenshot 2024-02-19 at 18 44 36](https://github.com/JoinColony/colonyCDapp/assets/18473896/60b72b46-6dd3-44de-8f8d-5cec5ea081d1)

## Testing

- Just create a simple payment action with a user without a profile and check that we are showing the masked address.
- The action should continue to show the other cases correctly, with no regressions.

Resolves #1858 
