### PR TITLE
Fix incoming funds table always using native token's decimals

### DIFF
--- a/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
@@ -95,7 +95,7 @@ const TokenTable: FC<TokenTableProps> = ({ token }) => {
               </span>
             </button>
             <div>
-              <Numeral value={claimsAmount} decimals={nativeToken.decimals} />{' '}
+              <Numeral value={claimsAmount} decimals={token.decimals} />{' '}
               {token?.symbol}
             </div>
           </div>


### PR DESCRIPTION
## Description

This PR fixes the incoming funds table always using the colony's native token decimals to display the incoming funds from other tokens.

![Screenshot 2024-02-19 at 19 34 52](https://github.com/JoinColony/colonyCDapp/assets/18473896/25b0ca40-d3b0-4e0e-a5c2-ca622932b4a5)

## Testing

The testing will be done pretty much on the same way it was done over  https://github.com/JoinColony/colonyCDapp/pull/1825 except the idea is to transfer a token with different decimals other than the classic `18`, for example:

```ts
// create new token (name, symbol, decimals)
t = await Token.new('Token name', 'TKN', 6)
t.unlock()
// mint some tokens
t.mint('10000000000000000000')
// transfer some tokens to your colony (0.5 in the case of 18 decimals, 500B in the case of 6)
t.transfer('<COLONY_ADDRESS>', '500000000000000000')
```

And see if the amount is displayed correctly, instead of using the wrong decimals.

Resolves #1843 
