### PR TITLE
Fix: Action form no longer forces validation on action type change

### DIFF
--- a/src/components/v5/common/ActionSidebar/hooks/useActionFormProps.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useActionFormProps.ts
@@ -90,7 +90,6 @@ export const useActionFormProps = (
           keepDirtyValues: true,
         },
       );
-      form.trigger();
     },
     [isReadonly, defaultValues, navigate],
   );


### PR DESCRIPTION
## Description

When creating a new action, title validation should not happen when selecting an action type.

This PR removes a form trigger which was forcing validation whenever the action type was changed. This addresses the title validation as described in the original issue, but also resolves the bug where validation messages do not correctly update when changing action types.

(Please comment if there is a valid reason why the form validation should be forced when changing action types)

## Testing

1. Create a new action and select an action type
2. No title validation should occur
3. Submit the form with an empty title and the title validation should occur

---

1. Create a new action and select an action type
2. Put the form into an invalid state so that validation messages show
3. Change action type, the validation messages related to the old action type should no longer show

## Diffs

**Deletions** ⚰️

* Form trigger removed when actionType is changed


https://github.com/JoinColony/colonyCDapp/assets/34915414/b478985f-2849-4bd4-8846-775cece5d281



Resolves #1888
