### PR TITLE
fix: close button not working on mobile actionSidebar

### DIFF
--- a/src/components/v5/common/ActionSidebar/hooks/useCloseSidebarClick.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useCloseSidebarClick.ts
@@ -15,7 +15,7 @@ export const useCloseSidebarClick = () => {
     closeSidebarClick: () => {
       const { dirtyFields } = (formContext || formRef.current)?.formState || {};
 
-      if (Object.keys(dirtyFields).length > 0) {
+      if (dirtyFields && Object.keys(dirtyFields).length > 0) {
         toggleCancelModal();
       } else {
         toggleActionSidebarOff();


### PR DESCRIPTION
## Description

this PR fixes the issue when a user tries closing an action summary on mobile. this issue only occurs on devices which use the close button. desktop doesn't use this close button so when testing please test on smaller devices.

## Testing

1. use mobile view / device that shows 'close' button on action summary
2. Create an action & submit
3. Try to close the action summary

## Diffs

**Changes** 🏗

Added extra check to the conditional check

now the close button works:
![closebuttonfix](https://github.com/JoinColony/colonyCDapp/assets/155957480/71f69754-6aa8-40fd-bde6-3f00e24d29b4)


Resolves #1954 
