### PR TITLE
fix: do not show question mark on user pills

### DIFF
--- a/src/components/v5/shared/CardWithBios/partials/UserStatus.tsx
+++ b/src/components/v5/shared/CardWithBios/partials/UserStatus.tsx
@@ -42,7 +42,7 @@ const UserStatusComponent: FC<UserStatusComponentProps> = ({
               className="flex items-center text-center text-sm px-3 py-1.5
             rounded-3xl border border-base-white h-[1.875rem] shrink-0 capitalize"
             >
-              <Icon size={12} />
+              {Icon ? <Icon size={12} /> : null}
               <span className="ml-1.5 text-sm">{userStatus}</span>
             </span>
           </span>

--- a/src/components/v5/shared/CardWithBios/partials/consts.ts
+++ b/src/components/v5/shared/CardWithBios/partials/consts.ts
@@ -2,7 +2,6 @@ import {
   CrownSimple,
   HandHeart,
   Medal,
-  Question,
   ShootingStar,
 } from '@phosphor-icons/react';
 
@@ -30,5 +29,5 @@ export const getIcon = (
   if (userStatus === 'active' || userStatus === 'active-filled') {
     return ShootingStar;
   }
-  return Question;
+  return undefined;
 };


### PR DESCRIPTION
## Description

This removes the weird question mark icon from a contributor's UserAvatar.

## Testing

Check the contributors page http://localhost:9091/planex/members/contributors (see also the issue itself)

## Diffs

- Only show UserBadge pill icon if there's meant to be one.

Fixes #1938 
