### PR TITLE
fix: agreement description, transfer funds field name

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/consts.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/consts.ts
@@ -1,6 +1,6 @@
 import { type InferType, object, string, number } from 'yup';
 
-import { MAX_OBJECTIVE_DESCRIPTION_LENGTH } from '~constants/index.ts';
+import { MAX_ANNOTATION_LENGTH } from '~constants/index.ts';
 import { ACTION_BASE_VALIDATION_SCHEMA } from '~v5/common/ActionSidebar/consts.tsx';
 
 export const validationSchema = object()
@@ -9,7 +9,7 @@ export const validationSchema = object()
       .trim()
       .required(() => 'Please enter a title.'),
     createdIn: number().defined(),
-    description: string().max(MAX_OBJECTIVE_DESCRIPTION_LENGTH).notRequired(),
+    description: string().max(MAX_ANNOTATION_LENGTH).required(),
     decisionMethod: string().defined(),
     walletAddress: string().address().required(),
   })

--- a/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/hooks.ts
@@ -33,7 +33,7 @@ export const useValidationSchema = () => {
           amount: object()
             .shape({
               amount: number()
-                .required(() => formatText({ id: 'validation.required' }))
+                .required(() => formatText({ id: 'errors.amount' }))
                 .transform((value) => toFinite(value))
                 .moreThan(0, () =>
                   formatText({ id: 'errors.amount.greaterThanZero' }),
@@ -51,7 +51,8 @@ export const useValidationSchema = () => {
                 ),
               tokenAddress: string().address().required(),
             })
-            .required(),
+            .required()
+            .defined(),
           createdIn: number().defined(),
           from: number().required(),
           to: number()


### PR DESCRIPTION
https://tw.auroracreation.com/app/tasks/15800786

## Description

- Changed agreement action description length to 4000 and made it required
- Changed transfer funds field name to `Amount` from `Field`

(Resolves | Contributes to) #31415
