### PR TITLE
fix: currency conversion uses token decimals

### DIFF
--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/hooks.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/hooks.tsx
@@ -92,6 +92,11 @@ export const useBalanceTableColumns = (
               />
               <CurrencyConversion
                 tokenBalance={currentTokenBalance}
+                tokenDecimals={
+                  row.original.token
+                    ? getTokenDecimalsWithFallback(row.original.token.decimals)
+                    : 0
+                }
                 contractAddress={row.original.token?.tokenAddress ?? ''}
                 className="text-gray-600 !text-sm"
               />

--- a/src/components/shared/CurrencyConversion/CurrencyConversion.tsx
+++ b/src/components/shared/CurrencyConversion/CurrencyConversion.tsx
@@ -1,5 +1,6 @@
 import Decimal from 'decimal.js';
 import { type BigNumber } from 'ethers';
+import moveDecimal from 'move-decimal-point';
 import React from 'react';
 
 import { useCurrencyContext } from '~context/CurrencyContext.tsx';
@@ -32,6 +33,9 @@ interface Props extends Omit<NumeralProps, 'value'> {
 
   /** Balance of token to be converted */
   tokenBalance: BigNumber;
+
+  /** Decimals of the token */
+  tokenDecimals: number;
 }
 
 const CurrencyConversion = ({
@@ -39,6 +43,7 @@ const CurrencyConversion = ({
   showSuffix = true,
   placeholder = '-',
   tokenBalance,
+  tokenDecimals,
   contractAddress,
   chainId,
   className,
@@ -59,7 +64,9 @@ const CurrencyConversion = ({
       value={
         conversionRate == null
           ? placeholder
-          : new Decimal(tokenBalance.toString()).mul(conversionRate)
+          : new Decimal(
+              moveDecimal(tokenBalance.toString(), -tokenDecimals),
+            ).mul(conversionRate)
       }
       {...rest}
     />


### PR DESCRIPTION
## Description

Currently when trying to fetch prices, we didn't move decimal points, so the entire value was way too high.
Now the `CurrencyConversion` component accepts `tokenDecimals` and modifies the number accordingly.

## Testing

TODO: High level overview of what reviewers are testing with your pr. 

TODO: Followed by step-by-step instructions for testing your branch so reviewers can easily jump straight in and start testing. 

* Step 1. E.g. add reputation
* Step 2. E.g. install Governance extension
* Step 3. E.g. Create motion

## Diffs


**Changes** 🏗

* `CurrencyConversion` accepts `tokenDecimals` and multiplies the conversion rate with moved decimals

Resolves #1936 
