### PR TITLE
Fix: Inconsistent versions of colony network and extensions

### DIFF
--- a/src/components/frame/Extensions/pages/ExtensionsPage/ExtensionsPage.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionsPage/ExtensionsPage.tsx
@@ -4,6 +4,7 @@ import ExtensionItem from '~common/Extensions/ExtensionItem/index.ts';
 import { useSetPageHeadingTitle } from '~context/PageHeadingContext/hooks.ts';
 import useExtensionsData from '~hooks/useExtensionsData.ts';
 import { type AnyExtensionData } from '~types/extensions.ts';
+import { isInstalledExtensionData } from '~utils/extensions.ts';
 import { formatText } from '~utils/intl.ts';
 
 const displayName = 'frame.Extensions.pages.ExtensionsPage';
@@ -48,7 +49,7 @@ const ExtensionsPage: FC = () => {
                   title={extension.name}
                   description={extension.descriptionShort}
                   version={
-                    'currentVersion' in extension
+                    isInstalledExtensionData(extension)
                       ? extension.currentVersion
                       : extension.availableVersion
                   }

--- a/src/components/frame/Extensions/pages/ExtensionsPage/ExtensionsPage.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionsPage/ExtensionsPage.tsx
@@ -47,7 +47,11 @@ const ExtensionsPage: FC = () => {
                 <ExtensionItem
                   title={extension.name}
                   description={extension.descriptionShort}
-                  version={extension.availableVersion}
+                  version={
+                    'currentVersion' in extension
+                      ? extension.currentVersion
+                      : extension.availableVersion
+                  }
                   icon={extension.icon}
                   extensionId={extension.extensionId}
                 />

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/UpgradeColonyDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/UpgradeColonyDescription.tsx
@@ -3,6 +3,7 @@ import { FormattedMessage } from 'react-intl';
 
 import { useColonyContext } from '~context/ColonyContext.tsx';
 import { ColonyActionType } from '~gql';
+import useColonyContractVersion from '~hooks/useColonyContractVersion.ts';
 
 import CurrentUser from './CurrentUser.tsx';
 
@@ -13,6 +14,7 @@ export const UpgradeColonyDescription = () => {
   const {
     colony: { version },
   } = useColonyContext();
+  const { colonyContractVersion: newVersion } = useColonyContractVersion();
 
   return (
     <FormattedMessage
@@ -20,7 +22,7 @@ export const UpgradeColonyDescription = () => {
       values={{
         actionType: ColonyActionType.VersionUpgrade,
         version,
-        newVersion: version + 1,
+        newVersion,
         initiator: <CurrentUser />,
       }}
     />

--- a/src/components/v5/common/ActionSidebar/partials/ColonyVersionField/ColonyVersionField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ColonyVersionField/ColonyVersionField.tsx
@@ -2,6 +2,7 @@ import { Browsers } from '@phosphor-icons/react';
 import React, { type FC } from 'react';
 
 import { useColonyContext } from '~context/ColonyContext.tsx';
+import useColonyContractVersion from '~hooks/useColonyContractVersion.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
 
@@ -11,7 +12,7 @@ const ColonyVersionField: FC = () => {
   const {
     colony: { version: currentVersion },
   } = useColonyContext();
-  const nextVersion = currentVersion + 1;
+  const { colonyContractVersion: newVersion } = useColonyContractVersion();
 
   return (
     <>
@@ -39,7 +40,7 @@ const ColonyVersionField: FC = () => {
           },
         }}
       >
-        <span className="text-md">{nextVersion}</span>
+        <span className="text-md">{newVersion}</span>
       </ActionFormRow>
     </>
   );


### PR DESCRIPTION
## Description

There are various inconsistencies with Colony network versions and extension versions that are shown or are being picked up in the UI.

Previously, the action sidebar new version was hardcoded to be +1 from the current version. This PR gets the correct version from the context.

Previously, the extensions page would show the latest available version even if an older version was installed, this would result in inconsistencies with the extension details page which shows the current version. This PR shows the currentVersion if the extension is enabled.

Please someone suggest a better approach to this as it feels bad. extension.isEnabled feels like the better thing to check against, but typescript will complain that extension.currentVersion does not exist on AnyExtensionData as it only exists on the InstalledExtensionData and not on InstallableExtensionData.
```
                  version={
                    'currentVersion' in extension
                      ? extension.currentVersion
                      : extension.availableVersion
                  }

```

## Testing

This is a bit hard to properly test as it would require installing older versions of the colony network and extensions, it should be possible to verify by looking at the code.

Create an action to upgrade the colony, the new version row and action description should both show the correct latest version (14).

Extensions page will now show current version if installed rather than the latest available version

## Diffs

**Changes** 🏗

* Action sidebar now correctly shows latest colony contract version
* Extensions page now shows current version if installed rather than available version

![Screenshot 2024-02-21 at 15 37 00](https://github.com/JoinColony/colonyCDapp/assets/34915414/14aaf333-1473-469c-bd7e-4aebc35b53f0)

Resolves #1838
