### PR TITLE
Fix: styling for different error states

### DIFF
--- a/src/components/v5/common/Fields/Input/partials/InputPills.tsx
+++ b/src/components/v5/common/Fields/Input/partials/InputPills.tsx
@@ -21,7 +21,7 @@ const InputPills: FC<PillProps> = ({ message, status }) => {
       )}
     >
       <StatusCircle size={14} status={status} />
-      {message && <span className="ml-1">{formatText(message)}</span>}
+      {message && <span>{formatText(message)}</span>}
     </div>
   );
 };

--- a/src/components/v5/common/Fields/InputBase/FormattedInput.tsx
+++ b/src/components/v5/common/Fields/InputBase/FormattedInput.tsx
@@ -112,7 +112,7 @@ const FormattedInput: FC<FormattedInputProps> = ({
           )}
         />
       </div>
-      <div className={clsx(messageClassName, 'text-negative-400 text-sm mt-2')}>
+      <div className={clsx(messageClassName, 'text-negative-400 text-sm mt-1')}>
         {message}
       </div>
     </div>

--- a/src/components/v5/common/Fields/Textarea/Textarea.tsx
+++ b/src/components/v5/common/Fields/Textarea/Textarea.tsx
@@ -33,7 +33,7 @@ const Textarea: FC<TextareaProps> = ({
   const isErrorStatus = isCharLenghtError || isError;
 
   return (
-    <div className="flex flex-col gap-1">
+    <div className="flex flex-col">
       {textareaTitle && (
         <label htmlFor="message" className="text-gray-700 text-1">
           {label}

--- a/src/components/v5/shared/FormError/FormError.tsx
+++ b/src/components/v5/shared/FormError/FormError.tsx
@@ -14,7 +14,7 @@ const FormError: FC<PropsWithChildren<FormErrorProps>> = ({
   <div
     className={clsx(
       `flex w-[8.75rem]`,
-      allowLayoutShift ? 'mt-1' : 'absolute',
+      allowLayoutShift ? 'pt-1' : 'absolute pt-1',
       {
         'w-full': isFullSize,
         'text-right justify-end': alignment === 'right',


### PR DESCRIPTION
## Description

This PR fixes the differences in the error validation type designs. this includes the padding between the input field and the standard error message, and the gap between the icon and message for errors which show the icon (error, warning, success) 

## Testing

Perform actions which would get the different types of messages to show. e.g. create a colony and use the URL inut field (like in the linked issue)

As far as we understand, yellow (warning) errors haven't been implemented in the new UI so we are unable to test these types of errors.

## Diffs

**Changes** 🏗

top padding is now 4px between standard error and input field
![Screenshot 2024-02-22 at 11 12 38](https://github.com/JoinColony/colonyCDapp/assets/155957480/2fb630d9-ebd3-4871-a7eb-94a547eeee23)

gap between icon and error message is also now 4px
![Screenshot 2024-02-22 at 11 14 03](https://github.com/JoinColony/colonyCDapp/assets/155957480/b546754f-f8e0-4efa-a329-d504ccf51884)

the gap in the activate / withdraw token modal input field and error reduced to 4px
![Screenshot 2024-02-22 at 12 42 25](https://github.com/JoinColony/colonyCDapp/assets/155957480/7ec64e43-fd46-493b-9fa5-f214eca8a7c6)

standard text errors in user settings now have a 4px gap
![Screenshot 2024-02-22 at 12 43 34](https://github.com/JoinColony/colonyCDapp/assets/155957480/39ddcc50-07aa-4215-8b6b-01146a79d90c)


 Resolves #1931 
