### PR TITLE
Connect expenditures with actions model

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,14 @@ _Note: at the end of the install there's a post-install script that will recursi
 
 Copy `.env.example` and rename it to `.env`. You should not need to change any of the values to get CDapp running.
 
+### (Linux only) Increase the limit of watched files
+
+On Linux, you'll need to run the following commands to increase the default limit of watched files. Otherwise, the `watchAmplifyFiles` script will not work properly.
+
+```bash
+echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+```
+
 ## Running the dev environment
 
 ```bash

--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -3240,12 +3240,16 @@ type Expenditure @model {
   Hash of the `ExpenditureAdded` event transaction
   @TODO: Make this a non-nullable field once existing data is updated
   """
-  createdTransactionHash: ID
-  action: ColonyAction @hasOne(fields: ["createdTransactionHash"])
+  transactionHash: ID
+  action: ColonyAction @hasOne(fields: ["transactionHash"])
   """
-  Hash of the `ExpenditureMadeViaStake` event transaction, if applicable
+  ID of the user stake associated with the expenditure, if any
   """
-  stakedTransactionHash: ID
+  userStakeId: ID
+  """
+  User stake associated with the expenditure, if any
+  """	  
+  userStake: UserStake @hasOne(fields: ["userStakeId"])
 }
 
 """

--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -749,6 +749,10 @@ enum ColonyActionType {
   """
   MAKE_ARBITRARY_TRANSACTION
   MAKE_ARBITRARY_TRANSACTIONS_MOTION
+  """
+  An action related to creating expenditure (dvanced payment) 
+  """
+  CREATE_EXPENDITURE
 }
 
 """
@@ -2898,6 +2902,14 @@ type ColonyAction @model @searchable {
   Metadata associated with the action (Eg. Custom action title)
   """
   metadata: ColonyActionMetadata @hasOne(fields: ["id"])
+  """
+  ID of the associated expenditure, if any
+  """
+  expenditureId: ID
+  """
+  Expenditure associated with the action, if any
+  """
+  expenditure: Expenditure @hasOne(fields: ["expenditureId"])
 }
 
 type ColonyActionMetadata @model {
@@ -3224,6 +3236,12 @@ type Expenditure @model {
   """
   isStaked: Boolean!
   type: ExpenditureType!
+  """
+  Hash of the `ExpenditureAdded` event transaction
+  @TODO: Make this a non-nullable field once existing data is updated
+  """
+  createdTransactionHash: ID
+  action: ColonyAction @hasOne(fields: ["createdTransactionHash"])
   """
   Hash of the `ExpenditureMadeViaStake` event transaction, if applicable
   """

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=3786cc0f90d3f55a3f052ef1be5585ff17ad82c3
+ENV BLOCK_INGESTOR_HASH=a48156cc4382a0c5fa0326b56991d8fabe63e7da
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "axios": "^1.4.0",
         "bn.js": "^5.1.1",
         "camelcase": "^6.0.0",
+        "chokidar": "^3.6.0",
         "classnames": "^2.2.6",
         "cleave-zen": "^0.0.17",
         "clsx": "^1.2.1",
@@ -17025,15 +17026,9 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -17045,6 +17040,9 @@
       },
       "engines": {
         "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -72343,9 +72341,9 @@
       }
     },
     "chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "docker:build:all": "npm run docker:build:base && npm run docker:build:network && npm run docker:build:monitor && npm run docker:build:ingestor && npm run docker:build:amplify && npm run docker:build:safe && npm run docker:build:auth",
     "docker:compose:core": "docker compose --file docker/colony-cdapp-dev-env-orchestration.yaml",
     "docker:compose:all": "docker compose --file docker/colony-cdapp-dev-env-orchestration-all.yaml",
-    "dev": "npm run docker:build:core && npm run docker:compose:core up -- --force-recreate -V",
+    "dev": "npm run watch-amplify & npm run docker:build:core && npm run docker:compose:core up -- --force-recreate -V",
     "dev:all": "npm run docker:build:all && npm run docker:compose:all up -- --force-recreate -V",
     "lint": "eslint --fix 'src/**/*.{ts,tsx}'",
     "lint:ci": "eslint 'src/**/*.{ts,tsx}'",
@@ -33,7 +33,8 @@
     "build-storybook": "storybook build",
     "chromatic": "npx chromatic --project-token=f08326e25dbf",
     "postinstall": "./scripts/lambda-functions-dependencies.sh && scripts/generate-amplify-local-config.sh",
-    "upgrade-colony-js": "./scripts/upgrade-colony-js.sh"
+    "upgrade-colony-js": "./scripts/upgrade-colony-js.sh",
+    "watch-amplify": "ts-node scripts/watchAmplifyFiles"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -201,6 +201,7 @@
     "axios": "^1.4.0",
     "bn.js": "^5.1.1",
     "camelcase": "^6.0.0",
+    "chokidar": "^3.6.0",
     "classnames": "^2.2.6",
     "cleave-zen": "^0.0.17",
     "clsx": "^1.2.1",

--- a/scripts/watchAmplifyFiles.ts
+++ b/scripts/watchAmplifyFiles.ts
@@ -1,0 +1,57 @@
+/**
+ * This script watches for changes in the amplify directory and copies the changed files to the `amplify` Docker container.
+ */
+/* eslint-disable no-console */
+import { execSync } from 'child_process';
+import chokidar from 'chokidar';
+import path from 'path';
+
+const watchDir = './amplify';
+const targetDir = '/colonyCDapp';
+
+const watcher = chokidar.watch(watchDir, {
+  ignored: /(^|[/\\])\../, // ignore dotfiles
+  ignoreInitial: true,
+});
+
+const copyToDockerContainer = (filePath: string) => {
+  // Compute the relative path from the watched directory
+  const relativePath = path.relative(process.cwd(), filePath);
+  // Construct the target path inside the Docker container
+  const targetPath = path.join(targetDir, relativePath);
+
+  // Extract the directory and create it in the container (it might exist, but if it doesn't `docker cp` fill error)
+  const targetDirPath = path.dirname(targetPath);
+  const createDirectoryCommand = `docker exec amplify mkdir -p "${targetDirPath}"`;
+  try {
+    execSync(createDirectoryCommand);
+    console.log(
+      `Directory ${targetDirPath} was created in amplify container (or it existed before).`,
+    );
+  } catch (err) {
+    console.error(`Error creating directory in amplify container: ${err}`);
+    return;
+  }
+
+  const dockerCopyCommand = `docker cp "${filePath}" "amplify:${targetPath}"`;
+  try {
+    execSync(dockerCopyCommand);
+    console.log(
+      `File ${filePath} was copied to amplify container successfully.`,
+    );
+  } catch (err) {
+    console.error(`Error copying file to amplify container: ${err}`);
+  }
+};
+
+watcher
+  .on('change', (filePath) => {
+    console.log(`File ${filePath} has been changed`);
+    copyToDockerContainer(filePath);
+  })
+  .on('add', (filePath) => {
+    console.log(`File ${filePath} has been added`);
+    copyToDockerContainer(filePath);
+  });
+
+console.log(`Watching for file changes in ${watchDir}`);

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -253,6 +253,10 @@ export type ColonyAction = {
   createdAt: Scalars['AWSDateTime'];
   /** Corresponding Decision data, if action is a Simple Decision */
   decisionData?: Maybe<ColonyDecision>;
+  /** Expenditure associated with the action, if any */
+  expenditure?: Maybe<Expenditure>;
+  /** ID of the associated expenditure, if any */
+  expenditureId?: Maybe<Scalars['ID']>;
   /** The source Domain of the action, if applicable */
   fromDomain?: Maybe<Domain>;
   /** The source Domain identifier, if applicable */
@@ -381,6 +385,8 @@ export enum ColonyActionType {
   CreateDomain = 'CREATE_DOMAIN',
   /** An action related to creating a domain within a Colony via a motion */
   CreateDomainMotion = 'CREATE_DOMAIN_MOTION',
+  /** An action related to creating expenditure (dvanced payment)  */
+  CreateExpenditure = 'CREATE_EXPENDITURE',
   /** An action related to editing a domain's details */
   EditDomain = 'EDIT_DOMAIN',
   /** An action related to editing a domain's details via a motion */
@@ -1086,6 +1092,7 @@ export type CreateColonyActionInput = {
   colonyDecisionId?: InputMaybe<Scalars['ID']>;
   colonyId: Scalars['ID'];
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
+  expenditureId?: InputMaybe<Scalars['ID']>;
   fromDomainId?: InputMaybe<Scalars['ID']>;
   id?: InputMaybe<Scalars['ID']>;
   individualEvents?: InputMaybe<Scalars['String']>;
@@ -1358,9 +1365,10 @@ export type CreateExpenditureInput = {
   nativeId: Scalars['Int'];
   ownerAddress: Scalars['ID'];
   slots: Array<ExpenditureSlotInput>;
-  stakedTransactionHash?: InputMaybe<Scalars['ID']>;
   status: ExpenditureStatus;
+  transactionHash?: InputMaybe<Scalars['ID']>;
   type: ExpenditureType;
+  userStakeId?: InputMaybe<Scalars['ID']>;
 };
 
 export type CreateExpenditureMetadataInput = {
@@ -1859,6 +1867,7 @@ export type DomainMetadataChangelogInput = {
 
 export type Expenditure = {
   __typename?: 'Expenditure';
+  action?: Maybe<ColonyAction>;
   /** Array containing balances of tokens in the expenditure */
   balances?: Maybe<Array<ExpenditureBalance>>;
   /** The Colony to which the expenditure belongs */
@@ -1891,12 +1900,19 @@ export type Expenditure = {
   ownerAddress: Scalars['ID'];
   /** Array containing expenditure slots */
   slots: Array<ExpenditureSlot>;
-  /** Hash of the `ExpenditureMadeViaStake` event transaction, if applicable */
-  stakedTransactionHash?: Maybe<Scalars['ID']>;
   /** Status of the expenditure */
   status: ExpenditureStatus;
+  /**
+   * Hash of the `ExpenditureAdded` event transaction
+   * @TODO: Make this a non-nullable field once existing data is updated
+   */
+  transactionHash?: Maybe<Scalars['ID']>;
   type: ExpenditureType;
   updatedAt: Scalars['AWSDateTime'];
+  /** User stake associated with the expenditure, if any */
+  userStake?: Maybe<UserStake>;
+  /** ID of the user stake associated with the expenditure, if any */
+  userStakeId?: Maybe<Scalars['ID']>;
 };
 
 
@@ -2238,6 +2254,7 @@ export type ModelColonyActionConditionInput = {
   colonyDecisionId?: InputMaybe<ModelIdInput>;
   colonyId?: InputMaybe<ModelIdInput>;
   createdAt?: InputMaybe<ModelStringInput>;
+  expenditureId?: InputMaybe<ModelIdInput>;
   fromDomainId?: InputMaybe<ModelIdInput>;
   individualEvents?: InputMaybe<ModelStringInput>;
   initiatorAddress?: InputMaybe<ModelIdInput>;
@@ -2273,6 +2290,7 @@ export type ModelColonyActionFilterInput = {
   colonyDecisionId?: InputMaybe<ModelIdInput>;
   colonyId?: InputMaybe<ModelIdInput>;
   createdAt?: InputMaybe<ModelStringInput>;
+  expenditureId?: InputMaybe<ModelIdInput>;
   fromDomainId?: InputMaybe<ModelIdInput>;
   id?: InputMaybe<ModelIdInput>;
   individualEvents?: InputMaybe<ModelStringInput>;
@@ -2929,9 +2947,10 @@ export type ModelExpenditureConditionInput = {
   not?: InputMaybe<ModelExpenditureConditionInput>;
   or?: InputMaybe<Array<InputMaybe<ModelExpenditureConditionInput>>>;
   ownerAddress?: InputMaybe<ModelIdInput>;
-  stakedTransactionHash?: InputMaybe<ModelIdInput>;
   status?: InputMaybe<ModelExpenditureStatusInput>;
+  transactionHash?: InputMaybe<ModelIdInput>;
   type?: InputMaybe<ModelExpenditureTypeInput>;
+  userStakeId?: InputMaybe<ModelIdInput>;
 };
 
 export type ModelExpenditureConnection = {
@@ -2953,9 +2972,10 @@ export type ModelExpenditureFilterInput = {
   not?: InputMaybe<ModelExpenditureFilterInput>;
   or?: InputMaybe<Array<InputMaybe<ModelExpenditureFilterInput>>>;
   ownerAddress?: InputMaybe<ModelIdInput>;
-  stakedTransactionHash?: InputMaybe<ModelIdInput>;
   status?: InputMaybe<ModelExpenditureStatusInput>;
+  transactionHash?: InputMaybe<ModelIdInput>;
   type?: InputMaybe<ModelExpenditureTypeInput>;
+  userStakeId?: InputMaybe<ModelIdInput>;
 };
 
 export type ModelExpenditureMetadataConditionInput = {
@@ -3405,6 +3425,7 @@ export type ModelSubscriptionColonyActionFilterInput = {
   colonyDecisionId?: InputMaybe<ModelSubscriptionIdInput>;
   colonyId?: InputMaybe<ModelSubscriptionIdInput>;
   createdAt?: InputMaybe<ModelSubscriptionStringInput>;
+  expenditureId?: InputMaybe<ModelSubscriptionIdInput>;
   fromDomainId?: InputMaybe<ModelSubscriptionIdInput>;
   id?: InputMaybe<ModelSubscriptionIdInput>;
   individualEvents?: InputMaybe<ModelSubscriptionStringInput>;
@@ -3665,9 +3686,10 @@ export type ModelSubscriptionExpenditureFilterInput = {
   nativeId?: InputMaybe<ModelSubscriptionIntInput>;
   or?: InputMaybe<Array<InputMaybe<ModelSubscriptionExpenditureFilterInput>>>;
   ownerAddress?: InputMaybe<ModelSubscriptionIdInput>;
-  stakedTransactionHash?: InputMaybe<ModelSubscriptionIdInput>;
   status?: InputMaybe<ModelSubscriptionStringInput>;
+  transactionHash?: InputMaybe<ModelSubscriptionIdInput>;
   type?: InputMaybe<ModelSubscriptionStringInput>;
+  userStakeId?: InputMaybe<ModelSubscriptionIdInput>;
 };
 
 export type ModelSubscriptionExpenditureMetadataFilterInput = {
@@ -4289,10 +4311,7 @@ export type Mutation = {
   deleteUser?: Maybe<User>;
   deleteUserStake?: Maybe<UserStake>;
   deleteUserTokens?: Maybe<UserTokens>;
-  /**
-   * Validates the user invite code and adds the user to the colony whitelist
-   * and as a colony contributor
-   */
+  /** Removes the user from the colony whitelist */
   removeMemberFromColonyWhitelist?: Maybe<Scalars['Boolean']>;
   /** Updates the latest available version of a Colony or an extension */
   setCurrentVersion?: Maybe<Scalars['Boolean']>;
@@ -6551,6 +6570,7 @@ export enum SearchableColonyActionAggregateField {
   ColonyDecisionId = 'colonyDecisionId',
   ColonyId = 'colonyId',
   CreatedAt = 'createdAt',
+  ExpenditureId = 'expenditureId',
   FromDomainId = 'fromDomainId',
   Id = 'id',
   IndividualEvents = 'individualEvents',
@@ -6594,6 +6614,7 @@ export type SearchableColonyActionFilterInput = {
   colonyDecisionId?: InputMaybe<SearchableIdFilterInput>;
   colonyId?: InputMaybe<SearchableIdFilterInput>;
   createdAt?: InputMaybe<SearchableStringFilterInput>;
+  expenditureId?: InputMaybe<SearchableIdFilterInput>;
   fromDomainId?: InputMaybe<SearchableIdFilterInput>;
   id?: InputMaybe<SearchableIdFilterInput>;
   individualEvents?: InputMaybe<SearchableStringFilterInput>;
@@ -6629,6 +6650,7 @@ export enum SearchableColonyActionSortableFields {
   ColonyDecisionId = 'colonyDecisionId',
   ColonyId = 'colonyId',
   CreatedAt = 'createdAt',
+  ExpenditureId = 'expenditureId',
   FromDomainId = 'fromDomainId',
   Id = 'id',
   IndividualEvents = 'individualEvents',
@@ -7723,6 +7745,7 @@ export type UpdateColonyActionInput = {
   colonyDecisionId?: InputMaybe<Scalars['ID']>;
   colonyId?: InputMaybe<Scalars['ID']>;
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
+  expenditureId?: InputMaybe<Scalars['ID']>;
   fromDomainId?: InputMaybe<Scalars['ID']>;
   id: Scalars['ID'];
   individualEvents?: InputMaybe<Scalars['String']>;
@@ -7978,9 +8001,10 @@ export type UpdateExpenditureInput = {
   nativeId?: InputMaybe<Scalars['Int']>;
   ownerAddress?: InputMaybe<Scalars['ID']>;
   slots?: InputMaybe<Array<ExpenditureSlotInput>>;
-  stakedTransactionHash?: InputMaybe<Scalars['ID']>;
   status?: InputMaybe<ExpenditureStatus>;
+  transactionHash?: InputMaybe<Scalars['ID']>;
   type?: InputMaybe<ExpenditureType>;
+  userStakeId?: InputMaybe<Scalars['ID']>;
 };
 
 export type UpdateExpenditureMetadataInput = {


### PR DESCRIPTION
## Description

Advanced payments feature requires displaying payments in the activity feed. This PR introduces relations between expenditures and actions model so that there's a corresponding action created for each expenditure.

Additionally, it refactors the relation between Expenditure and UserStake models, making the latter available as a field on the expenditure.

I have also pulled in the commits from #1973 to make them available on `feat/advanced-payments-2` after merge - it's not the last time we modify the schema on this feature branch and manual copying has become a bit annoying.

block-ingestor PR: https://github.com/JoinColony/block-ingestor/pull/179

## Testing

1. Create an expenditure using testing UI.
2. Run a query to verify an action of type `CREATE_EXPENDITURE` has been created and that it has a linked expenditure to it, for example:
```gql
query ListActions {
  listColonyActions {
    items {
      id
      type
      expenditure {
        id
        nativeId
      }
    }
  }
}
```
3. Run a query to verify the expenditure also has an action linked to it:
```gql
query ListExpenditures {
  listExpenditures {
    items {
      nativeId
      action {
        id
        type 
      }
    }
  }
}
```
4. Test Simple payments still function and are stored in the database as `PAYMENT` action as opposed to `CREATE_EXPENDITURE`. On the contracts level they emit the same events so we need extra checks in block-ingestor to distinguish between the two.

Resolves #1102 
