### PR TITLE
Fix: Colony profile location field is not saving

### DIFF
--- a/src/components/frame/v5/pages/UserProfilePage/partials/UserAccountForm/hooks.tsx
+++ b/src/components/frame/v5/pages/UserProfilePage/partials/UserAccountForm/hooks.tsx
@@ -16,6 +16,7 @@ import {
   profileFileOptions,
   MAX_BIO_CHARS,
   MAX_DISPLAYNAME_CHARS,
+  MAX_LOCATION_CHARS,
 } from '../consts.ts';
 import IconSuccessContent from '../IconSuccessContent.tsx';
 import { type RowGroup } from '../Row/types.ts';
@@ -199,6 +200,8 @@ export const useUserProfilePageForm = () => {
       inputProps: {
         name: 'location',
         register,
+        maxCharNumber: MAX_LOCATION_CHARS,
+        isError: !!formState?.errors.location?.message,
       },
     },
   ];

--- a/src/components/v5/common/Fields/Input/Input.tsx
+++ b/src/components/v5/common/Fields/Input/Input.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { type FC, useEffect, useLayoutEffect, useRef } from 'react';
+import React, { type FC, useEffect, useLayoutEffect } from 'react';
 import { useIntl } from 'react-intl';
 
 import Tooltip from '~shared/Extensions/Tooltip/index.ts';
@@ -51,20 +51,16 @@ const Input: FC<InputProps> = ({
     }
   }, [isTyping, setIsTyping]);
 
-  const ref = useRef<HTMLInputElement | null>(null);
-
   useLayoutEffect(() => {
-    if (ref.current) {
-      if (shouldFocus) {
-        ref.current.focus();
+    if (shouldFocus) {
+      const inputElement = document.querySelector(
+        `#id-${name}`,
+      ) as HTMLElement | null;
+      if (inputElement) {
+        inputElement.focus();
       }
-
-      // Forward the ref to hook-form
-      registerField?.ref(ref.current);
     }
-    // @NOTE: Including registerField would cause an infinite loop
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldFocus]);
+  }, [shouldFocus, name]);
 
   const input = (
     <div className="w-full relative">
@@ -91,7 +87,6 @@ const Input: FC<InputProps> = ({
         }}
         disabled={isDisabled}
         id={`id-${name}`}
-        ref={ref}
       />
     </div>
   );


### PR DESCRIPTION
## Description

This issue was first detected when trying to update the location at `/account/profile`, but this issue was actually affecting both text inputs on the page (website and location).

The ref forwarding in the input component was preventing the register function from properly updating the form values. This PR refactors the shouldFocus useEffect to remove the ref forwarding.

## Testing

1. Navigate to your account profile /account/profile
2. Update the "Location" and/or "website" field.
3. Reload the page, you and the values should remain updated.

## Diffs

**New stuff** ✨

* New stuff goes here

**Changes** 🏗

* Refactored shouldFocus useEffect
* Added MAX_LOCATION_CHARS validation to location input

Resolves #1928
