### PR TITLE
Fix: Changes to files inside amplify folder are not being picked up by amplify container

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,14 @@ _Note: at the end of the install there's a post-install script that will recursi
 
 Copy `.env.example` and rename it to `.env`. You should not need to change any of the values to get CDapp running.
 
+### (Linux only) Increase the limit of watched files
+
+On Linux, you'll need to run the following commands to increase the default limit of watched files. Otherwise, the `watchAmplifyFiles` script will not work properly.
+
+```bash
+echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+```
+
 ## Running the dev environment
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "axios": "^1.4.0",
         "bn.js": "^5.1.1",
         "camelcase": "^6.0.0",
+        "chokidar": "^3.6.0",
         "classnames": "^2.2.6",
         "cleave.js": "1.4.10",
         "clsx": "^1.2.1",
@@ -17035,15 +17036,9 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -17055,6 +17050,9 @@
       },
       "engines": {
         "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -71958,9 +71956,9 @@
       }
     },
     "chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",

--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     "axios": "^1.4.0",
     "bn.js": "^5.1.1",
     "camelcase": "^6.0.0",
+    "chokidar": "^3.6.0",
     "classnames": "^2.2.6",
     "cleave.js": "1.4.10",
     "clsx": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "docker:build:all": "npm run docker:build:base && npm run docker:build:network && npm run docker:build:monitor && npm run docker:build:ingestor && npm run docker:build:amplify && npm run docker:build:safe && npm run docker:build:auth",
     "docker:compose:core": "docker compose --file docker/colony-cdapp-dev-env-orchestration.yaml",
     "docker:compose:all": "docker compose --file docker/colony-cdapp-dev-env-orchestration-all.yaml",
-    "dev": "npm run docker:build:core && npm run docker:compose:core up -- --force-recreate -V",
+    "dev": "npm run watch-amplify & npm run docker:build:core && npm run docker:compose:core up -- --force-recreate -V",
     "dev:all": "npm run docker:build:all && npm run docker:compose:all up -- --force-recreate -V",
     "lint": "eslint --fix 'src/**/*.{ts,tsx}'",
     "lint:ci": "eslint 'src/**/*.{ts,tsx}'",
@@ -33,7 +33,8 @@
     "build-storybook": "storybook build",
     "chromatic": "npx chromatic --project-token=f08326e25dbf",
     "postinstall": "./scripts/lambda-functions-dependencies.sh && scripts/generate-amplify-local-config.sh",
-    "upgrade-colony-js": "./scripts/upgrade-colony-js.sh"
+    "upgrade-colony-js": "./scripts/upgrade-colony-js.sh",
+    "watch-amplify": "ts-node scripts/watchAmplifyFiles"
   },
   "repository": {
     "type": "git",

--- a/scripts/watchAmplifyFiles.ts
+++ b/scripts/watchAmplifyFiles.ts
@@ -1,0 +1,57 @@
+/**
+ * This script watches for changes in the amplify directory and copies the changed files to the `amplify` Docker container.
+ */
+/* eslint-disable no-console */
+import { execSync } from 'child_process';
+import chokidar from 'chokidar';
+import path from 'path';
+
+const watchDir = './amplify';
+const targetDir = '/colonyCDapp';
+
+const watcher = chokidar.watch(watchDir, {
+  ignored: /(^|[/\\])\../, // ignore dotfiles
+  ignoreInitial: true,
+});
+
+const copyToDockerContainer = (filePath: string) => {
+  // Compute the relative path from the watched directory
+  const relativePath = path.relative(process.cwd(), filePath);
+  // Construct the target path inside the Docker container
+  const targetPath = path.join(targetDir, relativePath);
+
+  // Extract the directory and create it in the container (it might exist, but if it doesn't `docker cp` fill error)
+  const targetDirPath = path.dirname(targetPath);
+  const createDirectoryCommand = `docker exec amplify mkdir -p "${targetDirPath}"`;
+  try {
+    execSync(createDirectoryCommand);
+    console.log(
+      `Directory ${targetDirPath} was created in amplify container (or it existed before).`,
+    );
+  } catch (err) {
+    console.error(`Error creating directory in amplify container: ${err}`);
+    return;
+  }
+
+  const dockerCopyCommand = `docker cp "${filePath}" "amplify:${targetPath}"`;
+  try {
+    execSync(dockerCopyCommand);
+    console.log(
+      `File ${filePath} was copied to amplify container successfully.`,
+    );
+  } catch (err) {
+    console.error(`Error copying file to amplify container: ${err}`);
+  }
+};
+
+watcher
+  .on('change', (filePath) => {
+    console.log(`File ${filePath} has been changed`);
+    copyToDockerContainer(filePath);
+  })
+  .on('add', (filePath) => {
+    console.log(`File ${filePath} has been added`);
+    copyToDockerContainer(filePath);
+  });
+
+console.log(`Watching for file changes in ${watchDir}`);


### PR DESCRIPTION
## Description

Please see issue for description.

## Testing

Run `npm run dev` and wait for the `amplify` container to start.

Make some changes in the `amplify` directory, e.g.: 
 - modify the schema
 - create a new lambda (`npm run amplify function add`)
 - add a new file

The files you add/update should be copied over to `amplify` container. You'll see a relevant message in the console. If you are Docker Desktop user, you can go to the container > Files and check they've been copied:
<img width="1146" alt="Screenshot 2024-02-23 at 16 37 11" src="https://github.com/JoinColony/colonyCDapp/assets/112586815/5c512f5f-54e4-4022-a358-7e689886c177">

For CLI people, I think you can use `docker exec -it amplify /bin/sh` to enter the container's shell and run a combination of `cd` and `ls` to see the copied files.

Resolves #1972 
