### PR TITLE
Add auto-opening functionality to user hub after tx error

### DIFF
--- a/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
+++ b/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
@@ -40,9 +40,6 @@ const UserHubButton: FC<UserHubButtonProps> = ({
   const [prevGroupStatus, setPrevGroupStatus] = useState<
     TransactionStatus | undefined
   >();
-  const [groupStatus, setGroupStatus] = useState<
-    TransactionStatus | undefined
-  >();
 
   const { trackEvent } = useAnalyticsContext();
   const walletAddress = wallet?.address;
@@ -95,6 +92,10 @@ const UserHubButton: FC<UserHubButtonProps> = ({
     toggleOff();
   };
 
+  const groupStatus = getGroupStatus(
+    findNewestGroup(transactionAndMessageGroups),
+  );
+
   useEffect(() => {
     if (
       groupStatus === TransactionStatus.Failed &&
@@ -111,14 +112,6 @@ const UserHubButton: FC<UserHubButtonProps> = ({
     }
   }, [groupStatus, prevGroupStatus]);
 
-  useEffect(() => {
-    if (transactionAndMessageGroups.length > 0) {
-      setGroupStatus(
-        getGroupStatus(findNewestGroup(transactionAndMessageGroups)),
-      );
-    }
-  }, [transactionAndMessageGroups]);
-
   return (
     <div ref={ref}>
       <Button
@@ -128,7 +121,7 @@ const UserHubButton: FC<UserHubButtonProps> = ({
         ref={setTriggerRef}
         className={clsx(
           {
-            '!border-blue-400': visible,
+            '!border-blue-400': visible || isUserHubOpen,
           },
           'md:hover:!border-blue-400',
         )}

--- a/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
+++ b/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { type FC, useState } from 'react';
+import React, { type FC, useState, useEffect } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
 
 import UserHub from '~common/Extensions/UserHub/index.ts';
@@ -7,6 +7,8 @@ import MemberReputation from '~common/Extensions/UserNavigation/partials/MemberR
 import { useAnalyticsContext } from '~context/AnalyticsContext/index.ts';
 import { useAppContext } from '~context/AppContext.tsx';
 import { useColonyContext } from '~context/ColonyContext.tsx';
+import { useUserTransactionContext } from '~context/UserTransactionContext.tsx';
+import { TransactionStatus } from '~gql';
 import { useMobile } from '~hooks/index.ts';
 import useDetectClickOutside from '~hooks/useDetectClickOutside.ts';
 import useDisableBodyScroll from '~hooks/useDisableBodyScroll/index.ts';
@@ -19,6 +21,7 @@ import { UserHubTabs } from '../UserHub/types.ts';
 
 import { OPEN_USER_HUB_EVENT } from './consts.ts';
 import { type UserHubButtonProps } from './types.ts';
+import { findNewestGroup, getGroupStatus } from './utils.ts';
 
 export const displayName =
   'common.Extensions.UserNavigation.partials.UserHubButton';
@@ -33,6 +36,13 @@ const UserHubButton: FC<UserHubButtonProps> = ({
   } = useColonyContext();
   const { wallet, user } = useAppContext();
   const [isUserHubOpen, setIsUserHubOpen] = useState(false);
+  const { transactionAndMessageGroups } = useUserTransactionContext();
+  const [prevGroupStatus, setPrevGroupStatus] = useState<
+    TransactionStatus | undefined
+  >();
+  const [groupStatus, setGroupStatus] = useState<
+    TransactionStatus | undefined
+  >();
 
   const { trackEvent } = useAnalyticsContext();
   const walletAddress = wallet?.address;
@@ -84,6 +94,30 @@ const UserHubButton: FC<UserHubButtonProps> = ({
     setOpenItemIndex(undefined);
     toggleOff();
   };
+
+  useEffect(() => {
+    if (
+      groupStatus === TransactionStatus.Failed &&
+      (prevGroupStatus === TransactionStatus.Pending ||
+        prevGroupStatus === TransactionStatus.Ready)
+    ) {
+      setIsUserHubOpen(true);
+    }
+  }, [groupStatus, prevGroupStatus]);
+
+  useEffect(() => {
+    if (groupStatus !== prevGroupStatus) {
+      setPrevGroupStatus(groupStatus);
+    }
+  }, [groupStatus, prevGroupStatus]);
+
+  useEffect(() => {
+    if (transactionAndMessageGroups.length > 0) {
+      setGroupStatus(
+        getGroupStatus(findNewestGroup(transactionAndMessageGroups)),
+      );
+    }
+  }, [transactionAndMessageGroups]);
 
   return (
     <div ref={ref}>

--- a/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
+++ b/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
@@ -107,7 +107,7 @@ const UserHubButton: FC<UserHubButtonProps> = ({
   }, [groupStatus, prevGroupStatus]);
 
   useEffect(() => {
-    if (groupStatus !== prevGroupStatus) {
+    if (groupStatus && groupStatus !== prevGroupStatus) {
       setPrevGroupStatus(groupStatus);
     }
   }, [groupStatus, prevGroupStatus]);

--- a/src/components/common/Extensions/UserHubButton/utils.ts
+++ b/src/components/common/Extensions/UserHubButton/utils.ts
@@ -1,0 +1,23 @@
+import { TransactionStatus } from '~gql';
+
+import {
+  type TransactionOrMessageGroup,
+  type TransactionOrMessageGroups,
+} from '../UserHub/partials/TransactionsTab/transactionGroup.ts';
+
+export const getGroupStatus = (txGroup: TransactionOrMessageGroup) => {
+  if (txGroup.some((tx) => tx.status === TransactionStatus.Failed))
+    return TransactionStatus.Failed;
+
+  if (txGroup.some((tx) => tx.status === TransactionStatus.Pending))
+    return TransactionStatus.Pending;
+  if (txGroup.every((tx) => tx.status === TransactionStatus.Succeeded))
+    return TransactionStatus.Succeeded;
+  return TransactionStatus.Ready;
+};
+
+export const findNewestGroup = (txGroups: TransactionOrMessageGroups) => {
+  // @ts-ignore
+  txGroups.sort((a, b) => new Date(b[0].createdAt) - new Date(a[0].createdAt));
+  return txGroups[0];
+};

--- a/src/components/common/Extensions/UserHubButton/utils.ts
+++ b/src/components/common/Extensions/UserHubButton/utils.ts
@@ -13,9 +13,14 @@ export const getGroupStatus = (
 
   if (txGroup?.some((tx) => tx.status === TransactionStatus.Pending))
     return TransactionStatus.Pending;
+
   if (txGroup?.every((tx) => tx.status === TransactionStatus.Succeeded))
     return TransactionStatus.Succeeded;
-  return TransactionStatus.Ready;
+
+  if (txGroup?.some((tx) => tx.status === TransactionStatus.Ready))
+    return TransactionStatus.Ready;
+
+  return null;
 };
 
 export const findNewestGroup = (

--- a/src/components/common/Extensions/UserHubButton/utils.ts
+++ b/src/components/common/Extensions/UserHubButton/utils.ts
@@ -5,19 +5,26 @@ import {
   type TransactionOrMessageGroups,
 } from '../UserHub/partials/TransactionsTab/transactionGroup.ts';
 
-export const getGroupStatus = (txGroup: TransactionOrMessageGroup) => {
-  if (txGroup.some((tx) => tx.status === TransactionStatus.Failed))
+export const getGroupStatus = (
+  txGroup: TransactionOrMessageGroup | undefined,
+) => {
+  if (txGroup?.some((tx) => tx.status === TransactionStatus.Failed))
     return TransactionStatus.Failed;
 
-  if (txGroup.some((tx) => tx.status === TransactionStatus.Pending))
+  if (txGroup?.some((tx) => tx.status === TransactionStatus.Pending))
     return TransactionStatus.Pending;
-  if (txGroup.every((tx) => tx.status === TransactionStatus.Succeeded))
+  if (txGroup?.every((tx) => tx.status === TransactionStatus.Succeeded))
     return TransactionStatus.Succeeded;
   return TransactionStatus.Ready;
 };
 
-export const findNewestGroup = (txGroups: TransactionOrMessageGroups) => {
-  // @ts-ignore
-  txGroups.sort((a, b) => new Date(b[0].createdAt) - new Date(a[0].createdAt));
+export const findNewestGroup = (
+  txGroups: TransactionOrMessageGroups,
+): TransactionOrMessageGroup | undefined => {
+  txGroups.sort(
+    (a, b) =>
+      new Date(b[0].createdAt || 0).getTime() -
+      new Date(a[0].createdAt || 0).getTime(),
+  );
   return txGroups[0];
 };


### PR DESCRIPTION
## Description

Implemented logic to open the user hub when a transaction fails. Inspired by the logic we had in the Dapp/Old UI.

## Testing

- We need to make a transaction fail and check if the user hub opens automatically and shows the error.
- One way I could think of is to transfer 1 token to a newly created team, and then try to make a simple payment from that team to any user for 1 token. This transaction should fail because you don't have enough tokens to cover the network fees.
- Another one is to try to transfer all of the tokens from one team to another through a motion, and before finalizing it, create an action and transfer any amount from the same team so that now the transfer motion can't be finalized because the funds aren't enough. (You are gonna have to go to `FinalizeStep` and remove the `!isFinalizable` from the submit button)

Resolves #1807 
