### PR TITLE
Fix: change not enough reputation error message

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/StakingStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/StakingStep.tsx
@@ -4,7 +4,6 @@ import { formatRelative } from 'date-fns';
 import React, { type FC } from 'react';
 
 import { useAppContext } from '~context/AppContext.tsx';
-import { useColonyContext } from '~context/ColonyContext.tsx';
 import useToggle from '~hooks/useToggle/index.ts';
 import { SpinnerLoader } from '~shared/Preloaders/index.ts';
 import { SystemMessages } from '~types/actions.ts';
@@ -28,9 +27,6 @@ const displayName =
 
 const StakingStep: FC<StakingStepProps> = ({ className, isActive }) => {
   const { canInteract } = useAppContext();
-  const {
-    colony: { domains },
-  } = useColonyContext();
   const { motionAction } = useMotionContext();
   const [isAccordionOpen, { toggle: toggleAccordion }] = useToggle();
   const {
@@ -66,8 +62,7 @@ const StakingStep: FC<StakingStepProps> = ({ className, isActive }) => {
     (message) => message?.name === SystemMessages.MotionVotingPhase,
   );
 
-  const teamName = domains?.items.find((domain) => domain?.metadata?.name)
-    ?.metadata?.name;
+  const teamName = motionAction.motionData.motionDomain.metadata?.name;
 
   const cardTitleMessageId = (() => {
     if (isFullyStaked) {

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/StakingStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/StakingStep.tsx
@@ -4,6 +4,7 @@ import { formatRelative } from 'date-fns';
 import React, { type FC } from 'react';
 
 import { useAppContext } from '~context/AppContext.tsx';
+import { useColonyContext } from '~context/ColonyContext.tsx';
 import useToggle from '~hooks/useToggle/index.ts';
 import { SpinnerLoader } from '~shared/Preloaders/index.ts';
 import { SystemMessages } from '~types/actions.ts';
@@ -27,6 +28,9 @@ const displayName =
 
 const StakingStep: FC<StakingStepProps> = ({ className, isActive }) => {
   const { canInteract } = useAppContext();
+  const {
+    colony: { domains },
+  } = useColonyContext();
   const { motionAction } = useMotionContext();
   const [isAccordionOpen, { toggle: toggleAccordion }] = useToggle();
   const {
@@ -61,6 +65,9 @@ const StakingStep: FC<StakingStepProps> = ({ className, isActive }) => {
   const votingPhaseStartedMessage = motionData.messages?.items.find(
     (message) => message?.name === SystemMessages.MotionVotingPhase,
   );
+
+  const teamName = domains?.items.find((domain) => domain?.metadata?.name)
+    ?.metadata?.name;
 
   const cardTitleMessageId = (() => {
     if (isFullyStaked) {
@@ -122,9 +129,12 @@ const StakingStep: FC<StakingStepProps> = ({ className, isActive }) => {
                   key: '1',
                   content: (
                     <p className="text-sm">
-                      {formatText({
-                        id: 'motion.staking.notEnoughReputation',
-                      })}
+                      {formatText(
+                        {
+                          id: 'motion.staking.notEnoughReputation',
+                        },
+                        { teamName },
+                      )}
                     </p>
                   ),
                   className: 'bg-negative-100 text-negative-400',

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1254,7 +1254,7 @@
     "motion.staking.status.text": "Stake “Support” if you think this action should happen or “Oppose” to take it to a vote.",
     "motion.staking.status.text.locked": "Fully supported and opposed {time}.",
     "motion.staking.passIfNotOpposed": "This action will pass if not fully opposed",
-    "motion.staking.notEnoughReputation": "You did not have enough reputation at the time this action was created to stake on this action.",
+    "motion.staking.notEnoughReputation": "When this action was created, your reputation in the {teamName} team was too low.",
     "motion.staking.status.text.supported": "The action has been fully supported and will pass. You can fully oppose the action to take it to a vote.",
     "motion.staking.status.text.opposed": "The action has been fully opposed and will fail. You can fully support the action to take it to a vote.",
     "motion.staking.activateTokens": "Activate tokens",


### PR DESCRIPTION
## Description

This PR changes the error message a user gets when they don't have enough reputation to contribute to a stake decision

## Testing

1. Create a motion in a team using the Reputation Decision method (I created an agreement).
2. View the decision from a user without any reputation in the team
3. Correctly, you won't be able to stake on the action and you will get an error message.

## Diffs

**Changes** 🏗

New error message can be seen here:
![Screenshot 2024-02-26 at 21 37 44](https://github.com/JoinColony/colonyCDapp/assets/155957480/7a4be1d1-3b82-4af2-a1df-26ad73344ea4)

I've added some code to get the user's team / domain name to display it in the error message, however it feels messy, if someone has a better suggestion on how to get the team name please let me know.


Resolves #1940 
