### PR TITLE
fix: team reputation summary and agreements widget

### DIFF
--- a/src/components/v5/common/TeamReputationSummary/TeamReputationSummary.tsx
+++ b/src/components/v5/common/TeamReputationSummary/TeamReputationSummary.tsx
@@ -63,10 +63,9 @@ const TeamReputationSummary: FC<TeamReputationSummaryProps> = ({
       </span>
       <span className="heading-4 mb-1">
         <Numeral
-          value={new Decimal(colonyReputation).abs().toString()}
+          value={new Decimal(colonyReputation).abs()}
           decimals={nativeToken?.decimals || DEFAULT_TOKEN_DECIMALS}
         />
-        {colonyReputation !== '0' && 'M'}
       </span>
       <span className="text-gray-600 text-sm border-b border-gray-200 pb-6 mb-6">
         {formatText({ id: 'teamReputation.reputationPoints.label' })}

--- a/src/components/v5/frame/ColonyHome/partials/Agreements/Agreements.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/Agreements/Agreements.tsx
@@ -17,6 +17,7 @@ import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.tsx';
 import WidgetBox from '~v5/common/WidgetBox/index.ts';
 import EmptyWidgetState from '~v5/common/WidgetBox/partials/index.ts';
 import MessageNumber from '~v5/shared/MessageNumber/index.ts';
+import RichTextDisplay from '~v5/shared/RichTextDisplay/index.ts';
 import TitleWithNumber from '~v5/shared/TitleWithNumber/index.ts';
 
 const displayName = 'v5.frame.ColonyHome.Agreements';
@@ -73,9 +74,13 @@ const Agreements = () => {
                 </span>
                 <MessageNumber message={1} />
               </div>
-              <p className="text-sm text-gray-600 line-clamp-3">
-                {newestAgreement.decisionData?.description}
-              </p>
+              {newestAgreement.decisionData?.description && (
+                <RichTextDisplay
+                  content={newestAgreement.decisionData?.description}
+                  className="!text-sm !text-gray-600 line-clamp-3"
+                  shouldFormat={false}
+                />
+              )}
             </div>
           )}
           {!newestAgreement && !loading && (


### PR DESCRIPTION
Agreement widget:
Before:
![image](https://github.com/JoinColony/colonyCDapp/assets/44369011/38a9cd74-0992-4f93-8aff-f7507269de4b)
After: 
![image](https://github.com/JoinColony/colonyCDapp/assets/44369011/bae75da8-7da8-4954-8286-45131ef5106d)

Team reputation Summary widget:
https://github.com/JoinColony/colonyCDapp/issues/1935
Does not show `M` when not needed
![image](https://github.com/JoinColony/colonyCDapp/assets/44369011/a75fb4d3-6389-471c-935f-ad00a4569a74)
