### PR TITLE
fix: agreements page error with date

### DIFF
--- a/src/components/frame/v5/pages/AgreementsPage/AgreementsPage.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/AgreementsPage.tsx
@@ -82,41 +82,7 @@ const AgreementsPage: FC = () => {
           {formatText({ id: 'agreementsPage.createAgreement' })}
         </Button>
       </div>
-      {agreements && agreements?.length > 0 && (
-        <ul className="grid auto-rows-fr sm:auto-rows-auto grid-cols-1 sm:grid-cols-2 gap-6">
-          {agreements.map(({ transactionHash }) => (
-            <motion.li
-              initial={{ opacity: 0 }}
-              whileInView={{
-                opacity: 1,
-                transition: {
-                  duration: 0.75,
-                },
-              }}
-              viewport={{ once: true }}
-              key={transactionHash}
-              className="w-full"
-            >
-              <AgreementCard transactionId={transactionHash} />
-            </motion.li>
-          ))}
-        </ul>
-      )}
-      {agreements?.length === 0 && !loading && (
-        <EmptyContent
-          description={{ id: 'agreementsPage.empty.description' }}
-          className="px-5 py-[5.75rem] border-dashed"
-          buttonText={{ id: 'agreementsPage.empty.button' }}
-          onClick={() => {
-            toggleActionSidebarOn({
-              [ACTION_TYPE_FIELD_NAME]: Action.CreateDecision,
-            });
-          }}
-          buttonIcon={FilePlus}
-          withBorder
-        />
-      )}
-      {loading && (
+      {loading ? (
         <ul className="grid sm:grid-cols-2 gap-6">
           {[...Array(4).keys()].map((key) => (
             <li
@@ -127,6 +93,42 @@ const AgreementsPage: FC = () => {
             </li>
           ))}
         </ul>
+      ) : (
+        <>
+          {agreements?.length ? (
+            <ul className="grid auto-rows-fr sm:auto-rows-auto grid-cols-1 sm:grid-cols-2 gap-6">
+              {agreements.map(({ transactionHash }) => (
+                <motion.li
+                  initial={{ opacity: 0 }}
+                  whileInView={{
+                    opacity: 1,
+                    transition: {
+                      duration: 0.75,
+                    },
+                  }}
+                  viewport={{ once: true }}
+                  key={transactionHash}
+                  className="w-full"
+                >
+                  <AgreementCard transactionId={transactionHash} />
+                </motion.li>
+              ))}
+            </ul>
+          ) : (
+            <EmptyContent
+              description={{ id: 'agreementsPage.empty.description' }}
+              className="px-5 py-[5.75rem] border-dashed"
+              buttonText={{ id: 'agreementsPage.empty.button' }}
+              onClick={() => {
+                toggleActionSidebarOn({
+                  [ACTION_TYPE_FIELD_NAME]: Action.CreateDecision,
+                });
+              }}
+              buttonIcon={FilePlus}
+              withBorder
+            />
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementCard/AgreementCard.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementCard/AgreementCard.tsx
@@ -42,8 +42,8 @@ const AgreementCard: FC<AgreementCardProps> = ({ transactionId }) => {
   } = useGetColonyAction(transactionId);
   const { decisionData, motionData } = action || {};
   const {
-    createdAt = '',
-    description = '',
+    createdAt,
+    description,
     title,
     motionDomainId,
     walletAddress = '',
@@ -102,11 +102,13 @@ const AgreementCard: FC<AgreementCardProps> = ({ transactionId }) => {
             }}
           >
             <h5 className="text-1 mb-2 truncate">{title}</h5>
-            <RichTextDisplay
-              content={description}
-              shouldFormat={false}
-              className="!text-sm !text-gray-600 line-clamp-4"
-            />
+            {description && (
+              <RichTextDisplay
+                content={description}
+                shouldFormat={false}
+                className="!text-sm !text-gray-600 line-clamp-4"
+              />
+            )}
           </button>
           <div className="flex items-center justify-between gap-2 pt-4 mt-auto border-t border-gray-200">
             <UserPopover
@@ -151,9 +153,11 @@ const AgreementCard: FC<AgreementCardProps> = ({ transactionId }) => {
                   color={currentTeam.metadata?.color}
                 />
               )}
-              <p className="text-sm text-gray-600">
-                {format(new Date(createdAt), 'd MMMM yyyy')}
-              </p>
+              {createdAt && (
+                <p className="text-sm text-gray-600">
+                  {format(new Date(createdAt), 'd MMMM yyyy')}
+                </p>
+              )}
               <MeatBallMenu
                 withVerticalIcon
                 contentWrapperClassName={clsx('sm:min-w-[17.375rem]', {


### PR DESCRIPTION
There was an error on the agreements page - https://jam.dev/c/a471bcb3-ea8f-4cd0-8fbe-f092b5c52646
It was caused by the fallback value of `createdIn` field. I've removed this fallback and right now I'm displaying the date only when `cretedIn` is not undefined.
Description should also be hidden if it's undefined.