### PR TITLE
feat: sanitize HTML before sending description to saga

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/hooks.ts
@@ -8,6 +8,7 @@ import { createDecisionAction } from '~redux/actionCreators/index.ts';
 import { ActionTypes } from '~redux/index.ts';
 import { mapPayload, pipe } from '~utils/actions.ts';
 import { type DecisionDraft } from '~utils/decisions.ts';
+import { sanitizeHTML } from '~utils/strings/index.ts';
 
 import { useActionFormBaseHook } from '../../../hooks/index.ts';
 import { type ActionFormBaseProps } from '../../../types.ts';
@@ -54,11 +55,13 @@ export const useCreateDecision = (
     transform: useCallback(
       pipe(
         mapPayload((payload: CreateDecisionFormValues) => {
+          const safeDescription = sanitizeHTML(payload.description || '');
+
           handleSaveAgreementInLocalStorage({
             colonyAddress,
             title: payload.title,
             motionDomainId: Number(payload.createdIn),
-            description: payload.description || '',
+            description: safeDescription,
             walletAddress,
           });
 
@@ -70,7 +73,7 @@ export const useCreateDecision = (
             draftDecision: {
               motionDomainId: Number(payload.createdIn),
               title: payload.title,
-              description: payload.description,
+              description: safeDescription,
               walletAddress,
             },
           };

--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateNewTeamForm/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateNewTeamForm/utils.tsx
@@ -1,4 +1,5 @@
 import { type Colony } from '~types/graphql.ts';
+import { sanitizeHTML } from '~utils/strings/index.ts';
 
 import { type CreateNewTeamFormValues } from './consts.ts';
 
@@ -13,5 +14,7 @@ export const getCreateNewTeamPayload = (
   colonyName: colony.name,
   customActionTitle: values.title,
   motionDomainId: values.createdIn,
-  annotationMessage: values.description,
+  annotationMessage: values.description
+    ? sanitizeHTML(values.description)
+    : undefined,
 });

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/utils.tsx
@@ -1,4 +1,5 @@
 import { type Colony } from '~types/graphql.ts';
+import { sanitizeHTML } from '~utils/strings/index.ts';
 
 import { type EditColonyDetailsFormValues } from './types.ts';
 
@@ -29,7 +30,9 @@ export const getEditColonyDetailsPayload = (
         ? colonyThumbnail
         : colony.metadata?.thumbnail,
     colonyExternalLinks: externalLinks || [],
-    annotationMessage,
+    annotationMessage: annotationMessage
+      ? sanitizeHTML(annotationMessage)
+      : undefined,
     customActionTitle: title,
   };
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditTeamForm/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditTeamForm/utils.tsx
@@ -1,4 +1,5 @@
 import { type Colony, type Domain } from '~types/graphql.ts';
+import { sanitizeHTML } from '~utils/strings/index.ts';
 
 import { type EditTeamFormValues } from './consts.ts';
 
@@ -13,7 +14,9 @@ export const getEditDomainPayload = (
   domainColor: values.domainColor,
   domainPurpose: values.domainPurpose,
   domain: selectedDomain,
-  annotationMessage: values.description,
+  annotationMessage: values.description
+    ? sanitizeHTML(values.description)
+    : undefined,
   customActionTitle: values.title,
   motionDomainId: values.createdIn,
   isCreateDomain: false,

--- a/src/components/v5/common/ActionSidebar/partials/forms/EnterRecoveryModeForm/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EnterRecoveryModeForm/utils.tsx
@@ -1,4 +1,5 @@
 import { type Colony, type User } from '~types/graphql.ts';
+import { sanitizeHTML } from '~utils/strings/index.ts';
 
 import { type EnterRecoveryModeFormValues } from './consts.ts';
 
@@ -10,6 +11,8 @@ export const getRecoveryModePayload = (
   colonyName: colony.name,
   colonyAddress: colony.colonyAddress,
   walletAddress: user?.walletAddress,
-  annotationMessage: values.description,
+  annotationMessage: values.description
+    ? sanitizeHTML(values.description)
+    : undefined,
   customActionTitle: '',
 });

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/utils.tsx
@@ -1,4 +1,5 @@
 import { type Colony } from '~types/graphql.ts';
+import { sanitizeHTML } from '~utils/strings/index.ts';
 
 import { type ManageColonyObjectivesFormValues } from './consts.ts';
 
@@ -13,5 +14,7 @@ export const getManageColonyObjectivesPayload = (
     progress: values.colonyObjectiveProgress,
   },
   motionDomainId: values.createdIn,
-  annotationMessage: values.description,
+  annotationMessage: values.description
+    ? sanitizeHTML(values.description)
+    : undefined,
 });

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/utils.tsx
@@ -8,6 +8,7 @@ import {
 import { type Colony } from '~types/graphql.ts';
 import { getEnumValueFromKey } from '~utils/getEnumValueFromKey.ts';
 import { formatText } from '~utils/intl.ts';
+import { sanitizeHTML } from '~utils/strings/index.ts';
 
 import {
   AVAILABLE_ROLES,
@@ -80,7 +81,9 @@ export const getManagePermissionsPayload = (
   colony: Colony,
   values: ManagePermissionsFormValues,
 ) => ({
-  annotationMessage: values.description,
+  annotationMessage: values.description
+    ? sanitizeHTML(values.description)
+    : undefined,
   domainId: Number(values.team),
   userAddress: values.member,
   colonyName: colony.name,

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageTokensForm/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageTokensForm/utils.tsx
@@ -1,5 +1,6 @@
 import { ADDRESS_ZERO } from '~constants/index.ts';
 import { type Colony } from '~types/graphql.ts';
+import { sanitizeHTML } from '~utils/strings/index.ts';
 import { createAddress } from '~utils/web3/index.ts';
 
 import { type ManageTokensFormValues } from './consts.ts';
@@ -30,7 +31,9 @@ export const getManageTokensPayload = (
   return {
     colony,
     tokenAddresses,
-    annotationMessage,
+    annotationMessage: annotationMessage
+      ? sanitizeHTML(annotationMessage)
+      : undefined,
     customActionTitle: title,
   };
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/MintTokenForm/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/MintTokenForm/utils.tsx
@@ -3,6 +3,7 @@ import moveDecimal from 'move-decimal-point';
 
 import { RootMotionMethodNames } from '~redux/index.ts';
 import { type Colony } from '~types/graphql.ts';
+import { sanitizeHTML } from '~utils/strings/index.ts';
 import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
 
 import { type MintTokenFormValues } from './consts.ts';
@@ -31,7 +32,9 @@ export const getMintTokenPayload = (
     nativeTokenAddress: colony.nativeToken.tokenAddress,
     motionParams: [amount],
     amount,
-    annotationMessage,
+    annotationMessage: annotationMessage
+      ? sanitizeHTML(annotationMessage)
+      : undefined,
     customActionTitle: title,
   };
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/utils.tsx
@@ -1,5 +1,6 @@
 import { type OneTxPaymentPayload } from '~redux/types/actions/colonyActions.ts';
 import { type Colony } from '~types/graphql.ts';
+import { sanitizeHTML } from '~utils/strings/index.ts';
 import {
   calculateFee,
   getSelectedToken,
@@ -47,7 +48,7 @@ export const getSimplePaymentPayload = (
 ) => {
   const {
     from,
-    description,
+    description: annotationMessage,
     createdIn,
     title,
     amount,
@@ -79,7 +80,9 @@ export const getSimplePaymentPayload = (
         }),
       ),
     ],
-    annotationMessage: description,
+    annotationMessage: annotationMessage
+      ? sanitizeHTML(annotationMessage)
+      : undefined,
     motionDomainId: createdInDomainId,
     customActionTitle: title,
   };

--- a/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/utils.tsx
@@ -3,6 +3,7 @@ import moveDecimal from 'move-decimal-point';
 
 import { type Colony } from '~types/graphql.ts';
 import { findDomainByNativeId } from '~utils/domains.ts';
+import { sanitizeHTML } from '~utils/strings/index.ts';
 import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
 
 import { type TransferFundsFormValues } from './hooks.ts';
@@ -36,7 +37,9 @@ export const getTransferFundsPayload = (
     fromDomain,
     toDomain,
     amount,
-    annotationMessage,
+    annotationMessage: annotationMessage
+      ? sanitizeHTML(annotationMessage)
+      : undefined,
     customActionTitle: title,
   };
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/UnlockTokenForm/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/UnlockTokenForm/utils.tsx
@@ -1,5 +1,6 @@
 import { RootMotionMethodNames } from '~redux/index.ts';
 import { type Colony } from '~types/graphql.ts';
+import { sanitizeHTML } from '~utils/strings/index.ts';
 
 import { type UnlockTokenFormValues } from './consts.ts';
 
@@ -7,7 +8,9 @@ export const getUnlockTokenPayload = (
   colony: Colony,
   { description: annotationMessage, title }: UnlockTokenFormValues,
 ) => ({
-  annotationMessage,
+  annotationMessage: annotationMessage
+    ? sanitizeHTML(annotationMessage)
+    : undefined,
   colonyAddress: colony.colonyAddress,
   operationName: RootMotionMethodNames.UnlockToken,
   motionParams: [],

--- a/src/components/v5/common/ActionSidebar/partials/forms/UpgradeColonyForm/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/UpgradeColonyForm/utils.tsx
@@ -1,5 +1,6 @@
 import { RootMotionMethodNames } from '~redux/index.ts';
 import { type Colony } from '~types/graphql.ts';
+import { sanitizeHTML } from '~utils/strings/index.ts';
 
 import { type UpgradeColonyFormValues } from './consts.ts';
 
@@ -12,5 +13,7 @@ export const getUpgradeColonyPayload = (
   colonyName: colony.name,
   version: colony.version,
   motionParams: [colony.version + 1],
-  annotationMessage: values.description,
+  annotationMessage: values.description
+    ? sanitizeHTML(values.description)
+    : undefined,
 });

--- a/src/components/v5/shared/RichTextDisplay/RichTextDisplay.tsx
+++ b/src/components/v5/shared/RichTextDisplay/RichTextDisplay.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
-import DOMPurify from 'dompurify';
 import React from 'react';
+
+import { sanitizeHTML, stripHTML } from '~utils/strings/index.ts';
 
 import styles from './RichTextDisplay.module.css';
 
@@ -20,8 +21,8 @@ const RichTextDisplay = ({
   shouldFormat = true,
 }: RichTextDisplayProps) => {
   const cleanContent = shouldFormat
-    ? DOMPurify.sanitize(content)
-    : DOMPurify.sanitize(content, { ALLOWED_TAGS: [], KEEP_CONTENT: true });
+    ? sanitizeHTML(content)
+    : stripHTML(content);
 
   return (
     <div

--- a/src/utils/strings/index.ts
+++ b/src/utils/strings/index.ts
@@ -1,4 +1,5 @@
 // import { addressNormalizer, addressValidator } from '@purser/core';
+import DOMPurify from 'dompurify';
 import { customAlphabet, urlAlphabet } from 'nanoid';
 
 import { type Address } from '~types/index.ts';
@@ -175,3 +176,8 @@ export const ensureHexPrefix = (value: string): string => {
  * Given a bool, returns 'Yes' or 'No'
  */
 export const boolToYesNo = (value: boolean) => (value ? 'Yes' : 'No');
+
+export const sanitizeHTML = (content: string) => DOMPurify.sanitize(content);
+
+export const stripHTML = (content: string) =>
+  DOMPurify.sanitize(content, { ALLOWED_TAGS: [], KEEP_CONTENT: true });


### PR DESCRIPTION
## Description

So turns out tiptap handles sanitization, and I wasn't able to inject a hacky iframe.
Nonetheless, I've created a helper for sanitizing HTML which we now call before sending annotation data to the saga.

## Testing
You can use this hacky iframe `<iframe src="javascript:alert(1)" />`

1. Install governance extension
2. Create new decision, save draft.
3. Go to localstorage to see where decision is being saved. Edit the html string with that iframe.
4. Refresh decision preview to see how it renders.
5. Publish decision to see how it renders.

You can also try setting the description to the iframe, it shouldn't alert you when pasting it or creating any action.

## Diffs

**Changes** 🏗

* Before submitting data to the saga, we sanitize the HTML

Resolves #1028
