### PR TITLE
Changes to expenditures after locking using permissions

### DIFF
--- a/amplify/backend/function/fetchVoterRewards/src/utils.js
+++ b/amplify/backend/function/fetchVoterRewards/src/utils.js
@@ -88,7 +88,7 @@ const getVoterReward = async (colonyAddress, motionId, userReputation) => {
       BigNumber.from(userReputation),
     );
     return reward;
-  } catch {
+  } catch (e) {
     console.error('Error getting voter reward', e);
     return undefined;
   }

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=9dfb3e8f058f5ea8c4343df166f3165ff37bd5b4
+ENV BLOCK_INGESTOR_HASH=b83546fa180e0541ca1038aa2b2e728fb9a28364
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -32,9 +32,11 @@ const TmpAdvancedPayments = () => {
   const { extensionData } = useExtensionData(Extension.StagedExpenditure);
   const { networkInverseFee = '0' } = useNetworkInverseFee();
 
-  const [tokenId, setTokenId] = useState('');
-  const [decimalAmount, setDecimalAmount] = useState('');
-  const [transactionAmount, setTransactionAmount] = useState('');
+  const [tokenAddress, setTokenAddress] = useState(
+    colony.nativeToken.tokenAddress,
+  );
+  const [decimalAmount, setDecimalAmount] = useState('18');
+  const [transactionAmount, setTransactionAmount] = useState('0');
   const [expenditureId, setExpenditureId] = useState('');
   const [releaseStage, setReleaseStage] = useState('');
 
@@ -109,7 +111,7 @@ const TmpAdvancedPayments = () => {
   const payouts = [
     {
       amount: transactionAmount,
-      tokenAddress: tokenId,
+      tokenAddress,
       recipientAddress: user?.walletAddress ?? '',
       claimDelay: 0,
       tokenDecimals: tokenDecimalAmount,
@@ -267,7 +269,20 @@ const TmpAdvancedPayments = () => {
       colonyAddress: colony.colonyAddress,
       expenditure,
       networkInverseFee,
-      payouts: [],
+      payouts: [
+        {
+          amount: '23.45',
+          tokenAddress: colony.nativeToken.tokenAddress,
+          recipientAddress: colony.colonyAddress,
+          claimDelay: 0,
+        },
+        {
+          amount: '67.89',
+          tokenAddress: colony.nativeToken.tokenAddress,
+          recipientAddress: user?.walletAddress ?? '',
+          claimDelay: 300,
+        },
+      ],
       userAddress: user?.walletAddress ?? '',
     };
 
@@ -278,16 +293,19 @@ const TmpAdvancedPayments = () => {
     <div className="flex flex-col gap-8">
       <div className="flex gap-4">
         <InputBase
-          onChange={(e) => setTokenId(e.currentTarget.value)}
-          placeholder="Token Address"
+          onChange={(e) => setTokenAddress(e.currentTarget.value)}
+          value={tokenAddress}
+          label="Token Address"
         />
         <InputBase
           onChange={(e) => setDecimalAmount(e.currentTarget.value)}
-          placeholder="Token Decimals"
+          value={decimalAmount}
+          label="Token Decimals"
         />
         <InputBase
           onChange={(e) => setTransactionAmount(e.currentTarget.value)}
-          placeholder="Transaction Amount"
+          value={transactionAmount}
+          label="Transaction Amount"
         />
         <ActionButton
           actionType={ActionTypes.EXPENDITURE_CREATE}

--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -124,7 +124,6 @@ const TmpAdvancedPayments = () => {
     createdInDomain: rootDomain,
     fundFromDomainId: 1,
     networkInverseFee,
-    annotationMessage: 'expenditure annotation',
   };
 
   const createStagedExpenditurePayload: CreateExpenditurePayload = {
@@ -340,6 +339,7 @@ const TmpAdvancedPayments = () => {
             Cancel and punish
           </Button>
           <Button onClick={handleEdit}>Edit</Button>
+          <Button onClick={() => refetch()}>Refetch</Button>
         </div>
       </div>
       <div className="flex gap-4">
@@ -348,7 +348,6 @@ const TmpAdvancedPayments = () => {
           onChange={(e) => setReleaseStage(e.currentTarget.value)}
           placeholder="Stage to release"
         />
-        <Button onClick={() => refetch()}>Refetch expenditure</Button>
         <Button
           onClick={handleReleaseExpenditureStageMotion}
           disabled={!expenditure}

--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 
 import { useAppContext } from '~context/AppContext.tsx';
 import { useColonyContext } from '~context/ColonyContext.tsx';
-import { type Expenditure, useGetExpenditureQuery } from '~gql';
+import { useGetExpenditureQuery } from '~gql';
 import useAsyncFunction from '~hooks/useAsyncFunction.ts';
 import useExpenditureStaking from '~hooks/useExpenditureStaking.ts';
 import useExtensionData from '~hooks/useExtensionData.ts';
@@ -12,6 +12,7 @@ import { ActionTypes } from '~redux';
 import { type ClaimExpenditurePayload } from '~redux/sagas/expenditures/claimExpenditure.ts';
 import { type CreateExpenditurePayload } from '~redux/sagas/expenditures/createExpenditure.ts';
 import { type CreateStakedExpenditurePayload } from '~redux/sagas/expenditures/createStakedExpenditure.ts';
+import { type EditExpenditurePayload } from '~redux/sagas/expenditures/editExpenditure.ts';
 import { type FinalizeExpenditurePayload } from '~redux/sagas/expenditures/finalizeExpenditure.ts';
 import { type FundExpenditurePayload } from '~redux/sagas/expenditures/fundExpenditure.ts';
 import { type LockExpenditurePayload } from '~redux/sagas/expenditures/lockExpenditure.ts';
@@ -93,6 +94,11 @@ const TmpAdvancedPayments = () => {
     submit: ActionTypes.MOTION_RELEASE_EXPENDITURE_STAGE,
     error: ActionTypes.MOTION_RELEASE_EXPENDITURE_STAGE_ERROR,
     success: ActionTypes.MOTION_RELEASE_EXPENDITURE_STAGE_SUCCESS,
+  });
+  const editExpenditure = useAsyncFunction({
+    submit: ActionTypes.EXPENDITURE_EDIT,
+    error: ActionTypes.EXPENDITURE_EDIT_ERROR,
+    success: ActionTypes.EXPENDITURE_EDIT_SUCCESS,
   });
 
   const rootDomain = findDomainByNativeId(Id.RootDomain, colony);
@@ -226,11 +232,7 @@ const TmpAdvancedPayments = () => {
   };
 
   const handleReleaseExpenditureStageMotion = async () => {
-    if (!expenditure) {
-      return;
-    }
-
-    if (!releaseStage) {
+    if (!expenditure || !releaseStage) {
       return;
     }
 
@@ -246,7 +248,7 @@ const TmpAdvancedPayments = () => {
     const payload: ReleaseExpenditureStageMotionPayload = {
       colonyAddress: colony.colonyAddress,
       colonyName: colony.name,
-      expenditure: expenditure as Expenditure,
+      expenditure,
       slotId: Number(releaseStage),
       motionDomainId: expenditure.nativeDomainId,
       tokenAddresses: [colony.nativeToken.tokenAddress],
@@ -254,6 +256,22 @@ const TmpAdvancedPayments = () => {
     };
 
     await releaseExpenditureStageMotion(payload);
+  };
+
+  const handleEdit = async () => {
+    if (!expenditure) {
+      return;
+    }
+
+    const payload: EditExpenditurePayload = {
+      colonyAddress: colony.colonyAddress,
+      expenditure,
+      networkInverseFee,
+      payouts: [],
+      userAddress: user?.walletAddress ?? '',
+    };
+
+    await editExpenditure(payload);
   };
 
   return (
@@ -293,17 +311,18 @@ const TmpAdvancedPayments = () => {
           onChange={(e) => setExpenditureId(e.currentTarget.value)}
           placeholder="Expenditure ID"
         />
-        <Button onClick={handleLockExpenditure}>Lock expenditure</Button>
-        <Button onClick={handleFundExpenditure} disabled={!expenditure}>
-          Fund expenditure
-        </Button>
-        <Button onClick={handleFinalizeExpenditure}>
-          Finalize expenditure
-        </Button>
-        <Button onClick={handleReclaimStake}>Reclaim stake</Button>
-        <Button onClick={handleCancelAndPunish} disabled={!expenditure}>
-          Cancel and punish
-        </Button>
+        <div className="flex gap-4 flex-wrap">
+          <Button onClick={handleLockExpenditure}>Lock</Button>
+          <Button onClick={handleFundExpenditure} disabled={!expenditure}>
+            Fund
+          </Button>
+          <Button onClick={handleFinalizeExpenditure}>Finalize</Button>
+          <Button onClick={handleReclaimStake}>Reclaim stake</Button>
+          <Button onClick={handleCancelAndPunish} disabled={!expenditure}>
+            Cancel and punish
+          </Button>
+          <Button onClick={handleEdit}>Edit</Button>
+        </div>
       </div>
       <div className="flex gap-4">
         <InputBase

--- a/src/redux/sagas/expenditures/createExpenditure.ts
+++ b/src/redux/sagas/expenditures/createExpenditure.ts
@@ -19,6 +19,7 @@ import {
   saveExpenditureMetadata,
   initiateTransaction,
   uploadAnnotation,
+  getPayoutsWithSlotIds,
 } from '../utils/index.ts';
 
 export type CreateExpenditurePayload =
@@ -44,11 +45,7 @@ function* createExpenditure({
   );
   const batchKey = 'createExpenditure';
 
-  // Add slot id to each payout
-  const payoutsWithSlotIds = payouts.map((payout, index) => ({
-    ...payout,
-    slotId: index + 1,
-  }));
+  const payoutsWithSlotIds = getPayoutsWithSlotIds(payouts);
 
   const {
     makeExpenditure,

--- a/src/redux/sagas/expenditures/createStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/createStakedExpenditure.ts
@@ -20,6 +20,7 @@ import {
   saveExpenditureMetadata,
   initiateTransaction,
   uploadAnnotation,
+  getPayoutsWithSlotIds,
 } from '../utils/index.ts';
 
 export type CreateStakedExpenditurePayload =
@@ -47,11 +48,7 @@ function* createStakedExpenditure({
   );
   const batchKey = 'createExpenditure';
 
-  // Add slot id to each payout
-  const payoutsWithSlotIds = payouts.map((payout, index) => ({
-    ...payout,
-    slotId: index + 1,
-  }));
+  const payoutsWithSlotIds = getPayoutsWithSlotIds(payouts);
 
   const {
     approveStake,

--- a/src/redux/sagas/expenditures/editExpenditure.ts
+++ b/src/redux/sagas/expenditures/editExpenditure.ts
@@ -53,7 +53,7 @@ function* editExpenditureAction({
 
   payouts.forEach((payout, index) => {
     // Add payout as specified in the form
-    resolvedPayouts.push(payout);
+    resolvedPayouts.push({ ...payout, slotId: index + 1 });
 
     const existingSlot = expenditure.slots.find((slot) => slot.id === index);
 
@@ -66,7 +66,7 @@ function* editExpenditureAction({
             BigNumber.from(slotPayout.amount).gt(0),
         )
         .map((slotPayout) => ({
-          slotId: index,
+          slotId: index + 1,
           recipientAddress: payout.recipientAddress,
           tokenAddress: slotPayout.tokenAddress,
           amount: '0',

--- a/src/redux/sagas/expenditures/editExpenditure.ts
+++ b/src/redux/sagas/expenditures/editExpenditure.ts
@@ -21,6 +21,7 @@ import {
   uploadAnnotation,
   getColonyManager,
   getMulticallDataForPayouts,
+  getPayoutsWithSlotIds,
 } from '../utils/index.ts';
 
 export type EditExpenditurePayload =
@@ -51,11 +52,15 @@ function* editExpenditureAction({
    */
   const resolvedPayouts: ExpenditurePayoutFieldValue[] = [];
 
-  payouts.forEach((payout, index) => {
-    // Add payout as specified in the form
-    resolvedPayouts.push({ ...payout, slotId: index + 1 });
+  const payoutsWithSlotIds = getPayoutsWithSlotIds(payouts);
 
-    const existingSlot = expenditure.slots.find((slot) => slot.id === index);
+  payoutsWithSlotIds.forEach((payout) => {
+    // Add payout as specified in the form
+    resolvedPayouts.push(payout);
+
+    const existingSlot = expenditure.slots.find(
+      (slot) => slot.id === payout.slotId,
+    );
 
     // Set the amounts for any existing payouts in different tokens to 0
     resolvedPayouts.push(
@@ -66,7 +71,7 @@ function* editExpenditureAction({
             BigNumber.from(slotPayout.amount).gt(0),
         )
         .map((slotPayout) => ({
-          slotId: index + 1,
+          slotId: payout.slotId,
           recipientAddress: payout.recipientAddress,
           tokenAddress: slotPayout.tokenAddress,
           amount: '0',

--- a/src/redux/sagas/utils/expenditureMulticallData.ts
+++ b/src/redux/sagas/utils/expenditureMulticallData.ts
@@ -1,7 +1,7 @@
 import { type AnyColonyClient } from '@colony/colony-js';
 import { BigNumber, type BigNumberish, utils } from 'ethers';
 
-import { type Expenditure } from '~gql';
+import { type Expenditure } from '~types/graphql.ts';
 
 const toB32 = (input: BigNumberish) =>
   utils.hexZeroPad(utils.hexlify(input), 32);

--- a/src/redux/sagas/utils/expenditures.ts
+++ b/src/redux/sagas/utils/expenditures.ts
@@ -20,7 +20,7 @@ import { calculateFee, getTokenDecimalsWithFallback } from '~utils/tokens.ts';
  */
 const groupExpenditurePayoutsByTokenAddresses = (
   payouts: ExpenditurePayoutFieldValue[],
-) => {
+): Map<string, ExpenditurePayoutFieldValue[]> => {
   const payoutsByTokenAddresses = new Map<
     string,
     ExpenditurePayoutFieldValue[]
@@ -151,3 +151,12 @@ export function* saveExpenditureMetadata({
     },
   });
 }
+
+export const getPayoutsWithSlotIds = (
+  payouts: ExpenditurePayoutFieldValue[],
+) => {
+  return payouts.map((payout, index) => ({
+    ...payout,
+    slotId: index + 1,
+  }));
+};

--- a/src/redux/sagas/utils/expenditures.ts
+++ b/src/redux/sagas/utils/expenditures.ts
@@ -37,7 +37,7 @@ const groupExpenditurePayoutsByTokenAddresses = (
   return payoutsByTokenAddresses;
 };
 
-const getPayoutAmount = (
+export const getPayoutAmount = (
   payout: ExpenditurePayoutFieldValue,
   networkInverseFee: string,
 ) => {

--- a/src/redux/sagas/utils/expendituresMulticall.ts
+++ b/src/redux/sagas/utils/expendituresMulticall.ts
@@ -1,0 +1,104 @@
+import {
+  getPermissionProofs,
+  type AnyColonyClient,
+  ColonyRole,
+} from '@colony/colony-js';
+import { BigNumber, type BigNumberish, utils } from 'ethers';
+
+import { type ExpenditurePayoutFieldValue } from '~types/expenditures.ts';
+import { type Expenditure } from '~types/graphql.ts';
+
+import { getPayoutAmount } from './expenditures.ts';
+
+const toB32 = (input: BigNumberish) =>
+  utils.hexZeroPad(utils.hexlify(input), 32);
+
+const EXPENDITURESLOTS_SLOT = BigNumber.from(26);
+
+const EXPENDITURESLOT_RECIPIENT = toB32(BigNumber.from(0));
+const EXPENDITURESLOT_CLAIMDELAY = toB32(BigNumber.from(1));
+
+/**
+ * Helper function returning an array of encoded multicall data containing transactions
+ * needed to update an expenditure payout
+ */
+export const getMulticallDataForPayouts = async (
+  expenditure: Expenditure,
+  payouts: ExpenditurePayoutFieldValue[],
+  colonyClient: AnyColonyClient,
+  networkInverseFee: string,
+) => {
+  const [permissionDomainId, childSkillIndex] = await getPermissionProofs(
+    colonyClient.networkClient,
+    colonyClient,
+    expenditure.nativeDomainId,
+    ColonyRole.Administration,
+  );
+
+  const encodedMulticallData: string[] = [];
+
+  payouts.forEach((payout) => {
+    const existingSlot = expenditure.slots.find(
+      (slot) => slot.id === payout.slotId,
+    );
+
+    // Set recipient
+    if (
+      !existingSlot ||
+      existingSlot.recipientAddress !== payout.recipientAddress
+    ) {
+      encodedMulticallData.push(
+        colonyClient.interface.encodeFunctionData('setExpenditureState', [
+          permissionDomainId,
+          childSkillIndex,
+          expenditure.nativeId,
+          EXPENDITURESLOTS_SLOT,
+          [false, true],
+          [toB32(payout.slotId ?? ''), EXPENDITURESLOT_RECIPIENT],
+          toB32(payout.recipientAddress),
+        ]),
+      );
+    }
+
+    // Set claim delay
+    if (!existingSlot || existingSlot.claimDelay !== payout.claimDelay) {
+      encodedMulticallData.push(
+        colonyClient.interface.encodeFunctionData('setExpenditureState', [
+          permissionDomainId,
+          childSkillIndex,
+          expenditure.nativeId,
+          EXPENDITURESLOTS_SLOT,
+          [false, true],
+          [toB32(payout.slotId ?? ''), EXPENDITURESLOT_CLAIMDELAY],
+          toB32(BigNumber.from(payout.claimDelay)),
+        ]),
+      );
+    }
+
+    // Set token address and amount
+    const amountWithFee = getPayoutAmount(payout, networkInverseFee);
+    const existingPayout = existingSlot?.payouts?.find(
+      (slotPayout) =>
+        BigNumber.from(slotPayout.amount)
+          .add(slotPayout.networkFee ?? '0')
+          .eq(amountWithFee) && slotPayout.tokenAddress === payout.tokenAddress,
+    );
+    if (!existingPayout) {
+      encodedMulticallData.push(
+        colonyClient.interface.encodeFunctionData(
+          'setExpenditurePayout(uint256,uint256,uint256,uint256,address,uint256)',
+          [
+            permissionDomainId,
+            childSkillIndex,
+            expenditure.nativeId,
+            payout.slotId ?? '',
+            payout.tokenAddress,
+            amountWithFee,
+          ],
+        ),
+      );
+    }
+  });
+
+  return encodedMulticallData;
+};

--- a/src/redux/sagas/utils/index.ts
+++ b/src/redux/sagas/utils/index.ts
@@ -13,15 +13,7 @@ export * from './annotations.ts';
 export * from './proofs.ts';
 export * from './expenditureMulticallData.ts';
 export * from './expenditures.ts';
+export * from './expendituresMulticall.ts';
 
-// export * from './updateColonyDisplayCache';
-// export { updateMotionValues } from './updateMotionValues';
-// export { uploadIfpsAnnotation } from './uploadIfpsAnnotation';
-// export {
-//   modifyParams,
-//   removeOldExtensionClients,
-//   setupEnablingGroupTransactions,
-//   Channel,
-// } from './enableExtensionHelpers';
 export { updateDomainReputation } from './updateDomainReputation.ts';
 export { createActionMetadataInDB } from './createActionMetadata.ts';

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -88,6 +88,7 @@ export type ExpendituresActionTypes =
         payouts: ExpenditurePayoutFieldValue[];
         networkInverseFee: string;
         annotationMessage?: string;
+        userAddress: Address;
       },
       MetaWithSetter<object>
     >

--- a/src/redux/types/actions/motion.ts
+++ b/src/redux/types/actions/motion.ts
@@ -2,8 +2,9 @@ import { type ColonyRole } from '@colony/colony-js';
 import { type BigNumber } from 'ethers';
 
 import { type NetworkInfo } from '~constants/index.ts';
-import { type Expenditure, type ExternalLink } from '~gql';
+import { type ExternalLink } from '~gql';
 import {
+  type Expenditure,
   type Colony,
   type ColonyObjective,
   type Domain,


### PR DESCRIPTION
## Description

This PR will enable making changes to locked expenditures using permissions.

block-ingestor PR: https://github.com/JoinColony/block-ingestor/pull/181

## Testing

Test the following scenario with draft and locked expenditure:

1. Create an expenditure. Run the following query and inspect the values of the slots (recipient address, claim delay, payouts):
```gql
query ListExpenditures {
  listExpenditures(filter: {nativeId: {gt: 32}}) {
    items {
      nativeId
      slots {
        id
        recipientAddress
        claimDelay
        payouts {
          amount
          tokenAddress
        }
      }
    }
  }
}
```

2. Enter the expenditure ID in the field and click on "Edit expenditure". The hardcoded payload should change the existing slot's recipient to the colony address, change its token address to the native token and set the amount to `23.45`. It should also add a second slot with colony's native token, user address set as recipient, amount of `67.89` and claim delay of `300`. Feel free to customise those values.

3. Run the query again to verify the values have updated accordingly.

Bonus points: When creating expenditure, use a token address that's not the colony's native (e.g. `0x0000000000000000000000000000000000000000`) to test that deleting tokens from payouts work. After editing, the payout amount for this token should be set to 0.

Resolves #1975 
