### PR TITLE
fix: handle transaction rejected from wallet error 

### DIFF
--- a/src/components/shared/Fields/Form/ActionForm.tsx
+++ b/src/components/shared/Fields/Form/ActionForm.tsx
@@ -69,7 +69,7 @@ const ActionForm = <V extends Record<string, any>>({
       const res = await asyncFunction(values);
       onSuccess?.(values, formHelpers, res);
     } catch (e) {
-      console.error(e);
+      console.error('Error while submitting form', e);
       onError?.(e, formHelpers);
     }
   };

--- a/src/redux/sagas/actions/createDomain.ts
+++ b/src/redux/sagas/actions/createDomain.ts
@@ -176,11 +176,10 @@ function* createDomainAction({
       });
     }
   } catch (error) {
-    return yield putError(ActionTypes.ACTION_DOMAIN_CREATE_ERROR, error, meta);
+    yield putError(ActionTypes.ACTION_DOMAIN_CREATE_ERROR, error, meta);
   } finally {
     txChannel.close();
   }
-  return null;
 }
 
 export default function* createDomainActionSaga() {

--- a/src/redux/sagas/actions/createDomain.ts
+++ b/src/redux/sagas/actions/createDomain.ts
@@ -132,8 +132,6 @@ function* createDomainAction({
       },
     } = yield waitForTxResult(createDomain.channel);
 
-    setTxHash?.(txHash);
-
     const { domainId } = eventData?.DomainAdded || {};
     const nativeDomainId = toNumber(domainId);
 
@@ -164,6 +162,8 @@ function* createDomainAction({
         txHash,
       });
     }
+
+    setTxHash?.(txHash);
 
     yield put<AllActions>({
       type: ActionTypes.ACTION_DOMAIN_CREATE_SUCCESS,

--- a/src/redux/sagas/actions/editColony.ts
+++ b/src/redux/sagas/actions/editColony.ts
@@ -138,13 +138,10 @@ function* editColonyAction({
     yield initiateTransaction({ id: editColony.id });
 
     const {
-      payload: { hash: txHash },
-    } = yield takeFrom(
-      editColony.channel,
-      ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
-
-    yield waitForTxResult(editColony.channel);
+      payload: {
+        receipt: { transactionHash: txHash },
+      },
+    } = yield waitForTxResult(editColony.channel);
 
     const existingTokenAddresses = getExistingTokenAddresses(colony);
     const modifiedTokenAddresses = getModifiedTokenAddresses(
@@ -225,11 +222,10 @@ function* editColonyAction({
       });
     }
   } catch (error) {
-    return yield putError(ActionTypes.ACTION_EDIT_COLONY_ERROR, error, meta);
+    yield putError(ActionTypes.ACTION_EDIT_COLONY_ERROR, error, meta);
   } finally {
     txChannel.close();
   }
-  return null;
 }
 
 export default function* editColonyActionSaga() {

--- a/src/redux/sagas/actions/editDomain.ts
+++ b/src/redux/sagas/actions/editDomain.ts
@@ -126,15 +126,12 @@ function* editDomainAction({
     yield initiateTransaction({ id: editDomain.id });
 
     const {
-      payload: { hash: txHash },
-    } = yield takeFrom(
-      editDomain.channel,
-      ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
+      payload: {
+        receipt: { transactionHash: txHash },
+      },
+    } = yield waitForTxResult(editDomain.channel);
 
     setTxHash?.(txHash);
-
-    yield waitForTxResult(editDomain.channel);
 
     /**
      * Save the updated metadata in the database
@@ -185,11 +182,10 @@ function* editDomainAction({
       });
     }
   } catch (error) {
-    return yield putError(ActionTypes.ACTION_DOMAIN_EDIT_ERROR, error, meta);
+    yield putError(ActionTypes.ACTION_DOMAIN_EDIT_ERROR, error, meta);
   } finally {
     txChannel.close();
   }
-  return null;
 }
 
 export default function* editDomainActionSaga() {

--- a/src/redux/sagas/actions/editDomain.ts
+++ b/src/redux/sagas/actions/editDomain.ts
@@ -131,8 +131,6 @@ function* editDomainAction({
       },
     } = yield waitForTxResult(editDomain.channel);
 
-    setTxHash?.(txHash);
-
     /**
      * Save the updated metadata in the database
      */
@@ -170,6 +168,8 @@ function* editDomainAction({
         txHash,
       });
     }
+
+    setTxHash?.(txHash);
 
     yield put<AllActions>({
       type: ActionTypes.ACTION_DOMAIN_EDIT_SUCCESS,

--- a/src/redux/sagas/actions/initiateSafeTransaction.ts
+++ b/src/redux/sagas/actions/initiateSafeTransaction.ts
@@ -113,13 +113,10 @@ function* initiateSafeTransactionAction({
     yield put(transactionReady(initiateSafeTransaction.id));
 
     const {
-      payload: { hash: txHash },
-    } = yield takeFrom(
-      initiateSafeTransaction.channel,
-      ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
-
-    yield waitForTxResult(initiateSafeTransaction.channel);
+      payload: {
+        receipt: { transactionHash: txHash },
+      },
+    } = yield waitForTxResult(initiateSafeTransaction.channel);
 
     /**
      * Create parent safe transaction in the database
@@ -177,7 +174,7 @@ function* initiateSafeTransactionAction({
       },
     });
   } catch (error) {
-    return yield putError(
+    yield putError(
       ActionTypes.ACTION_INITIATE_SAFE_TRANSACTION_ERROR,
       error,
       meta,
@@ -185,7 +182,6 @@ function* initiateSafeTransactionAction({
   } finally {
     txChannel.close();
   }
-  return null;
 }
 
 export default function* initiateSafeTransactionSaga() {

--- a/src/redux/sagas/actions/manageExistingSafes.ts
+++ b/src/redux/sagas/actions/manageExistingSafes.ts
@@ -121,11 +121,10 @@ function* manageExistingSafesAction({
     yield put(transactionReady(manageExistingSafes.id));
 
     const {
-      payload: { hash: txHash },
-    } = yield takeFrom(
-      manageExistingSafes.channel,
-      ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
+      payload: {
+        receipt: { transactionHash: txHash },
+      },
+    } = yield waitForTxResult(manageExistingSafes.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 
@@ -136,8 +135,6 @@ function* manageExistingSafesAction({
         txHash,
       });
     }
-
-    yield waitForTxResult(manageExistingSafes.channel);
 
     /**
      * Update colony metadata in the db
@@ -182,15 +179,10 @@ function* manageExistingSafesAction({
       },
     });
   } catch (error) {
-    return yield putError(
-      ActionTypes.ACTION_MANAGE_EXISTING_SAFES_ERROR,
-      error,
-      meta,
-    );
+    yield putError(ActionTypes.ACTION_MANAGE_EXISTING_SAFES_ERROR, error, meta);
   } finally {
     txChannel.close();
   }
-  return null;
 }
 
 export default function* manageExistingSafeSaga() {

--- a/src/redux/sagas/actions/managePermissions.ts
+++ b/src/redux/sagas/actions/managePermissions.ts
@@ -144,8 +144,6 @@ function* managePermissionsAction({
       },
     } = yield waitForTxResult(setUserRoles.channel);
 
-    setTxHash?.(txHash);
-
     yield createActionMetadataInDB(txHash, customActionTitle);
 
     if (annotationMessage) {
@@ -155,6 +153,8 @@ function* managePermissionsAction({
         txHash,
       });
     }
+
+    setTxHash?.(txHash);
 
     yield put<AllActions>({
       type: ActionTypes.ACTION_USER_ROLES_SET_SUCCESS,

--- a/src/redux/sagas/actions/managePermissions.ts
+++ b/src/redux/sagas/actions/managePermissions.ts
@@ -139,15 +139,12 @@ function* managePermissionsAction({
     yield initiateTransaction({ id: setUserRoles.id });
 
     const {
-      payload: { hash: txHash },
-    } = yield takeFrom(
-      setUserRoles.channel,
-      ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
+      payload: {
+        receipt: { transactionHash: txHash },
+      },
+    } = yield waitForTxResult(setUserRoles.channel);
 
     setTxHash?.(txHash);
-
-    yield waitForTxResult(setUserRoles.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 
@@ -170,11 +167,10 @@ function* managePermissionsAction({
       });
     }
   } catch (error) {
-    return yield putError(ActionTypes.ACTION_USER_ROLES_SET_ERROR, error, meta);
+    yield putError(ActionTypes.ACTION_USER_ROLES_SET_ERROR, error, meta);
   } finally {
     txChannel.close();
   }
-  return null;
 }
 
 export default function* managePermissionsActionSaga() {

--- a/src/redux/sagas/actions/manageReputation.ts
+++ b/src/redux/sagas/actions/manageReputation.ts
@@ -136,8 +136,6 @@ function* manageReputationAction({
       },
     } = yield waitForTxResult(manageReputation.channel);
 
-    setTxHash?.(txHash);
-
     yield createActionMetadataInDB(txHash, customActionTitle);
 
     if (annotationMessage) {
@@ -147,6 +145,8 @@ function* manageReputationAction({
         txHash,
       });
     }
+
+    setTxHash?.(txHash);
 
     yield put<AllActions>({
       type: ActionTypes.ACTION_MANAGE_REPUTATION_SUCCESS,

--- a/src/redux/sagas/actions/manageReputation.ts
+++ b/src/redux/sagas/actions/manageReputation.ts
@@ -131,15 +131,12 @@ function* manageReputationAction({
     yield initiateTransaction({ id: manageReputation.id });
 
     const {
-      payload: { hash: txHash },
-    } = yield takeFrom(
-      manageReputation.channel,
-      ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
+      payload: {
+        receipt: { transactionHash: txHash },
+      },
+    } = yield waitForTxResult(manageReputation.channel);
 
     setTxHash?.(txHash);
-
-    yield waitForTxResult(manageReputation.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 
@@ -162,15 +159,10 @@ function* manageReputationAction({
       });
     }
   } catch (error) {
-    return yield putError(
-      ActionTypes.ACTION_MANAGE_REPUTATION_ERROR,
-      error,
-      meta,
-    );
+    yield putError(ActionTypes.ACTION_MANAGE_REPUTATION_ERROR, error, meta);
   } finally {
     txChannel.close();
   }
-  return null;
 }
 
 export default function* manageReputationActionSaga() {

--- a/src/redux/sagas/actions/mintTokens.ts
+++ b/src/redux/sagas/actions/mintTokens.ts
@@ -107,8 +107,6 @@ function* createMintTokensAction({
       },
     } = yield waitForTxResult(mintTokens.channel);
 
-    setTxHash?.(txHash);
-
     yield initiateTransaction({ id: claimColonyFunds.id });
 
     yield waitForTxResult(claimColonyFunds.channel);
@@ -122,6 +120,8 @@ function* createMintTokensAction({
         txHash,
       });
     }
+
+    setTxHash?.(txHash);
 
     yield put<AllActions>({
       type: ActionTypes.ACTION_MINT_TOKENS_SUCCESS,

--- a/src/redux/sagas/actions/mintTokens.ts
+++ b/src/redux/sagas/actions/mintTokens.ts
@@ -102,13 +102,12 @@ function* createMintTokensAction({
     yield initiateTransaction({ id: mintTokens.id });
 
     const {
-      payload: { hash: txHash },
-    } = yield takeFrom(
-      mintTokens.channel,
-      ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
+      payload: {
+        receipt: { transactionHash: txHash },
+      },
+    } = yield waitForTxResult(mintTokens.channel);
 
-    yield waitForTxResult(mintTokens.channel);
+    setTxHash?.(txHash);
 
     yield initiateTransaction({ id: claimColonyFunds.id });
 
@@ -129,8 +128,6 @@ function* createMintTokensAction({
       meta,
     });
 
-    setTxHash?.(txHash);
-
     // Redirect to actions page
     if (colonyName && navigate) {
       navigate(`/${colonyName}?tx=${txHash}`, {
@@ -138,7 +135,7 @@ function* createMintTokensAction({
       });
     }
   } catch (caughtError) {
-    putError(ActionTypes.ACTION_MINT_TOKENS_ERROR, caughtError, meta);
+    yield putError(ActionTypes.ACTION_MINT_TOKENS_ERROR, caughtError, meta);
   } finally {
     txChannel.close();
   }

--- a/src/redux/sagas/actions/moveFunds.ts
+++ b/src/redux/sagas/actions/moveFunds.ts
@@ -138,8 +138,6 @@ function* createMoveFundsAction({
       },
     } = yield waitForTxResult(moveFunds.channel);
 
-    setTxHash?.(txHash);
-
     yield createActionMetadataInDB(txHash, customActionTitle);
 
     if (annotationMessage) {
@@ -149,6 +147,8 @@ function* createMoveFundsAction({
         txHash,
       });
     }
+
+    setTxHash?.(txHash);
 
     yield put<AllActions>({
       type: ActionTypes.ACTION_MOVE_FUNDS_SUCCESS,

--- a/src/redux/sagas/actions/moveFunds.ts
+++ b/src/redux/sagas/actions/moveFunds.ts
@@ -133,15 +133,12 @@ function* createMoveFundsAction({
     yield initiateTransaction({ id: moveFunds.id });
 
     const {
-      payload: { hash: txHash },
-    } = yield takeFrom(
-      moveFunds.channel,
-      ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
+      payload: {
+        receipt: { transactionHash: txHash },
+      },
+    } = yield waitForTxResult(moveFunds.channel);
 
     setTxHash?.(txHash);
-
-    yield waitForTxResult(moveFunds.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 
@@ -164,7 +161,7 @@ function* createMoveFundsAction({
       });
     }
   } catch (caughtError) {
-    putError(ActionTypes.ACTION_MOVE_FUNDS_ERROR, caughtError, meta);
+    yield putError(ActionTypes.ACTION_MOVE_FUNDS_ERROR, caughtError, meta);
   } finally {
     txChannel.close();
   }

--- a/src/redux/sagas/actions/payment.ts
+++ b/src/redux/sagas/actions/payment.ts
@@ -175,8 +175,6 @@ function* createPaymentAction({
       },
     } = yield waitForTxResult(paymentAction.channel);
 
-    setTxHash?.(txHash);
-
     yield createActionMetadataInDB(txHash, customActionTitle);
 
     if (annotationMessage) {
@@ -186,6 +184,8 @@ function* createPaymentAction({
         txHash,
       });
     }
+
+    setTxHash?.(txHash);
 
     yield put<AllActions>({
       type: ActionTypes.ACTION_EXPENDITURE_PAYMENT_SUCCESS,

--- a/src/redux/sagas/actions/unlockToken.ts
+++ b/src/redux/sagas/actions/unlockToken.ts
@@ -81,8 +81,6 @@ function* tokenUnlockAction({
       },
     } = yield waitForTxResult(tokenUnlock.channel);
 
-    setTxHash?.(txHash);
-
     yield createActionMetadataInDB(txHash, customActionTitle);
 
     if (annotationMessage) {
@@ -92,6 +90,8 @@ function* tokenUnlockAction({
         txHash,
       });
     }
+
+    setTxHash?.(txHash);
 
     yield put<AllActions>({
       type: ActionTypes.ACTION_UNLOCK_TOKEN_SUCCESS,

--- a/src/redux/sagas/actions/versionUpgrade.ts
+++ b/src/redux/sagas/actions/versionUpgrade.ts
@@ -90,12 +90,12 @@ function* createVersionUpgradeAction({
     yield initiateTransaction({ id: upgrade.id });
 
     const {
-      payload: { hash: txHash },
-    } = yield takeFrom(upgrade.channel, ActionTypes.TRANSACTION_HASH_RECEIVED);
+      payload: {
+        receipt: { transactionHash: txHash },
+      },
+    } = yield waitForTxResult(upgrade.channel);
 
     setTxHash?.(txHash);
-
-    yield waitForTxResult(upgrade.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 
@@ -120,7 +120,7 @@ function* createVersionUpgradeAction({
       });
     }
   } catch (caughtError) {
-    putError(ActionTypes.ACTION_VERSION_UPGRADE_ERROR, caughtError, meta);
+    yield putError(ActionTypes.ACTION_VERSION_UPGRADE_ERROR, caughtError, meta);
   } finally {
     txChannel.close();
   }

--- a/src/redux/sagas/actions/versionUpgrade.ts
+++ b/src/redux/sagas/actions/versionUpgrade.ts
@@ -95,8 +95,6 @@ function* createVersionUpgradeAction({
       },
     } = yield waitForTxResult(upgrade.channel);
 
-    setTxHash?.(txHash);
-
     yield createActionMetadataInDB(txHash, customActionTitle);
 
     if (supportAnnotation) {
@@ -107,6 +105,7 @@ function* createVersionUpgradeAction({
       });
     }
 
+    setTxHash?.(txHash);
     yield colonyManager.setColonyClient(colonyAddress);
 
     yield put<AllActions>({

--- a/src/redux/sagas/motions/createDecisionMotion.ts
+++ b/src/redux/sagas/motions/createDecisionMotion.ts
@@ -132,8 +132,6 @@ function* createDecisionMotion({
       ActionTypes.TRANSACTION_ERROR,
     ]);
 
-    setTxHash?.(txHash);
-
     yield apolloClient.mutate<
       CreateColonyDecisionMutation,
       CreateColonyDecisionMutationVariables
@@ -165,6 +163,8 @@ function* createDecisionMotion({
     // yield put(transactionReady(annotateMotion.id));
 
     // yield waitForTxResult(annotateMotion.channel);
+    //
+    setTxHash?.(txHash);
 
     yield put<AllActions>({
       type: ActionTypes.MOTION_CREATE_DECISION_SUCCESS,

--- a/src/redux/sagas/motions/createDecisionMotion.ts
+++ b/src/redux/sagas/motions/createDecisionMotion.ts
@@ -127,10 +127,10 @@ function* createDecisionMotion({
 
     const {
       payload: { hash: txHash },
-    } = yield takeFrom(
-      createMotion.channel,
+    } = yield takeFrom(createMotion.channel, [
       ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
+      ActionTypes.TRANSACTION_ERROR,
+    ]);
 
     setTxHash?.(txHash);
 
@@ -182,7 +182,8 @@ function* createDecisionMotion({
       payload: { walletAddress, colonyAddress },
     });
   } catch (caughtError) {
-    putError(ActionTypes.MOTION_CREATE_DECISION_ERROR, caughtError, meta);
+    console.error('the kot error', caughtError);
+    yield putError(ActionTypes.MOTION_CREATE_DECISION_ERROR, caughtError, meta);
   } finally {
     txChannel.close();
   }

--- a/src/redux/sagas/motions/createEditDomainMotion.ts
+++ b/src/redux/sagas/motions/createEditDomainMotion.ts
@@ -193,8 +193,6 @@ function* createEditDomainMotion({
       },
     } = yield waitForTxResult(createMotion.channel);
 
-    setTxHash?.(txHash);
-
     if (isCreateDomain) {
       /**
        * Save domain metadata in the database
@@ -246,6 +244,8 @@ function* createEditDomainMotion({
         txHash,
       });
     }
+
+    setTxHash?.(txHash);
 
     yield put<AllActions>({
       type: ActionTypes.MOTION_DOMAIN_CREATE_EDIT_SUCCESS,

--- a/src/redux/sagas/motions/createEditDomainMotion.ts
+++ b/src/redux/sagas/motions/createEditDomainMotion.ts
@@ -188,15 +188,12 @@ function* createEditDomainMotion({
     yield initiateTransaction({ id: createMotion.id });
 
     const {
-      payload: { hash: txHash },
-    } = yield takeFrom(
-      createMotion.channel,
-      ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
+      payload: {
+        receipt: { transactionHash: txHash },
+      },
+    } = yield waitForTxResult(createMotion.channel);
 
     setTxHash?.(txHash);
-
-    yield waitForTxResult(createMotion.channel);
 
     if (isCreateDomain) {
       /**
@@ -261,7 +258,11 @@ function* createEditDomainMotion({
       });
     }
   } catch (caughtError) {
-    putError(ActionTypes.MOTION_DOMAIN_CREATE_EDIT_ERROR, caughtError, meta);
+    yield putError(
+      ActionTypes.MOTION_DOMAIN_CREATE_EDIT_ERROR,
+      caughtError,
+      meta,
+    );
   } finally {
     txChannel.close();
   }

--- a/src/redux/sagas/motions/editColonyMotion.ts
+++ b/src/redux/sagas/motions/editColonyMotion.ts
@@ -183,8 +183,6 @@ function* editColonyMotion({
       },
     } = yield waitForTxResult(createMotion.channel);
 
-    setTxHash?.(txHash);
-
     const modifiedTokenAddresses = getPendingModifiedTokenAddresses(
       colony,
       tokenAddresses,
@@ -258,6 +256,8 @@ function* editColonyMotion({
         txHash,
       });
     }
+
+    setTxHash?.(txHash);
 
     yield put<AllActions>({
       type: ActionTypes.MOTION_EDIT_COLONY_SUCCESS,

--- a/src/redux/sagas/motions/editColonyMotion.ts
+++ b/src/redux/sagas/motions/editColonyMotion.ts
@@ -178,14 +178,12 @@ function* editColonyMotion({
     yield initiateTransaction({ id: createMotion.id });
 
     const {
-      payload: { hash: txHash },
-    } = yield takeFrom(
-      createMotion.channel,
-      ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
+      payload: {
+        receipt: { transactionHash: txHash },
+      },
+    } = yield waitForTxResult(createMotion.channel);
 
     setTxHash?.(txHash);
-    yield waitForTxResult(createMotion.channel);
 
     const modifiedTokenAddresses = getPendingModifiedTokenAddresses(
       colony,
@@ -272,7 +270,7 @@ function* editColonyMotion({
       });
     }
   } catch (caughtError) {
-    putError(ActionTypes.MOTION_EDIT_COLONY_ERROR, caughtError, meta);
+    yield putError(ActionTypes.MOTION_EDIT_COLONY_ERROR, caughtError, meta);
   } finally {
     txChannel.close();
   }

--- a/src/redux/sagas/motions/initiateSafeTransactionMotion.ts
+++ b/src/redux/sagas/motions/initiateSafeTransactionMotion.ts
@@ -171,8 +171,6 @@ function* initiateSafeTransactionMotion({
       },
     } = yield waitForTxResult(createMotion.channel);
 
-    setTxHash?.(txHash);
-
     /**
      * Create parent safe transaction in the database
      */
@@ -207,6 +205,8 @@ function* initiateSafeTransactionMotion({
         },
       });
     }
+
+    setTxHash?.(txHash);
 
     yield put<AllActions>({
       type: ActionTypes.MOTION_INITIATE_SAFE_TRANSACTION_SUCCESS,

--- a/src/redux/sagas/motions/initiateSafeTransactionMotion.ts
+++ b/src/redux/sagas/motions/initiateSafeTransactionMotion.ts
@@ -45,7 +45,7 @@ function* initiateSafeTransactionMotion({
     network,
     customActionTitle,
   },
-  meta: { id: metaId, navigate },
+  meta: { id: metaId, navigate, setTxHash },
   meta,
 }: Action<ActionTypes.MOTION_INITIATE_SAFE_TRANSACTION>) {
   let txChannel;
@@ -166,13 +166,12 @@ function* initiateSafeTransactionMotion({
     yield put(transactionReady(createMotion.id));
 
     const {
-      payload: { hash: txHash },
-    } = yield takeFrom(
-      createMotion.channel,
-      ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
+      payload: {
+        receipt: { transactionHash: txHash },
+      },
+    } = yield waitForTxResult(createMotion.channel);
 
-    yield waitForTxResult(createMotion.channel);
+    setTxHash?.(txHash);
 
     /**
      * Create parent safe transaction in the database

--- a/src/redux/sagas/motions/managePermissionsMotion.ts
+++ b/src/redux/sagas/motions/managePermissionsMotion.ts
@@ -168,8 +168,6 @@ function* managePermissionsMotion({
       },
     } = yield waitForTxResult(createMotion.channel);
 
-    setTxHash?.(txHash);
-
     yield createActionMetadataInDB(txHash, customActionTitle);
 
     if (annotationMessage) {
@@ -179,6 +177,8 @@ function* managePermissionsMotion({
         txHash,
       });
     }
+
+    setTxHash?.(txHash);
 
     yield put<AllActions>({
       type: ActionTypes.MOTION_USER_ROLES_SET_SUCCESS,

--- a/src/redux/sagas/motions/managePermissionsMotion.ts
+++ b/src/redux/sagas/motions/managePermissionsMotion.ts
@@ -163,14 +163,12 @@ function* managePermissionsMotion({
     yield initiateTransaction({ id: createMotion.id });
 
     const {
-      payload: { hash: txHash },
-    } = yield takeFrom(
-      createMotion.channel,
-      ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
+      payload: {
+        receipt: { transactionHash: txHash },
+      },
+    } = yield waitForTxResult(createMotion.channel);
 
     setTxHash?.(txHash);
-    yield waitForTxResult(createMotion.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 
@@ -193,7 +191,7 @@ function* managePermissionsMotion({
       });
     }
   } catch (caughtError) {
-    putError(ActionTypes.MOTION_USER_ROLES_SET_ERROR, caughtError, meta);
+    yield putError(ActionTypes.MOTION_USER_ROLES_SET_ERROR, caughtError, meta);
   } finally {
     txChannel.close();
   }

--- a/src/redux/sagas/motions/manageReputationMotion.ts
+++ b/src/redux/sagas/motions/manageReputationMotion.ts
@@ -178,15 +178,12 @@ function* manageReputationMotion({
     yield initiateTransaction({ id: createMotion.id });
 
     const {
-      payload: { hash: txHash },
-    } = yield takeFrom(
-      createMotion.channel,
-      ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
+      payload: {
+        receipt: { transactionHash: txHash },
+      },
+    } = yield waitForTxResult(createMotion.channel);
 
     setTxHash?.(txHash);
-
-    yield waitForTxResult(createMotion.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 
@@ -214,7 +211,7 @@ function* manageReputationMotion({
       });
     }
   } catch (error) {
-    putError(ActionTypes.MOTION_MANAGE_REPUTATION_ERROR, error, meta);
+    yield putError(ActionTypes.MOTION_MANAGE_REPUTATION_ERROR, error, meta);
   } finally {
     txChannel.close();
   }

--- a/src/redux/sagas/motions/manageReputationMotion.ts
+++ b/src/redux/sagas/motions/manageReputationMotion.ts
@@ -183,8 +183,6 @@ function* manageReputationMotion({
       },
     } = yield waitForTxResult(createMotion.channel);
 
-    setTxHash?.(txHash);
-
     yield createActionMetadataInDB(txHash, customActionTitle);
 
     if (annotationMessage) {
@@ -195,6 +193,7 @@ function* manageReputationMotion({
       });
     }
 
+    setTxHash?.(txHash);
     /*
      * Refesh the user & colony reputation
      */

--- a/src/redux/sagas/motions/moveFundsMotion.ts
+++ b/src/redux/sagas/motions/moveFundsMotion.ts
@@ -201,8 +201,6 @@ function* moveFundsMotion({
       },
     } = yield waitForTxResult(createMotion.channel);
 
-    setTxHash?.(txHash);
-
     yield createActionMetadataInDB(txHash, customActionTitle);
 
     if (annotationMessage) {
@@ -212,6 +210,8 @@ function* moveFundsMotion({
         txHash,
       });
     }
+
+    setTxHash?.(txHash);
 
     yield put<AllActions>({
       type: ActionTypes.MOTION_MOVE_FUNDS_SUCCESS,

--- a/src/redux/sagas/motions/moveFundsMotion.ts
+++ b/src/redux/sagas/motions/moveFundsMotion.ts
@@ -196,15 +196,12 @@ function* moveFundsMotion({
     yield initiateTransaction({ id: createMotion.id });
 
     const {
-      payload: { hash: txHash },
-    } = yield takeFrom(
-      createMotion.channel,
-      ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
+      payload: {
+        receipt: { transactionHash: txHash },
+      },
+    } = yield waitForTxResult(createMotion.channel);
 
     setTxHash?.(txHash);
-
-    yield waitForTxResult(createMotion.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 
@@ -227,7 +224,7 @@ function* moveFundsMotion({
       });
     }
   } catch (caughtError) {
-    putError(ActionTypes.MOTION_MOVE_FUNDS_ERROR, caughtError, meta);
+    yield putError(ActionTypes.MOTION_MOVE_FUNDS_ERROR, caughtError, meta);
   } finally {
     txChannel.close();
   }

--- a/src/redux/sagas/motions/paymentMotion.ts
+++ b/src/redux/sagas/motions/paymentMotion.ts
@@ -220,8 +220,6 @@ function* createPaymentMotion({
       },
     } = yield waitForTxResult(createMotion.channel);
 
-    setTxHash?.(txHash);
-
     yield createActionMetadataInDB(txHash, customActionTitle);
 
     if (annotationMessage) {
@@ -231,6 +229,8 @@ function* createPaymentMotion({
         txHash,
       });
     }
+
+    setTxHash?.(txHash);
     yield put<AllActions>({
       type: ActionTypes.MOTION_EXPENDITURE_PAYMENT_SUCCESS,
       meta,

--- a/src/redux/sagas/motions/rootMotion.ts
+++ b/src/redux/sagas/motions/rootMotion.ts
@@ -135,8 +135,6 @@ function* createRootMotionSaga({
       },
     } = yield waitForTxResult(createMotion.channel);
 
-    setTxHash?.(txHash);
-
     yield createActionMetadataInDB(txHash, customActionTitle);
 
     if (annotationMessage) {
@@ -147,6 +145,7 @@ function* createRootMotionSaga({
       });
     }
 
+    setTxHash?.(txHash);
     yield put<AllActions>({
       type: ActionTypes.ROOT_MOTION_SUCCESS,
       meta,

--- a/src/redux/sagas/motions/stakeMotion.ts
+++ b/src/redux/sagas/motions/stakeMotion.ts
@@ -214,13 +214,10 @@ function* stakeMotion({
     yield initiateTransaction({ id: stakeMotionTransaction.id });
 
     const {
-      payload: { hash: txHash },
-    } = yield takeFrom(
-      stakeMotionTransaction.channel,
-      ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
-
-    yield waitForTxResult(stakeMotionTransaction.channel);
+      payload: {
+        receipt: { transactionHash: txHash },
+      },
+    } = yield waitForTxResult(stakeMotionTransaction.channel);
 
     if (annotationMessage) {
       yield uploadAnnotation({

--- a/src/redux/sagas/transactions/createTransaction.ts
+++ b/src/redux/sagas/transactions/createTransaction.ts
@@ -145,20 +145,6 @@ export function* waitForTxResult(channel: Channel<any>) {
   }
 }
 
-export function* waitForTxHash(channel: Channel<any>) {
-  const result = yield takeFrom(channel, [
-    ActionTypes.TRANSACTION_ERROR,
-    ActionTypes.TRANSACTION_HASH_RECEIVED,
-  ]);
-
-  switch (result.type) {
-    case ActionTypes.TRANSACTION_ERROR:
-      throw new Error('Transaction failed');
-    default:
-      return result;
-  }
-}
-
 export const createGroupTransaction = (
   { id, index }: { id: string; index: number },
   key: string,

--- a/src/redux/sagas/transactions/createTransaction.ts
+++ b/src/redux/sagas/transactions/createTransaction.ts
@@ -145,6 +145,20 @@ export function* waitForTxResult(channel: Channel<any>) {
   }
 }
 
+export function* waitForTxHash(channel: Channel<any>) {
+  const result = yield takeFrom(channel, [
+    ActionTypes.TRANSACTION_ERROR,
+    ActionTypes.TRANSACTION_HASH_RECEIVED,
+  ]);
+
+  switch (result.type) {
+    case ActionTypes.TRANSACTION_ERROR:
+      throw new Error('Transaction failed');
+    default:
+      return result;
+  }
+}
+
 export const createGroupTransaction = (
   { id, index }: { id: string; index: number },
   key: string,

--- a/src/redux/sagas/transactions/transactionChannel.ts
+++ b/src/redux/sagas/transactions/transactionChannel.ts
@@ -152,7 +152,15 @@ const channelStart = async (
 ) => {
   try {
     const sentTx = await channelSendTransaction(tx, txPromise, emit);
-    if (!sentTx) return null;
+    if (!sentTx) {
+      emit(
+        transactionUnsuccessfulError(
+          tx.id,
+          new Error('The transaction was unsuccessful'),
+        ),
+      );
+      return null;
+    }
 
     const receipt = await channelGetTransactionReceipt(
       tx,


### PR DESCRIPTION
## Description

Turns out, our way of doing sagas failed if the user rejected a transaction when it was first created.
This was due to us trying to get the `txHash` but not listening to events for a transaction failing.
I've unified that to just always get the result and use the `txHash` from there.
Additionally, the helper for sending transactions emits a transaction failed error if the signing failed.

## Testing

My friend, I am very sorry.... The testing scope for this is to test **ALL** the actions.

1. Start up your dev environment, enable the Reputation extension
2. go to `http://localhost:3006/ganache-accounts.json` and copy the private key for "leela" - the wallet address is `0xb77d57f4959eafa0339424b83fcfaf9c15407461`
3. Go to Metamask and add an account by importing the private key
4. Maybe you will need to refresh the page after disconnecting your wallet, but open Metamask again and you should see this:
![image](https://github.com/JoinColony/colonyCDapp/assets/23449297/3c53e3d5-c550-4463-a6a2-a12423f78451)
Click `Connect` to connect with your second account (if this is your only account you can probably just immediately connect)
5. Login with your imported account and now you should have all the tokens and permissions the colony creator has (and the test ETH which is **very** important for trying all of this out
6. Test all the actions in the UI for the following cases
- Create with permissions -> Reject in Metamask -> The button should not be pending and you can click it again
- Create with reputation -> Reject in Metamask -> The button should not be pending and you can click it again
- Create with permissions -> Sign in Metamask -> The transaction should go through and the completed action view should show
- Create with reputation -> Sign in Metamask -> The transaction should go through and the completed action view should show with the motion sidebar to the right. You don't need to test motions going through technically since that part wasn't touched

## Diffs

**Changes** 🏗

* the `sendTransaction` helper emits a transaction failed error when it fails (previously it returned null and that was it)
* all the sagas applicable were realigned, using the `txHash` from `waitForTxResult`'s response instead of listening for that specific event
* all the sagas that didn't yield the error in the catch block now do, thus correctly refreshing the UI
* the `setTxHash` helper gets called after all the transactions are completed, so we can cancel any transaction in between and retry. Additionally the title now doesn't jank in, but gets displayed with the action

Resolves #1939
