### PR TITLE
fix: changed copy in finances sidebar

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -34,7 +34,7 @@
     "navigation.members.teams": "Teams",
     "navigation.finances": "Finances",
     "navigation.finances.title": "Finances",
-    "navigation.finances.description": "Latest activity in the Colony, including motions & actions.",
+    "navigation.finances.description": "The financial overview, asset balances, revenue, and expenses of the colony.",
     "navigation.finances.overview": "Overview",
     "navigation.finances.balance": "Balance",
     "navigation.finances.incomingFunds": "Incoming funds",


### PR DESCRIPTION
https://tw.auroracreation.com/app/tasks/15814597

## Description

- Changed description in finances sidebar to `The financial overview, asset balances, revenue, and expenses of the colony."`

Resolves [https://github.com/JoinColony/colonyCDapp/issues/2008](https://github.com/JoinColony/colonyCDapp/issues/2008)
