### PR TITLE
Fix: not able to load extension pages directly in production

### DIFF
--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/ExtensionDetailsPage.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/ExtensionDetailsPage.tsx
@@ -39,7 +39,7 @@ const ExtensionDetailsPage: FC = () => {
     refetchColony,
   } = useColonyContext();
   const navigate = useNavigate();
-  const { extensionData, refetchExtensionData } = useExtensionData(
+  const { extensionData, loading, refetchExtensionData } = useExtensionData(
     extensionId ?? '',
   );
   const [waitingForEnableConfirmation, setWaitingForEnableConfirmation] =
@@ -47,7 +47,7 @@ const ExtensionDetailsPage: FC = () => {
 
   useSetPageHeadingTitle(formatText({ id: 'extensionsPage.title' }));
 
-  if (!extensionData) {
+  if (!extensionData && !loading) {
     return <NotFoundRoute />;
   }
 


### PR DESCRIPTION
## Description

This PR fixes the issue where an extension directs to a 404 page when the direct URL is used, or if the page is refreshed on the extension details page. This happens because extensionData is not available fast enough so NotFoundRoute is rendered.

## Testing

Use a direct URL like `http://localhost:9091/planex/extensions/OneTxPayment` and see if the extension details page loads

AND

go to an extension detail page e.g. Voting reputation or One tx payment and refresh the page

The expected behaviour is that the extension details page is loaded without issues and does not redirect to a 404.

## Diffs

**Changes** 🏗

!loading added to the if check which renders NotFoundRoute

Resolves #1995
