### PR TITLE
Fix/2010 edit colony details created in default value

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/EditColonyDetailsForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/EditColonyDetailsForm.tsx
@@ -19,7 +19,7 @@ const EditColonyDetailsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
     <>
       <ColonyDetailsFields />
       <DecisionMethodField />
-      <CreatedIn />
+      <CreatedIn readonly />
       <Description />
       <SocialLinksTable name="externalLinks" />
     </>

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/hooks.ts
@@ -33,7 +33,7 @@ export const useEditColonyDetails = (
         thumbnail: metadata?.thumbnail,
       },
       colonyDescription: metadata?.description || '',
-      createdIn: Id.RootDomain.toString(),
+      createdIn: Id.RootDomain,
       externalLinks: metadata?.externalLinks ?? [],
     }),
     [

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/types.ts
@@ -6,7 +6,7 @@ export interface EditColonyDetailsFormValues {
     thumbnail?: string | null;
   };
   colonyName: string;
-  createdIn: string;
+  createdIn: number;
   decisionMethod: string;
   description?: string;
   colonyDescription: string;

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/ManageColonyObjectivesForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/ManageColonyObjectivesForm.tsx
@@ -22,7 +22,7 @@ const ManageColonyObjectivesForm: FC<ActionFormBaseProps> = ({
     <>
       <ColonyObjectiveFields />
       <DecisionMethodField />
-      <CreatedIn />
+      <CreatedIn readonly />
       <Description maxDescriptionLength={MAX_OBJECTIVE_DESCRIPTION_LENGTH} />
     </>
   );


### PR DESCRIPTION
## Description

The 'Created In' field of the 'Edit Colony Details' action had no default value. It should also be readonly.

This PR fixes these issues and also sets the 'Manage colony objective' 'Created In' field to readonly.

## Testing

Install the reputation weighted extension.
Create a 'Edit colony details' action and set the decision method to 'Reputation'.
The 'Created in' field should default to 'General' and should not be possible to change.

Also check the 'Manage colony objective' action.

## Diffs

**Changes** 🏗

* Fixed default value for 'createdIn' field for 'Edit colony details' action
* Set 'createdIn' field to readonly for 'Edit colony details' and 'Manage colony objective' actions

Resolves #2010
