### PR TITLE
Fix: Action button isLoading issue

### DIFF
--- a/src/components/v5/shared/Button/ActionButton.tsx
+++ b/src/components/v5/shared/Button/ActionButton.tsx
@@ -16,6 +16,7 @@ const ActionButton: FC<ActionButtonProps> = ({
   onError,
   transform,
   values,
+  isLoading,
   ...props
 }) => {
   const submitAction = submit || actionType;
@@ -45,7 +46,9 @@ const ActionButton: FC<ActionButtonProps> = ({
     }
   };
 
-  return <Button onClick={handleClick} loading={loading} {...props} />;
+  return (
+    <Button onClick={handleClick} loading={loading || isLoading} {...props} />
+  );
 };
 
 export default ActionButton;

--- a/src/components/v5/shared/Button/ActionButton.tsx
+++ b/src/components/v5/shared/Button/ActionButton.tsx
@@ -16,7 +16,7 @@ const ActionButton: FC<ActionButtonProps> = ({
   onError,
   transform,
   values,
-  isLoading,
+  isLoading = false,
   ...props
 }) => {
   const submitAction = submit || actionType;


### PR DESCRIPTION
## Description

The actionButton component currently does not actually use the isLoading property that can be passed to it. This is causing a console error on the extension installation page (http://localhost:9091/planex/extensions/VotingReputation). This PR ensures isLoading is actually used and resolves the console error.

## Testing

Go to the extension installation page (http://localhost:9091/planex/extensions/VotingReputation) ensure the 'Install' button works correctly and no console errors are logged.

## Diffs

**Changes** 🏗

* ActionButton now uses isLoading property