### PR TITLE
fix: Not able to finalize agreements

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
@@ -199,13 +199,11 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
                         mode="primarySolid"
                         disabled={!canClaimStakes || wrongMotionState}
                         isFullSize
-                        text={
-                          isMotionAgreement
-                            ? formatText({
-                                id: 'motion.finalizeStep.returnStakes',
-                              })
-                            : formatText({ id: buttonTextId })
-                        }
+                        text={formatText({
+                          id: isMotionAgreement
+                            ? 'motion.finalizeStep.returnStakes'
+                            : buttonTextId,
+                        })}
                         type="submit"
                       />
                     )}

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
@@ -5,6 +5,7 @@ import { defineMessages } from 'react-intl';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { ColonyActionType } from '~gql';
 import { ActionTypes } from '~redux/index.ts';
 import { ActionForm } from '~shared/Fields/index.ts';
 import { MotionState } from '~utils/colonyMotions.ts';
@@ -84,7 +85,8 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
   };
   if (
     actionData.motionData.isFinalized ||
-    actionData.motionData.motionStateHistory.hasFailedNotFinalizable
+    actionData.motionData.motionStateHistory.hasFailedNotFinalizable ||
+    actionData.type === ColonyActionType.CreateDecisionMotion
   ) {
     action = {
       actionType: ActionTypes.MOTION_CLAIM,
@@ -175,28 +177,38 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
                       }
                     />
                   )}
-                  {!isPolling && !actionData.motionData.isFinalized && (
-                    <Button
-                      mode="primarySolid"
-                      disabled={!isFinalizable || wrongMotionState}
-                      isFullSize
-                      text={formatText({ id: 'motion.finalizeStep.submit' })}
-                      type="submit"
-                    />
-                  )}
+                  {!isPolling &&
+                    !actionData.motionData.isFinalized &&
+                    actionData.type !==
+                      ColonyActionType.CreateDecisionMotion && (
+                      <Button
+                        mode="primarySolid"
+                        disabled={!isFinalizable || wrongMotionState}
+                        isFullSize
+                        text={formatText({
+                          id: 'motion.finalizeStep.submit',
+                        })}
+                        type="submit"
+                      />
+                    )}
                   {!isPolling &&
                     (actionData.motionData.isFinalized ||
                       actionData.motionData.motionStateHistory
-                        .hasFailedNotFinalizable) &&
+                        .hasFailedNotFinalizable ||
+                      actionData.type ===
+                        ColonyActionType.CreateDecisionMotion) &&
                     !isClaimed &&
                     canClaimStakes && (
                       <Button
                         mode="primarySolid"
                         disabled={!canClaimStakes || wrongMotionState}
                         isFullSize
-                        text={formatText({
-                          id: buttonTextId,
-                        })}
+                        text={
+                          actionData.type ===
+                          ColonyActionType.CreateDecisionMotion
+                            ? formatText('Return Stakes')
+                            : formatText({ id: buttonTextId })
+                        }
                         type="submit"
                       />
                     )}

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
@@ -206,7 +206,9 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
                         text={
                           actionData.type ===
                           ColonyActionType.CreateDecisionMotion
-                            ? formatText('Return Stakes')
+                            ? formatText({
+                                id: 'motion.finalizeStep.returnStakes',
+                              })
                             : formatText({ id: buttonTextId })
                         }
                         type="submit"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1345,6 +1345,7 @@
     "motion.finalizeStep.winnings": "Winnings",
     "motion.finalizeStep.total": "Total",
     "motion.finalizeStep.submit": "Finalize",
+    "motion.finalizeStep.returnStakes": "Return stakes",
     "motion.finalizeStep.transactions.remaining": "{transactions} transactions remaining",
     "motion.finalizeStep.claimed": "Claimed",
     "table.row.recipient": "Recipient",


### PR DESCRIPTION
## Description

This PR fixes the issue which was occuring when trying to finalize an agreement / decision action. this was done by adding a condition so agreements used `MOTION_CLAIM` instead of `MOTION_FINALIZE`. By doing this the stakes can be returned to the user and the agreement is closed. When the agreement is at the 'Finalize' step, the button should also be labelled 'Return Stakes' rather than 'Claim' like other actions. 

## Testing

* Install reputation extension
* Create agreement motion and go through the steps
* Get to finalize step, and return the stakes

Expected result: you should not see any errors and the stakes are returned to the user:
![finalizeagreements](https://github.com/JoinColony/colonyCDapp/assets/155957480/6e351885-57ec-4e26-9113-05f5b75f8558)


You can also repeat these steps but instead of claiming via the motion 'Return stakes' claim via the user hub and check if the decision finalizes without any issues.

## Diffs

**Changes** 🏗
Decision motion check added into finalizeStep to use MOTION_CLAIM to theoretically 'finalize' the motion  


Resolves #1876 
