### PR TITLE
fix: permissions type filtering, page layout

### DIFF
--- a/src/components/frame/Extensions/pages/PermissionsPage/hooks.tsx
+++ b/src/components/frame/Extensions/pages/PermissionsPage/hooks.tsx
@@ -364,10 +364,12 @@ export const useGetMembersForPermissions = () => {
     return filteredMembersList;
   }, [filterValue, mappedMembers, mappedExtensions, isFilterActive]);
 
-  const searchedMembers = filteredMembers.filter((member) =>
-    member.userAvatarProps.userName
-      ?.toLowerCase()
-      .includes(searchValue.toLowerCase()),
+  const searchedMembers = filteredMembers.filter(
+    (member) =>
+      member.userAvatarProps.userName
+        ?.toLowerCase()
+        .includes(searchValue.toLowerCase()) ||
+      member.role?.name?.toLowerCase().includes(searchValue.toLowerCase()),
   );
 
   const individualMembers: Partial<GroupedByPermissionMembersProps> =

--- a/src/components/v5/frame/PageLayout/PageLayout.tsx
+++ b/src/components/v5/frame/PageLayout/PageLayout.tsx
@@ -123,7 +123,7 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
                   className="flex-grow overflow-auto pr-4 pb-4"
                   style={{ scrollbarGutter: 'stable' }}
                 >
-                  <div className="w-full mx-auto max-w-[79.875rem]">
+                  <div className="w-full xl:mx-auto max-w-[79.875rem]">
                     {children}
                   </div>
                 </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -139,7 +139,7 @@ module.exports = {
         sm: '48rem',
         md: '64rem',
         lg: '80rem',
-        xl: '90rem',
+        xl: 'calc(90rem + 1px)',
       },
       zIndex: {
         1: '1',


### PR DESCRIPTION
## Description

- Added search by permission type to permissions filters
- Changed xl size so it starts at 1401

Resolves [https://github.com/JoinColony/colonyCDapp/issues/2051](https://github.com/JoinColony/colonyCDapp/issues/2051)
