### PR TITLE
Fix leading decimal points crashing CDapp on manage rep form

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/ManageReputationDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/ManageReputationDescription.tsx
@@ -8,6 +8,7 @@ import { ColonyActionType } from '~gql';
 import useUserByAddress from '~hooks/useUserByAddress.ts';
 import Numeral from '~shared/Numeral/Numeral.tsx';
 import { formatText } from '~utils/intl.ts';
+import { toFinite } from '~utils/lodash.ts';
 import { formatReputationChange } from '~utils/reputation.ts';
 import { splitWalletAddress } from '~utils/splitWalletAddress.ts';
 import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
@@ -61,14 +62,14 @@ const ManageReputationDescription: FC = () => {
           : ColonyActionType.EmitDomainReputationReward,
         initiator: <CurrentUser />,
         reputationChange: formatReputationChange(
-          amount || '0',
+          toFinite(amount),
           getTokenDecimalsWithFallback(
             nativeToken.decimals,
             DEFAULT_TOKEN_DECIMALS,
           ),
         ),
         reputationChangeNumeral: amount ? (
-          <Numeral value={amount} />
+          <Numeral value={toFinite(amount)} />
         ) : (
           formatText({
             id: 'actionSidebar.metadataDescription.anAmount',

--- a/src/utils/reputation.ts
+++ b/src/utils/reputation.ts
@@ -43,7 +43,7 @@ export const calculatePercentageReputation = (
 };
 
 export const formatReputationChange = (
-  reputationChange: string,
+  reputationChange: Decimal.Value,
   decimals: number,
 ) => {
   const absoluteChange = new Decimal(reputationChange).abs();


### PR DESCRIPTION
Check out the issue linked to this PR for info on how this bug was reproduced, but basically, inputting a `.` first thing in the amount field was crashing CDapp due to that char reaching the `new Decimal()` inside `formatReputationChange`. With `toFinite` this shouldn't be a problem any longer and it should be treated as a `0`.

![Screenshot 2024-03-19 at 21 25 35](https://github.com/JoinColony/colonyCDapp/assets/18473896/1f20a591-e1b9-4bc4-b3d0-4037344cdff0)

Resolves #2067 
