### PR TITLE
Payment builder widgets UI

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/ExpenditureBadge/ExpenditureBadge.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ExpenditureBadge/ExpenditureBadge.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import React, { type FC } from 'react';
 
 import { ExpenditureStatus } from '~gql';
+import Tooltip from '~shared/Extensions/Tooltip/index.ts';
 import { formatText } from '~utils/intl.ts';
 import PillsBase from '~v5/common/Pills/PillsBase.tsx';
 
@@ -16,7 +17,7 @@ const ExpenditureBadge: FC<ExpenditureBadgeProps> = ({ status }) => {
     [ExpenditureStatus.Locked]: formatText({ id: 'expenditure.locked' }),
   };
 
-  return (
+  const pill = (
     <PillsBase
       className={clsx(
         EXPENDITURE_STATE_TO_CLASSNAME_MAP[status],
@@ -25,6 +26,16 @@ const ExpenditureBadge: FC<ExpenditureBadgeProps> = ({ status }) => {
     >
       {badgeTexts[status]}
     </PillsBase>
+  );
+
+  return status === ExpenditureStatus.Draft ? (
+    <Tooltip
+      tooltipContent={formatText({ id: 'expenditure.reviewStage.tooltip' })}
+    >
+      {pill}
+    </Tooltip>
+  ) : (
+    pill
   );
 };
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/hooks.tsx
@@ -93,7 +93,6 @@ export const useRecipientsFieldTableColumns = (
                     return {
                       ...result,
                       [tokenAddress]: {
-                        ...tokenData,
                         amount: BigNumber.from(
                           !result[tokenAddress]?.amount ||
                             result[tokenAddress]?.amount === ''

--- a/src/components/v5/common/CompletedAction/CompletedAction.tsx
+++ b/src/components/v5/common/CompletedAction/CompletedAction.tsx
@@ -7,7 +7,6 @@ import { ExtendedColonyActionType } from '~types/actions.ts';
 import { type ColonyAction } from '~types/graphql.ts';
 import { getExtendedActionType } from '~utils/colonyActions.ts';
 
-import { useGetExpenditureData } from '../ActionSidebar/hooks/useGetExpenditureData.ts';
 import PermissionSidebar from '../ActionSidebar/partials/ActionSidebarContent/partials/PermissionSidebar.tsx';
 import Motions from '../ActionSidebar/partials/Motions/index.ts';
 
@@ -15,6 +14,7 @@ import CreateDecision from './partials/CreateDecision/index.ts';
 import EditColonyDetails from './partials/EditColonyDetails/index.ts';
 import ManageTeam from './partials/ManageTeam/index.ts';
 import MintTokens from './partials/MintTokens/index.ts';
+import PaymentBuilderWidget from './partials/PaymentBuilder/partials/PaymentBuilderWidget/index.ts';
 import PaymentBuilder from './partials/PaymentBuilder/PaymentBuilder.tsx';
 import SetUserRoles from './partials/SetUserRoles/index.ts';
 import SimplePayment from './partials/SimplePayment/index.ts';
@@ -31,9 +31,6 @@ const displayName = 'v5.common.CompletedAction';
 
 const CompletedAction = ({ action }: CompletedActionProps) => {
   const { colony } = useColonyContext();
-  const { expenditure, loadingExpenditure } = useGetExpenditureData(
-    action.expenditureId,
-  );
 
   const actionType = getExtendedActionType(action, colony.metadata);
 
@@ -70,15 +67,30 @@ const CompletedAction = ({ action }: CompletedActionProps) => {
       case ExtendedColonyActionType.UpdateColonyObjective:
         return <UpgradeColonyObjective action={action} />;
       case ColonyActionType.CreateExpenditure:
-        return (
-          !loadingExpenditure &&
-          expenditure && (
-            <PaymentBuilder action={action} expenditure={expenditure} />
-          )
-        );
+        return <PaymentBuilder action={action} />;
       default:
         console.warn('Unsupported action display', action);
         return <div>Not implemented yet</div>;
+    }
+  };
+
+  const getSidebarWidgetContent = () => {
+    switch (actionType) {
+      case ColonyActionType.PaymentMotion:
+      case ColonyActionType.MintTokensMotion:
+      case ColonyActionType.MoveFundsMotion:
+      case ColonyActionType.CreateDomainMotion:
+      case ColonyActionType.EditDomainMotion:
+      case ColonyActionType.UnlockTokenMotion:
+      case ColonyActionType.VersionUpgradeMotion:
+      case ColonyActionType.CreateDecisionMotion:
+      case ColonyActionType.SetUserRolesMotion:
+      case ColonyActionType.ColonyEditMotion:
+        return <Motions transactionId={action.transactionHash} />;
+      case ColonyActionType.CreateExpenditure:
+        return <PaymentBuilderWidget action={action} />;
+      default:
+        return <PermissionSidebar transactionId={action.transactionHash} />;
     }
   };
 
@@ -110,11 +122,7 @@ const CompletedAction = ({ action }: CompletedActionProps) => {
             sm:border-l-gray-200
           `}
       >
-        {action.isMotion ? (
-          <Motions transactionId={action.transactionHash} />
-        ) : (
-          <PermissionSidebar transactionId={action.transactionHash} />
-        )}
+        {getSidebarWidgetContent()}
       </div>
     </div>
   );

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizeWithPermissionsInfo/FinalizeWithPermissionsInfo.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizeWithPermissionsInfo/FinalizeWithPermissionsInfo.tsx
@@ -1,0 +1,64 @@
+import React, { type FC } from 'react';
+
+import PermissionRow from '~frame/v5/pages/VerifiedPage/partials/PermissionRow/index.ts';
+import { formatText } from '~utils/intl.ts';
+import MenuWithStatusText from '~v5/shared/MenuWithStatusText/index.ts';
+import { StatusTypes } from '~v5/shared/StatusText/consts.ts';
+import UserAvatarPopover from '~v5/shared/UserAvatarPopover/index.ts';
+
+import { type FinalizeWithPermissionsInfoProps } from './types.ts';
+
+const FinalizeWithPermissionsInfo: FC<FinalizeWithPermissionsInfoProps> = ({
+  userAdddress,
+}) => {
+  return (
+    <MenuWithStatusText
+      statusTextSectionProps={{
+        status: StatusTypes.Info,
+        children: formatText({
+          id: 'action.executed.permissions.description',
+        }),
+        textClassName: 'text-4 text-gray-900',
+        iconAlignment: 'top',
+        iconSize: 16,
+        iconClassName: 'text-gray-500',
+      }}
+      sections={[
+        {
+          key: '1',
+          content: (
+            <>
+              <h4 className="text-1">
+                {formatText({
+                  id: 'action.executed.permissions.overview',
+                })}
+              </h4>
+              {userAdddress && (
+                <>
+                  <div className="mt-2 flex items-center justify-between gap-2">
+                    <span className="text-sm text-gray-600">
+                      {formatText({
+                        id: 'action.executed.permissions.member',
+                      })}
+                    </span>
+                    <UserAvatarPopover walletAddress={userAdddress || ''} />
+                  </div>
+                  <div className="mt-2 flex items-center justify-between gap-2">
+                    <span className="text-sm text-gray-600">
+                      {formatText({
+                        id: 'action.executed.permissions.permission',
+                      })}
+                    </span>
+                    <PermissionRow contributorAddress={userAdddress} />
+                  </div>
+                </>
+              )}
+            </>
+          ),
+        },
+      ]}
+    />
+  );
+};
+
+export default FinalizeWithPermissionsInfo;

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizeWithPermissionsInfo/index.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizeWithPermissionsInfo/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FinalizeWithPermissionsInfo.tsx';

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizeWithPermissionsInfo/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizeWithPermissionsInfo/types.ts
@@ -1,0 +1,3 @@
+export interface FinalizeWithPermissionsInfoProps {
+  userAdddress: string | undefined | null;
+}

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/PaymentBuilderWidget.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/PaymentBuilderWidget.tsx
@@ -1,0 +1,122 @@
+import React, { useState, type FC } from 'react';
+
+import { useAppContext } from '~context/AppContext/AppContext.ts';
+import SpinnerLoader from '~shared/Preloaders/SpinnerLoader.tsx';
+import { formatText } from '~utils/intl.ts';
+import { useGetExpenditureData } from '~v5/common/ActionSidebar/hooks/useGetExpenditureData.ts';
+import Stepper from '~v5/shared/Stepper/index.ts';
+import { type StepperItem } from '~v5/shared/Stepper/types.ts';
+
+import FinalizeWithPermissionsInfo from '../FinalizeWithPermissionsInfo/index.ts';
+import PaymentStepDetailsBlock from '../PaymentStepDetailsBlock/index.ts';
+import StepDetailsBlock from '../StepDetailsBlock/index.ts';
+
+import { ExpenditureStep, type PaymentBuilderWidgetProps } from './types.ts';
+import { getExpenditureStep } from './utils.ts';
+
+const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
+  const { user } = useAppContext();
+  const { walletAddress } = user || {};
+  const { expenditureId } = action;
+
+  const { expenditure, loadingExpenditure } =
+    useGetExpenditureData(expenditureId);
+
+  const { status } = expenditure || {};
+
+  const [activeStepKey, setActiveStepKey] = useState<ExpenditureStep>(
+    getExpenditureStep(status),
+  );
+
+  const items: StepperItem<ExpenditureStep>[] = [
+    {
+      key: ExpenditureStep.Create,
+      heading: { label: formatText({ id: 'expenditure.createStage.label' }) },
+      content: (
+        <FinalizeWithPermissionsInfo userAdddress={expenditure?.ownerAddress} />
+      ),
+    },
+    {
+      key: ExpenditureStep.Review,
+      heading: { label: formatText({ id: 'expenditure.reviewStage.label' }) },
+      content:
+        activeStepKey === ExpenditureStep.Review ? (
+          <StepDetailsBlock
+            text={formatText({
+              id: 'expenditure.reviewStage.confirmDetails.info',
+            })}
+            buttonProps={{
+              disabled:
+                !expenditure?.ownerAddress ||
+                walletAddress !== expenditure?.ownerAddress,
+              // @todo: replace onClick with actual functionality
+              onClick: () => setActiveStepKey(ExpenditureStep.Funding),
+              text: formatText({
+                id: 'expenditure.reviewStage.confirmDetails.button',
+              }),
+            }}
+          />
+        ) : (
+          <FinalizeWithPermissionsInfo
+            userAdddress={expenditure?.ownerAddress}
+          />
+        ),
+    },
+    {
+      key: ExpenditureStep.Funding,
+      heading: { label: formatText({ id: 'expenditure.fundingStage.label' }) },
+      content: (
+        <StepDetailsBlock
+          text={formatText({
+            id: 'expenditure.fundingStage.info',
+          })}
+          buttonProps={{
+            // @todo: replace onClick with actual functionality
+            onClick: () => setActiveStepKey(ExpenditureStep.Release),
+            text: formatText({
+              id: 'expenditure.fundingStage.button',
+            }),
+          }}
+        />
+      ),
+    },
+    {
+      key: ExpenditureStep.Release,
+      heading: { label: formatText({ id: 'expenditure.releaseStage.label' }) },
+      // @todo: add completed state content
+      content: (
+        <StepDetailsBlock
+          text={formatText({
+            id: 'expenditure.releaseStage.info',
+          })}
+          buttonProps={{
+            // @todo: replace onClick with actual functionality
+            onClick: () => setActiveStepKey(ExpenditureStep.Payment),
+            text: formatText({
+              id: 'expenditure.releaseStage.button',
+            }),
+          }}
+        />
+      ),
+    },
+    {
+      key: ExpenditureStep.Payment,
+      heading: { label: formatText({ id: 'expenditure.paymentStage.label' }) },
+      content: <PaymentStepDetailsBlock />,
+    },
+  ];
+
+  if (loadingExpenditure) {
+    return <SpinnerLoader appearance={{ size: 'medium' }} />;
+  }
+
+  return (
+    <Stepper<ExpenditureStep>
+      items={items}
+      activeStepKey={activeStepKey}
+      setActiveStepKey={setActiveStepKey}
+    />
+  );
+};
+
+export default PaymentBuilderWidget;

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/index.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PaymentBuilderWidget.tsx';

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/types.ts
@@ -1,0 +1,13 @@
+import { type ColonyAction } from '~types/graphql.ts';
+
+export enum ExpenditureStep {
+  Create = 'CREATE',
+  Review = 'REVIEW',
+  Funding = 'FUNDING',
+  Release = 'RELEASE',
+  Payment = 'PAYMENT',
+}
+
+export interface PaymentBuilderWidgetProps {
+  action: ColonyAction;
+}

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/utils.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/utils.ts
@@ -1,0 +1,15 @@
+import { ExpenditureStatus } from '~gql';
+
+import { ExpenditureStep } from './types.ts';
+
+// @todo: update steps
+export const getExpenditureStep = (status?: ExpenditureStatus) => {
+  switch (status) {
+    case ExpenditureStatus.Draft:
+      return ExpenditureStep.Review;
+    case ExpenditureStatus.Locked:
+      return ExpenditureStep.Funding;
+    default:
+      return ExpenditureStep.Create;
+  }
+};

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/PaymentStepDetailsBlock.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/PaymentStepDetailsBlock.tsx
@@ -1,0 +1,145 @@
+import { ArrowsClockwise } from '@phosphor-icons/react';
+import React, { type FC } from 'react';
+
+import { formatText } from '~utils/intl.ts';
+import Button from '~v5/shared/Button/index.ts';
+import MenuWithStatusText from '~v5/shared/MenuWithStatusText/index.ts';
+import { StatusTypes } from '~v5/shared/StatusText/consts.ts';
+import StatusText from '~v5/shared/StatusText/index.ts';
+
+import PaymentOverview from './partials/PaymentOverview/index.ts';
+
+// @todo: replace mock data with real data
+const PaymentStepDetailsBlock: FC = () => {
+  const allPaid = false;
+
+  return allPaid ? (
+    <PaymentOverview
+      className="rounded-lg border border-gray-200 bg-base-white px-[1.125rem] pb-3.5 pt-[1.125rem]"
+      total={[
+        {
+          amount: '500000000000000000000',
+          tokenAddress: '0x90B0A9A9Fe382423aEECBb22e5c1CaEBaeF1Af4C',
+          isClaimed: true,
+        },
+        {
+          amount: '90000000000000000000',
+          tokenAddress: '0x90B0A9A9Fe382423aEECBb22e5c1CaEBaeF1Af4C',
+          isClaimed: true,
+        },
+      ]}
+      paid={[
+        {
+          amount: '500000000000000000000',
+          tokenAddress: '0x90B0A9A9Fe382423aEECBb22e5c1CaEBaeF1Af4C',
+          isClaimed: true,
+        },
+        {
+          amount: '90000000000000000000',
+          tokenAddress: '0x90B0A9A9Fe382423aEECBb22e5c1CaEBaeF1Af4C',
+          isClaimed: true,
+        },
+      ]}
+      payable={[
+        {
+          amount: '500000000000000000000',
+          tokenAddress: '0x90B0A9A9Fe382423aEECBb22e5c1CaEBaeF1Af4C',
+          isClaimed: true,
+        },
+        {
+          amount: '90000000000000000000',
+          tokenAddress: '0x90B0A9A9Fe382423aEECBb22e5c1CaEBaeF1Af4C',
+          isClaimed: true,
+        },
+      ]}
+    />
+  ) : (
+    <MenuWithStatusText
+      statusTextSectionProps={{
+        status: StatusTypes.Info,
+        children: formatText({ id: 'expenditure.paymentStage.info' }),
+        textClassName: 'text-4 text-gray-900',
+        iconAlignment: 'top',
+        iconClassName: 'text-gray-500',
+        iconSize: 16,
+        content: (
+          <StatusText
+            icon={ArrowsClockwise}
+            iconAlignment="top"
+            iconSize={16}
+            status={StatusTypes.Info}
+            textClassName="text-4 text-gray-900"
+            className="mt-2"
+            iconClassName="text-gray-500"
+          >
+            {formatText(
+              { id: 'expenditure.paymentStage.info.nextClaim' },
+              {
+                // @todo: update counter value
+                counter: 'counter',
+              },
+            )}
+          </StatusText>
+        ),
+      }}
+      sections={[
+        {
+          key: 'test',
+          className: '!p-[1.125rem]',
+          content: (
+            <div>
+              <PaymentOverview
+                total={[
+                  {
+                    amount: '500000000000000000000',
+                    tokenAddress: '0x90B0A9A9Fe382423aEECBb22e5c1CaEBaeF1Af4C',
+                    isClaimed: false,
+                  },
+                  {
+                    amount: '90000000000000000000',
+                    tokenAddress: '0x90B0A9A9Fe382423aEECBb22e5c1CaEBaeF1Af4C',
+                    isClaimed: false,
+                  },
+                ]}
+                paid={[
+                  {
+                    amount: '50000000000000000000',
+                    tokenAddress: '0x90B0A9A9Fe382423aEECBb22e5c1CaEBaeF1Af4C',
+                    isClaimed: false,
+                  },
+                  {
+                    amount: '00000000000000000000',
+                    tokenAddress: '0x90B0A9A9Fe382423aEECBb22e5c1CaEBaeF1Af4C',
+                    isClaimed: false,
+                  },
+                ]}
+                payable={[
+                  {
+                    amount: '00000000000000000000',
+                    tokenAddress: '0x90B0A9A9Fe382423aEECBb22e5c1CaEBaeF1Af4C',
+                    isClaimed: false,
+                  },
+                  {
+                    amount: '10000000000000000000',
+                    tokenAddress: '0x90B0A9A9Fe382423aEECBb22e5c1CaEBaeF1Af4C',
+                    isClaimed: false,
+                  },
+                ]}
+              />
+              <Button
+                className="mt-4 w-full"
+                // @todo: add onClick handler
+                // eslint-disable-next-line no-console
+                onClick={() => console.log('make payment')}
+              >
+                {formatText({ id: 'expenditure.paymentStage.button' })}
+              </Button>
+            </div>
+          ),
+        },
+      ]}
+    />
+  );
+};
+
+export default PaymentStepDetailsBlock;

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/index.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PaymentStepDetailsBlock.tsx';

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/partials/PaymentItem/PaymentItem.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/partials/PaymentItem/PaymentItem.tsx
@@ -1,61 +1,52 @@
 import { CaretDown } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import { AnimatePresence, motion } from 'framer-motion';
-import React, { useMemo, type FC } from 'react';
+import React, { type FC, useMemo } from 'react';
 
 import { accordionAnimation } from '~constants/accordionAnimation.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useToggle from '~hooks/useToggle/index.ts';
 import Numeral from '~shared/Numeral/index.ts';
-import TokenIcon from '~shared/TokenIcon/index.ts';
 import { type ExpenditurePayout } from '~types/graphql.ts';
 import { sortPayouts } from '~utils/sortPayouts.ts';
 import { getSelectedToken } from '~utils/tokens.ts';
 
-import { type PaymentBuilderPayoutsTotalProps } from './types.ts';
+import { type PaymentItemProps } from './types.ts';
 
-const PaymentBuilderTokensTotal: FC<PaymentBuilderPayoutsTotalProps> = ({
-  payouts,
-}) => {
+const PaymentItem: FC<PaymentItemProps> = ({ payouts }) => {
   const { colony } = useColonyContext();
   const [isExpanded, { toggle }] = useToggle();
   const sortedPayouts = useMemo(() => sortPayouts(payouts), [payouts]) || [];
-
-  const getItem = (token: ExpenditurePayout) => {
-    const tokenData = getSelectedToken(colony, token.tokenAddress);
-
-    return tokenData ? (
-      <div className="flex items-center gap-3 text-gray-900 text-1">
-        <Numeral value={token.amount} decimals={tokenData?.decimals} />
-        <div className="flex items-center gap-1">
-          <TokenIcon
-            token={tokenData}
-            size="xxs"
-            className="flex-shrink-0 text-gray-900"
-          />
-          <span>{tokenData?.symbol}</span>
-        </div>
-      </div>
-    ) : null;
-  };
 
   if (!sortedPayouts.length) {
     return null;
   }
 
+  const getItem = (token: ExpenditurePayout) => {
+    const tokenData = getSelectedToken(colony, token.tokenAddress);
+
+    return tokenData ? (
+      <Numeral
+        value={token.amount}
+        decimals={tokenData?.decimals}
+        suffix={tokenData?.symbol}
+      />
+    ) : null;
+  };
+
   return (
-    <div className="w-full">
+    <div className="w-full py-[.125rem]">
       {sortedPayouts.length > 1 ? (
         <>
           <button
             type="button"
-            className="flex w-full items-center gap-2 py-[.3125rem]"
+            className="flex w-full items-center justify-end gap-2 py-[.125rem]"
             onClick={toggle}
           >
             {getItem(sortedPayouts[0])}
             <CaretDown
-              size={12}
-              className={clsx('flex-shrink-0 transition', {
+              size={16}
+              className={clsx('flex-shrink-0 text-gray-500 transition', {
                 'rotate-180': isExpanded,
               })}
             />
@@ -69,11 +60,11 @@ const PaymentBuilderTokensTotal: FC<PaymentBuilderPayoutsTotalProps> = ({
                 exit="hidden"
                 className="overflow-hidden"
               >
-                <ul>
+                <ul className="pr-6">
                   {sortedPayouts.slice(1).map((token) => (
                     <li
                       key={token.tokenAddress}
-                      className="w-full py-[.3125rem]"
+                      className="w-full py-[.125rem]"
                     >
                       {getItem(token)}
                     </li>
@@ -84,10 +75,10 @@ const PaymentBuilderTokensTotal: FC<PaymentBuilderPayoutsTotalProps> = ({
           </AnimatePresence>
         </>
       ) : (
-        <div className="w-full py-[.3125rem]">{getItem(sortedPayouts[0])}</div>
+        <div className="w-full py-[.125rem]">{getItem(sortedPayouts[0])}</div>
       )}
     </div>
   );
 };
 
-export default PaymentBuilderTokensTotal;
+export default PaymentItem;

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/partials/PaymentItem/index.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/partials/PaymentItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PaymentItem.tsx';

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/partials/PaymentItem/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/partials/PaymentItem/types.ts
@@ -1,5 +1,5 @@
 import { type ExpenditurePayout } from '~types/graphql.ts';
 
-export interface PaymentBuilderPayoutsTotalProps {
+export interface PaymentItemProps {
   payouts: ExpenditurePayout[];
 }

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/partials/PaymentOverview/PaymentOverview.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/partials/PaymentOverview/PaymentOverview.tsx
@@ -1,0 +1,45 @@
+import clsx from 'clsx';
+import React, { type FC } from 'react';
+
+import PaymentItem from '../PaymentItem/index.ts';
+
+import { type PaymentOverviewProps } from './types.ts';
+
+const PaymentOverview: FC<PaymentOverviewProps> = ({
+  paid,
+  payable,
+  total,
+  className,
+}) => (
+  <div className={clsx(className, 'w-full')}>
+    <h4 className="mb-1 text-gray-900 text-1">Payment overview</h4>
+    <table className="w-full text-sm">
+      <tbody>
+        <tr>
+          <th className="py-1 align-top font-normal text-gray-600">
+            Total payments
+          </th>
+          <td className="text-right">
+            <PaymentItem payouts={total} />
+          </td>
+        </tr>
+        <tr>
+          <th className="py-1 align-top font-normal text-gray-600">Paid</th>
+          <td className="text-right">
+            <PaymentItem payouts={paid} />
+          </td>
+        </tr>
+        <tr>
+          <th className="py-1 align-top font-normal text-gray-600">
+            Payable now
+          </th>
+          <td className="text-right">
+            <PaymentItem payouts={payable} />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+);
+
+export default PaymentOverview;

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/partials/PaymentOverview/index.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/partials/PaymentOverview/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PaymentOverview.tsx';

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/partials/PaymentOverview/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/partials/PaymentOverview/types.ts
@@ -1,0 +1,8 @@
+import { type ExpenditurePayout } from '~types/graphql.ts';
+
+export interface PaymentOverviewProps {
+  total: ExpenditurePayout[];
+  paid: ExpenditurePayout[];
+  payable: ExpenditurePayout[];
+  className?: string;
+}

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StepDetailsBlock/StepDetailsBlock.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StepDetailsBlock/StepDetailsBlock.tsx
@@ -1,0 +1,35 @@
+import clsx from 'clsx';
+import React, { type FC } from 'react';
+
+import Button from '~v5/shared/Button/index.ts';
+import MenuWithStatusText from '~v5/shared/MenuWithStatusText/index.ts';
+import { StatusTypes } from '~v5/shared/StatusText/consts.ts';
+
+import { type StepDetailsBlockProps } from './types.ts';
+
+const StepDetailsBlock: FC<StepDetailsBlockProps> = ({ text, buttonProps }) => (
+  <MenuWithStatusText
+    statusTextSectionProps={{
+      status: StatusTypes.Info,
+      children: text,
+      textClassName: 'text-4 text-gray-900',
+      iconAlignment: 'top',
+      iconSize: 16,
+      iconClassName: 'text-gray-500',
+    }}
+    sections={[
+      {
+        key: 'fund',
+        content: (
+          <Button
+            {...buttonProps}
+            className={clsx(buttonProps.className, 'w-full')}
+          />
+        ),
+        className: '!p-[1.125rem]',
+      },
+    ]}
+  />
+);
+
+export default StepDetailsBlock;

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StepDetailsBlock/index.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StepDetailsBlock/index.ts
@@ -1,0 +1,1 @@
+export { default } from './StepDetailsBlock.tsx';

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StepDetailsBlock/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StepDetailsBlock/types.ts
@@ -1,0 +1,6 @@
+import { type ButtonProps } from '~v5/shared/Button/types.ts';
+
+export interface StepDetailsBlockProps {
+  text: string;
+  buttonProps: ButtonProps;
+}

--- a/src/components/v5/common/CompletedAction/partials/rows/PaymentBuilderTable/PaymentBuilderTable.tsx
+++ b/src/components/v5/common/CompletedAction/partials/rows/PaymentBuilderTable/PaymentBuilderTable.tsx
@@ -6,16 +6,15 @@ import React, { useMemo } from 'react';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useMobile } from '~hooks';
 import useWrapWithRef from '~hooks/useWrapWithRef.ts';
+import { type ExpenditurePayout } from '~types/graphql.ts';
 import { formatText } from '~utils/intl.ts';
 import { getSelectedToken } from '~utils/tokens.ts';
 import PaymentBuilderPayoutsTotal from '~v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderPayoutsTotal/index.ts';
-import { type PaymentBuilderPayoutItem } from '~v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderPayoutsTotal/types.ts';
 import Table from '~v5/common/Table/index.ts';
 
 import AmountField from './AmountField.tsx';
 import RecipientField from './RecipientField.tsx';
 import {
-  type SelectedTokensProps,
   type PaymentBuilderTableModel,
   type PaymentBuilderTableProps,
 } from './types.ts';
@@ -61,7 +60,7 @@ const useGetPaymentBuilderColumns = (data: PaymentBuilderTableModel[]) => {
         hasMoreThanOneToken && !isMobile
           ? () => {
               const selectedTokens = dataRef.current?.reduce(
-                (result: SelectedTokensProps, { amount }) => {
+                (result: ExpenditurePayout[], { amount }) => {
                   if (!amount || !amount[0].token) {
                     return result;
                   }
@@ -74,21 +73,18 @@ const useGetPaymentBuilderColumns = (data: PaymentBuilderTableModel[]) => {
 
                   return [
                     {
-                      ...tokenData,
+                      tokenAddress: amount[0].token,
                       amount: BigNumber.from(result[0]?.amount || '0')
                         .add(BigNumber.from(amount[0].amount || '0'))
                         .toString(),
+                      isClaimed: false,
                     },
                   ];
                 },
                 [],
               );
 
-              return (
-                <PaymentBuilderPayoutsTotal
-                  payouts={selectedTokens as PaymentBuilderPayoutItem[]}
-                />
-              );
+              return <PaymentBuilderPayoutsTotal payouts={selectedTokens} />;
             }
           : undefined,
       cell: ({ row }) => (
@@ -105,7 +101,7 @@ const useGetPaymentBuilderColumns = (data: PaymentBuilderTableModel[]) => {
         hasMoreThanOneToken && isMobile
           ? () => {
               const selectedTokens = dataRef.current?.reduce(
-                (result: SelectedTokensProps, { amount }) => {
+                (result: ExpenditurePayout[], { amount }) => {
                   if (!amount) {
                     return result;
                   }
@@ -122,21 +118,18 @@ const useGetPaymentBuilderColumns = (data: PaymentBuilderTableModel[]) => {
 
                   return [
                     {
-                      ...tokenData,
+                      tokenAddress: amount[0].token,
                       amount: BigNumber.from(result[0]?.amount || '0')
                         .add(BigNumber.from(amount[0].amount || '0'))
                         .toString(),
+                      isClaimed: false,
                     },
                   ];
                 },
                 [],
               );
 
-              return (
-                <PaymentBuilderPayoutsTotal
-                  payouts={selectedTokens as PaymentBuilderPayoutItem[]}
-                />
-              );
+              return <PaymentBuilderPayoutsTotal payouts={selectedTokens} />;
             }
           : undefined,
       cell: ({ row }) => {

--- a/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
+++ b/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
@@ -108,12 +108,6 @@ const SearchItem: FC<SearchItemProps> = ({
                     </div>
                   )}
                   {isLabelVisible && labelText}
-                  {isVerified && (
-                    <CircleWavyCheck
-                      size={14}
-                      className="ml-1 flex-shrink-0 text-blue-400"
-                    />
-                  )}
                   {!label && <span className="truncate">{walletAddress}</span>}
                   {isVerified && (
                     <CircleWavyCheck

--- a/src/components/v5/shared/Stepper/partials/StepperButton/StepperButton.tsx
+++ b/src/components/v5/shared/Stepper/partials/StepperButton/StepperButton.tsx
@@ -40,8 +40,12 @@ const StepperButton: React.FC<StepperButtonProps> = ({
         `,
         {
           'border-gray-900 bg-base-white text-gray-900':
-            !isHighlighted && stage !== StepStage.Skipped,
-          '!border-gray-900 !bg-gray-900 !text-base-white': isHighlighted,
+            !isHighlighted && stage !== StepStage.Current,
+          'border-gray-900 bg-gray-900 text-base-white':
+            (isHighlighted && stage !== StepStage.Completed) ||
+            (!isHighlighted && stage === StepStage.Current),
+          'border-blue-400 bg-blue-400 text-base-white':
+            isHighlighted && stage === StepStage.Completed,
           'border-gray-400 bg-base-white text-gray-400':
             stage === StepStage.Skipped,
         },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1671,5 +1671,20 @@
     "teamsPage.empty.title": "No results to display",
     "teamsPage.empty.description": "There are teams in the Colony that match your search. Try searching again",
     "expenditure.description": "Payment to {recipientsNumber} {recipientsNumber, plural, one {recipient} other {recipients}} with {tokensNumber} {tokensNumber, plural, one {token} other {tokens}} by {initiator}",
-    "expenditure.description.placeholder": "Payment with multiple recipients and tokens by {initiator}"
+    "expenditure.description.placeholder": "Payment with multiple recipients and tokens by {initiator}",
+    "expenditure.createStage.label": "Create",
+    "expenditure.reviewStage.label": "Review",
+    "expenditure.reviewStage.tooltip": "Payment is currently in review. The payment creator can make changes freely until details are confirmed.",
+    "expenditure.reviewStage.confirmDetails.info": "If all details are correct, confirm the payment details to move onto funding. Changing after this point will require a governance process.",
+    "expenditure.reviewStage.confirmDetails.button": "Confirm details",
+    "expenditure.fundingStage.label": "Funding",
+    "expenditure.fundingStage.info": "You need collective approval in order to fund the payment, click “Fund” to start the process.",
+    "expenditure.fundingStage.button": "Fund",
+    "expenditure.releaseStage.label": "Release",
+    "expenditure.releaseStage.info": "To allow recipients to claim their funds, you need to release them first. This will start the countdown on any claim delays as well.",
+    "expenditure.releaseStage.button": "Release",
+    "expenditure.paymentStage.label": "Payment",
+    "expenditure.paymentStage.info": "You are now able to pay funds to recipients who have passed their claim delay.",
+    "expenditure.paymentStage.info.nextClaim": "Next claim in {counter}",
+    "expenditure.paymentStage.button": "Make payment"
 }

--- a/src/utils/sortPayouts.ts
+++ b/src/utils/sortPayouts.ts
@@ -1,0 +1,11 @@
+import { BigNumber } from 'ethers';
+
+import { type ExpenditurePayout } from '~types/graphql.ts';
+
+export const sortPayouts = (payouts: ExpenditurePayout[]) =>
+  payouts?.sort((a, b) => {
+    if (!a.amount || !b.amount || BigNumber.from(a.amount).eq(b.amount))
+      return 0;
+
+    return BigNumber.from(a.amount).gt(b.amount) ? -1 : 1;
+  });


### PR DESCRIPTION
Part of https://github.com/JoinColony/colonyCDapp/issues/2005

**Payment Builder widget with mock data. Right now you can go to the next steps, but no actual action will be triggered to proceed with the action. I also wasn't able to get the info about who clicked `Fund` or `Release` buttons, and because of that I wasn't able to display the box with the info about it when going back to these stages.** - there's an issue related to this: https://github.com/JoinColony/colonyCDapp/issues/2082

**We are focusing on one flow right now - with the permissions decision method only.**

**Stepper - Stage - Create**
- Clicking back on the Create stage pill will show the permission decision method was used.

**Stepper - Stage - Review**
- First stage after creating the payment, it makes the payment public for others to review.
- Owner has the option to confirm details, locking the payment details and moving it to the Funding stage.
  - User who didn't create an action should not see a button/button should be diabled (TBD)
- Clicking back on the Review stage pill will show the permission decision method was used.
- "Review" pill appears at the top of the action panel
  - Show tooltip when mouseover
    - "Payment is currently in review. The payment creator can make changes freely until details are confirmed."

**Stepper - Stage - Funding**
- Step to fund the payment with the required funds to make the payment.

Out of scope:
- Opens the Funding modal.
- Funding opens a modal that allows the user see the total amount of what is going to get funded for each token and the network fee. The user also will need to select from one of the decision methods that is available to them.
- Funding with Permissions decision method:
  - Immediately moves the process to the Release stage.
  - Clicking back on the funding stage pill will show the permission decision method was used.

**Stepper - Stage - Release**
Out of scope:
- Opens the Release payment modal with the users possible decision methods
- If funded, the owner can release the funds for the payment, starting the claim delay.
- If any claim delays are 0, then those payments will happen immediately on release and also release the creators stake if present.
- Alternatively, users can use available decision methods, including "Admin" tiered permissions or higher (Arbitration on the contracts)

**Stepper - Stage - Payment**
- Appears after the funds have been released.

Out of scope:
- Provides a break down of total funds to be paid, paid, and are ready to be paid.
- Shows a timer that counts down to the next available claim time.
- Button to "Make payment"
  - Button is disabled if there is nothing to pay out
  - Button is enabled as long as there is something to pay out. Anyone connected member is able to click and make the payment.
  - First payout will return the creators stake.
  - Button does not appear anymore if there are no more funds to be paid out and there are no claims to be released.