### PR TITLE
Fix: App freezes when switching from create agreement to simple payment

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/SaveDraftButton/SaveDraftButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/SaveDraftButton/SaveDraftButton.tsx
@@ -18,7 +18,7 @@ const SaveDraftButton: FC = () => {
   const { wallet } = useAppContext();
   const dispatch = useDispatch();
   const {
-    formState: { isValid, isValidating },
+    formState: { isValid, ...formState },
     getValues,
     trigger,
   } = useFormContext();
@@ -65,7 +65,7 @@ const SaveDraftButton: FC = () => {
         }
       }}
       isFullSize={isMobile}
-      disabled={isValidating || isDraftSaved}
+      disabled={formState.isValidating || isDraftSaved}
     >
       {!isDraftSaved && <FileDashed size={18} className="mr-2" />}
       {formatText({


### PR DESCRIPTION
## Description

The entire app was freezing when switching from 'Create agreement' to 'Simple payment' (this would also occur when switching from 'Create agreement' to any other action type then to 'Simple payment').

## Testing

Create a new action, select 'Create agreement', switch to 'Simple payment'. No freeze should occur.

## Diffs

**Changes** 🏗

* Changed `SaveDraftButton` `isValidating` check.

Resolves #2047
