### PR TITLE
Update Change Action modal logic

### DIFF
--- a/src/components/v5/common/ActionSidebar/ActionTypeSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionTypeSelect.tsx
@@ -12,10 +12,7 @@ import SearchSelect from '~v5/shared/SearchSelect/index.ts';
 
 import ActionFormRow from '../ActionFormRow/index.ts';
 
-import {
-  ACTION_TYPE_FIELD_NAME,
-  DECISION_METHOD_FIELD_NAME,
-} from './consts.ts';
+import { ACTION_TYPE_FIELD_NAME, TITLE_FIELD_NAME } from './consts.ts';
 import useActionsList from './hooks/useActionsList.ts';
 import { translateAction } from './utils.ts';
 
@@ -42,8 +39,9 @@ const ActionTypeSelect: FC<ActionTypeSelectProps> = ({ className }) => {
     HTMLButtonElement,
     HTMLDivElement
   >([isSelectVisible]);
-  const { formState, setValue } = useFormContext();
+  const { formState, setValue, reset, watch } = useFormContext();
   const { readonly } = useAdditionalFormOptionsContext();
+  const title = watch('title');
 
   return (
     <div className={className}>
@@ -103,16 +101,19 @@ const ActionTypeSelect: FC<ActionTypeSelectProps> = ({ className }) => {
                     return;
                   }
 
-                  if (
-                    Object.keys(formState.dirtyFields).length > 0 &&
-                    actionType
-                  ) {
+                  const hasMadeChanges = Object.keys(
+                    formState.dirtyFields,
+                  ).find(
+                    (fieldName) =>
+                      fieldName !== 'title' && fieldName !== 'actionType',
+                  );
+
+                  if (hasMadeChanges && actionType) {
                     setNextActionType(action);
 
                     return;
                   }
 
-                  setValue(DECISION_METHOD_FIELD_NAME, undefined);
                   onChange(action);
                 }}
               />
@@ -128,8 +129,15 @@ const ActionTypeSelect: FC<ActionTypeSelectProps> = ({ className }) => {
         isOpen={!!nextActionType}
         onClose={() => setNextActionType(undefined)}
         onConfirm={() => {
-          setValue(ACTION_TYPE_FIELD_NAME, nextActionType);
-          setValue(DECISION_METHOD_FIELD_NAME, undefined);
+          reset();
+
+          if (title) {
+            setValue(TITLE_FIELD_NAME, title, { shouldDirty: true });
+          }
+
+          setValue(ACTION_TYPE_FIELD_NAME, nextActionType, {
+            shouldDirty: true,
+          });
           setNextActionType(undefined);
         }}
         icon={WarningCircle}

--- a/src/components/v5/common/ActionSidebar/ActionTypeSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionTypeSelect.tsx
@@ -12,7 +12,7 @@ import SearchSelect from '~v5/shared/SearchSelect/index.ts';
 
 import ActionFormRow from '../ActionFormRow/index.ts';
 
-import { ACTION_TYPE_FIELD_NAME, TITLE_FIELD_NAME } from './consts.ts';
+import { ACTION_TYPE_FIELD_NAME, NON_RESETTABLE_FIELDS } from './consts.ts';
 import useActionsList from './hooks/useActionsList.ts';
 import { translateAction } from './utils.ts';
 
@@ -39,9 +39,19 @@ const ActionTypeSelect: FC<ActionTypeSelectProps> = ({ className }) => {
     HTMLButtonElement,
     HTMLDivElement
   >([isSelectVisible]);
-  const { formState, setValue, reset, watch } = useFormContext();
+  const { formState, reset, watch } = useFormContext();
   const { readonly } = useAdditionalFormOptionsContext();
-  const title = watch('title');
+
+  const defaultValues = NON_RESETTABLE_FIELDS.reduce(
+    (acc, fieldName) => ({
+      ...acc,
+      [fieldName]:
+        fieldName === ACTION_TYPE_FIELD_NAME
+          ? nextActionType
+          : watch(fieldName),
+    }),
+    {},
+  );
 
   return (
     <div className={className}>
@@ -105,7 +115,7 @@ const ActionTypeSelect: FC<ActionTypeSelectProps> = ({ className }) => {
                     formState.dirtyFields,
                   ).find(
                     (fieldName) =>
-                      fieldName !== 'title' && fieldName !== 'actionType',
+                      NON_RESETTABLE_FIELDS.indexOf(fieldName) === -1,
                   );
 
                   if (hasMadeChanges && actionType) {
@@ -129,15 +139,7 @@ const ActionTypeSelect: FC<ActionTypeSelectProps> = ({ className }) => {
         isOpen={!!nextActionType}
         onClose={() => setNextActionType(undefined)}
         onConfirm={() => {
-          reset();
-
-          if (title) {
-            setValue(TITLE_FIELD_NAME, title, { shouldDirty: true });
-          }
-
-          setValue(ACTION_TYPE_FIELD_NAME, nextActionType, {
-            shouldDirty: true,
-          });
+          reset(defaultValues);
           setNextActionType(undefined);
         }}
         icon={WarningCircle}

--- a/src/components/v5/common/ActionSidebar/consts.ts
+++ b/src/components/v5/common/ActionSidebar/consts.ts
@@ -15,6 +15,8 @@ export const TITLE_FIELD_NAME = 'title';
 export const DESCRIPTION_FIELD_NAME = 'description';
 export const CREATED_IN_FIELD_NAME = 'createdIn';
 
+export const NON_RESETTABLE_FIELDS = [TITLE_FIELD_NAME, ACTION_TYPE_FIELD_NAME];
+
 export const actionSidebarAnimation: Variants = {
   hidden: {
     x: '100%',

--- a/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
@@ -42,7 +42,7 @@ const AmountField: FC<AmountFieldProps> = ({
   } = useController({
     name: 'tokenAddress',
   });
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState<string | undefined>(undefined);
   const isError = !!error || !!tokenAddressError;
   const { colony } = useColonyContext();
   const [
@@ -65,9 +65,12 @@ const AmountField: FC<AmountFieldProps> = ({
   };
 
   useEffect(() => {
-    const unformattedValue = unformatNumeral(value);
-    if (field.value !== unformattedValue) {
-      field.onChange(unformatNumeral(value));
+    if (value) {
+      const unformattedValue = unformatNumeral(value);
+
+      if (field.value !== unformattedValue) {
+        field.onChange(unformatNumeral(value));
+      }
     }
   }, [value, field]);
 


### PR DESCRIPTION
With these changes, now the modal should show only when you edit any fields other than the action type and title. Otherwise, it should never show when you change from one action type to another, for example.

Resolves #2089 
