### PR TITLE
fix: two way binding of FormFormattedInput

### DIFF
--- a/src/components/v5/common/Fields/InputBase/FormFormattedInput.tsx
+++ b/src/components/v5/common/Fields/InputBase/FormFormattedInput.tsx
@@ -14,7 +14,7 @@ const FormFormattedInput: FC<FormFormattedInputProps> = ({
   ...rest
 }) => {
   const {
-    field: { value },
+    field: { value, onChange },
     fieldState: { invalid, error },
   } = useController({
     name,
@@ -24,6 +24,7 @@ const FormFormattedInput: FC<FormFormattedInputProps> = ({
     <FormattedInput
       message={error?.message}
       {...rest}
+      onChange={onChange}
       type={type}
       value={value}
       state={invalid ? FieldState.Error : undefined}


### PR DESCRIPTION
## Description

This fixes 2 bugs, both appearing on the token activation modal
![image](https://github.com/JoinColony/colonyCDapp/assets/23449297/3c1cb314-6cc5-4204-914c-0da847e51e59)

and the staking widget

![image](https://github.com/JoinColony/colonyCDapp/assets/23449297/452b7198-b5c3-4fdb-8532-5c05178fc16c)

The first bug was that if you entered a number manually, it didn't work, it just threw an error that you need to enter a value.
The second bug was that if you clicked `Max` and then tried to change the value, it broke and the console spat out an error.

## Testing

Try both of those cases to see if they were fixed :D 

## Diffs

**Changes** 🏗

* two way data binding for `FormFormattedInput` restored



Resolves #2092 and #2093 (maybe I should have foreseen them being the same issue :facepalm: )
