### PR TITLE
Fix: Restore UserNavigation submenu classes

### DIFF
--- a/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Contact/Contact.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Contact/Contact.tsx
@@ -21,6 +21,7 @@ import { formatText } from '~utils/intl.ts';
 import { ICON_SIZE, ICON_SIZE_MOBILE } from '../consts.ts';
 import MenuList from '../MenuList/index.ts';
 import MenuListItem from '../MenuListItem/index.ts';
+import { actionItemClass, actionItemLabelClass } from '../submenu.styles.ts';
 
 const displayName =
   'common.Extensions.UserNavigation.partials.UserSubmenu.partials.Contact';
@@ -55,33 +56,41 @@ const Contact = () => {
   return (
     <MenuList>
       <MenuListItem>
-        <ExternalLink href={COLONY_DOCS}>
+        <ExternalLink href={COLONY_DOCS} className={actionItemClass}>
           <Lifebuoy size={iconSize} />
-          <p className="ml-2">{formatText(MSG.getHelp)}</p>
+          <p className={actionItemLabelClass}>{formatText(MSG.getHelp)}</p>
         </ExternalLink>
       </MenuListItem>
       <MenuListItem>
-        <button type="button" onClick={openWhatsNew}>
+        <button
+          type="button"
+          onClick={openWhatsNew}
+          className={actionItemClass}
+        >
           <Star size={iconSize} />
-          <p className="ml-2">{formatText(MSG.whatsNew)}</p>
+          <p className={actionItemLabelClass}>{formatText(MSG.whatsNew)}</p>
         </button>
       </MenuListItem>
       <MenuListItem>
-        <button type="button" onClick={openFeaturesBugs}>
+        <button
+          type="button"
+          onClick={openFeaturesBugs}
+          className={actionItemClass}
+        >
           <Bug size={iconSize} />
-          <p className="ml-2">{formatText(MSG.featureBugs)}</p>
+          <p className={actionItemLabelClass}>{formatText(MSG.featureBugs)}</p>
         </button>
       </MenuListItem>
       <MenuListItem>
-        <ExternalLink href={COLONY_DISCORD}>
+        <ExternalLink href={COLONY_DISCORD} className={actionItemClass}>
           <DiscordLogo size={iconSize} />
-          <p className="ml-2">{formatText(MSG.discord)}</p>
+          <p className={actionItemLabelClass}>{formatText(MSG.discord)}</p>
         </ExternalLink>
       </MenuListItem>
       <MenuListItem>
-        <ExternalLink href={COLONY_TWITTER}>
+        <ExternalLink href={COLONY_TWITTER} className={actionItemClass}>
           <TwitterLogo size={iconSize} />
-          <p className="ml-2">{formatText(MSG.twitter)}</p>
+          <p className={actionItemLabelClass}>{formatText(MSG.twitter)}</p>
         </ExternalLink>
       </MenuListItem>
     </MenuList>

--- a/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Currency/Currency.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Currency/Currency.tsx
@@ -28,13 +28,13 @@ const Currency = ({ closeSubmenu }: CurrencyProps) => {
 
   return (
     <>
-      <MenuList className="columns-2">
+      <MenuList className="grid w-[calc(100%+2rem)] grid-cols-2">
         {Object.values(SupportedCurrencies)
           .reverse()
           .map((currency) => {
             const CurrencyIcon = currencyIcons[currency] || ClnyTokenIcon;
             return (
-              <MenuListItem key={currency}>
+              <MenuListItem key={currency} className="w-full">
                 <button
                   type="button"
                   onClick={() => {

--- a/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Currency/Currency.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Currency/Currency.tsx
@@ -8,6 +8,7 @@ import { currencyIcons } from '../../../UserMenu/consts.ts';
 import CoinGeckoAttribution from '../../CoinGeckoAttribution.tsx';
 import MenuList from '../MenuList/index.ts';
 import MenuListItem from '../MenuListItem/index.ts';
+import { actionItemClass, actionItemLabelClass } from '../submenu.styles.ts';
 
 const displayName =
   'common.Extensions.UserNavigation.partials.UserSubmenu.partials.Currency';
@@ -39,9 +40,12 @@ const Currency = ({ closeSubmenu }: CurrencyProps) => {
                   onClick={() => {
                     handleCurrencyClick(currency);
                   }}
+                  className={actionItemClass}
                 >
                   <CurrencyIcon size={iconSize} />
-                  <p>{currency.toUpperCase()}</p>
+                  <p className={actionItemLabelClass}>
+                    {currency.toUpperCase()}
+                  </p>
                 </button>
               </MenuListItem>
             );

--- a/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Developers/Developers.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Developers/Developers.tsx
@@ -10,6 +10,7 @@ import { formatText } from '~utils/intl.ts';
 import { ICON_SIZE, ICON_SIZE_MOBILE } from '../consts.ts';
 import MenuList from '../MenuList/index.ts';
 import MenuListItem from '../MenuListItem/index.ts';
+import { actionItemClass, actionItemLabelClass } from '../submenu.styles.ts';
 
 const displayName =
   'common.Extensions.UserNavigation.partials.UserSubmenu.partials.Developers';
@@ -32,15 +33,17 @@ const Developers = () => {
   return (
     <MenuList>
       <MenuListItem>
-        <ExternalLink href={COLONY_DEV_DOCS}>
+        <ExternalLink href={COLONY_DEV_DOCS} className={actionItemClass}>
           <Code size={iconSize} />
-          <p className="ml-2">{formatText(MSG.developerDocs)}</p>
+          <p className={actionItemLabelClass}>
+            {formatText(MSG.developerDocs)}
+          </p>
         </ExternalLink>
       </MenuListItem>
       <MenuListItem>
-        <ExternalLink href={COLONY_GITHUB}>
+        <ExternalLink href={COLONY_GITHUB} className={actionItemClass}>
           <GithubLogo size={iconSize} />
-          <p className="ml-2">{formatText(MSG.github)}</p>
+          <p className={actionItemLabelClass}>{formatText(MSG.github)}</p>
         </ExternalLink>
       </MenuListItem>
     </MenuList>

--- a/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Legal/Legal.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Legal/Legal.tsx
@@ -10,6 +10,7 @@ import { formatText } from '~utils/intl.ts';
 import { ICON_SIZE, ICON_SIZE_MOBILE } from '../consts.ts';
 import MenuList from '../MenuList/index.ts';
 import MenuListItem from '../MenuListItem/index.ts';
+import { actionItemClass, actionItemLabelClass } from '../submenu.styles.ts';
 
 const displayName =
   'common.Extensions.UserNavigation.partials.UserSubmenu.partials.Legal';
@@ -32,15 +33,17 @@ const Legal = () => {
   return (
     <MenuList>
       <MenuListItem>
-        <ExternalLink href={PRIVACY_POLICY}>
+        <ExternalLink href={PRIVACY_POLICY} className={actionItemClass}>
           <FileText size={iconSize} />
-          <p className="ml-2">{formatText(MSG.privacyPolicy)}</p>
+          <p className={actionItemLabelClass}>
+            {formatText(MSG.privacyPolicy)}
+          </p>
         </ExternalLink>
       </MenuListItem>
       <MenuListItem>
-        <ExternalLink href={TERMS_AND_CONDITIONS}>
+        <ExternalLink href={TERMS_AND_CONDITIONS} className={actionItemClass}>
           <Files size={iconSize} />
-          <p className="ml-2">{formatText(MSG.termsOfUse)}</p>
+          <p className={actionItemLabelClass}>{formatText(MSG.termsOfUse)}</p>
         </ExternalLink>
       </MenuListItem>
     </MenuList>

--- a/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/MenuListItem/MenuListItem.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/MenuListItem/MenuListItem.tsx
@@ -1,13 +1,19 @@
+import clsx from 'clsx';
 import React, { type PropsWithChildren } from 'react';
 
 const displayName =
   'common.Extensions.UserNavigation.partials.UserSubmenu.blocks.MenuListItem';
 
-type MenuListItemProps = PropsWithChildren<unknown>;
+type MenuListItemProps = PropsWithChildren<unknown> & { className?: string };
 
-const MenuListItem = ({ children }: MenuListItemProps) => {
+const MenuListItem = ({ children, className }: MenuListItemProps) => {
   return (
-    <li className="-ml-4 mb-2 w-[calc(100%+2rem)] rounded last:mb-0 hover:bg-gray-50 sm:mb-0">
+    <li
+      className={clsx(
+        '-ml-4 mb-2 w-[calc(100%+2rem)] rounded last:mb-0 hover:bg-gray-50 sm:mb-0',
+        className,
+      )}
+    >
       {children}
     </li>
   );

--- a/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/MenuListItem/MenuListItem.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/MenuListItem/MenuListItem.tsx
@@ -4,7 +4,7 @@ import React, { type PropsWithChildren } from 'react';
 const displayName =
   'common.Extensions.UserNavigation.partials.UserSubmenu.blocks.MenuListItem';
 
-type MenuListItemProps = PropsWithChildren<unknown> & { className?: string };
+type MenuListItemProps = PropsWithChildren<{ className?: string }>;
 
 const MenuListItem = ({ children, className }: MenuListItemProps) => {
   return (

--- a/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/submenu.styles.ts
+++ b/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/submenu.styles.ts
@@ -1,0 +1,6 @@
+import { tw } from '~utils/css/index.ts';
+
+const actionItemClass = tw`sm:mr-0" navigation-link mr-2 flex shrink-0 flex-grow items-center`;
+const actionItemLabelClass = tw`ml-2`;
+
+export { actionItemClass, actionItemLabelClass };


### PR DESCRIPTION
## Description

This PR restores the UserNavigation submenu classes that were accidentally removed as part of the vite refactor.

## Testing

Check each of the usernavigation submenus are styled as expected.

## Diffs

**Changes** 🏗

* Created new submenu.styles.ts file for shared tailwind classes
* Restored the classes to each of the submenus.

Resolves #2091

<img width="413" alt="Screenshot 2024-03-27 at 12 27 22" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/269a115b-8cf1-4de0-a2e7-8fc4c25992f1">

<img width="423" alt="Screenshot 2024-03-27 at 12 27 27" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/58ea517f-0c05-4e12-9e78-4fb92c0d923a">
