### PR TITLE
feat: funding overview box

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizeWithPermissionsInfo/index.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizeWithPermissionsInfo/index.ts
@@ -1,1 +1,0 @@
-export { default } from './FinalizeWithPermissionsInfo.tsx';

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/index.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/index.ts
@@ -1,1 +1,0 @@
-export { default } from './PaymentStepDetailsBlock.tsx';

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StepDetailsBlock/index.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StepDetailsBlock/index.ts
@@ -1,1 +1,0 @@
-export { default } from './StepDetailsBlock.tsx';


### PR DESCRIPTION
## Description

- Added overview box for funding step

## Testing

* Step 1. Create Payment Builder Action
* Step 2. Click the "Confirm details" button and wait for the lock expenditure action to be completed
* Step 3. Click the "Fund" button to open the Funding modal, select "Permissions" decision method and click "Confirm payment" and wait for the action to be completed
* Step 4. Click on "Funding" step pill

## Diffs

**New stuff** ✨

* `FinalizeWithPermissionsInfo` component rendered instead of `StepDetailsBlock` component, when the active step is different than `ExpenditureStep.Funding` and if there are any `items` in `fundingActions` object from `expenditure`

**Changes** 🏗

* no changes

**Deletions** ⚰️

* no deletions

Contributes to https://github.com/JoinColony/colonyCDapp/issues/2005
Waiting for https://github.com/JoinColony/colonyCDapp/pull/2085 to be merged
