### PR TITLE
fix: payment builder table tablet layout

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/PaymentBuilderRecipientsField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/PaymentBuilderRecipientsField.tsx
@@ -84,6 +84,7 @@ const PaymentBuilderRecipientsField: FC<PaymentBuilderRecipientsFieldProps> = ({
           className={clsx('[&_tfoot_td]:py-2 [&_tfoot_td]:align-top', {
             '!border-negative-400': !!fieldState.error,
           })}
+          changeLayoutBreakpoint="tablet"
           getRowId={({ key }) => key}
           columns={columns}
           data={data}

--- a/src/components/v5/common/CompletedAction/partials/rows/PaymentBuilderTable/PaymentBuilderTable.tsx
+++ b/src/components/v5/common/CompletedAction/partials/rows/PaymentBuilderTable/PaymentBuilderTable.tsx
@@ -200,8 +200,9 @@ const PaymentBuilderTable = ({ items }: PaymentBuilderTableProps) => {
       </h5>
       <Table<PaymentBuilderTableModel>
         className={clsx(
-          'sm:[&_tbody>td>div]:p-[1.1rem] sm:[&_tbody>tr>td]:!border-none [&_tfoot>tr>td]:border-gray-200 [&_tfoot>tr>td]:py-2 sm:[&_tfoot>tr>td]:border-t',
+          'md:[&_tbody>td>div]:p-[1.1rem] md:[&_tbody>tr>td]:!border-none [&_tfoot>tr>td]:border-gray-200 [&_tfoot>tr>td]:py-2 md:[&_tfoot>tr>td]:border-t',
         )}
+        changeLayoutBreakpoint="tablet"
         data={data}
         columns={columns}
       />

--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -9,7 +9,7 @@ import {
 import clsx from 'clsx';
 import React, { useMemo } from 'react';
 
-import { useMobile } from '~hooks/index.ts';
+import { useMobile, useTablet } from '~hooks/index.ts';
 import { formatText } from '~utils/intl.ts';
 import Button from '~v5/shared/Button/index.ts';
 import MeatBallMenu from '~v5/shared/MeatBallMenu/index.ts';
@@ -43,15 +43,20 @@ const Table = <T,>({
   columns,
   renderSubComponent,
   getRowCanExpand,
+  changeLayoutBreakpoint = 'mobile',
   ...rest
 }: TableProps<T>) => {
   const isMobile = useMobile();
+  const isTablet = useTablet();
+  const shouldShowMobileContent =
+    (changeLayoutBreakpoint === 'mobile' && isMobile) ||
+    (changeLayoutBreakpoint === 'tablet' && isTablet);
   const helper = useMemo(() => createColumnHelper<T>(), []);
 
   const columnsWithMenu = useMemo(
     () => [
       ...columns,
-      ...(getMenuProps && !(isMobile && verticalOnMobile)
+      ...(getMenuProps && !(shouldShowMobileContent && verticalOnMobile)
         ? [
             makeMenuColumn<T>(
               helper,
@@ -65,7 +70,7 @@ const Table = <T,>({
     [
       columns,
       getMenuProps,
-      isMobile,
+      shouldShowMobileContent,
       verticalOnMobile,
       helper,
       meatBallMenuSize,
@@ -118,7 +123,7 @@ const Table = <T,>({
         cellPadding="0"
         cellSpacing="0"
       >
-        {isMobile && verticalOnMobile ? (
+        {shouldShowMobileContent && verticalOnMobile ? (
           rows.map((row) => {
             const cells = row.getVisibleCells();
             const columnsCount = cells.length - 1;
@@ -353,7 +358,13 @@ const Table = <T,>({
                 {footerGroup.headers.map((column) => (
                   <td
                     key={column.id}
-                    className="h-full border-gray-200 px-[1.1rem] text-md text-gray-500 sm:border-t"
+                    className={clsx(
+                      'h-full border-gray-200 px-[1.1rem] text-md text-gray-500',
+                      {
+                        'sm:border-t': changeLayoutBreakpoint === 'mobile',
+                        'md:border-t': changeLayoutBreakpoint === 'tablet',
+                      },
+                    )}
                   >
                     {flexRender(
                       column.column.columnDef.footer,
@@ -375,18 +386,42 @@ const Table = <T,>({
               {
                 'sm:grid-cols-[1fr_auto_auto]':
                   canGoToNextPage ||
-                  (additionalPaginationButtonsContent && isMobile),
+                  (additionalPaginationButtonsContent &&
+                    shouldShowMobileContent &&
+                    changeLayoutBreakpoint === 'mobile'),
+                'md:grid-cols-[1fr_auto_auto]':
+                  canGoToNextPage ||
+                  (additionalPaginationButtonsContent &&
+                    shouldShowMobileContent &&
+                    changeLayoutBreakpoint === 'tablet'),
                 'sm:grid-cols-[1fr_auto]': !(
                   canGoToNextPage ||
-                  (additionalPaginationButtonsContent && isMobile)
+                  (additionalPaginationButtonsContent &&
+                    shouldShowMobileContent &&
+                    changeLayoutBreakpoint === 'mobile')
+                ),
+                'md:grid-cols-[1fr_auto]': !(
+                  canGoToNextPage ||
+                  (additionalPaginationButtonsContent &&
+                    shouldShowMobileContent &&
+                    changeLayoutBreakpoint === 'tablet')
                 ),
               },
             )}
           >
             {(canGoToPreviousPage ||
-              (additionalPaginationButtonsContent && !isMobile)) && (
-              <div className="col-start-1 row-start-1 flex items-center justify-start gap-3 sm:col-start-2">
-                {!isMobile && additionalPaginationButtonsContent}
+              (additionalPaginationButtonsContent &&
+                !shouldShowMobileContent)) && (
+              <div
+                className={clsx(
+                  'col-start-1 row-start-1 flex items-center justify-start gap-3',
+                  {
+                    'sm:col-start-2': changeLayoutBreakpoint === 'mobile',
+                    'md:col-start-2': changeLayoutBreakpoint === 'tablet',
+                  },
+                )}
+              >
+                {!shouldShowMobileContent && additionalPaginationButtonsContent}
                 {canGoToPreviousPage && (
                   <Button
                     onClick={goToPreviousPage}
@@ -400,7 +435,17 @@ const Table = <T,>({
               </div>
             )}
             {showPageNumber && (
-              <p className="col-start-2 row-start-1 w-full text-center text-gray-700 text-3 sm:col-start-1 sm:w-auto sm:text-left">
+              <p
+                className={clsx(
+                  'col-start-2 row-start-1 w-full text-center text-gray-700 text-3 ',
+                  {
+                    'sm:col-start-1 sm:w-auto sm:text-left':
+                      changeLayoutBreakpoint === 'mobile',
+                    'md:col-start-1 md:w-auto md:text-left':
+                      changeLayoutBreakpoint === 'tablet',
+                  },
+                )}
+              >
                 {formatText(
                   {
                     id: showTotalPagesNumber
@@ -415,9 +460,10 @@ const Table = <T,>({
               </p>
             )}
             {(canGoToNextPage ||
-              (additionalPaginationButtonsContent && isMobile)) && (
+              (additionalPaginationButtonsContent &&
+                shouldShowMobileContent)) && (
               <div className="col-start-3 row-start-1 flex items-center justify-end gap-3">
-                {isMobile && additionalPaginationButtonsContent}
+                {shouldShowMobileContent && additionalPaginationButtonsContent}
                 {canGoToNextPage && (
                   <Button
                     onClick={goToNextPage}

--- a/src/components/v5/common/Table/types.ts
+++ b/src/components/v5/common/Table/types.ts
@@ -37,4 +37,5 @@ export interface TableProps<T>
   meatBallMenuStaticSize?: string;
   renderSubComponent?: (props: { row: Row<T> }) => React.ReactElement;
   getRowCanExpand?: (row: Row<T>) => boolean;
+  changeLayoutBreakpoint?: 'mobile' | 'tablet';
 }


### PR DESCRIPTION
## Description

- Payment Builder table tablet view is the same as the mobile view

A bug with not showing the total values in the table was resolved in this PR: https://github.com/JoinColony/colonyCDapp/pull/2102

## Testing

* Step 1. Open Action Sidebar on tablet screen size i.e. between 1040px and 480px.
* Step 2. Select "Payment builder" action type
* Step 3. Add payment

## Diffs

**New stuff** ✨

* no new stuff

**Changes** 🏗

* additional `changeLayoutBreakpoint` prop added to the `Table` component so that we can pick if the mobile view should start from tablet or mobile breakpoint.

**Deletions** ⚰️

* no deletions


Resolves https://github.com/JoinColony/colonyCDapp/issues/2072
