### PR TITLE
fix: added expenditure refetch after funding/releasing

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/PaymentBuilder.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/PaymentBuilder.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { defineMessages } from 'react-intl';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
-import useToggle from '~hooks/useToggle/index.ts';
 import SpinnerLoader from '~shared/Preloaders/SpinnerLoader.tsx';
 import { type ColonyAction } from '~types/graphql.ts';
 import { findDomainByNativeId } from '~utils/domains.ts';
@@ -21,9 +20,6 @@ import DecisionMethodRow from '../rows/DecisionMethod.tsx';
 import DescriptionRow from '../rows/Description.tsx';
 import PaymentBuilderTable from '../rows/PaymentBuilderTable/PaymentBuilderTable.tsx';
 import TeamFromRow from '../rows/TeamFrom.tsx';
-
-import FundingModal from './partials/FundingModal/FundingModal.tsx';
-import ReleasePaymentModal from './partials/ReleasePaymentModal/index.ts';
 
 interface PaymentBuilderProps {
   action: ColonyAction;
@@ -47,15 +43,10 @@ const PaymentBuilder = ({ action }: PaymentBuilderProps) => {
   const { colony } = useColonyContext();
   const { customTitle = formatText(MSG.defaultTitle) } = action?.metadata || {};
   const { initiatorUser } = action;
-  const [isFundingModalOpen, { toggleOn, toggleOff }] = useToggle();
 
-  const { expenditure, refetchExpenditure, loadingExpenditure } =
-    useGetExpenditureData(action.expenditureId);
-
-  const [
-    isReleasePaymentModalOpen,
-    { toggleOn: releasePaymentToggleOn, toggleOff: releasePaymentToggleOff },
-  ] = useToggle();
+  const { expenditure, loadingExpenditure } = useGetExpenditureData(
+    action.expenditureId,
+  );
 
   if (loadingExpenditure) {
     return (
@@ -143,28 +134,6 @@ const PaymentBuilder = ({ action }: PaymentBuilderProps) => {
         <DescriptionRow description={action.annotation.message} />
       )}
       {!!slots.length && <PaymentBuilderTable items={slots} />}
-
-      <button type="button" onClick={toggleOn}>
-        temp fund
-      </button>
-
-      <FundingModal
-        isOpen={isFundingModalOpen}
-        onClose={toggleOff}
-        expenditure={expenditure}
-        refetchExpenditure={refetchExpenditure}
-      />
-
-      <button type="button" onClick={releasePaymentToggleOn}>
-        temp release payment modal
-      </button>
-
-      <ReleasePaymentModal
-        expenditure={expenditure}
-        isOpen={isReleasePaymentModalOpen}
-        onClose={releasePaymentToggleOff}
-        refetchExpenditure={refetchExpenditure}
-      />
     </>
   );
 };

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/PaymentBuilder.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/PaymentBuilder.tsx
@@ -49,9 +49,8 @@ const PaymentBuilder = ({ action }: PaymentBuilderProps) => {
   const { initiatorUser } = action;
   const [isFundingModalOpen, { toggleOn, toggleOff }] = useToggle();
 
-  const { expenditure, loadingExpenditure } = useGetExpenditureData(
-    action.expenditureId,
-  );
+  const { expenditure, refetchExpenditure, loadingExpenditure } =
+    useGetExpenditureData(action.expenditureId);
 
   const [
     isReleasePaymentModalOpen,
@@ -153,6 +152,7 @@ const PaymentBuilder = ({ action }: PaymentBuilderProps) => {
         isOpen={isFundingModalOpen}
         onClose={toggleOff}
         expenditure={expenditure}
+        refetchExpenditure={refetchExpenditure}
       />
 
       <button type="button" onClick={releasePaymentToggleOn}>

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/PaymentBuilder.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/PaymentBuilder.tsx
@@ -163,6 +163,7 @@ const PaymentBuilder = ({ action }: PaymentBuilderProps) => {
         expenditure={expenditure}
         isOpen={isReleasePaymentModalOpen}
         onClose={releasePaymentToggleOff}
+        refetchExpenditure={refetchExpenditure}
       />
     </>
   );

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/FundingModal.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/FundingModal.tsx
@@ -24,6 +24,7 @@ import { type FundingModalProps, type TokenItemProps } from './types.ts';
 const FundingModal: FC<FundingModalProps> = ({
   onClose,
   expenditure,
+  refetchExpenditure,
   ...rest
 }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -79,6 +80,10 @@ const FundingModal: FC<FundingModalProps> = ({
       };
 
       await fundExpenditure(payload);
+      await refetchExpenditure({
+        expenditureId: expenditure.id,
+      });
+
       setIsSubmitting(false);
       onClose();
     } catch (err) {

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/types.ts
@@ -2,8 +2,11 @@ import { type ExpenditurePayout } from '~gql';
 import { type Expenditure } from '~types/graphql.ts';
 import { type ModalProps } from '~v5/shared/Modal/types.ts';
 
+import { type RefetchExpenditureType } from '../../types.ts';
+
 export type TokenItemProps = Omit<ExpenditurePayout, 'isClaimed'>;
 
 export interface FundingModalProps extends ModalProps {
   expenditure: Expenditure;
+  refetchExpenditure: RefetchExpenditureType;
 }

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/PaymentBuilderWidget.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/PaymentBuilderWidget.tsx
@@ -2,6 +2,7 @@ import React, { useState, type FC, useEffect } from 'react';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import useToggle from '~hooks/useToggle/index.ts';
 import { ActionTypes } from '~redux';
 import { type LockExpenditurePayload } from '~redux/sagas/expenditures/lockExpenditure.ts';
 import SpinnerLoader from '~shared/Preloaders/SpinnerLoader.tsx';
@@ -14,7 +15,9 @@ import Stepper from '~v5/shared/Stepper/index.ts';
 import { type StepperItem } from '~v5/shared/Stepper/types.ts';
 
 import FinalizeWithPermissionsInfo from '../FinalizeWithPermissionsInfo/index.ts';
+import FundingModal from '../FundingModal/FundingModal.tsx';
 import PaymentStepDetailsBlock from '../PaymentStepDetailsBlock/index.ts';
+import ReleasePaymentModal from '../ReleasePaymentModal/ReleasePaymentModal.tsx';
 import StepDetailsBlock from '../StepDetailsBlock/index.ts';
 
 import { ExpenditureStep, type PaymentBuilderWidgetProps } from './types.ts';
@@ -25,6 +28,12 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
   const { user } = useAppContext();
   const { walletAddress } = user || {};
   const { expenditureId } = action;
+
+  const [isFundingModalOpen, { toggleOn, toggleOff }] = useToggle();
+  const [
+    isReleasePaymentModalOpen,
+    { toggleOn: releasePaymentToggleOn, toggleOff: releasePaymentToggleOff },
+  ] = useToggle();
 
   const {
     expenditure,
@@ -115,8 +124,7 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
           content={
             <Button
               className="w-full"
-              // @todo: replace onClick with actual functionality
-              onClick={() => setActiveStepKey(ExpenditureStep.Release)}
+              onClick={toggleOn}
               text={formatText({
                 id: 'expenditure.fundingStage.button',
               })}
@@ -137,8 +145,7 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
           content={
             <Button
               className="w-full"
-              // @todo: replace onClick with actual functionality
-              onClick={() => setActiveStepKey(ExpenditureStep.Payment)}
+              onClick={releasePaymentToggleOn}
               text={formatText({
                 id: 'expenditure.releaseStage.button',
               })}
@@ -159,11 +166,29 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
   }
 
   return (
-    <Stepper<ExpenditureStep>
-      items={items}
-      activeStepKey={activeStepKey}
-      setActiveStepKey={setActiveStepKey}
-    />
+    <>
+      <Stepper<ExpenditureStep>
+        items={items}
+        activeStepKey={activeStepKey}
+        setActiveStepKey={setActiveStepKey}
+      />
+      {expenditure && (
+        <>
+          <ReleasePaymentModal
+            expenditure={expenditure}
+            isOpen={isReleasePaymentModalOpen}
+            onClose={releasePaymentToggleOff}
+            refetchExpenditure={refetchExpenditure}
+          />
+          <FundingModal
+            isOpen={isFundingModalOpen}
+            onClose={toggleOff}
+            expenditure={expenditure}
+            refetchExpenditure={refetchExpenditure}
+          />
+        </>
+      )}
+    </>
   );
 };
 

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/ReleasePaymentModal/ReleasePaymentModal.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/ReleasePaymentModal/ReleasePaymentModal.tsx
@@ -24,6 +24,7 @@ const ReleasePaymentModal: FC<ReleasePaymentModalProps> = ({
   expenditure,
   isOpen,
   onClose,
+  refetchExpenditure,
   ...rest
 }) => {
   const { colony } = useColonyContext();
@@ -52,6 +53,7 @@ const ReleasePaymentModal: FC<ReleasePaymentModalProps> = ({
       };
 
       await finalizeExpenditure(finalizePayload);
+      await refetchExpenditure({ expenditureId: expenditure.id });
       setIsSubmitting(false);
       onClose();
     } catch (err) {

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/ReleasePaymentModal/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/ReleasePaymentModal/types.ts
@@ -1,6 +1,9 @@
 import { type Expenditure } from '~types/graphql.ts';
 import { type ModalProps } from '~v5/shared/Modal/types.ts';
 
+import { type RefetchExpenditureType } from '../../types.ts';
+
 export interface ReleasePaymentModalProps extends ModalProps {
   expenditure: Expenditure;
+  refetchExpenditure: RefetchExpenditureType;
 }

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/types.ts
@@ -1,0 +1,7 @@
+import { type ApolloQueryResult } from '@apollo/client';
+
+import { type GetExpenditureQuery } from '~gql';
+
+export type RefetchExpenditureType = (variables?: {
+  expenditureId: string;
+}) => Promise<ApolloQueryResult<GetExpenditureQuery>>;


### PR DESCRIPTION
## Description

- Refetching expenditure data after funding and releasing actions. This is needed to refresh the data in the stepper and move to the next step
- Going from funding step to release is handled in this [PR](https://github.com/JoinColony/colonyCDapp/pull/2101)