### PR TITLE
Close colony menu on action button push

### DIFF
--- a/src/components/frame/Extensions/layouts/ColonySidebar.tsx
+++ b/src/components/frame/Extensions/layouts/ColonySidebar.tsx
@@ -9,6 +9,7 @@ import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import LearnMore from '~shared/Extensions/LearnMore/index.ts';
 import { formatText } from '~utils/intl.ts';
 import NavigationSidebar from '~v5/frame/NavigationSidebar/index.ts';
+import useNavigationSidebarContext from '~v5/frame/NavigationSidebar/partials/NavigationSidebarContext/hooks.ts';
 import Button from '~v5/shared/Button/index.ts';
 
 import { useMainMenuItems } from './hooks.tsx';
@@ -25,6 +26,8 @@ interface Props {
 }
 
 const ColonySidebar = ({ txButtons, userHub, transactionId }: Props) => {
+  const { mobileMenuToggle } = useNavigationSidebarContext();
+  const [, { toggleOff: toggleOffMenu }] = mobileMenuToggle;
   const mainMenuItems = useMainMenuItems(!!transactionId);
   const {
     actionSidebarToggle: [, { toggle: toggleActionSideBar }],
@@ -47,7 +50,10 @@ const ColonySidebar = ({ txButtons, userHub, transactionId }: Props) => {
           <Button
             icon={Plus}
             className="w-full"
-            onClick={() => toggleActionSideBar()}
+            onClick={() => {
+              toggleOffMenu();
+              toggleActionSideBar();
+            }}
           >
             {formatText({ id: 'button.createNewAction' })}
           </Button>

--- a/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarThirdLevel/NavigationSidebarThirdLevel.tsx
+++ b/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarThirdLevel/NavigationSidebarThirdLevel.tsx
@@ -22,7 +22,8 @@ const NavigationSidebarThirdLevel: FC<NavigationSidebarThirdLevelProps> = ({
 }) => {
   const isTablet = useTablet();
   const [isOpen, { toggle }] = useToggle();
-  const { setOpenItemIndex } = useNavigationSidebarContext();
+  const { mobileMenuToggle, setOpenItemIndex } = useNavigationSidebarContext();
+  const [, { toggleOff: toggleOffMenu }] = mobileMenuToggle;
 
   if (!items.length) {
     throw new Error('NavigationSidebarThirdLevel: items are required');
@@ -44,6 +45,7 @@ const NavigationSidebarThirdLevel: FC<NavigationSidebarThirdLevelProps> = ({
               type="button"
               className={ctaClassName}
               onClick={(e) => {
+                toggleOffMenu();
                 setOpenItemIndex(undefined);
                 onClick?.(e);
               }}


### PR DESCRIPTION
## Description

When on mobile or generally small-ish screens the colony menu stayed open when clicking the "Create action" button. This resulted in a state where seemingly nothing happened as the colony menu was covering the action sidebar. This fixes that by closing the colony menu before the action sidebar is opened. This also applies for all the "related actions" that now close the menu as well, when clicked.


## Testing

* Step 1. Be on mobile or a small screen
* Step 2. Click the "Create action" button in the colony sidebar
* Step 2a) Click on any of the "related actions"
* Step 3. The action sidebar appears

Closes #2078 
