### PR TITLE
feat: remove reputation decision method from payment builder form

### DIFF
--- a/src/components/v5/common/ActionSidebar/hooks/permissions/helpers.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/helpers.ts
@@ -44,6 +44,8 @@ export const getPermissionsNeededForAction = (
       return [ColonyRole.Root];
     case Action.EnterRecoveryMode:
       return [ColonyRole.Recovery];
+    case Action.PaymentBuilder:
+      return [ColonyRole.Administration];
     default:
       return undefined;
   }
@@ -57,6 +59,7 @@ const getPermissionsDomainIdForAction = (
   switch (actionType) {
     case Action.SimplePayment:
     case Action.TransferFunds:
+    case Action.PaymentBuilder:
       return formValues.from;
     case Action.ManageReputation:
     case Action.ManagePermissions:

--- a/src/components/v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts
@@ -1,5 +1,6 @@
 import { useFormContext } from 'react-hook-form';
 
+import { Action } from '~constants/actions.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useEnabledExtensions from '~hooks/useEnabledExtensions.ts';
@@ -24,7 +25,8 @@ const useHasNoDecisionMethods = () => {
     return true;
   }
 
-  if (isVotingReputationEnabled) {
+  // User can't use reputation to create Payment builder action
+  if (isVotingReputationEnabled && actionType !== Action.PaymentBuilder) {
     return false;
   }
 

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -240,7 +240,6 @@ const ActionSidebarContent: FC<ActionSidebarContentProps> = ({
             border-b
             border-b-gray-200
             bg-gray-25
-            bg-gray-25
             px-6
             py-8
             md:h-full

--- a/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx
@@ -12,13 +12,17 @@ import { FormCardSelect } from '~v5/common/Fields/CardSelect/index.ts';
 
 import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
 
-import { type DecisionMethodFieldProps } from './types.ts';
+import {
+  type DecisionMethodOption,
+  type DecisionMethodFieldProps,
+} from './types.ts';
 
 const displayName = 'v5.common.ActionSidebar.partials.DecisionMethodField';
 
 const DecisionMethodField = ({
   reputationOnly,
   disabled,
+  filterOptionsFn,
 }: DecisionMethodFieldProps) => {
   const { colony } = useColonyContext();
   const { user } = useAppContext();
@@ -30,24 +34,32 @@ const DecisionMethodField = ({
 
   const shouldShowPermissions = !reputationOnly && userRoles.length > 0;
 
-  const decisionMethods = [
-    ...(shouldShowPermissions
-      ? [
-          {
-            label: formatText({ id: 'actionSidebar.method.permissions' }),
-            value: DecisionMethod.Permissions,
-          },
-        ]
-      : []),
-    ...(isVotingReputationEnabled
-      ? [
-          {
-            label: formatText({ id: 'actionSidebar.method.reputation' }),
-            value: DecisionMethod.Reputation,
-          },
-        ]
-      : []),
-  ];
+  const getDecisionMethods = () => {
+    const decisionMethods: DecisionMethodOption[] = [
+      ...(shouldShowPermissions
+        ? [
+            {
+              label: formatText({ id: 'actionSidebar.method.permissions' }),
+              value: DecisionMethod.Permissions,
+            },
+          ]
+        : []),
+      ...(isVotingReputationEnabled
+        ? [
+            {
+              label: formatText({ id: 'actionSidebar.method.reputation' }),
+              value: DecisionMethod.Reputation,
+            },
+          ]
+        : []),
+    ];
+
+    if (filterOptionsFn) {
+      return decisionMethods?.filter(filterOptionsFn);
+    }
+
+    return decisionMethods;
+  };
 
   return (
     <ActionFormRow
@@ -65,7 +77,7 @@ const DecisionMethodField = ({
     >
       <FormCardSelect
         name="decisionMethod"
-        options={decisionMethods}
+        options={getDecisionMethods()}
         title={formatText({ id: 'actionSidebar.availableDecisions' })}
         placeholder={formatText({
           id: 'actionSidebar.decisionMethod.placeholder',

--- a/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/types.ts
@@ -1,4 +1,12 @@
+import { type DecisionMethod } from '~types/actions.ts';
+
+export interface DecisionMethodOption {
+  label: string;
+  value: DecisionMethod;
+}
+
 export interface DecisionMethodFieldProps {
   reputationOnly?: boolean;
   disabled?: boolean;
+  filterOptionsFn?: (option: DecisionMethodOption) => boolean;
 }

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/PaymentBuilderForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/PaymentBuilderForm.tsx
@@ -1,8 +1,10 @@
 import { UsersThree } from '@phosphor-icons/react';
 import React, { type FC } from 'react';
 
+import { DecisionMethod } from '~types/actions.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/index.ts';
 
 import { type ActionFormBaseProps } from '../../../types.ts';
@@ -17,6 +19,7 @@ const displayName = 'v5.common.ActionSidebar.partials.PaymentBuilderForm';
 
 const PaymentBuilderForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
   usePaymentBuilder(getFormOptions);
+  const hasNoDecisionMethods = useHasNoDecisionMethods();
 
   return (
     <>
@@ -31,10 +34,13 @@ const PaymentBuilderForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
           },
         }}
         title={formatText({ id: 'actionSidebar.fundFrom' })}
+        isDisabled={hasNoDecisionMethods}
       >
-        <TeamsSelect name="from" />
+        <TeamsSelect name="from" disabled={hasNoDecisionMethods} />
       </ActionFormRow>
-      <DecisionMethodField />
+      <DecisionMethodField
+        filterOptionsFn={({ value }) => value !== DecisionMethod.Reputation}
+      />
       <CreatedIn />
       <Description />
       <PaymentBuilderRecipientsField name="payments" />

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/PaymentBuilderRecipientsField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/PaymentBuilderRecipientsField.tsx
@@ -6,6 +6,7 @@ import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useTablet } from '~hooks/index.ts';
 import { formatText } from '~utils/intl.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import Table from '~v5/common/Table/index.ts';
 import Button from '~v5/shared/Button/Button.tsx';
 
@@ -28,6 +29,8 @@ const PaymentBuilderRecipientsField: FC<PaymentBuilderRecipientsFieldProps> = ({
   const fieldArrayMethods = useFieldArray({
     name,
   });
+  const hasNoDecisionMethods = useHasNoDecisionMethods();
+
   const data: PaymentBuilderRecipientsTableModel[] =
     fieldArrayMethods.fields.map(({ id }) => ({
       key: id,
@@ -79,7 +82,7 @@ const PaymentBuilderRecipientsField: FC<PaymentBuilderRecipientsFieldProps> = ({
       <h5 className="mb-3 mt-6 text-2">
         {formatText({ id: 'actionSidebar.payments' })}
       </h5>
-      {!!data.length && (
+      {!!data.length && !hasNoDecisionMethods && (
         <Table<PaymentBuilderRecipientsTableModel>
           className={clsx('[&_tfoot_td]:py-2 [&_tfoot_td]:align-top', {
             '!border-negative-400': !!fieldState.error,
@@ -104,6 +107,7 @@ const PaymentBuilderRecipientsField: FC<PaymentBuilderRecipientsFieldProps> = ({
             delay: undefined,
           });
         }}
+        disabled={hasNoDecisionMethods}
       >
         {formatText({ id: 'button.addPayment' })}
       </Button>


### PR DESCRIPTION
## Description

- Removed reputation decision method from payment builder form

## Testing

* Step 1. Check if you have the `Reputation Weighted` extension installed and enabled
* Step 2. Open Action sidebar
* Step 2. Select `Payment builder` action type
* Step 3. Open `Decision method` dropdown - `Reputation` option shouldn't be on the list

## Diffs

**New stuff** ✨

* 

**Changes** 🏗

* `filterOptionsFn` prop added to `DecisionMethodField`
* `filterOptionsFn` prop used on `DecisionMethodField` component in `PaymentBuilderForm` to filter Reputation decision method

**Deletions** ⚰️

* 

Contributes to https://github.com/JoinColony/colonyCDapp/issues/2005
