### PR TITLE
fix: user account area mobile styles

### DIFF
--- a/src/components/frame/v5/pages/UserPreferencesPage/hooks.tsx
+++ b/src/components/frame/v5/pages/UserPreferencesPage/hooks.tsx
@@ -11,22 +11,19 @@ import { isEmailAlreadyRegistered } from '~common/Onboarding/wizardSteps/StepCre
 import { isFullScreen } from '~constants/index.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useUpdateUserProfileMutation } from '~gql';
-import { useMobile } from '~hooks/index.ts';
 import useCopyToClipboard from '~hooks/useCopyToClipboard.ts';
 import Toast from '~shared/Extensions/Toast/index.ts';
 import { formatText } from '~utils/intl.ts';
-import { multiLineTextEllipsis } from '~utils/strings/index.ts';
 import { Input } from '~v5/common/Fields/index.ts';
 import Button from '~v5/shared/Button/index.ts';
 
 import { type UserPreferencesFormProps } from './types.ts';
 
-export const useUserPreferencesPage = (truncateLimit = 20) => {
+export const useUserPreferencesPage = () => {
   const { formatMessage } = useIntl();
   const { updateUser, user } = useAppContext();
   const [editUser] = useUpdateUserProfileMutation();
   const [isEmailInputVisible, setIsEmailInputVisible] = useState(false);
-  const isMobile = useMobile();
   const { handleClipboardCopy, isCopied } = useCopyToClipboard();
 
   const validationSchema = object<UserPreferencesFormProps>({
@@ -97,23 +94,24 @@ export const useUserPreferencesPage = (truncateLimit = 20) => {
   const emailValue = getValues('email');
 
   const rowStyles =
-    'flex md:items-start sm:justify-between gap-6 md:gap-0 flex-col md:flex-row w-full';
+    'flex md:items-start md:justify-between gap-4 md:gap-0 flex-col md:flex-row w-full';
 
   const columnsList = [
     {
       key: '1',
       title: formatText({ id: 'field.email' }),
       description: formatText({ id: 'description.email' }),
-      className: clsx(rowStyles, {
-        '!flex-row !justify-normal !gap-[6.5rem]':
-          !emailValue || isEmailInputVisible,
+      className: clsx('flex w-full md:items-start ', {
+        'flex-row md:gap-[6.5rem]': !emailValue || isEmailInputVisible,
+        'flex-col gap-2 md:flex-row md:justify-between md:gap-0':
+          emailValue || !isEmailInputVisible,
       }),
       descriptionClassName: 'md:w-[16.375rem]',
       contentProps: (
         <>
           {emailValue && !isEmailInputVisible && (
-            <div className="flex items-center justify-end">
-              <span className="mr-6 text-md">{emailValue}</span>
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-end md:gap-6">
+              <span className="text-md">{emailValue}</span>
               <Button
                 mode="primarySolid"
                 text={{ id: 'button.updateEmail' }}
@@ -128,8 +126,9 @@ export const useUserPreferencesPage = (truncateLimit = 20) => {
                 register={register}
                 isError={!!errors.email?.message}
                 customErrorMessage={errors.email?.message}
+                allowLayoutShift
               />
-              <div className="ml-auto mt-2 flex items-center gap-2">
+              <div className="mt-4 flex flex-col-reverse items-center gap-2 md:ml-auto md:mt-6 md:flex-row">
                 <Button
                   mode="primaryOutline"
                   text={{ id: 'button.cancel' }}
@@ -137,11 +136,13 @@ export const useUserPreferencesPage = (truncateLimit = 20) => {
                     reset({ email: user?.profile?.email || '' });
                     setIsEmailInputVisible(false);
                   }}
+                  className="w-full md:w-auto"
                 />
                 <Button
                   mode="primarySolid"
-                  text={{ id: 'button.saveEmail' }}
+                  text={{ id: 'button.saveUserProfile' }}
                   type="submit"
+                  className="w-full md:w-auto"
                 />
               </div>
             </div>
@@ -158,15 +159,12 @@ export const useUserPreferencesPage = (truncateLimit = 20) => {
       },
       copyAddressProps: {
         icon: Cardholder,
-        walletAddress: isMobile
-          ? multiLineTextEllipsis(user?.walletAddress || '', truncateLimit)
-          : user?.walletAddress,
+        walletAddress: user?.walletAddress,
       },
       className: rowStyles,
       buttonProps: {
         mode: isCopied ? 'completed' : 'septenary',
         icon: isCopied ? undefined : CopySimple,
-        isFullSize: isMobile,
         onClick: () => handleClipboardCopy(user?.walletAddress || ''),
         text: formatText({
           id: isCopied ? 'copy.addressCopied' : 'copy.address',

--- a/src/components/frame/v5/pages/UserProfilePage/partials/RowItem/RowItem.tsx
+++ b/src/components/frame/v5/pages/UserProfilePage/partials/RowItem/RowItem.tsx
@@ -90,25 +90,27 @@ const RowItem: FC<RowItemProps> = (props): JSX.Element => {
     'buttonProps' in props
   ) {
     const { buttonProps, copyAddressProps } = props;
+    const { walletAddress, icon: Icon } = copyAddressProps || {};
 
     return (
       <>
-        {headerProps && (
-          <div className="flex w-full">
-            <h5 className="heading-5">{headerProps?.title}</h5>
-          </div>
+        {headerProps?.title && (
+          <h5 className="heading-5">{headerProps?.title}</h5>
         )}
-        {copyAddressProps && (
+        {walletAddress && Icon && (
           <div className="flex w-full flex-col items-center justify-between rounded-lg bg-gray-50 p-3 md:flex-row">
-            <div className="mb-3 flex items-center md:mb-0">
-              {copyAddressProps.icon ? (
-                <copyAddressProps.icon size={18} />
-              ) : null}
-              <span className="ml-2 block w-full truncate text-md">
-                {copyAddressProps.walletAddress}
+            <div className="mb-3 flex w-full items-center md:mb-0 md:w-auto">
+              <Icon size={18} className="mr-2 flex-shrink-0" />
+              <span className="block w-[calc(100%-18px-8px)] truncate text-md">
+                {walletAddress}
               </span>
             </div>
-            {buttonProps && <Button {...buttonProps} />}
+            {buttonProps && (
+              <Button
+                {...buttonProps}
+                className={clsx(buttonProps.className, 'w-full md:w-auto')}
+              />
+            )}
           </div>
         )}
       </>

--- a/src/components/frame/v5/pages/UserProfilePage/partials/UserAccountForm/hooks.tsx
+++ b/src/components/frame/v5/pages/UserProfilePage/partials/UserAccountForm/hooks.tsx
@@ -101,9 +101,9 @@ export const useUserProfilePageForm = () => {
   const uploaderText = useGetUploaderText(profileFileOptions);
 
   const rowStyles =
-    'flex md:items-center gap-6 sm:!gap-[6.5rem] flex-col sm:flex-row w-full';
+    'flex md:items-center gap-2 md:gap-[6.5rem] flex-col md:flex-row w-full';
 
-  const descriptionClassName = 'w-[23.375rem]';
+  const descriptionClassName = 'max-w-[23.375rem] w-full';
 
   const columnsList: RowGroup[] = [
     {

--- a/src/components/shared/Extensions/Toast/Toast.css
+++ b/src/components/shared/Extensions/Toast/Toast.css
@@ -1,9 +1,13 @@
 .Toastify__toast-container {
-  @apply w-auto;
+  @apply w-[calc(100%-2em)] sm:w-auto;
+}
+
+.Toastify__toast-container--top-right {
+  @apply left-auto top-[1em];
 }
 
 .Toastify__toast {
-  @apply min-w-[24.375rem] p-6 mb-0 right-4 rounded-r-lg rounded-l-none shadow-lg border border-gray-200 bg-base-white relative before:block before:content-[''] before:h-full before:absolute before:top-0 before:left-0 before:w-[0.375rem];
+  @apply relative mb-0 rounded-l-none rounded-r-lg border border-gray-200 bg-base-white p-6 shadow-lg before:absolute before:left-0 before:top-0 before:block before:h-full before:w-[0.375rem] before:content-[''] sm:min-w-[24.375rem];
 }
 
 .Toastify__toast-body {

--- a/src/components/v5/common/Fields/Input/Input.tsx
+++ b/src/components/v5/common/Fields/Input/Input.tsx
@@ -35,6 +35,7 @@ const Input: FC<InputProps> = ({
   subLabelMessage,
   setIsTyping,
   shouldFocus,
+  allowLayoutShift = false,
 }) => {
   const { formatMessage } = useIntl();
   const { isTyping, isCharLenghtError, currentCharNumber, onChange } = useInput(
@@ -145,7 +146,11 @@ const Input: FC<InputProps> = ({
             {isDecoratedError ? (
               <InputPills message={customErrorMessage} status="error" />
             ) : (
-              <FormError isFullSize alignment="left" allowLayoutShift={false}>
+              <FormError
+                isFullSize
+                alignment="left"
+                allowLayoutShift={allowLayoutShift}
+              >
                 {customErrorMessage ||
                   (errorMaxChar
                     ? formatMessage(

--- a/src/components/v5/common/Fields/Input/types.ts
+++ b/src/components/v5/common/Fields/Input/types.ts
@@ -25,6 +25,7 @@ export type InputProps = {
   subLabelMessage?: Message;
   setIsTyping?: React.Dispatch<React.SetStateAction<boolean>>;
   shouldFocus?: boolean;
+  allowLayoutShift?: boolean;
 };
 
 export type PillProps = {


### PR DESCRIPTION
## Description

- User account area styles update on mobile

## Testing

* Step 1. Go to the user account page
* Step 2. Check the `User account` tab using mobile view
* Step 3. Go to the `Preferences` tab on mobile and check if it's the same as on a design.

## Diffs

**New stuff** ✨

* 

**Changes** 🏗

* Styles update for `Toast` component
* Styles update for the items that are returned from `useUserPreferencesPage` and `useUserProfilePageForm` hooks
* `allowLayoutShift` prop added to `InputProps` to avoid error text overflow

**Deletions** ⚰️

* removed redundant classNames and `!important`s


Resolves https://github.com/JoinColony/colonyCDapp/issues/2079
