### PR TITLE
Fix: Card select title and Action sidebar decision method dropdown padding increased

### DIFF
--- a/src/components/v5/common/Fields/CardSelect/CardSelect.tsx
+++ b/src/components/v5/common/Fields/CardSelect/CardSelect.tsx
@@ -150,7 +150,7 @@ function CardSelect<TValue = string>({
                   {groupedOptions.map((group) => (
                     <li key={group.key} className={OPTION_LIST_ITEM_CLASSES}>
                       {group.title && (
-                        <h5 className="section-title px-4 pt-2 uppercase text-gray-400 text-4">
+                        <h5 className="section-title px-4 py-2 uppercase text-gray-400 text-4">
                           {group.title}
                         </h5>
                       )}


### PR DESCRIPTION
## Description

This PR adjusts the "Card select" title padding to bring it inline with similar components. This was initially raised specifically referencing the decision method dropdown in the action sidebar, however the same component is used in multiple places - for the sake of consistency this PR changes them all (@JoinColony/design please let me know if this is not desired!)

## Testing

1. Create a new action
2. Open the "Decision method" dropdown
3. Check the padding below the words "Available dcision methods" - it should be 8px

## Diffs

**Changes** 🏗

* Increased padding on card select title

Resolves #2113

Available decision methods:
<img width="1108" alt="Screenshot 2024-04-03 at 22 44 53" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/aa0f797b-48d6-47b8-8d50-398aa084e7fc">

Add/Remove verified members
<img width="1137" alt="Screenshot 2024-04-03 at 22 45 02" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/31e7694c-e33f-449b-a595-816fb029a0c6">

Permission types
<img width="624" alt="Screenshot 2024-04-03 at 22 45 50" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/4ae91d7d-ba6f-4562-a853-55f2573d1730">

Team select breadcrumb
<img width="421" alt="Screenshot 2024-04-03 at 22 46 38" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/cafb63f3-936a-4fa2-a0b0-c9b1ada02638">
