### PR TITLE
Fix: Pending reputation next update shows incorrect time

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/ReputationTab/partials/PendingReputation/PendingReputation.tsx
+++ b/src/components/common/Extensions/UserHub/partials/ReputationTab/partials/PendingReputation/PendingReputation.tsx
@@ -31,7 +31,7 @@ const PendingReputation: FC<PendingReputationProps> = ({
   const { data } = useGetReputationMiningCycleMetadataQuery();
   const { lastCompletedAt } = data?.getReputationMiningCycleMetadata ?? {};
 
-  const [nextMiningCycleDate, setNextMiningCyleDate] = useState(
+  const [nextMiningCycleDate, setNextMiningCycleDate] = useState(
     lastCompletedAt
       ? getNextMiningCycleDate(new Date(lastCompletedAt ?? ''))
       : null,
@@ -48,7 +48,7 @@ const PendingReputation: FC<PendingReputationProps> = ({
       );
 
       if (nextMiningCycleDate < halfIntervalAgo) {
-        setNextMiningCyleDate(getNextMiningCycleDate(halfIntervalAgo));
+        setNextMiningCycleDate(getNextMiningCycleDate(halfIntervalAgo));
       }
     }, UPDATE_INTERVAL * 1000);
 

--- a/src/components/common/Extensions/UserHub/partials/ReputationTab/partials/PendingReputation/PendingReputation.tsx
+++ b/src/components/common/Extensions/UserHub/partials/ReputationTab/partials/PendingReputation/PendingReputation.tsx
@@ -1,4 +1,4 @@
-import React, { type FC } from 'react';
+import React, { type FC, useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import { useGetReputationMiningCycleMetadataQuery } from '~gql';
@@ -17,6 +17,8 @@ import {
 const displayName =
   'common.Extensions.UserHub.partials.ReputationTab.partials.PendingReputation';
 
+const UPDATE_INTERVAL = 15;
+
 const PendingReputation: FC<PendingReputationProps> = ({
   colonyAddress,
   wallet,
@@ -28,9 +30,30 @@ const PendingReputation: FC<PendingReputationProps> = ({
 
   const { data } = useGetReputationMiningCycleMetadataQuery();
   const { lastCompletedAt } = data?.getReputationMiningCycleMetadata ?? {};
-  const nextMiningCycleDate = lastCompletedAt
-    ? getNextMiningCycleDate(new Date(lastCompletedAt ?? ''))
-    : null;
+
+  const [nextMiningCycleDate, setNextMiningCyleDate] = useState(
+    lastCompletedAt
+      ? getNextMiningCycleDate(new Date(lastCompletedAt ?? ''))
+      : null,
+  );
+
+  useEffect(() => {
+    const intervalTimer = setInterval(() => {
+      if (!nextMiningCycleDate) {
+        return;
+      }
+
+      const halfIntervalAgo = new Date(
+        Date.now() - (UPDATE_INTERVAL / 2) * 1000,
+      );
+
+      if (nextMiningCycleDate < halfIntervalAgo) {
+        setNextMiningCyleDate(getNextMiningCycleDate(halfIntervalAgo));
+      }
+    }, UPDATE_INTERVAL * 1000);
+
+    return () => clearInterval(intervalTimer);
+  }, [nextMiningCycleDate]);
 
   return (
     <div className="pt-6">
@@ -42,7 +65,10 @@ const PendingReputation: FC<PendingReputationProps> = ({
           </p>
           <span className="text-sm">
             {nextMiningCycleDate ? (
-              <TimeRelative value={nextMiningCycleDate} />
+              <TimeRelative
+                value={nextMiningCycleDate}
+                updateInterval={UPDATE_INTERVAL}
+              />
             ) : (
               '-'
             )}

--- a/src/components/common/Extensions/UserHub/partials/ReputationTab/partials/PendingReputation/PendingReputation.tsx
+++ b/src/components/common/Extensions/UserHub/partials/ReputationTab/partials/PendingReputation/PendingReputation.tsx
@@ -48,7 +48,7 @@ const PendingReputation: FC<PendingReputationProps> = ({
       );
 
       if (nextMiningCycleDate < halfIntervalAgo) {
-        setNextMiningCycleDate(getNextMiningCycleDate(halfIntervalAgo));
+        setNextMiningCycleDate(getNextMiningCycleDate(nextMiningCycleDate));
       }
     }, UPDATE_INTERVAL * 1000);
 


### PR DESCRIPTION
## Description

When the "Next update" time is passed, it does not update - so it will show an incorrect time: "15 seconds ago".

This PR adds a check to see if the "next update" time has passed, and gets the next cycle date to update the time.

## Testing

1. Select a colony.
2. Open the User Hub.
3. Navigate to the "Your balance" tab.
4. The "Next reputation update" field will show how much time there is left untill the next reputation update.
5. The countdown is reached and the user does not refresh the page or open a new page.

Once the timer reaches 0, it should briefly show "Now" before refreshing to the new time "60 minutes".

## Diffs

**Changes** 🏗

* `PendingReputation` component now checks if the `nextMiningCycleDate` has passed and updates it if necessary

Resolves #2121

https://github.com/JoinColony/colonyCDapp/assets/34915414/da392ebc-70fd-4e6f-935c-20524ffcac64