### PR TITLE
Fix: URL showing capitalization on create colony confirmation

### DIFF
--- a/src/components/common/Onboarding/wizardSteps/CreateColony/CreateColonyCardRow.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/CreateColonyCardRow.tsx
@@ -41,7 +41,7 @@ const CardRow = ({ updatedWizardValues, setStep }: CardRowProps) => {
     {
       title: 'navigation.admin.colonyDetails',
       text: colonyDisplayName,
-      subText: `app.colony.io/${colonyName}`,
+      subText: `app.colony.io/${colonyName.toLowerCase()}`,
       step: 0,
     },
     {

--- a/src/components/common/Onboarding/wizardSteps/CreateColony/CreateColonyCardRow.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/CreateColonyCardRow.tsx
@@ -2,6 +2,7 @@ import { Image } from '@phosphor-icons/react';
 import React from 'react';
 import { defineMessages } from 'react-intl';
 
+import { APP_URL } from '~constants';
 import { type WizardStepProps } from '~shared/Wizard/index.ts';
 import { formatText } from '~utils/intl.ts';
 import Avatar from '~v5/shared/Avatar/index.ts';
@@ -41,7 +42,7 @@ const CardRow = ({ updatedWizardValues, setStep }: CardRowProps) => {
     {
       title: 'navigation.admin.colonyDetails',
       text: colonyDisplayName,
-      subText: `app.colony.io/${colonyName.toLowerCase()}`,
+      subText: `${APP_URL.origin}/${colonyName.toLowerCase()}`,
       step: 0,
     },
     {


### PR DESCRIPTION
## Description

The colony URL on the 'Create Colony' conformation should not allow capital letters. This PR enforces lowercase.

## Testing

1. Create a new colony.
2. Proceed to the confirmation step.
3. Pay attention to the capitalization of the domain.

## Diffs

**Changes** 🏗

* Colony URL is now lowercase

Resolves #2136

<img width="559" alt="Screenshot 2024-04-04 at 16 13 30" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/9d7022b0-0b0b-4d7e-8548-2e6fbab2df2b">
