### PR TITLE
Fix: New colony URL should not allow capital letters

### DIFF
--- a/amplify/backend/function/createColonyEtherealMetadata/src/index.js
+++ b/amplify/backend/function/createColonyEtherealMetadata/src/index.js
@@ -114,7 +114,7 @@ exports.handler = async (event) => {
         id: `etherealcolonymetadata-${transactionHash}`,
         displayName: colonyDisplayName,
         etherealData: {
-          colonyName,
+          colonyName: colonyName.toLowerCase(),
           colonyDisplayName,
           colonyAvatar,
           colonyThumbnail,

--- a/src/components/common/Onboarding/wizardSteps/CreateColony/CreateColonyCardRow.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/CreateColonyCardRow.tsx
@@ -42,7 +42,7 @@ const CardRow = ({ updatedWizardValues, setStep }: CardRowProps) => {
     {
       title: 'navigation.admin.colonyDetails',
       text: colonyDisplayName,
-      subText: `${APP_URL.origin}/${colonyName.toLowerCase()}`,
+      subText: `${APP_URL.origin}/${colonyName}`,
       step: 0,
     },
     {

--- a/src/components/common/Onboarding/wizardSteps/CreateColony/validation.ts
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/validation.ts
@@ -56,6 +56,7 @@ export const colonyNameValidationSchema = object({
   colonyName: string()
     .required(formatMessage({ id: 'error.colonyURLRequired' }))
     .max(MAX_COLONY_DISPLAY_NAME, '')
+    .lowercase()
     .test('isValidName', formatMessage({ id: 'error.colonyURL' }), isValidName)
     .test('isNameTaken', formatMessage({ id: 'error.urlTaken' }), isNameTaken),
 }).defined();


### PR DESCRIPTION
## Description

The colony URL input in the new colony creation wizard appears to only let you enter lowercase letters, however the actual value will accept uppercase and lowercase letters.

This PR adds new validation to the input to ensure only lowercase letters are allowed.

## Testing

1. Create a new colony.
2. Try entering capital letters to the colony URL field
3. Proceed with the creation wizard and create the colony.
4. Check in the database that the colony has been created with a lowercase name:

```
query MyQuery {
  listColonies {
    items {
      name
    }
  }
}
```


## Diffs

**Changes** 🏗

* Added lowercase validation to the new colony URL input

**Deletions** ⚰️

* Removed the now unnecessary .toLowerCase() on the confirmation screen

Resolves #2145