### PR TITLE
Fix: Duplicate incoming funds

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=875e1db23943a6a6ff810ba4bae8b310ad09fedd
+ENV BLOCK_INGESTOR_HASH=6a7c1a87a5ca333f1ad2abccc8114381a8089731
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]


### PR DESCRIPTION
This fix is on the block-ingestor (https://github.com/JoinColony/block-ingestor/pull/198). This PR simply updates the block-ingestor hash.

## Description

Incoming funds were incorrectly being duplicated. This was due to both the 'transfer' and 'expenditurePayoutClaimed' events being emitted when a payment is made from one colony to another via the OneTxPayment extension.

This PR adds a check to the 'expenditurePayoutClaimed' event to check if the event was emitted by the OneTxPayment extension and to skip creating a new claim if so (as the 'transfer' event will already do this).

## Testing

1. Send funds to a colony. (Copy the colony wallet address, switch to another colony, create a simple payment action with the colony address as the recipient)
2. Navigate to the incoming funds page.
3. The incoming funds should correctly show no duplicates.

You can also verify no duplicates are being created in the database:
```
query MyQuery {
  listColonies {
    items {
      name
      fundsClaims {
        items {
          amount
          id
        }
      }
    }
  }
}
```

## Diffs

**Changes** 🏗

* 'expenditurePayoutClaimed' event checks if the event was emitted by the OneTxPayment extension and skips creating a new claim if so (as the 'transfer' event will already do this).

Resolves #2137 

<img width="1318" alt="Screenshot 2024-04-08 at 11 08 04" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/1c57e178-4ee9-4c7e-826b-c5a0ad20f4b4">
