### PR TITLE
Fix: Incoming funds table border UI issue

### DIFF
--- a/src/components/frame/v5/pages/FundsPage/partials/FundsTable/FundsTable.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/FundsTable/FundsTable.tsx
@@ -97,7 +97,7 @@ const FundsTable: FC = () => {
         className="w-full [&_td>div]:p-0 [&_td]:border-b [&_td]:border-gray-100 [&_th:empty]:border-none [&_th:last-child]:text-right [&_tr:last-child>td]:border-0"
         emptyContent={
           (!searchedTokens.length || claims.length <= 0) && (
-            <div className="w-full rounded-lg border border-gray-200">
+            <div className="w-full rounded-lg">
               <EmptyContent
                 title={{ id: 'incomingFundsPage.table.emptyTitle' }}
                 description={{ id: 'incomingFundsPage.table.emptyDescription' }}


### PR DESCRIPTION
## Description

When in the empty state, the incoming funds table was displaying a double border across all responsive sizes. This PR removes the extra border when in the empty state.

## Testing

1. Navigate to the 'Incoming funds' page
2. Claim an incoming funds
3. The empty table should not have any duplicate borders

<img width="1318" alt="Screenshot 2024-04-08 at 11 24 39" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/be80f2a8-26c8-4e5f-a151-a276d5463b19">

## Diffs

**Deletions** ⚰️

* Removed unnecessary border on funds table when empty

Resolves #2155 