### PR TITLE
Global dropdown H5 padding

### DIFF
--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/ActionsTableFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/ActionsTableFilters.tsx
@@ -33,7 +33,7 @@ const ActionsTableFilters: FC = () => {
 
   const filtersContent = (
     <div>
-      <h4 className="mb-6 text-gray-900 heading-5 sm:mb-0 sm:px-4 sm:uppercase sm:text-gray-400 sm:text-4">
+      <h4 className="mb-6 pb-2 text-gray-900 heading-5 sm:mb-0 sm:px-4 sm:uppercase sm:text-gray-400 sm:text-4">
         {formatText({ id: isMobile ? 'filterAndSort' : 'filters' })}
       </h4>
       <ul className="flex flex-col gap-7 sm:gap-0">

--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/ActionTypeFilters/ActionTypeFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/ActionTypeFilters/ActionTypeFilters.tsx
@@ -12,7 +12,7 @@ const ActionTypeFilters: FC = () => {
 
   return (
     <div>
-      <h5 className="hidden px-3.5 uppercase text-gray-400 text-4 sm:block">
+      <h5 className="hidden px-3.5 pb-2 uppercase text-gray-400 text-4 sm:block">
         {formatText({ id: 'activityFeedTable.filters.actionType' })}
       </h5>
       <ul>

--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/DateFilters/DateFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/DateFilters/DateFilters.tsx
@@ -39,7 +39,7 @@ const DateFilters: FC = () => {
           );
         })}
       </ul>
-      <h5 className="mt-2 pb-2 uppercase text-gray-400 text-4 sm:px-3.5">
+      <h5 className="mt-2 uppercase text-gray-400 text-4 sm:px-3.5">
         {formatText({ id: 'activityFeedTable.filters.date.custom' })}
       </h5>
       <div className="mt-4 sm:px-3.5">

--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/DateFilters/DateFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/DateFilters/DateFilters.tsx
@@ -18,7 +18,7 @@ const DateFilters: FC = () => {
 
   return (
     <div className="pb-2">
-      <h5 className="hidden px-3.5 uppercase text-gray-400 text-4 sm:block">
+      <h5 className="hidden px-3.5 pb-2 uppercase text-gray-400 text-4 sm:block">
         {formatText({ id: 'activityFeedTable.filters.date' })}
       </h5>
       <ul>
@@ -39,7 +39,7 @@ const DateFilters: FC = () => {
           );
         })}
       </ul>
-      <h5 className="mt-2 uppercase text-gray-400 text-4 sm:px-3.5">
+      <h5 className="mt-2 pb-2 uppercase text-gray-400 text-4 sm:px-3.5">
         {formatText({ id: 'activityFeedTable.filters.date.custom' })}
       </h5>
       <div className="mt-4 sm:px-3.5">

--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/DecisionMethodFilters/DecisionMethodFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/DecisionMethodFilters/DecisionMethodFilters.tsx
@@ -12,7 +12,7 @@ const DecisionMethodFilters: FC = () => {
 
   return (
     <div>
-      <h5 className="hidden px-3.5 uppercase text-gray-400 text-4 sm:block">
+      <h5 className="hidden px-3.5 pb-2 uppercase text-gray-400 text-4 sm:block">
         {formatText({ id: 'activityFeedTable.filters.decisionMethod' })}
       </h5>
       <ul>

--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/StatusFilters/StatusFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/StatusFilters/StatusFilters.tsx
@@ -11,7 +11,7 @@ const StatusFilters: FC = () => {
 
   return (
     <div>
-      <h5 className="hidden px-3.5 uppercase text-gray-400 text-4 sm:block">
+      <h5 className="hidden px-3.5 pb-2 uppercase text-gray-400 text-4 sm:block">
         {formatText({ id: 'activityFeedTable.filters.status' })}
       </h5>
       <ul>

--- a/src/components/common/Extensions/UserNavigation/partials/UserMenu/UserMenu.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserMenu/UserMenu.tsx
@@ -123,7 +123,10 @@ const UserMenu: FC<UserMenuProps> = ({
             'mb-5 border-b border-b-gray-200 pb-4 sm:pb-3': wallet,
           })}
         >
-          <TitleLabel text={formatText({ id: 'userMenu.optionsTitle' })} />
+          <TitleLabel
+            text={formatText({ id: 'userMenu.optionsTitle' })}
+            className="pb-2"
+          />
           <ul className="text-left">
             <li className="-ml-4 mb-2 w-[calc(100%+2rem)] rounded hover:bg-gray-50 sm:mb-0">
               <Link to="/" className="navigation-link">
@@ -175,7 +178,10 @@ const UserMenu: FC<UserMenuProps> = ({
         </div>
         {wallet && (
           <div className="w-full">
-            <TitleLabel text={formatText({ id: 'userMenu.other' })} />
+            <TitleLabel
+              text={formatText({ id: 'userMenu.other' })}
+              className="pb-2"
+            />
             <div className="navigation-link -ml-4 w-[calc(100%+2rem)] rounded hover:bg-gray-50">
               <Plugs size={iconSize} />
               <button type="button" className="ml-2" onClick={disconnectWallet}>

--- a/src/components/frame/Extensions/pages/PermissionsPage/partials/FilterItem.tsx
+++ b/src/components/frame/Extensions/pages/PermissionsPage/partials/FilterItem.tsx
@@ -145,7 +145,7 @@ const RootFilter: FC<PermissionsPageFilterRootProps> = ({
               }}
               classNames="w-full sm:max-w-[13.25rem]"
             >
-              <span className="px-3.5 uppercase text-gray-400 text-4">
+              <span className="px-3.5 pb-2 uppercase text-gray-400 text-4">
                 {formatText({ id: 'permissions.type' })}
               </span>
               {items.map(

--- a/src/components/frame/Extensions/pages/PermissionsPage/partials/PermissionsPageFilter.tsx
+++ b/src/components/frame/Extensions/pages/PermissionsPage/partials/PermissionsPageFilter.tsx
@@ -136,7 +136,10 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
               value={searchValue}
             />
           </div>
-          <Header title={{ id: 'permissionsPage.filter.filterBy' }} />
+          <Header
+            title={{ id: 'permissionsPage.filter.filterBy' }}
+            className="pb-2"
+          />
           {RootItems}
         </PopoverBase>
       )}

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/AgreementsPageFilters.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/AgreementsPageFilters.tsx
@@ -45,7 +45,7 @@ const AgreementsPageFilters: FC = () => {
   const FiltersContent = (
     <div>
       <h4
-        className={clsx('mb-6 sm:mb-0 sm:px-4', {
+        className={clsx('mb-6 pb-2 sm:mb-0 sm:px-4', {
           'uppercase text-gray-400 text-4': !isMobile,
           'capitalize text-gray-900 heading-5': isMobile,
         })}

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/partials/DateFilters/DateFilters.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/partials/DateFilters/DateFilters.tsx
@@ -18,7 +18,7 @@ const DateFilters: FC = () => {
 
   return (
     <div className="pb-2">
-      <h5 className="hidden px-3.5 uppercase text-gray-400 text-4 sm:block">
+      <h5 className="hidden px-3.5 pb-2 uppercase text-gray-400 text-4 sm:block">
         {formatText({ id: 'agreementsPage.filters.date' })}
       </h5>
       <ul>

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/partials/StatusFilters/StatusFilters.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/partials/StatusFilters/StatusFilters.tsx
@@ -11,7 +11,7 @@ const StatusFilters: FC = () => {
 
   return (
     <div>
-      <h5 className="hidden px-3.5 uppercase text-gray-400 text-4 sm:block">
+      <h5 className="hidden px-3.5 pb-2 uppercase text-gray-400 text-4 sm:block">
         {formatText({ id: 'agreementsPage.filter.status' })}
       </h5>
       <ul>

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/BalanceFilters/BalanceFilters.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/BalanceFilters/BalanceFilters.tsx
@@ -34,7 +34,7 @@ const BalanceFilters: FC = () => {
 
   const filtersContent = (
     <div>
-      <h4 className="mb-6 text-gray-900 heading-5 sm:mb-0 sm:px-4 sm:uppercase sm:text-gray-400 sm:text-4">
+      <h4 className="mb-6 pb-2 text-gray-900 heading-5 sm:mb-0 sm:px-4 sm:uppercase sm:text-gray-400 sm:text-4">
         {formatText({ id: isMobile ? 'filterAndSort' : 'filters' })}
       </h4>
       <ul className="flex flex-col gap-7 sm:gap-0">

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/partials/filters/AttributeFilters/AttributeFilters.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/partials/filters/AttributeFilters/AttributeFilters.tsx
@@ -12,7 +12,7 @@ const AttributeFilters: FC = () => {
 
   return (
     <div>
-      <h5 className="hidden px-3.5 uppercase text-gray-400 text-4 sm:block">
+      <h5 className="hidden px-3.5 pb-2 uppercase text-gray-400 text-4 sm:block">
         {formatText({ id: 'balancePage.filter.attributeTypes' })}
       </h5>
       <ul>

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/partials/filters/TokenFilters/TokenFilters.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/partials/filters/TokenFilters/TokenFilters.tsx
@@ -29,7 +29,7 @@ const TokenFilters: FC = () => {
 
   return (
     <div>
-      <h5 className="hidden px-3.5 uppercase text-gray-400 text-4 sm:block">
+      <h5 className="hidden px-3.5 pb-2 uppercase text-gray-400 text-4 sm:block">
         {formatText({ id: 'balancePage.filter.approvedTokenTypes' })}
       </h5>
       <ul>

--- a/src/components/frame/v5/pages/FundsPage/partials/Filter/Filter.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/Filter/Filter.tsx
@@ -144,7 +144,7 @@ function Filter<TValue extends FilterValue>({
               value={searchValue}
             />
           </div>
-          <Header title={{ id: filtersHeader }} />
+          <Header title={{ id: filtersHeader }} className="pb-2" />
           {RootItems}
         </PopoverBase>
       )}

--- a/src/components/frame/v5/pages/FundsPage/partials/Filter/FilterItem.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/Filter/FilterItem.tsx
@@ -80,7 +80,7 @@ function FilterItem<TValue extends FilterValue>({
               classNames="w-full sm:max-w-[13.25rem] mr-2"
             >
               <>
-                <span className="px-3.5 uppercase text-gray-400 text-4">
+                <span className="px-3.5 pb-2 uppercase text-gray-400 text-4">
                   {title}
                 </span>
                 {FilterItems}

--- a/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/FilterItem.tsx
+++ b/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/FilterItem.tsx
@@ -86,7 +86,7 @@ const FilterItem: FC<TeamsPageFilterRootProps> = ({
               classNames="w-full sm:max-w-[13.25rem] mr-2"
             >
               <>
-                <span className="px-3.5 uppercase text-gray-400 text-4">
+                <span className="px-3.5 pb-2 uppercase text-gray-400 text-4">
                   {title}
                 </span>
                 {items.map(({ value, label: checkboxLabel }) => (

--- a/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/TeamsPageFilter.tsx
+++ b/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/TeamsPageFilter.tsx
@@ -139,8 +139,9 @@ const TeamsPageFilter: FC<TeamsPageFilterProps> = ({
           </div>
           <Header
             title={{
-              id: !isMobile ? 'teamsPage.filter.sortBy' : undefined,
+              id: 'teamsPage.filter.sortBy',
             }}
+            className="pb-2"
           />
           {RootItems}
         </PopoverBase>

--- a/src/components/v5/common/Filter/partials/FilterOptions.tsx
+++ b/src/components/v5/common/Filter/partials/FilterOptions.tsx
@@ -30,7 +30,7 @@ const FilterOptions: FC<FilterOptionsProps> = ({ excludeFilterType }) => {
     <div>
       <Header
         title={{ id: isMobile ? 'filterAndSort' : 'filterBy' }}
-        className={clsx({
+        className={clsx('pb-2', {
           'mb-6 capitalize text-gray-900': isMobile,
         })}
         textSizeClassName={isMobile ? 'heading-5' : 'text-4'}
@@ -42,7 +42,7 @@ const FilterOptions: FC<FilterOptionsProps> = ({ excludeFilterType }) => {
           {filteredOptions?.map(
             ({ id, icon, title, filterType, content, header }) => (
               <li key={id}>
-                {header && <Header title={{ id: header }} className="mt-2" />}
+                {header && <Header title={{ id: header }} className="my-2" />}
                 <SubNavigationItem
                   icon={icon}
                   title={title}

--- a/src/components/v5/shared/SubNavigationItem/partials/NestedOptions.tsx
+++ b/src/components/v5/shared/SubNavigationItem/partials/NestedOptions.tsx
@@ -53,10 +53,10 @@ const NestedOptions: FC<NestedOptionsProps> = ({
 
   return (
     <>
-      {!isMobile && <Header title={{ id: filterTitle }} />}
+      {!isMobile && <Header title={{ id: filterTitle }} className="pb-2" />}
       <ul
         className={clsx('flex flex-col', {
-          'mt-1': isMobile,
+          'mt-2': isMobile,
         })}
       >
         {(nestedFilters || []).map(


### PR DESCRIPTION
## Description

Add padding to the headings of dropdown cards / filters across the app. Applies on both desktop and mobile.

## Testing

Check that the padding is correct on all filter dropdown cards across all pages where a filter is present (including sub filter menus).

Check the dropdown cards / filters in the following places:

* Contributors and All Members pages
* Permissions page
* Teams page
* Balance page
* Incoming funds page
* Agreements page
* Hamburger menu

## Diffs

**Changes** 🏗

* Increased paddings for headings in dropdown cards.

Resolves #2133
