### PR TITLE
Add masked address to user popover

### DIFF
--- a/src/components/v5/shared/UserPopover/UserPopover.tsx
+++ b/src/components/v5/shared/UserPopover/UserPopover.tsx
@@ -3,6 +3,7 @@ import React, { type FC } from 'react';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useGetColonyContributorQuery } from '~gql';
+import MaskedAddress from '~shared/MaskedAddress/index.ts';
 import { getColonyContributorId } from '~utils/members.ts';
 
 import { UserAvatar } from '../UserAvatar/UserAvatar.tsx';
@@ -48,7 +49,12 @@ const UserPopover: FC<UserPopoverProps> = ({
           userAddress={walletAddress}
         />
         <p className="ml-2 truncate text-md font-medium">
-          {userDisplayName ?? walletAddress}
+          {userDisplayName ?? (
+            <MaskedAddress
+              address={walletAddress}
+              className="!text-md !font-medium"
+            />
+          )}
         </p>
       </div>
     </UserInfoPopover>


### PR DESCRIPTION
Added masked address to the user popover, so now every place where the popover is used and there's no user profile, it should show the partial address instead like the other places where we show addresses.

Every recipient address in the completed action side panel should now be masked:
![Screenshot 2024-04-09 at 15 57 34](https://github.com/JoinColony/colonyCDapp/assets/18473896/fde9f9dd-ea80-437c-a160-5817affbfd6c)

Resolves #2177 
