### PR TITLE
Update skeleton loader in contributors tab

### DIFF
--- a/src/components/frame/v5/pages/MembersPage/partials/MembersTabContent/MembersTabContent.tsx
+++ b/src/components/frame/v5/pages/MembersPage/partials/MembersTabContent/MembersTabContent.tsx
@@ -11,6 +11,7 @@ import useCopyToClipboard from '~hooks/useCopyToClipboard.ts';
 import { formatText } from '~utils/intl.ts';
 import EmptyContent from '~v5/common/EmptyContent/index.ts';
 import MemberCard from '~v5/common/MemberCard/index.ts';
+import MemberCardSkeleton from '~v5/common/MemberCard/MemberCardSkeleton.tsx';
 import MemberCardList from '~v5/common/MemberCardList/index.ts';
 import SimpleMemberCard from '~v5/common/SimpleMemberCard/SimpleMemberCard.tsx';
 import SimpleMemberCardSkeleton from '~v5/common/SimpleMemberCard/SimpleMemberCardSkeleton.tsx';
@@ -105,10 +106,17 @@ const MembersTabContent: FC<PropsWithChildren<MembersTabContentProps>> = ({
           (selectedFilterCount > 0 || searchValue) && (
             <EmptyContent {...emptyContentProps} withBorder />
           )}
-        {isLoading && (
-          <MemberCardList isSimple={withSimpleCards}>
+        {isLoading && withSimpleCards && (
+          <MemberCardList isSimple>
             {[...Array(16).keys()].map((key) => (
               <SimpleMemberCardSkeleton key={key} />
+            ))}
+          </MemberCardList>
+        )}
+        {isLoading && !withSimpleCards && (
+          <MemberCardList>
+            {[...Array(8).keys()].map((key) => (
+              <MemberCardSkeleton key={key} />
             ))}
           </MemberCardList>
         )}

--- a/src/components/v5/common/MemberCard/MemberCardSkeleton.tsx
+++ b/src/components/v5/common/MemberCard/MemberCardSkeleton.tsx
@@ -1,0 +1,27 @@
+import { DotsThree } from '@phosphor-icons/react';
+import React from 'react';
+
+const displayName = 'v5.common.MemberCardSkeleton';
+
+export const MemberCardSkeleton = () => {
+  return (
+    <div className="flex h-full w-full flex-col rounded-lg border border-gray-200 bg-gray-25 p-5">
+      <div className="relative flex w-full flex-col items-center justify-center">
+        <div className="absolute right-0 top-0 text-gray-400">
+          <DotsThree size={16} className="gray-300 rotate-90" />
+        </div>
+        <div className="mb-5 h-[60px] w-[60px] overflow-hidden rounded-full bg-gray-300 skeleton" />
+        <div className="h-[20px] w-3/5 overflow-hidden rounded bg-gray-300 skeleton" />
+      </div>
+      <div className="my-2.5 flex w-full items-center justify-between gap-4 border-t border-t-gray-200 py-px" />
+      <div className="flex w-full items-center justify-between gap-4">
+        <div className="h-[20px] w-1/5 overflow-hidden rounded bg-gray-300 skeleton" />
+        <div className="h-[20px] w-2/6 overflow-hidden rounded-full bg-gray-300 skeleton" />
+      </div>
+    </div>
+  );
+};
+
+MemberCardSkeleton.displayName = displayName;
+
+export default MemberCardSkeleton;

--- a/src/components/v5/common/MemberCardList/MemberCardList.tsx
+++ b/src/components/v5/common/MemberCardList/MemberCardList.tsx
@@ -18,10 +18,7 @@ const MemberCardList: FC<MemberCardListProps> = ({
     (childrenLength === 0 && placeholderCardProps) ? (
     <ul
       className={clsx('grid', {
-        'grid-cols-[repeat(auto-fit,minmax(14.75rem,1fr))]':
-          !isSimple && childrenLength > 2,
-        'grid-cols-[repeat(auto-fit,minmax(14.75rem,1fr))] lg:grid-cols-4':
-          !isSimple && childrenLength <= 2,
+        'grid-cols-1 md:grid-cols-2 lg:grid-cols-4': !isSimple,
         'grid-cols-[repeat(auto-fit,minmax(18.75rem,1fr))]':
           isSimple && childrenLength > 3,
         'grid-cols-[repeat(auto-fit,minmax(18.75rem,1fr))] md:grid-cols-4':


### PR DESCRIPTION
## Description

Create a new skeleton member card component and use it on the contributors tab when the cards are loading.

Update the number of cards shown in the contributors tab when it is loading, and update the grid columns / rows for this page. 


https://github.com/JoinColony/colonyCDapp/assets/38098203/37f8ddfc-63b6-4cd1-b7e2-f52f56897204


## Testing

Load the contributors page and check that the correct skeleton member cards are shown while the page is loading. There should be a different grid on desktop (4x2), tablet (2x4) and mobile (1x8).

## Diffs

**New stuff** ✨

* New skeleton member card

**Changes** 🏗

* Update the number of member cards shown when loading the contributors tab, and update the grid on that page.

Resolves #2176
