### PR TITLE
fix: calculate cleave input width excluding letters

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/AmountField/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/hooks.ts
@@ -41,7 +41,10 @@ export const useAmountField = (
     }
 
     inputRef.current.style.width = `${Math.min(
-      getInputTextWidth(inputRef.current, { usePlaceholderAsFallback: true }),
+      getInputTextWidth(inputRef.current, {
+        usePlaceholderAsFallback: true,
+        formattingOptions,
+      }),
       maxWidth || 120,
     )}px`;
   };

--- a/src/utils/elements.ts
+++ b/src/utils/elements.ts
@@ -1,10 +1,16 @@
+import { type FormatNumeralOptions, formatNumeral } from 'cleave-zen';
+
 interface GetInputTextWidthOptions {
   usePlaceholderAsFallback?: boolean;
+  formattingOptions?: FormatNumeralOptions;
 }
 
 export const getInputTextWidth = (
   input: HTMLInputElement,
-  { usePlaceholderAsFallback }: GetInputTextWidthOptions = {},
+  {
+    usePlaceholderAsFallback,
+    formattingOptions,
+  }: GetInputTextWidthOptions = {},
 ): number => {
   const textMeasureContainer = document.createElement('span');
   document.body.appendChild(textMeasureContainer);
@@ -23,10 +29,16 @@ export const getInputTextWidth = (
     }
   });
 
-  textMeasureContainer.innerHTML =
-    (input.type === 'number' && !Number.isNaN(input.valueAsNumber)
-      ? input.valueAsNumber.toString()
-      : input.value) || (usePlaceholderAsFallback ? input.placeholder : '0');
+  if (formattingOptions) {
+    textMeasureContainer.innerHTML =
+      formatNumeral(input.value, formattingOptions) ||
+      (usePlaceholderAsFallback ? input.placeholder : '0');
+  } else {
+    textMeasureContainer.innerHTML =
+      (input.type === 'number' && !Number.isNaN(input.valueAsNumber)
+        ? input.valueAsNumber.toString()
+        : input.value) || (usePlaceholderAsFallback ? input.placeholder : '0');
+  }
 
   const textWidth = textMeasureContainer.getBoundingClientRect().width + 2;
 


### PR DESCRIPTION
## Description

A letter wasn't displayed in the amount field, but it was detected in `getInputTextWidth` as the input's value and then used to calculate the input width 

## Testing

* Step 1. Create an action that includes the amount field, for example, `Simple payment`
* Step 2. Try to add a letter, number (or a few more) then a letter

## Diffs

**New stuff** ✨

* 

**Changes** 🏗

* `formattingOptions` added to `getInputTextWidth` function

**Deletions** ⚰️

* 

Resolves [#31415](https://github.com/JoinColony/colonyCDapp/issues/2164)
