### PR TITLE
fix: prevent page body from scrolling when sidebar is visible

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -240,16 +240,15 @@ const ActionSidebarContent: FC<ActionSidebarContentProps> = ({
             border-b
             border-b-gray-200
             bg-gray-25
-            bg-gray-25
             px-6
             py-8
-            md:h-full
-            md:w-[35%]
-            md:flex-shrink-0
-            md:overflow-y-auto
-            md:border-b-0
-            md:border-l
-            md:border-l-gray-200
+            sm:h-full
+            sm:w-[35%]
+            sm:flex-shrink-0
+            sm:overflow-y-auto
+            sm:border-b-0
+            sm:border-l
+            sm:border-l-gray-200
           "
         >
           {isMotion ? (

--- a/src/components/v5/common/CompletedAction/CompletedAction.tsx
+++ b/src/components/v5/common/CompletedAction/CompletedAction.tsx
@@ -107,13 +107,13 @@ const CompletedAction = ({ action }: CompletedActionProps) => {
             bg-gray-25
             px-6
             py-8
-            md:h-full
-            md:w-[35%]
-            md:flex-shrink-0
-            md:overflow-y-auto
-            md:border-b-0
-            md:border-l
-            md:border-l-gray-200
+            sm:h-full
+            sm:w-[35%]
+            sm:flex-shrink-0
+            sm:overflow-y-auto
+            sm:border-b-0
+            sm:border-l
+            sm:border-l-gray-200
           `}
       >
         {action.isMotion ? (

--- a/src/components/v5/frame/PageLayout/PageLayout.tsx
+++ b/src/components/v5/frame/PageLayout/PageLayout.tsx
@@ -72,7 +72,7 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
       <div className="w-full md:flex md:h-screen md:flex-col" ref={wrapperRef}>
         {/* This div has to always be rendered, otherwise the height of the top content wrapper won't be calculated correctly */}
         <div
-          className="sticky left-0 right-0 top-0 z-base w-full bg-base-white sm:z-sidebar md:static md:left-auto md:right-auto md:top-auto md:bg-transparent"
+          className="z-base w-full bg-base-white sm:z-sidebar md:bg-transparent"
           ref={topContentWrapperRef}
         >
           <div className="relative w-full">
@@ -82,7 +82,7 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
         </div>
         <AnimatePresence>
           {isTablet ? (
-            <div className="inner py-6">
+            <div className="inner h-[calc(100vh-var(--top-content-height))] overflow-auto py-6">
               {pageHeadingProps && (
                 <PageHeading {...pageHeadingProps} className="mb-6" />
               )}


### PR DESCRIPTION
## Description

A user was able to scroll page content while the cursor was positioned over the action sidebar.

## Testing

* Step 1. Open the action sidebar
* Step 2. Position your cursor over the action sidebar.
* Step 3. Start scrolling.

## Diffs

**New stuff** ✨

* 

**Changes** 🏗

* height is now set on page content wrapper and overflow auto is applied

**Deletions** ⚰️

* 

Resolves [#31415](https://github.com/JoinColony/colonyCDapp/issues/2138)
