### PR TITLE
fix: changed decision method tooltip in verified action

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx
@@ -19,6 +19,7 @@ const displayName = 'v5.common.ActionSidebar.partials.DecisionMethodField';
 const DecisionMethodField = ({
   reputationOnly,
   disabled,
+  tooltipContent = 'actionSidebar.tooltip.decisionMethod',
 }: DecisionMethodFieldProps) => {
   const { colony } = useColonyContext();
   const { user } = useAppContext();
@@ -56,7 +57,7 @@ const DecisionMethodField = ({
       tooltips={{
         label: {
           tooltipContent: formatText({
-            id: 'actionSidebar.tooltip.decisionMethod',
+            id: tooltipContent,
           }),
         },
       }}

--- a/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/types.ts
@@ -1,4 +1,5 @@
 export interface DecisionMethodFieldProps {
   reputationOnly?: boolean;
   disabled?: boolean;
+  tooltipContent?: string;
 }

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageVerifiedMembersForm/ManageVerifiedMembersForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageVerifiedMembersForm/ManageVerifiedMembersForm.tsx
@@ -54,7 +54,7 @@ const ManageVerifiedMembersForm: FC<ActionFormBaseProps> = ({
           title={formatText({ id: 'actionSidebar.manageMembers.placeholder' })}
         />
       </ActionFormRow>
-      <DecisionMethodField />
+      <DecisionMethodField tooltipContent="actionSidebar.manageMembers.decisionMethod" />
       <CreatedIn readonly />
       <Description />
       {manageMembers !== undefined && <VerifiedMembersTable name="members" />}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1070,6 +1070,7 @@
     "actionSidebar.availableDecisions": "Available decision methods",
     "actionSidebar.manageMembers": "Add/remove",
     "actionSidebar.manageMembers.placeholder": "Select option",
+    "actionSidebar.manageMembers.decisionMethod": "The decision to Manage verified members can only be done in the Root domain.",
     "actionSidebar.manageMembers.table": "Selected members",
     "actionSidebar.decisionMethod": "Decision method",
     "actionSidebar.decisionMethod.placeholder": "Select method",


### PR DESCRIPTION
Small bug was found by our QA, in [issue](https://github.com/JoinColony/colonyCDapp/issues/1570) it says to change the tooltip content to `"The decision to Manage verified members can only be done in the Root domain."`

## Description

- Changed decision method field tooltip content in verified members action
