### PR TITLE
Fix: Ensure action fields are disabled when no permissions

### DIFF
--- a/src/components/v5/common/ActionSidebar/hooks/permissions/helpers.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/helpers.ts
@@ -55,7 +55,7 @@ export const getPermissionsNeededForAction = (
 };
 
 // Function returning the domain ID in which the user needs to have required permissions to create the action
-const getPermissionsDomainIdForAction = (
+export const getPermissionsDomainIdForAction = (
   actionType: Action,
   formValues: Record<string, any>,
 ) => {

--- a/src/components/v5/common/ActionSidebar/hooks/permissions/helpers.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/helpers.ts
@@ -6,6 +6,8 @@ import { type Colony } from '~types/graphql.ts';
 import { type Address } from '~types/index.ts';
 import { addressHasRoles } from '~utils/checks/index.ts';
 
+import { ModificationOption } from '../../partials/forms/ManageReputationForm/consts.ts';
+
 export const getPermissionsNeededForAction = (
   actionType: Action,
   formValues: Record<string, any>,
@@ -26,16 +28,19 @@ export const getPermissionsNeededForAction = (
     case Action.EditExistingTeam:
       return [ColonyRole.Architecture];
     case Action.ManageReputation:
-      /**
-       * @TODO: Once this action is wired, we'll need to tell if
-       * it's a smite or award action (most likely from `formValues`)
-       * If smite: Arbitration, else: Root
-       */
-      return undefined;
+      if (!formValues.modification) {
+        return [ColonyRole.Arbitration];
+      }
+      return formValues.modification === ModificationOption.RemoveReputation
+        ? [ColonyRole.Arbitration]
+        : [ColonyRole.Root];
     case Action.ManagePermissions: {
       return formValues.team === Id.RootDomain
         ? [ColonyRole.Root, ColonyRole.Architecture]
         : [ColonyRole.Architecture];
+    }
+    case Action.ManageVerifiedMembers: {
+      return [ColonyRole.Administration];
     }
     case Action.EditColonyDetails:
     case Action.ManageColonyObjectives:

--- a/src/components/v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts
@@ -1,9 +1,10 @@
 import { useFormContext } from 'react-hook-form';
 
+import { Action } from '~constants/actions.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useEnabledExtensions from '~hooks/useEnabledExtensions.tsx';
-import { getAllUserRoles } from '~transformers';
+import { getAllUserRoles, getUserRolesForDomain } from '~transformers';
 
 import { ACTION_TYPE_FIELD_NAME } from '../../consts.ts';
 
@@ -24,6 +25,10 @@ const useHasNoDecisionMethods = () => {
     return true;
   }
 
+  if (!isVotingReputationEnabled && actionType === Action.CreateDecision) {
+    return true;
+  }
+
   if (isVotingReputationEnabled) {
     return false;
   }
@@ -31,6 +36,15 @@ const useHasNoDecisionMethods = () => {
   const requiredPermissions = getPermissionsNeededForAction(actionType, {});
   if (!requiredPermissions) {
     return false;
+  }
+
+  // Check if the user has the required permissions in root domain
+  // for action types which can only be actioned in root domain
+  const userRootRoles = getUserRolesForDomain(colony, user.walletAddress, 1);
+  if (!requiredPermissions.every((role) => userRootRoles.includes(role))) {
+    if (actionType === Action.ManageVerifiedMembers) {
+      return true;
+    }
   }
 
   // Check if the user has the required permissions in any domain

--- a/src/components/v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts
@@ -44,26 +44,24 @@ const useHasNoDecisionMethods = () => {
 
   const requiredRolesDomain = getPermissionsDomainIdForAction(actionType, {});
 
-  // If the requiredRolesDomain is root, check the user has the required permissions in root
-  if (requiredRolesDomain === Id.RootDomain) {
-    const userRootRoles = getUserRolesForDomain(
-      colony,
-      user.walletAddress,
-      Id.RootDomain,
-    );
+  const userRootRoles = getUserRolesForDomain(
+    colony,
+    user.walletAddress,
+    Id.RootDomain,
+  );
 
-    if (
-      !requiredPermissions.every((requiredPermission) =>
-        userRootRoles.includes(requiredPermission),
-      )
-    ) {
-      return true;
-    }
-  }
-
-  // Check if the user has the required permissions in any domain
   const userRoles = getAllUserRoles(colony, user.walletAddress);
-  if (!requiredPermissions.every((role) => userRoles.includes(role))) {
+
+  if (
+    !requiredPermissions.every((role) => {
+      // If the requiredRolesDomain is root, check the user has the required permissions in root
+      if (requiredRolesDomain === Id.RootDomain) {
+        return userRootRoles.includes(role);
+      }
+      // Otherwise, check the user has the required permissions in any domain
+      return userRoles.includes(role);
+    })
+  ) {
     return true;
   }
 

--- a/src/components/v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts
@@ -1,3 +1,4 @@
+import { Id } from '@colony/colony-js';
 import { useFormContext } from 'react-hook-form';
 
 import { Action } from '~constants/actions.ts';
@@ -8,7 +9,10 @@ import { getAllUserRoles, getUserRolesForDomain } from '~transformers';
 
 import { ACTION_TYPE_FIELD_NAME } from '../../consts.ts';
 
-import { getPermissionsNeededForAction } from './helpers.ts';
+import {
+  getPermissionsDomainIdForAction,
+  getPermissionsNeededForAction,
+} from './helpers.ts';
 
 /**
  * Hook determining if the user has no decision methods available for the currently selected action type
@@ -38,11 +42,21 @@ const useHasNoDecisionMethods = () => {
     return false;
   }
 
-  // Check if the user has the required permissions in root domain
-  // for action types which can only be actioned in root domain
-  const userRootRoles = getUserRolesForDomain(colony, user.walletAddress, 1);
-  if (!requiredPermissions.every((role) => userRootRoles.includes(role))) {
-    if (actionType === Action.ManageVerifiedMembers) {
+  const requiredRolesDomain = getPermissionsDomainIdForAction(actionType, {});
+
+  // If the requiredRolesDomain is root, check the user has the required permissions in root
+  if (requiredRolesDomain === Id.RootDomain) {
+    const userRootRoles = getUserRolesForDomain(
+      colony,
+      user.walletAddress,
+      Id.RootDomain,
+    );
+
+    if (
+      !requiredPermissions.every((requiredPermission) =>
+        userRootRoles.includes(requiredPermission),
+      )
+    ) {
       return true;
     }
   }

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/NoPermissionsError.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/NoPermissionsError.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useWatch } from 'react-hook-form';
 import { defineMessages, useIntl } from 'react-intl';
 
-import { type Action } from '~constants/actions.ts';
+import { Action } from '~constants/actions.ts';
 import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import useHasActionPermissions from '~v5/common/ActionSidebar/hooks/permissions/useHasActionPermissions.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
@@ -29,7 +29,11 @@ const NoPermissionsError = () => {
   const hasPermissions = useHasActionPermissions();
   const hasNoDecisionMethods = useHasNoDecisionMethods();
 
-  if (actionType && (hasNoDecisionMethods || hasPermissions === false)) {
+  if (
+    actionType &&
+    actionType !== Action.CreateDecision &&
+    (hasNoDecisionMethods || hasPermissions === false)
+  ) {
     return (
       <div className="mt-6">
         <NotificationBanner status="error" icon={WarningCircle}>

--- a/src/components/v5/common/ActionSidebar/partials/SaveDraftButton/SaveDraftButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/SaveDraftButton/SaveDraftButton.tsx
@@ -11,6 +11,8 @@ import { type DecisionDraft } from '~utils/decisions.ts';
 import { formatText } from '~utils/intl.ts';
 import Button from '~v5/shared/Button/index.ts';
 
+import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
+
 const SaveDraftButton: FC = () => {
   const [isDraftSaved, setIsDraftSaved] = useState(false);
   const isMobile = useMobile();
@@ -24,6 +26,8 @@ const SaveDraftButton: FC = () => {
   } = useFormContext();
 
   const formValues = getValues();
+
+  const hasNoDecisionMethods = useHasNoDecisionMethods();
 
   const handleSaveAgreementInLocalStorage = useCallback(
     (values: DecisionDraft) => {
@@ -65,7 +69,7 @@ const SaveDraftButton: FC = () => {
         }
       }}
       isFullSize={isMobile}
-      disabled={formState.isValidating || isDraftSaved}
+      disabled={formState.isValidating || isDraftSaved || hasNoDecisionMethods}
     >
       {!isDraftSaved && <FileDashed size={18} className="mr-2" />}
       {formatText({

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageVerifiedMembersForm/ManageVerifiedMembersForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageVerifiedMembersForm/ManageVerifiedMembersForm.tsx
@@ -4,6 +4,7 @@ import { useFormContext, useWatch } from 'react-hook-form';
 
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 import { FormCardSelect } from '~v5/common/Fields/CardSelect/index.ts';
 
@@ -28,6 +29,8 @@ const ManageVerifiedMembersForm: FC<ActionFormBaseProps> = ({
   const { resetField } = useFormContext();
   useManageVerifiedMembers(getFormOptions);
 
+  const hasNoDecisionMethods = useHasNoDecisionMethods();
+
   return (
     <>
       <ActionFormRow
@@ -41,6 +44,7 @@ const ManageVerifiedMembersForm: FC<ActionFormBaseProps> = ({
             }),
           },
         }}
+        isDisabled={hasNoDecisionMethods}
       >
         <FormCardSelect
           name="manageMembers"
@@ -52,6 +56,7 @@ const ManageVerifiedMembersForm: FC<ActionFormBaseProps> = ({
             id: 'actionSidebar.manageMembers.placeholder',
           })}
           title={formatText({ id: 'actionSidebar.manageMembers.placeholder' })}
+          disabled={hasNoDecisionMethods}
         />
       </ActionFormRow>
       <DecisionMethodField />


### PR DESCRIPTION
## Description

All inputs (except title and action type) should be disabled when you lack the permissions for the action.

The description field was not disabled for "Manage verified members" or "Create agreement".
On "Manage verified members" the "Decision method" field is not disabled and the "You don't have the correct permissions" error message does not show.

This PR fixes these issues. It also fixes similar issues with "Manage reputation" which was not included in the original issue as it has only recently been merged into master.

For "Manage verified members" the form should only be interactive if the current user has the correct permissions in the root domain (having the administration role in a team only will not be enough).

The PR also handles a TODO comment to ensure "removing reputation" requires the "Arbitration" role and "awarding reputation" requires the "root" role.

And also disables the "Save draft" button on the "Create agreement" form when the "Reputation weighting" extension is not installed.

## Testing

This is best tested with three different users:
1. No permissions at all
2. Arbitration and Administration permissions in the "General" team
3. Arbitration and Administration permissions in any other team

**Create agreement**
All fields (including the "save draft" button) should be disabled unless the reputation weighting extension is installed.

**Manage verified members**
All fields should be disabled, unless you are user 2.

**Manage reputation"
When "awarding reputation", and team is "General" then all fields should be disabled, user you are user 2.
When "removing reputation" fields should not be disabled for user 2 ever, or for user 3 if the team matches the team they have permissions in.

## Diffs

**New stuff** ✨

* "Manage reputation" permissions are checked depending on whether awarding or removing reputation
* "Manage verified members" permissions are set to "Administration" and only valid if in the root domain
* "Save draft" button now disabled when reputation weighting is not installed.

Resolves #2221

Create agreement:
<img width="678" alt="Screenshot 2024-04-12 at 16 03 27" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/7780f95b-57f9-4404-9ebd-2ee7c1533ae5">

Manage verified members:
<img width="676" alt="Screenshot 2024-04-12 at 16 03 06" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/f4d10092-c075-4861-aeaa-02db72ba6925">

Manage reputation:
 
<img width="673" alt="Screenshot 2024-04-12 at 16 01 50" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/bebf9d8f-fc6c-4f9a-82bd-2cecda55e9b5">