### PR TITLE
Fix: Action sidebar fields should be text-gray-300 when disabled

### DIFF
--- a/src/components/v5/common/ActionFormRow/ActionFormRow.tsx
+++ b/src/components/v5/common/ActionFormRow/ActionFormRow.tsx
@@ -42,7 +42,7 @@ const ActionFormRow = React.forwardRef<HTMLDivElement, ActionFormRowProps>(
           className={clsx({
             'text-negative-400': !isDisabled && isError,
             'text-gray-900': !isDisabled && !isError,
-            'text-gray-400': isDisabled,
+            'text-gray-300': isDisabled,
           })}
         />
         <span
@@ -51,7 +51,7 @@ const ActionFormRow = React.forwardRef<HTMLDivElement, ActionFormRowProps>(
             {
               'text-negative-400': !isDisabled && isError,
               'text-gray-900': !isDisabled && !isError,
-              'text-gray-400': isDisabled,
+              'text-gray-300': isDisabled,
             },
             'ml-2 flex items-center gap-2 text-md',
           )}
@@ -64,7 +64,7 @@ const ActionFormRow = React.forwardRef<HTMLDivElement, ActionFormRowProps>(
                 {
                   'rotate-90': isExpanded,
                   'text-gray-900': !isError && !isDisabled,
-                  'text-gray-400': isDisabled && !isError,
+                  'text-gray-300': !isError && isDisabled,
                 },
               )}
             >

--- a/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
@@ -93,7 +93,7 @@ const AmountField: FC<AmountFieldProps> = ({
       />
       <span
         className={clsx('text-md', {
-          'text-gray-400': isDisabled,
+          'text-gray-300': isDisabled,
         })}
       >
         {selectedToken?.symbol || colonyTokens[0].symbol}
@@ -114,7 +114,8 @@ const AmountField: FC<AmountFieldProps> = ({
         readOnly={readonly || isDisabled}
         name={name}
         className={clsx('flex-shrink text-gray-900 outline-none outline-0', {
-          'placeholder:text-gray-400': !isError || isDisabled,
+          'placeholder:text-gray-400': !isError && !isDisabled,
+          'placeholder:text-gray-300': isDisabled,
           'text-negative-400 placeholder:text-negative-400':
             !isDisabled && isError,
         })}

--- a/src/components/v5/common/ActionSidebar/partials/ColonyDetailsFields/partials/ColonyAvatarField/ColonyAvatarField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ColonyDetailsFields/partials/ColonyAvatarField/ColonyAvatarField.tsx
@@ -57,8 +57,9 @@ const ColonyAvatarField: FC<ColonyAvatarFieldProps> = ({
       {!readonly && (
         <button
           type="button"
-          className={clsx('text-gray-700 underline text-3', {
-            'md:hover:text-blue-400': !disabled,
+          className={clsx('underline text-3', {
+            'text-gray-700 md:hover:text-blue-400': !disabled,
+            'text-gray-300': disabled,
           })}
           onClick={() => {
             toggleAvatarModalOn();

--- a/src/components/v5/common/ActionSidebar/partials/ColonyObjectiveFields/ColonyObjectiveFields.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ColonyObjectiveFields/ColonyObjectiveFields.tsx
@@ -1,4 +1,5 @@
 import { Article, FileText, Percent } from '@phosphor-icons/react';
+import clsx from 'clsx';
 import React, { type FC } from 'react';
 import { defineMessages } from 'react-intl';
 
@@ -87,7 +88,15 @@ const ColonyObjectiveFields: FC = () => {
           max={100}
           name="colonyObjectiveProgress"
           placeholder="0"
-          suffix={<span className="text-md">%</span>}
+          suffix={
+            <span
+              className={clsx('text-md', {
+                'text-gray-300': hasNoDecisionMethods,
+              })}
+            >
+              %
+            </span>
+          }
           mode="secondary"
           autoWidth
           message={undefined}

--- a/src/components/v5/common/ActionSidebar/partials/ColonyVersionField/ColonyVersionField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ColonyVersionField/ColonyVersionField.tsx
@@ -1,10 +1,13 @@
 import { Browsers } from '@phosphor-icons/react';
+import clsx from 'clsx';
 import React, { type FC } from 'react';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useColonyContractVersion from '~hooks/useColonyContractVersion.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
+
+import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
 
 const displayName = 'v5.common.ActionsContent.partials.ColonyVersionField';
 
@@ -13,6 +16,8 @@ const ColonyVersionField: FC = () => {
     colony: { version: currentVersion },
   } = useColonyContext();
   const { colonyContractVersion: newVersion } = useColonyContractVersion();
+
+  const hasNoDecisionMethods = useHasNoDecisionMethods();
 
   return (
     <>
@@ -26,8 +31,13 @@ const ColonyVersionField: FC = () => {
             }),
           },
         }}
+        isDisabled={hasNoDecisionMethods}
       >
-        <span className="text-md">{currentVersion}</span>
+        <span
+          className={clsx('text-md', { 'text-gray-300': hasNoDecisionMethods })}
+        >
+          {currentVersion}
+        </span>
       </ActionFormRow>
       <ActionFormRow
         icon={Browsers}
@@ -39,8 +49,13 @@ const ColonyVersionField: FC = () => {
             }),
           },
         }}
+        isDisabled={hasNoDecisionMethods}
       >
-        <span className="text-md">{newVersion}</span>
+        <span
+          className={clsx('text-md', { 'text-gray-300': hasNoDecisionMethods })}
+        >
+          {newVersion}
+        </span>
       </ActionFormRow>
     </>
   );

--- a/src/components/v5/common/ActionSidebar/partials/ManageReputationTable/ManageReputationTable.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ManageReputationTable/ManageReputationTable.tsx
@@ -6,6 +6,8 @@ import Numeral from '~shared/Numeral/index.ts';
 import { SpinnerLoader } from '~shared/Preloaders/index.ts';
 import { formatText } from '~utils/intl.ts';
 
+import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
+
 import { type ManageReputationTableProps } from './types.ts';
 
 const ManageReputationTable: FC<ManageReputationTableProps> = ({
@@ -20,10 +22,20 @@ const ManageReputationTable: FC<ManageReputationTableProps> = ({
 }) => {
   const isMobile = useMobile();
 
+  const hasNoDecisionMethods = useHasNoDecisionMethods();
+
   const currentReputationContent = isLoading ? (
     <SpinnerLoader />
   ) : (
-    <p className="flex flex-wrap items-center gap-x-2 text-md font-normal text-gray-400">
+    <p
+      className={clsx(
+        'flex flex-wrap items-center gap-x-2 text-md font-normal',
+        {
+          'text-gray-300': hasNoDecisionMethods,
+          'text-gray-400': !hasNoDecisionMethods,
+        },
+      )}
+    >
       <Numeral value={formattedReputationPoints} />
       <span className="flex-shrink-0">
         {formatText(
@@ -39,7 +51,15 @@ const ManageReputationTable: FC<ManageReputationTableProps> = ({
   );
 
   const newReputationContent = (
-    <p className="flex flex-wrap items-center gap-x-2 text-md font-normal text-gray-400">
+    <p
+      className={clsx(
+        'flex flex-wrap items-center gap-x-2 text-md font-normal',
+        {
+          'text-gray-300': hasNoDecisionMethods,
+          'text-gray-400': !hasNoDecisionMethods,
+        },
+      )}
+    >
       <Numeral value={formattedNewReputationPoints} />
       <span className="flex-shrink-0">
         {formatText(

--- a/src/components/v5/common/ActionSidebar/partials/TeamColorField/TeamColorField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TeamColorField/TeamColorField.tsx
@@ -53,7 +53,9 @@ const TeamColorField: FC<TeamColourFieldProps> = ({ name, disabled }) => {
             ref={relativeElementRef}
             type="button"
             className={clsx('flex text-md transition-colors', {
-              'text-gray-400': !isError && !isTeamColourSelectVisible,
+              'text-gray-400':
+                !isError && !isTeamColourSelectVisible && !disabled,
+              'text-gray-300': disabled,
               'text-negative-400': isError,
               'text-blue-400': isTeamColourSelectVisible,
               'md:hover:text-blue-400': !disabled,

--- a/src/components/v5/common/ActionSidebar/partials/TeamsSelect/TeamsSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TeamsSelect/TeamsSelect.tsx
@@ -72,7 +72,8 @@ const TeamsSelect: FC<TeamSelectProps> = ({
             type="button"
             ref={relativeElementRef}
             className={clsx('flex text-md transition-colors', {
-              'text-gray-400': (!isError && !isTeamSelectVisible) || disabled,
+              'text-gray-400': !isError && !isTeamSelectVisible && !disabled,
+              'text-gray-300': disabled,
               'text-negative-400': !disabled && isError,
               'text-blue-400': isTeamSelectVisible,
               'md:hover:text-blue-400': !disabled,

--- a/src/components/v5/common/ActionSidebar/partials/TokenSelect/TokenSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TokenSelect/TokenSelect.tsx
@@ -15,7 +15,7 @@ import { type TokenSelectProps } from './types.ts';
 
 const displayName = 'v5.common.ActionsContent.partials.TokenSelect';
 
-const TokenSelect: FC<TokenSelectProps> = ({ name }) => {
+const TokenSelect: FC<TokenSelectProps> = ({ name, disabled = false }) => {
   const [searchError, setSearchError] = useState(false);
   const {
     field,
@@ -63,8 +63,9 @@ const TokenSelect: FC<TokenSelectProps> = ({ name }) => {
             className={clsx(
               'flex text-md transition-colors md:hover:text-blue-400',
               {
-                'text-gray-400': !isError,
+                'text-gray-400': !isError && !disabled,
                 'text-negative-400': isError,
+                'text-gray-300': disabled,
                 'pointer-events-none': isNativeToken,
               },
             )}

--- a/src/components/v5/common/ActionSidebar/partials/TokenSelect/partials/TokenSymbol/TokenSymbol.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TokenSelect/partials/TokenSymbol/TokenSymbol.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import React, { type FC } from 'react';
 
 import { useGetAllTokens } from '~hooks/useGetAllTokens.ts';
@@ -7,7 +8,7 @@ import { type TokenSymbolProps } from './types.ts';
 const displayName =
   'v5.common.ActionsContent.partials.TokenSelect.partials.TokenSymbol';
 
-const TokenSymbol: FC<TokenSymbolProps> = ({ address }) => {
+const TokenSymbol: FC<TokenSymbolProps> = ({ address, disabled = false }) => {
   const allTokens = useGetAllTokens();
 
   const selectedToken = allTokens.find(
@@ -20,7 +21,11 @@ const TokenSymbol: FC<TokenSymbolProps> = ({ address }) => {
 
   const { symbol } = selectedToken || {};
 
-  return <span className="text-md">{symbol}</span>;
+  return (
+    <span className={clsx('text-md', { 'text-gray-300': disabled })}>
+      {symbol}
+    </span>
+  );
 };
 
 TokenSymbol.displayName = displayName;

--- a/src/components/v5/common/ActionSidebar/partials/TokenSelect/partials/TokenSymbol/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/TokenSelect/partials/TokenSymbol/types.ts
@@ -1,3 +1,4 @@
 export interface TokenSymbolProps {
   address: string;
+  disabled?: boolean;
 }

--- a/src/components/v5/common/ActionSidebar/partials/TokenSelect/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/TokenSelect/types.ts
@@ -1,3 +1,4 @@
 export interface TokenSelectProps {
   name: string;
+  disabled?: boolean;
 }

--- a/src/components/v5/common/ActionSidebar/partials/TokensTable/TokensTable.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TokensTable/TokensTable.tsx
@@ -64,6 +64,7 @@ const TokensTable: FC<TokensTableProps> = ({
           columns={columns}
           data={data}
           getMenuProps={getMenuProps}
+          isDisabled={isDisabled}
         />
       )}
       {!readonly && (

--- a/src/components/v5/common/ActionSidebar/partials/TokensTable/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TokensTable/hooks.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from 'react';
 import useWrapWithRef from '~hooks/useWrapWithRef.ts';
 import { formatText } from '~utils/intl.ts';
 
+import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
 import TokenSelect from '../TokenSelect/index.ts';
 import TokenSymbol from '../TokenSelect/partials/TokenSymbol/index.ts';
 
@@ -19,18 +20,28 @@ export const useTokensTableColumns = (
   );
   const dataRef = useWrapWithRef(data);
 
+  const hasNoDecisionMethods = useHasNoDecisionMethods();
+
   const columns: ColumnDef<TokensTableModel, string>[] = useMemo(
     () => [
       columnHelper.display({
         id: 'token',
         header: () => formatText({ id: 'table.row.token' }),
-        cell: ({ row }) => <TokenSelect name={`${name}.${row.index}.token`} />,
+        cell: ({ row }) => (
+          <TokenSelect
+            name={`${name}.${row.index}.token`}
+            disabled={hasNoDecisionMethods}
+          />
+        ),
       }),
       columnHelper.display({
         id: 'symbol',
         header: () => formatText({ id: 'table.row.symbol' }),
         cell: ({ row }) => (
-          <TokenSymbol address={dataRef.current?.[row.index]?.token} />
+          <TokenSymbol
+            address={dataRef.current?.[row.index]?.token}
+            disabled={hasNoDecisionMethods}
+          />
         ),
       }),
     ],

--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
@@ -87,7 +87,8 @@ const UserSelect: FC<UserSelectProps> = ({
       type="button"
       ref={relativeElementRef}
       className={clsx('flex items-center text-md transition-colors', {
-        'text-gray-400': !isError && !isUserSelectVisible,
+        'text-gray-400': !isError && !isUserSelectVisible && !disabled,
+        'text-gray-300': disabled,
         'text-negative-400': isError,
         'text-blue-400': isUserSelectVisible,
         'md:hover:text-blue-400': !disabled,

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/ManageReputationTable.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/ManageReputationTable.tsx
@@ -69,7 +69,7 @@ const ManageReputationTable: FC = () => {
     <div
       className={clsx('flex flex-wrap items-center gap-x-2 text-md', {
         'text-negative-400': !!error,
-        'text-gray-400': isChangeFieldDisabled,
+        'text-gray-300': isChangeFieldDisabled,
         'text-gray-900': !isChangeFieldDisabled && !error,
       })}
     >
@@ -81,8 +81,9 @@ const ManageReputationTable: FC = () => {
         disabled={isChangeFieldDisabled}
         name="amount"
         className={clsx('flex-shrink outline-none outline-0', {
-          'placeholder:text-gray-400': !error,
           'placeholder:text-negative-400': !!error,
+          'bg-transparent placeholder:text-gray-300': isChangeFieldDisabled,
+          'placeholder:text-gray-400': !isChangeFieldDisabled && !error,
         })}
         placeholder="0"
         value={value}

--- a/src/components/v5/common/Fields/CardSelect/CardSelect.tsx
+++ b/src/components/v5/common/Fields/CardSelect/CardSelect.tsx
@@ -99,7 +99,7 @@ function CardSelect<TValue = string>({
       {readonly || disabled ? (
         <span
           className={clsx('text-md', {
-            'text-gray-400': disabled,
+            'text-gray-300': disabled,
             'text-gray-900': readonly,
           })}
         >

--- a/src/components/v5/common/Fields/InputBase/InputBase.tsx
+++ b/src/components/v5/common/Fields/InputBase/InputBase.tsx
@@ -70,9 +70,11 @@ const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
           className={clsx(
             className,
             state ? stateClassNames[state] : undefined,
-            'w-full text-md text-gray-900 outline-0 placeholder:text-gray-400 focus:outline-none',
+            'w-full text-md outline-0 focus:outline-none',
             {
-              'pointer-events-none text-gray-400': disabled,
+              'text-gray-900 placeholder:text-gray-400': !disabled,
+              'pointer-events-none text-gray-300 placeholder:text-gray-300':
+                disabled,
               'rounded border border-gray-300 bg-base-white px-3.5 py-2 focus:border-blue-200 focus:shadow-light-blue':
                 mode === 'primary',
               'border-none': mode === 'secondary',

--- a/src/components/v5/common/Fields/TextareaBase/TextareaBase.tsx
+++ b/src/components/v5/common/Fields/TextareaBase/TextareaBase.tsx
@@ -50,9 +50,11 @@ const TextareaBase = React.forwardRef<HTMLTextAreaElement, TextareaBaseProps>(
           className={clsx(
             className,
             state ? stateClassNames[state] : undefined,
-            'w-full resize-none text-md outline-none placeholder:text-gray-400',
+            'w-full resize-none text-md outline-none',
             {
-              'pointer-events-none text-gray-400': disabled,
+              'placeholder:text-gray-400': !disabled,
+              'pointer-events-none text-gray-300 placeholder:text-gray-300':
+                disabled,
             },
           )}
           value={value}

--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -43,6 +43,7 @@ const Table = <T,>({
   renderSubComponent,
   getRowCanExpand,
   withBorder = true,
+  isDisabled = false,
   ...rest
 }: TableProps<T>) => {
   const isMobile = useMobile();
@@ -273,7 +274,11 @@ const Table = <T,>({
                         {row.getVisibleCells().map((cell) => {
                           const renderCellWrapperCommonArgs = [
                             clsx(
-                              'flex h-full flex-col items-start justify-center p-[1.1rem] text-md text-gray-500',
+                              'flex h-full flex-col items-start justify-center p-[1.1rem] text-md',
+                              {
+                                'text-gray-500': !isDisabled,
+                                'text-gray-300': isDisabled,
+                              },
                               cell.column.columnDef.cellContentWrapperClassName,
                             ),
                             flexRender(

--- a/src/components/v5/common/Table/types.ts
+++ b/src/components/v5/common/Table/types.ts
@@ -38,4 +38,5 @@ export interface TableProps<T>
   renderSubComponent?: (props: { row: Row<T> }) => React.ReactElement;
   getRowCanExpand?: (row: Row<T>) => boolean;
   withBorder?: boolean;
+  isDisabled?: boolean;
 }

--- a/src/components/v5/shared/RichText/RichText.tsx
+++ b/src/components/v5/shared/RichText/RichText.tsx
@@ -119,7 +119,8 @@ const RichText: FC<RichTextProps> = ({
                 onClick={toggleOnDecriptionSelect}
                 className={clsx('text-left transition', {
                   'text-gray-900': characterCount,
-                  'text-gray-400': !characterCount,
+                  'text-gray-400': !characterCount && !isDisabled,
+                  'text-gray-300': isDisabled,
                   'sm:hover:text-blue-400': !isDisabled,
                 })}
                 disabled={isDisabled}

--- a/src/hooks/useSocialLinksTableColumns.tsx
+++ b/src/hooks/useSocialLinksTableColumns.tsx
@@ -1,8 +1,10 @@
 import { createColumnHelper, type ColumnDef } from '@tanstack/react-table';
+import clsx from 'clsx';
 import React, { useMemo } from 'react';
 
 import { type SocialLinksTableModel } from '~types/colony.ts';
 import { formatText } from '~utils/intl.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 
 export const useSocialLinksTableColumns = (): ColumnDef<
   SocialLinksTableModel,
@@ -12,6 +14,8 @@ export const useSocialLinksTableColumns = (): ColumnDef<
     () => createColumnHelper<SocialLinksTableModel>(),
     [],
   );
+
+  const hasNoDecisionMethods = useHasNoDecisionMethods();
 
   const columns: ColumnDef<SocialLinksTableModel, string>[] = useMemo(
     () => [
@@ -23,7 +27,14 @@ export const useSocialLinksTableColumns = (): ColumnDef<
           </span>
         ),
         cell: ({ getValue }) => (
-          <span className="text-gray-900 text-1">{getValue()}</span>
+          <span
+            className={clsx('text-1', {
+              'text-gray-900': !hasNoDecisionMethods,
+              'text-gray-300': hasNoDecisionMethods,
+            })}
+          >
+            {getValue()}
+          </span>
         ),
         size: 23,
       }),
@@ -35,14 +46,22 @@ export const useSocialLinksTableColumns = (): ColumnDef<
           </span>
         ),
         cell: ({ getValue }) => (
-          <span className="block overflow-hidden overflow-ellipsis whitespace-nowrap text-md font-normal text-gray-700">
+          <span
+            className={clsx(
+              'block overflow-hidden overflow-ellipsis whitespace-nowrap text-md font-normal',
+              {
+                'text-gray-700': !hasNoDecisionMethods,
+                'text-gray-300': hasNoDecisionMethods,
+              },
+            )}
+          >
             {getValue()}
           </span>
         ),
         size: 67,
       }),
     ],
-    [columnHelper],
+    [columnHelper, hasNoDecisionMethods],
   );
 
   return columns;


### PR DESCRIPTION
## Description

Action sidebar fields should be text-gray-300 when disabled, currently they are text-gray-400.

This PR changes the current colour value. I also picked up a few cases where the disabled styling was not being properly applied.

(Using #2233 as a base branch as it contains new logic for disabling fields)

## Testing

This is most easily checked by switching to a user who has no permissions. Look through all the action types and confirm the disabled states are using text-gray-300.

Switch to a user who does have permissions and check the default and error states are unaffected.

## Diffs

**Changes** 🏗

* Disabled fields now use text-gray-300
* Some tables now have a "disabled" prop to show disabled states

Resolves #2234 

<img width="674" alt="Screenshot 2024-04-15 at 12 44 35" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/f4e3ca08-c345-4c7e-903f-563fecdb3ba9">
<img width="670" alt="Screenshot 2024-04-15 at 12 44 58" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/f8591c46-daf1-4035-b57f-3b94e8631b26">
<img width="672" alt="Screenshot 2024-04-15 at 12 45 10" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/37cd7e0f-9db7-4404-9a26-6ab67c82fe61">
<img width="669" alt="Screenshot 2024-04-15 at 12 45 24" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/c756c680-bab5-4613-b1ed-010e21c478f1">
<img width="674" alt="Screenshot 2024-04-15 at 12 45 28" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/480e45a8-5f5b-4a0a-ad15-0b6b481c908d">
