### PR TITLE
Add streaming payment testing UI and add amount conversion in saga

### DIFF
--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
-import { useGetExpenditureQuery } from '~gql';
+import { StreamingPaymentEndCondition, useGetExpenditureQuery } from '~gql';
 import useAsyncFunction from '~hooks/useAsyncFunction.ts';
 import useCurrentBlockTime from '~hooks/useCurrentBlockTime.ts';
 import useEnabledExtensions from '~hooks/useEnabledExtensions.ts';
@@ -14,6 +14,7 @@ import { type CancelExpenditurePayload } from '~redux/sagas/expenditures/cancelE
 import { type ClaimExpenditurePayload } from '~redux/sagas/expenditures/claimExpenditure.ts';
 import { type CreateExpenditurePayload } from '~redux/sagas/expenditures/createExpenditure.ts';
 import { type CreateStakedExpenditurePayload } from '~redux/sagas/expenditures/createStakedExpenditure.ts';
+import { type CreateStreamingPaymentPayload } from '~redux/sagas/expenditures/createStreamingPayment.ts';
 import { type EditExpenditurePayload } from '~redux/sagas/expenditures/editExpenditure.ts';
 import { type FinalizeExpenditurePayload } from '~redux/sagas/expenditures/finalizeExpenditure.ts';
 import { type FundExpenditurePayload } from '~redux/sagas/expenditures/fundExpenditure.ts';
@@ -173,6 +174,19 @@ const TmpAdvancedPayments = () => {
         tokenAddress: colony.nativeToken.tokenAddress,
       },
     ],
+  };
+
+  const createStreamingPaymentPayload: CreateStreamingPaymentPayload = {
+    colonyAddress: colony.colonyAddress,
+    createdInDomain: rootDomain,
+    amount: transactionAmount,
+    endCondition: StreamingPaymentEndCondition.FixedTime,
+    interval: 60,
+    recipientAddress: user?.walletAddress ?? '',
+    startTimestamp: Math.floor(Date.now() / 1000),
+    tokenAddress,
+    tokenDecimals: parseInt(decimalAmount, 10),
+    endTimestamp: Math.floor(Date.now() / 1000) + 120,
   };
 
   const handleLockExpenditure = async () => {
@@ -427,6 +441,12 @@ const TmpAdvancedPayments = () => {
           values={createStagedExpenditurePayload}
         >
           Create staged expenditure
+        </ActionButton>
+        <ActionButton
+          actionType={ActionTypes.STREAMING_PAYMENT_CREATE}
+          values={createStreamingPaymentPayload}
+        >
+          Create streaming payment
         </ActionButton>
       </div>
       <div className="flex gap-4">

--- a/src/constants/extensions.ts
+++ b/src/constants/extensions.ts
@@ -11,16 +11,15 @@ import oneTransactionHero from '~images/assets/extensions/one-transaction-hero.p
 import oneTransactionInterface from '~images/assets/extensions/one-transaction-interface.png';
 import reputationHero from '~images/assets/extensions/reputation-hero.png';
 import reputationInterface from '~images/assets/extensions/reputation-interface.png';
+import streamingHero from '~images/assets/extensions/streaming-hero.png';
+import streamingInterface from '~images/assets/extensions/streaming-interface.png';
 import { type ExtensionConfig, ExtensionParamType } from '~types/extensions.ts';
 import {
   convertFractionToWei,
   convertPeriodToSeconds,
 } from '~utils/extensions.ts';
 import { toFinite } from '~utils/lodash.ts';
-
 // @BETA: Disabled for now
-// import streamingHero from '~images/assets/extensions/streaming-hero.png';
-// import streamingInterface from '~images/assets/extensions/streaming-interface.png';
 
 export enum ExtensionCategory {
   Payments = 'Payments',
@@ -538,16 +537,16 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
     uninstallable: true,
     createdAt: 1692048380000,
   },
-  // {
-  //   icon: 'extension-streaming-payments',
-  //   imageURLs: [streamingHero, streamingInterface],
-  //   category: ExtensionCategory.Expenditures,
-  //   extensionId: Extension.StreamingPayments,
-  //   name: MSG.streamingPaymentsName,
-  //   descriptionShort: MSG.streamingPaymentsDescriptionShort,
-  //   descriptionLong: MSG.streamingPaymentsDescriptionLong,
-  //   neededColonyPermissions: [ColonyRole.Administration, ColonyRole.Funding],
-  //   uninstallable: true,
-  //   createdAt: 1692048380000,
-  // },
+  {
+    icon: ExtensionAdvancedPaymentsIcon,
+    imageURLs: [streamingHero, streamingInterface],
+    category: ExtensionCategory.Expenditures,
+    extensionId: Extension.StreamingPayments,
+    name: MSG.streamingPaymentsName,
+    descriptionShort: MSG.streamingPaymentsDescriptionShort,
+    descriptionLong: MSG.streamingPaymentsDescriptionLong,
+    neededColonyPermissions: [ColonyRole.Administration, ColonyRole.Funding],
+    uninstallable: true,
+    createdAt: 1692048380000,
+  },
 ];

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -191,9 +191,10 @@ export type ExpendituresActionTypes =
         createdInDomain: Domain;
         recipientAddress: Address;
         tokenAddress: Address;
+        tokenDecimals: number;
         amount: string;
-        startTime: number;
-        endTime?: number;
+        startTimestamp: number;
+        endTimestamp?: number;
         interval: number;
         endCondition: StreamingPaymentEndCondition;
         limitAmount?: string;


### PR DESCRIPTION
## Description

* Add a button to the testing UI to test streaming payment create.
* Add a conversion of the amount in the create streaming payment saga to ensure the correct amount is sent.

## Testing

Test that streaming payments can be created in the db successfully.

* Step 1. Click on the create streaming payment button in the temporary testing UI on the dashboard.
* Step 2. Wait for it to complete.
* Step 3. Check that the payment was created in the db with the correct payload.

## Diffs

**New stuff** ✨

* New temporary button on the dashboard for testing.

**Changes** 🏗

* Changed the createStreamingPayment saga to ensure the correct amount is sent.

Resolves #2211
