### PR TITLE
Truncate addresses on member cards

### DIFF
--- a/src/components/v5/common/MemberCard/MemberCard.tsx
+++ b/src/components/v5/common/MemberCard/MemberCard.tsx
@@ -1,6 +1,7 @@
 import { SealCheck } from '@phosphor-icons/react';
 import React, { type FC } from 'react';
 
+import { splitAddress } from '~utils/strings.ts';
 import ContributorTypeWrapper from '~v5/shared/ContributorTypeWrapper/ContributorTypeWrapper.tsx';
 import MeatBallMenu from '~v5/shared/MeatBallMenu/index.ts';
 import ReputationBadge from '~v5/shared/ReputationBadge/index.ts';
@@ -21,7 +22,8 @@ const MemberCard: FC<MemberCardProps> = ({
   contributorType,
   isVerified,
 }) => {
-  const userName = user?.profile?.displayName || userAddress;
+  const { header, start, end } = splitAddress(userAddress);
+  const userName = user?.profile?.displayName || `${header}${start}...${end}`;
 
   return (
     <div className="flex h-full w-full flex-col rounded-lg border border-gray-200 bg-gray-25 p-5">

--- a/src/components/v5/common/SimpleMemberCard/SimpleMemberCard.tsx
+++ b/src/components/v5/common/SimpleMemberCard/SimpleMemberCard.tsx
@@ -1,5 +1,6 @@
 import React, { type FC } from 'react';
 
+import { splitAddress } from '~utils/strings.ts';
 import MeatBallMenu from '~v5/shared/MeatBallMenu/index.ts';
 import UserAvatar from '~v5/shared/UserAvatar/UserAvatar.tsx';
 import UserInfoPopover from '~v5/shared/UserInfoPopover/UserInfoPopover.tsx';
@@ -13,7 +14,8 @@ const SimpleMemberCard: FC<SimpleMemberCardProps> = ({
   userAddress,
   meatBallMenuProps,
 }) => {
-  const userName = user?.profile?.displayName || userAddress;
+  const { header, start, end } = splitAddress(userAddress);
+  const userName = user?.profile?.displayName || `${header}${start}...${end}`;
 
   return (
     <div className="flex h-full w-full items-center justify-between gap-4 rounded-lg border border-gray-200 bg-gray-25 p-5">


### PR DESCRIPTION
## Description

* Truncate addresses on member cards and simple member cards.

## Testing

Check that the addresses are truncated on all member cards.

* Step 1. Find a member card without a display name
* Step 2. Check that the address is truncated properly

## Diffs

**Changes** 🏗

* Truncate addresses on member cards and simple member cards.

Resolves #2204
