### PR TITLE
Fix: Improvements to transaction errors

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/CancelTransaction.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/CancelTransaction.tsx
@@ -36,7 +36,11 @@ const CancelTransaction: FC<CancelTransactionProps> = ({
           </TextButton>
         </div>
       ) : (
-        <TextButton type="button" onClick={toggleCancelConfirmation}>
+        <TextButton
+          type="button"
+          onClick={toggleCancelConfirmation}
+          className="text-xs underline hover:text-gray-900 hover:no-underline"
+        >
           {formatMessage({ id: 'button.cancel' })}
         </TextButton>
       )}

--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransactionContent.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransactionContent.tsx
@@ -93,26 +93,42 @@ const GroupedTransactionContent: FC<GroupedTransactionContentProps> = ({
             toggleCancelConfirmation={toggleCancelConfirmation}
           />
         ) : (
-          <TransactionStatus status={status} />
+          <TransactionStatus status={status} hasError={!!error} />
         )}
       </div>
       {failed && error && (
-        <div className="mt-2 md:max-w-[24rem]">
+        <div className="mt-2 md:mr-2">
           <NotificationBanner
             status="error"
+            callToActionClassName="w-full"
             callToAction={
-              <button type="button" onClick={handleRetryAction}>
-                <FormattedMessage id="retry" />
-              </button>
+              <div className="flex justify-between">
+                <button
+                  type="button"
+                  onClick={handleRetryAction}
+                  className="underline hover:no-underline"
+                >
+                  <FormattedMessage id="retry" />
+                </button>
+                <button
+                  type="button"
+                  onClick={handleCancelTransaction}
+                  className="underline hover:no-underline"
+                >
+                  <FormattedMessage id="cancel" />
+                </button>
+              </div>
             }
           >
-            <FormattedMessage
-              {...MSG.failedTx}
-              values={{
-                type: error.type,
-                message: shortErrorMessage(error.message),
-              }}
-            />
+            <p className="text-sm font-normal">
+              <FormattedMessage
+                {...MSG.failedTx}
+                values={{
+                  type: error.type,
+                  message: shortErrorMessage(error.message),
+                }}
+              />
+            </p>
           </NotificationBanner>
         </div>
       )}

--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransactionContent.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransactionContent.tsx
@@ -100,7 +100,7 @@ const GroupedTransactionContent: FC<GroupedTransactionContentProps> = ({
         <div className="mt-2 md:mr-2">
           <NotificationBanner
             status="error"
-            callToActionClassName="w-full"
+            callToActionClassName="w-full no-underline"
             callToAction={
               <div className="flex justify-between">
                 <button
@@ -110,13 +110,11 @@ const GroupedTransactionContent: FC<GroupedTransactionContentProps> = ({
                 >
                   <FormattedMessage id="retry" />
                 </button>
-                <button
-                  type="button"
-                  onClick={handleCancelTransaction}
-                  className="underline hover:no-underline"
-                >
-                  <FormattedMessage id="cancel" />
-                </button>
+                <CancelTransaction
+                  isShowingCancelConfirmation={isShowingCancelConfirmation}
+                  handleCancelTransaction={handleCancelTransaction}
+                  toggleCancelConfirmation={toggleCancelConfirmation}
+                />
               </div>
             }
           >

--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/TransactionStatus.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/TransactionStatus.tsx
@@ -1,4 +1,9 @@
-import { SpinnerGap, CheckCircle, XCircle } from '@phosphor-icons/react';
+import {
+  SpinnerGap,
+  CheckCircle,
+  XCircle,
+  WarningCircle,
+} from '@phosphor-icons/react';
 import clsx from 'clsx';
 import { format } from 'date-fns';
 import React, { type FC } from 'react';
@@ -10,7 +15,11 @@ import { type TransactionStatusProps } from '../types.ts';
 const displayName =
   'common.Extensions.UserHub.partials.TransactionTab.partials.TransactionStatus';
 
-const TransactionStatus: FC<TransactionStatusProps> = ({ status, date }) => {
+const TransactionStatus: FC<TransactionStatusProps> = ({
+  status,
+  date,
+  hasError,
+}) => {
   const failed = status === TransactionStatusEnum.Failed;
   const succeeded = status === TransactionStatusEnum.Succeeded;
   const pending = status === TransactionStatusEnum.Pending;
@@ -31,7 +40,9 @@ const TransactionStatus: FC<TransactionStatusProps> = ({ status, date }) => {
         />
       )}
       {succeeded && <CheckCircle size={14} />}
-      {failed && <XCircle size={14} />}
+      {failed && (
+        <>{hasError ? <WarningCircle size={14} /> : <XCircle size={14} />}</>
+      )}
       {createdAt && (
         <span className="mt-1 block text-xs text-gray-400">{createdAt}</span>
       )}

--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/hooks.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/hooks.tsx
@@ -59,28 +59,6 @@ export const useGroupedTransactionContent = (
     }${methodName}.${methodContext ? `${methodContext}.` : ''}title`,
   };
 
-  /*
-   * Commenting this effect out for now.
-   * I believe it's only useful for the old flow where the gas station would pop open automatically.
-   */
-  // useEffect(() => {
-  //   if (!error) {
-  //     if (metatransaction) {
-  //       dispatch(transactionSend(id));
-  //     } else {
-  //       dispatch(transactionEstimateGas(id));
-  //     }
-  //   }
-  // }, [dispatch, id, error, metatransaction]);
-
-  // const transform = useCallback(() => withId(id), [id])();
-  // const asyncFunction = useAsyncFunction({
-  //   submit: ActionTypes.TRANSACTION_RETRY,
-  //   error: ActionTypes.TRANSACTION_ERROR,
-  //   success: ActionTypes.TRANSACTION_SENT,
-  //   transform,
-  // });
-
   const handleRetryAction = () => {
     dispatch(transactionRetry(id));
     dispatch(transactionEstimateGas(id));

--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/utils.ts
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/utils.ts
@@ -1,3 +1,3 @@
 export const shortErrorMessage = (message: string) => {
-  return `${message.substring(0, 30)}${message.length > 20 ? '...' : ''}`;
+  return message.length > 120 ? `${message.substring(0, 117)}...` : message;
 };

--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/types.ts
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/types.ts
@@ -63,6 +63,7 @@ export interface TransactionStatusProps {
   status: TransactionStatus;
   loadingRelated?: boolean;
   date?: Date;
+  hasError?: boolean;
 }
 
 export interface CancelTransactionProps {

--- a/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
+++ b/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
@@ -58,7 +58,7 @@ const UserHubButton: FC = () => {
     },
   });
 
-  const { getTooltipProps, setTooltipRef, setTriggerRef, visible } =
+  const { getTooltipProps, setTooltipRef, setTriggerRef, triggerRef, visible } =
     usePopperTooltip(
       {
         delayShow: isMobile ? 0 : 200,
@@ -80,6 +80,14 @@ const UserHubButton: FC = () => {
         ],
       },
     );
+
+  // If visible is not true, then clicking buttons within the popover will close it
+  // So if isUserHubOpen is true, trigger a triggerRef click to ensure visible is true
+  useEffect(() => {
+    if (isUserHubOpen && !visible) {
+      triggerRef?.click();
+    }
+  }, [isUserHubOpen, visible, triggerRef]);
 
   useDisableBodyScroll(visible && isMobile);
 

--- a/src/components/v5/shared/NotificationBanner/NotificationBanner.tsx
+++ b/src/components/v5/shared/NotificationBanner/NotificationBanner.tsx
@@ -13,6 +13,7 @@ const NotificationBanner: FC<NotificationBannerProps> = ({
   description,
   callToAction,
   descriptionClassName,
+  callToActionClassName,
 }) => {
   return (
     <div
@@ -39,7 +40,7 @@ const NotificationBanner: FC<NotificationBannerProps> = ({
           })}
         />
       ) : null}
-      <div className="flex flex-1 flex-col items-start gap-3 @[600px]/notificationBanner:flex-row @[600px]/notificationBanner:items-center">
+      <div className="flex flex-1 flex-col items-start gap-2 @[600px]/notificationBanner:flex-row @[600px]/notificationBanner:items-center">
         <div className="flex flex-1 flex-col items-start gap-2 text-md break-word">
           {children}
           {description ? (
@@ -54,6 +55,7 @@ const NotificationBanner: FC<NotificationBannerProps> = ({
           <div
             className={clsx(
               'flex-shrink-0 text-xs font-medium underline md:hover:no-underline',
+              callToActionClassName,
             )}
           >
             {callToAction}

--- a/src/components/v5/shared/NotificationBanner/types.ts
+++ b/src/components/v5/shared/NotificationBanner/types.ts
@@ -9,4 +9,5 @@ export type NotificationBannerProps = PropsWithChildren<{
   description?: ReactNode;
   callToAction?: ReactNode;
   descriptionClassName?: string;
+  callToActionClassName?: string;
 }>;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -918,6 +918,7 @@
     "darkMode": "Dark",
     "help": "Help",
     "retry": "Retry",
+    "cancel": "Cancel",
     "menu": "Menu",
     "total.balance": "Total balance",
     "active": "Active",

--- a/src/redux/sagas/transactions/createTransaction.ts
+++ b/src/redux/sagas/transactions/createTransaction.ts
@@ -91,7 +91,7 @@ export function* createTransaction(id: string, config: TxConfig) {
 }
 
 export function* getTxChannel(id: string) {
-  return yield actionChannel(filterUniqueAction(id), buffers.fixed());
+  return yield actionChannel(filterUniqueAction(id), buffers.expanding());
 }
 
 export interface ChannelDefinition {


### PR DESCRIPTION
## Description

There were a few issues with how transaction errors were handled in the user hub.

Issue 1 - UserHub transactions were missing the "Cancel" option. This PR adds a "Cancel" button in addition to the existing "Retry" button. It has the same behaviour as the existing "Cancel" button and requires a confirmation step.

Issue 2 - Transaction error message character limits were too short. This PR increases the allowed length and fixes the logic in the short description utility function.

Issue 3 - The transaction error messages were incorrectly styled. Should now match [figma](https://www.figma.com/file/l1dOM5qiQYwF0ElvKDqqjg/Design-System---Colony-v3?type=design&node-id=1782-51131&mode=design&t=EIF9brlfr9amkOk9-4)

Issue 4 - Clicking "Retry" was closing the UserHub. This was occurring only when the UserHub was automatically opened by a failed transaction. This is because the visibility of the menu is being controlled by both the popper tooltip and the isUserHubOpen state and probably warrants a bigger refactor at some point, for now this issue has been resolved by ensuring the popper tooltip visibility is true when isUserHubOpen is true.

Issue 5 - Clicking the "Retry" button on a failed transaction in the UserHub transactions tab would sometimes not trigger the transaction to retry. When attempting to reproduce this, I found the first retry would work, but the second would fail. This was being caused by the action channel buffer overflowing when too many actions are queued. To resolve this I have changed the action channel buffer type from fixed to expanding. (I'm unsure if further investigation is needed here, or if the fixed buffer size was simply too small?)

Issue 6 - When creating a colony, if you cancelled your transaction at the first step, the entire app would crash. This PR fixes this and returns you the "Confirm all" step if the transaction is cancelled.

## Testing

Connect with a metamask wallet rather than a developer wallet so that you can easily cancel transactions.

Issue 1 - Create a new action, when you submit the form, decline the transaction in metamask. The UserHub should automatically open. Cancel the transaction, you should be prompted for a confirmation.

Issue 2 - Check UserHub transaction error messages are visible up to 120 characters.

Issue 3 - Check UserHub transaction error message styling matches figma design.

Issue 4 - Repeat steps in issue 1. Retry the transaction, the UserHub should stay open.

Issue 5 - Repeat steps in issue 1. Retry and reject the transaction multiple times.

Issue 6 - Run `node scripts/create-colony-url.js` to get a link to create a new colony. Complete the form and reject the first transaction. Cancel the transaction and you should be returned to the previous step.

## Diffs

**Changes** 🏗

* UserHub transaction error styling
* UserHub transaction now has "Cancel" button
* UserHub transaction retry button no longer closes UserHub
* Cancelling the create colony transaction no longer crashes the app

Resolves #2222

<img width="673" alt="Screenshot 2024-04-19 at 15 46 38" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/f42e7ff4-2394-443d-9672-955e40dbc6d5">


https://github.com/JoinColony/colonyCDapp/assets/34915414/eeff4c9b-b931-4aed-86c3-621c4d5c9b75

