### PR TITLE
Update UI of the wrong chain connected tooltip

### DIFF
--- a/src/components/common/Extensions/UserNavigation/UserNavigation.tsx
+++ b/src/components/common/Extensions/UserNavigation/UserNavigation.tsx
@@ -21,7 +21,7 @@ const displayName = 'common.Extensions.UserNavigation';
 const MSG = defineMessages({
   wrongNetwork: {
     id: `${displayName}.unlockedToken`,
-    defaultMessage: `Your wallet is connected to a nework the app was not deployed to yet. ({networkName}).  Please switch your wallet to the "{correctNetworkName}" network.`,
+    defaultMessage: `Please switch your wallet to the {correctNetworkName} network. More chains will be supported in future.`,
   },
 });
 
@@ -74,7 +74,6 @@ const UserNavigation: FC<UserNavigationProps> = ({
               networkInfo={networkInfo}
               error={networkInfo?.chainId !== DEFAULT_NETWORK_INFO.chainId}
               errorMessage={formatText(MSG.wrongNetwork, {
-                networkName: networkInfo?.name,
                 correctNetworkName: DEFAULT_NETWORK_INFO.name,
               })}
             />

--- a/src/components/common/Extensions/UserNavigation/partials/NetworkName/NetworkName.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/NetworkName/NetworkName.tsx
@@ -1,3 +1,4 @@
+import { WarningCircle } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { type FC } from 'react';
 
@@ -23,21 +24,22 @@ const NetworkName: FC<NetworkNameProps> = ({
       tooltipContent={errorMessage}
       placement={isMobile ? 'bottom' : 'left'}
       trigger={error ? 'hover' : null}
-      isError={error}
     >
       <div
         className={clsx(
-          'flex min-h-[2.5rem] min-w-[2.625rem] items-center justify-center rounded-full border border-gray-200 bg-base-white px-[0.875rem] py-[0.625rem]',
+          'flex min-h-[2.5rem] min-w-[2.625rem] items-center justify-center gap-1 rounded-full border border-gray-200 bg-base-white px-[0.875rem] py-[0.625rem]',
           {
-            'border-negative-400': error,
+            'border-warning-400': error,
             'cursor-pointer': error,
+            'text-warning-400': error,
           },
         )}
       >
         <Icon size={size} />
-        <p className="ml-1 hidden text-gray-700 text-3 md:block">
+        <p className="hidden text-gray-700 text-3 md:block">
           {networkInfo.name}
         </p>
+        {error && <WarningCircle size={16} />}
       </div>
     </Tooltip>
   );


### PR DESCRIPTION
## Description

- Update the UI of the wrong chain connected warning & tooltip to match the Figma designs.

## Testing

* Step 1. Connect to a different network in metamask (not Ganache and not Arbitrum)
* Step 2. Connect the metamask wallet to Colony
* Step 3. Check and hover over the network pill in the top right. It should display the correct warnings and the correct tooltip as per designs.

## Diffs

**Changes** 🏗

* Update the UI of the wrong chain connected warning & tooltip

Resolves #2218
