### PR TITLE
Fix agreement titles not showing on stake tab

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/StakesTab/partials/StakeItem.tsx
+++ b/src/components/common/Extensions/UserHub/partials/StakesTab/partials/StakeItem.tsx
@@ -13,14 +13,17 @@ const displayName =
 const StakeItem: FC<StakeItemProps> = ({ nativeToken, stake, colony }) => {
   const { formatMessage } = useIntl();
 
+  const stakeItemTitle =
+    stake.action?.metadata?.customTitle ||
+    stake.action?.decisionData?.title ||
+    stake.action?.type;
+
   return (
     <li className="flex flex-col border-b border-gray-100 py-3.5 first:pt-2 last:pb-6 sm:first:pt-0 sm:last:border-none sm:last:pb-1.5">
       <div className="relative w-full">
         <div className="flex items-center justify-between">
           <div className="mr-2 flex min-w-0 items-center">
-            <p className="mr-2 min-w-0 truncate text-1">
-              {stake.action?.metadata?.customTitle ?? stake.action?.type}
-            </p>
+            <p className="mr-2 min-w-0 truncate text-1">{stakeItemTitle}</p>
             <span className="text-xs text-gray-400">
               <FormattedDate value={stake.createdAt} />
             </span>


### PR DESCRIPTION
Agreements should now show the correct title on the stakes tab of the user hub:

![Screenshot 2024-04-25 at 16 25 04](https://github.com/JoinColony/colonyCDapp/assets/18473896/cfbd558d-03b9-4274-9b40-1bba98c42e08)

Resolves #2260 
