### PR TITLE
Image upload form styling & interaction issues

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/ColonyDetailsFields/partials/ColonyAvatarField/ColonyAvatarField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ColonyDetailsFields/partials/ColonyAvatarField/ColonyAvatarField.tsx
@@ -79,10 +79,16 @@ const ColonyAvatarField: FC<ColonyAvatarFieldProps> = ({
         }}
         buttonMode="primarySolid"
         icon={Image}
-        confirmMessage={formatText({
-          id: 'button.confirmChange',
-        })}
-        closeMessage={formatText({ id: 'button.cancel' })}
+        confirmMessage={
+          avatarFileError
+            ? undefined
+            : formatText({
+                id: 'button.confirmChange',
+              })
+        }
+        closeMessage={
+          avatarFileError ? undefined : formatText({ id: 'button.cancel' })
+        }
       >
         <h5 className="mb-1.5 heading-5">
           {formatText({ id: 'editColonyLogo.modal.title' })}

--- a/src/components/v5/common/ActionSidebar/partials/ColonyDetailsFields/partials/ColonyAvatarField/ColonyAvatarField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ColonyDetailsFields/partials/ColonyAvatarField/ColonyAvatarField.tsx
@@ -80,7 +80,7 @@ const ColonyAvatarField: FC<ColonyAvatarFieldProps> = ({
         buttonMode="primarySolid"
         icon={Image}
         confirmMessage={formatText({
-          id: 'button.changeConfirm',
+          id: 'button.confirmChange',
         })}
         closeMessage={formatText({ id: 'button.cancel' })}
       >

--- a/src/components/v5/common/AvatarUploader/partials/ErrorContent.tsx
+++ b/src/components/v5/common/AvatarUploader/partials/ErrorContent.tsx
@@ -48,7 +48,7 @@ const ErrorContent: FC<ErrorContentProps> = ({
         <TextButton
           onClick={open}
           isErrorColor
-          className="text-sm font-bold underline"
+          className="text-sm font-semibold underline"
         >
           {formatMessage({ id: 'button.try.again' })}
           <input {...getInputProps()} />

--- a/src/components/v5/common/AvatarUploader/partials/ErrorContent.tsx
+++ b/src/components/v5/common/AvatarUploader/partials/ErrorContent.tsx
@@ -31,7 +31,7 @@ const ErrorContent: FC<ErrorContentProps> = ({
       </div>
       <div className="flex w-full flex-col gap-1">
         <div className="flex items-center justify-between">
-          <span className="text-negative-400 text-1">
+          <span className=" text-left text-negative-400 text-1">
             {formatMessage(errorMessage)}
           </span>
           <button
@@ -42,8 +42,14 @@ const ErrorContent: FC<ErrorContentProps> = ({
             <Trash size={18} />
           </button>
         </div>
-        <span className="text-sm text-gray-600">{fileRejections}</span>
-        <TextButton onClick={open} mode="underlined" isErrorColor>
+        <span className="text-left text-sm text-gray-600">
+          {fileRejections}
+        </span>
+        <TextButton
+          onClick={open}
+          isErrorColor
+          className="text-sm font-bold underline"
+        >
           {formatMessage({ id: 'button.try.again' })}
           <input {...getInputProps()} />
         </TextButton>

--- a/src/components/v5/common/AvatarUploader/partials/ErrorContent.tsx
+++ b/src/components/v5/common/AvatarUploader/partials/ErrorContent.tsx
@@ -30,13 +30,13 @@ const ErrorContent: FC<ErrorContentProps> = ({
         </div>
       </div>
       <div className="flex w-full flex-col gap-1">
-        <div className="flex items-center justify-between">
+        <div className="items-top flex justify-between">
           <span className=" text-left text-negative-400 text-1">
             {formatMessage(errorMessage)}
           </span>
           <button
             type="button"
-            className="flex text-negative-400"
+            className="flex pt-[1px] text-negative-400 hover:text-blue-400"
             onClick={handleFileRemove}
           >
             <Trash size={18} />

--- a/src/components/v5/shared/Button/TextButton.tsx
+++ b/src/components/v5/shared/Button/TextButton.tsx
@@ -52,7 +52,8 @@ const TextButton: FC<PropsWithChildren<TextButtonProps>> = ({
               'text-md': mode === 'medium',
             },
             {
-              'text-xs underline hover:text-blue-400': mode === 'underlined',
+              'bold text-xs underline hover:text-blue-400':
+                mode === 'underlined',
               'pointer-events-none': disabled,
               'disabled:text-gray-400': !isErrorColor,
               'text-negative-400': isErrorColor,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -178,7 +178,7 @@
     "button.editLink": "Edit link",
     "button.addToken": "Add token",
     "button.pending": "Pending",
-    "button.changeConfirm": "Change confirm",
+    "button.confirmChange": "Confirm change",
     "button.addBatchPayments": "Add batch payments",
     "button.addFunds": "Add funds",
     "button.apply": "Apply",


### PR DESCRIPTION
## Description

Fix some image upload form UI issues:
- Fix text of the confirm change button
- Fix styling of error state
- Don't show the cancel and confirm buttons in the Colony Avatar upload modal when there's an error

More details here:
https://github.com/JoinColony/colonyCDapp/issues/2267

Note: I could not reproduce issue number 4 in the above issue, and since there is already another investigation ticket raised to fix some problems with the image upload, I think it is better if this part of the issue is moved to that ticket, since it seems very related. Details in comments of issue 2267.

## Testing

Check that the UI of the image upload is as expected

* Confirm Change button text
* Styling of the error
* Buttons don't show on the colony avatar modal when there's an error in uploading

## Diffs

**Changes** 🏗

* Changes to the image upload UI

Resolves #2267
