### PR TITLE
[Multi-sig] Gate user access to multi sig action creation

### DIFF
--- a/src/components/v5/common/ActionSidebar/hooks/permissions/helpers.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/helpers.ts
@@ -76,8 +76,9 @@ export const getHasActionPermissions = (
   userAddress: Address,
   actionType: Action,
   formValues: Record<string, any>,
+  isMultiSig = false,
 ) => {
-  const allUserRoles = getAllUserRoles(colony, userAddress);
+  const allUserRoles = getAllUserRoles(colony, userAddress, isMultiSig);
   if (allUserRoles.length === 0) {
     return false;
   }
@@ -97,6 +98,7 @@ export const getHasActionPermissions = (
     requiredRolesDomains: [relevantDomainId],
     colony,
     address: userAddress,
+    isMultiSig,
   });
 
   return hasPermissions;

--- a/src/components/v5/common/ActionSidebar/hooks/permissions/useHasActionPermissions.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/useHasActionPermissions.ts
@@ -2,6 +2,7 @@ import { useFormContext } from 'react-hook-form';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import useEnabledExtensions from '~hooks/useEnabledExtensions.tsx';
 import { DecisionMethod } from '~types/actions.ts';
 
 import {
@@ -15,6 +16,8 @@ const useHasActionPermissions = () => {
   const { colony } = useColonyContext();
   const { user } = useAppContext();
 
+  const { isMultiSigEnabled } = useEnabledExtensions();
+
   const { watch } = useFormContext();
   const formValues = watch();
 
@@ -22,7 +25,11 @@ const useHasActionPermissions = () => {
     [ACTION_TYPE_FIELD_NAME]: actionType,
     [DECISION_METHOD_FIELD_NAME]: decisionMethod,
   } = formValues;
-  if (!actionType || decisionMethod !== DecisionMethod.Permissions) {
+  if (
+    !actionType ||
+    (!isMultiSigEnabled && decisionMethod !== DecisionMethod.Permissions) ||
+    (isMultiSigEnabled && decisionMethod !== DecisionMethod.MultiSig)
+  ) {
     return undefined;
   }
 
@@ -33,7 +40,23 @@ const useHasActionPermissions = () => {
     formValues,
   );
 
-  return hasPermissions;
+  if (decisionMethod === DecisionMethod.Permissions) {
+    return hasPermissions;
+  }
+
+  const hasMultiSigPermissions = getHasActionPermissions(
+    colony,
+    user?.walletAddress ?? '',
+    actionType,
+    formValues,
+    true,
+  );
+
+  if (decisionMethod === DecisionMethod.MultiSig) {
+    return hasMultiSigPermissions;
+  }
+
+  return hasPermissions || hasMultiSigPermissions;
 };
 
 export default useHasActionPermissions;

--- a/src/components/v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts
@@ -20,7 +20,8 @@ import {
 const useHasNoDecisionMethods = () => {
   const { colony } = useColonyContext();
   const { user } = useAppContext();
-  const { isVotingReputationEnabled } = useEnabledExtensions();
+  const { isVotingReputationEnabled, isMultiSigEnabled } =
+    useEnabledExtensions();
 
   const { watch } = useFormContext();
   const actionType = watch(ACTION_TYPE_FIELD_NAME);
@@ -50,16 +51,34 @@ const useHasNoDecisionMethods = () => {
     Id.RootDomain,
   );
 
+  const userRootMultiSigRoles = getUserRolesForDomain(
+    colony,
+    user.walletAddress,
+    Id.RootDomain,
+    false,
+    true,
+  );
+
   const userRoles = getAllUserRoles(colony, user.walletAddress);
+
+  const userMultiSigRoles = getAllUserRoles(colony, user.walletAddress, true);
 
   if (
     !requiredPermissions.every((role) => {
       // If the requiredRolesDomain is root, check the user has the required permissions in root
       if (requiredRolesDomain === Id.RootDomain) {
-        return userRootRoles.includes(role);
+        return (
+          userRootRoles.includes(role) ||
+          // If multiSig is enabled, check if the user has the required multiSig permissions in root
+          (isMultiSigEnabled && userRootMultiSigRoles.includes(role))
+        );
       }
       // Otherwise, check the user has the required permissions in any domain
-      return userRoles.includes(role);
+      return (
+        userRoles.includes(role) ||
+        // If multiSig is enabled, check if the user has the required multiSig permissions
+        (isMultiSigEnabled && userMultiSigRoles.includes(role))
+      );
     })
   ) {
     return true;

--- a/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx
@@ -1,5 +1,6 @@
 import { Scales } from '@phosphor-icons/react';
 import React from 'react';
+import { defineMessages } from 'react-intl';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
@@ -16,6 +17,21 @@ import { type DecisionMethodFieldProps } from './types.ts';
 
 const displayName = 'v5.common.ActionSidebar.partials.DecisionMethodField';
 
+const MSG = defineMessages({
+  permissions: {
+    id: `${displayName}.permissions`,
+    defaultMessage: 'Permissions',
+  },
+  reputation: {
+    id: `${displayName}.reputation`,
+    defaultMessage: 'Reputation',
+  },
+  multiSig: {
+    id: `${displayName}.multiSig`,
+    defaultMessage: 'Multi-Sig',
+  },
+});
+
 const DecisionMethodField = ({
   reputationOnly,
   disabled,
@@ -24,18 +40,22 @@ const DecisionMethodField = ({
   const { colony } = useColonyContext();
   const { user } = useAppContext();
   const userRoles = getAllUserRoles(colony, user?.walletAddress);
+  const userMultiSigRoles = getAllUserRoles(colony, user?.walletAddress, true);
 
   const hasNoDecisionMethods = useHasNoDecisionMethods();
 
-  const { isVotingReputationEnabled } = useEnabledExtensions();
+  const { isVotingReputationEnabled, isMultiSigEnabled } =
+    useEnabledExtensions();
 
   const shouldShowPermissions = !reputationOnly && userRoles.length > 0;
+  const shouldShowMultiSig =
+    !reputationOnly && isMultiSigEnabled && userMultiSigRoles.length > 0;
 
   const decisionMethods = [
     ...(shouldShowPermissions
       ? [
           {
-            label: formatText({ id: 'actionSidebar.method.permissions' }),
+            label: formatText(MSG.permissions),
             value: DecisionMethod.Permissions,
           },
         ]
@@ -43,8 +63,16 @@ const DecisionMethodField = ({
     ...(isVotingReputationEnabled
       ? [
           {
-            label: formatText({ id: 'actionSidebar.method.reputation' }),
+            label: formatText(MSG.reputation),
             value: DecisionMethod.Reputation,
+          },
+        ]
+      : []),
+    ...(shouldShowMultiSig
+      ? [
+          {
+            label: formatText(MSG.multiSig),
+            value: DecisionMethod.MultiSig,
           },
         ]
       : []),

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -93,13 +93,16 @@ export const getUserRolesForDomain = (
 export const getAllUserRoles = (
   colony: ColonyFragment,
   userAddress: Address | undefined,
+  isMultiSig = false,
 ): ColonyRole[] => {
   if (!userAddress) return [];
 
-  const userRolesInAnyDomain = colony.roles?.items.find(
-    (domainRole) =>
-      domainRole?.targetAddress === userAddress && !domainRole.isMultiSig,
-  );
+  const userRolesInAnyDomain = colony.roles?.items.find((domainRole) => {
+    const isMatchingUser = domainRole?.targetAddress === userAddress;
+    const isMatchingMultiSig = isMultiSig === !!domainRole?.isMultiSig;
+
+    return isMatchingUser && isMatchingMultiSig;
+  });
 
   return Array.from(new Set([...convertRolesToArray(userRolesInAnyDomain)]));
 };

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -169,4 +169,5 @@ export enum SystemMessages {
 export enum DecisionMethod {
   Permissions = 'Permissions',
   Reputation = 'Reputation',
+  MultiSig = 'MultiSig',
 }

--- a/src/utils/checks/userHasRoles.ts
+++ b/src/utils/checks/userHasRoles.ts
@@ -11,11 +11,13 @@ export const addressHasRoles = ({
   colony,
   address,
   requiredRoles,
+  isMultiSig = false,
 }: {
   requiredRolesDomains: number[];
   colony: Colony;
   address: string;
   requiredRoles: ColonyRole[];
+  isMultiSig: boolean;
 }) => {
   return requiredRolesDomains.every((domainId) => {
     const userDomainRoles = getUserRolesForDomain(
@@ -24,7 +26,20 @@ export const addressHasRoles = ({
       domainId,
     );
 
-    return requiredRoles.every((role) => userHasRole(userDomainRoles, role));
+    const userMultiSigDomainRoles = getUserRolesForDomain(
+      colony,
+      address || '',
+      domainId,
+      false,
+      true,
+    );
+
+    return requiredRoles.every((role) => {
+      return (
+        userDomainRoles.includes(role) ||
+        (isMultiSig && userMultiSigDomainRoles.includes(role))
+      );
+    });
   });
 };
 

--- a/src/utils/checks/userHasRoles.ts
+++ b/src/utils/checks/userHasRoles.ts
@@ -17,7 +17,7 @@ export const addressHasRoles = ({
   colony: Colony;
   address: string;
   requiredRoles: ColonyRole[];
-  isMultiSig: boolean;
+  isMultiSig?: boolean;
 }) => {
   return requiredRolesDomains.every((domainId) => {
     const userDomainRoles = getUserRolesForDomain(


### PR DESCRIPTION
## Description

As a user creating an action, I shouldn't be able to create actions I don't have permissions for.

This PR changes the permissions checks for actions to include multi sig permissions to ensure the invalid permissions notification banner.

<img width="681" alt="Screenshot 2024-04-30 at 11 33 35" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/f8113e5a-6ee3-4121-a670-78e0bf39220f">

## Testing

(For extra thorough testing, check the notification banner shows as expected before the multi sig extension is installed to check the existing functionality hasn't been impacted.)

Step 1 - Install the multi sig extension.
Step 2 - Give Amy 'Payer' permissions in any team other than General with 'multi-sig' authority.
Step 3 - Switch to Amy and attempt to create an action.
Step 4 - Switch between the different actions, the notification should show on actions which are not covered by the payer permission.
Step 5 - Switch to an action which is covered by the payer permission (such as Simple Payment), select multi-sig as the decision method, switch between the teams, the notification banner should show on all teams except the one you gave permissions.

For further testing, check the notification banner shows as expected after each scenario:
- Remove permissions from Amy
- Give different sets of permissions (both multi-sig and regular)
- Install the weighted reputation extension

## Diffs

**Changes** 🏗

* Changed the permissions checks for actions to include multi sig permissions to ensure the invalid permissions notification banner.

Resolves #2148
