### PR TITLE
Fix Motion Vote Reveal

### DIFF
--- a/src/redux/sagas/motions/revealVoteMotion.ts
+++ b/src/redux/sagas/motions/revealVoteMotion.ts
@@ -1,6 +1,12 @@
-import { ClientType, type AnyVotingReputationClient } from '@colony/colony-js';
-import { utils } from 'ethers';
+import {
+  ClientType,
+  type AnyVotingReputationClient,
+  Extension,
+} from '@colony/colony-js';
+import { utils, providers } from 'ethers';
 import { call, put, takeEvery } from 'redux-saga/effects';
+
+import { GANACHE_LOCAL_RPC_URL, isDev } from '~constants/index.ts';
 
 import { ActionTypes } from '../../actionTypes.ts';
 import { type AllActions, type Action } from '../../types/actions/index.ts';
@@ -11,12 +17,8 @@ import {
   getTxChannel,
   waitForTxResult,
 } from '../transactions/index.ts';
-import {
-  putError,
-  takeFrom,
-  getColonyManager,
-  initiateTransaction,
-} from '../utils/index.ts';
+import getNetworkClient from '../utils/getNetworkClient.ts';
+import { putError, takeFrom, initiateTransaction } from '../utils/index.ts';
 
 export type RevealMotionPayload =
   Action<ActionTypes.MOTION_REVEAL_VOTE>['payload'];
@@ -27,16 +29,25 @@ function* revealVoteMotion({
 }: Action<ActionTypes.MOTION_REVEAL_VOTE>) {
   const txChannel = yield call(getTxChannel, meta.id);
   try {
-    const colonyManager = yield getColonyManager();
-    const colonyClient = yield colonyManager.getClient(
-      ClientType.ColonyClient,
-      colonyAddress,
-    );
+    /*
+     * We need to set up a non-retry provider when revealing votes
+     * This is because we gas estimate both sides, and one will always fail
+     * The retry provider is designed to retry the failing estimate or transaction
+     * meaning it will never actually catch the error
+     */
+    const provider = (() => {
+      if (isDev) {
+        return new providers.JsonRpcProvider(GANACHE_LOCAL_RPC_URL);
+      }
+      return new providers.Web3Provider(window.ethereum!);
+    })();
+
+    const networkClient = yield call(getNetworkClient, provider);
+
+    const colonyClient = yield networkClient.getColonyClient(colonyAddress);
+
     const votingReputationClient: AnyVotingReputationClient =
-      yield colonyManager.getClient(
-        ClientType.VotingReputationClient,
-        colonyAddress,
-      );
+      yield colonyClient.getExtensionClient(Extension.VotingReputation);
 
     const { domainId, rootHash } =
       yield votingReputationClient.getMotion(motionId);
@@ -78,6 +89,7 @@ function* revealVoteMotion({
         value,
         branchMask,
         siblings,
+        { from: userAddress },
       );
       sideVoted = 0;
     } catch (error) {
@@ -98,14 +110,12 @@ function* revealVoteMotion({
         value,
         branchMask,
         siblings,
+        { from: userAddress },
       );
       sideVoted = 1;
     } catch (error) {
       // Same as above. Silent error
     }
-
-    // eslint-disable-next-line no-console
-    console.log('REVEAL for', sideVoted, { signature, salt, message });
 
     if (sideVoted !== undefined) {
       const { revealVoteMotionTransaction } = yield createTransactionChannels(

--- a/src/redux/sagas/motions/revealVoteMotion.ts
+++ b/src/redux/sagas/motions/revealVoteMotion.ts
@@ -103,6 +103,10 @@ function* revealVoteMotion({
     } catch (error) {
       // Same as above. Silent error
     }
+
+    // eslint-disable-next-line no-console
+    console.log('REVEAL for', sideVoted, { signature, salt, message });
+
     if (sideVoted !== undefined) {
       const { revealVoteMotionTransaction } = yield createTransactionChannels(
         meta.id,

--- a/src/redux/sagas/motions/voteMotion.ts
+++ b/src/redux/sagas/motions/voteMotion.ts
@@ -66,9 +66,6 @@ function* voteMotion({
       [utils.keccak256(signature), vote],
     );
 
-    // eslint-disable-next-line no-console
-    console.log('VOTE for', vote, { signature, hash, message });
-
     const { voteMotionTransaction } = yield createTransactionChannels(meta.id, [
       'voteMotionTransaction',
     ]);

--- a/src/redux/sagas/motions/voteMotion.ts
+++ b/src/redux/sagas/motions/voteMotion.ts
@@ -66,6 +66,9 @@ function* voteMotion({
       [utils.keccak256(signature), vote],
     );
 
+    // eslint-disable-next-line no-console
+    console.log('VOTE for', vote, { signature, hash, message });
+
     const { voteMotionTransaction } = yield createTransactionChannels(meta.id, [
       'voteMotionTransaction',
     ]);

--- a/src/redux/sagas/utils/getNetworkClient.ts
+++ b/src/redux/sagas/utils/getNetworkClient.ts
@@ -9,10 +9,12 @@ import { ContextModule, getContext } from '~context/index.ts';
 import { ColonyJSNetworkMapping, Network } from '~types/network.ts';
 import { isFullWallet } from '~types/wallet.ts';
 
+import type { SignerOrProvider } from '@colony/colony-js';
+
 /*
  * Return an initialized ColonyNetworkClient instance.
  */
-const getNetworkClient = async () => {
+const getNetworkClient = async (signerOrProvider?: SignerOrProvider) => {
   const wallet = getContext(ContextModule.Wallet);
 
   if (!isFullWallet(wallet)) {
@@ -21,7 +23,7 @@ const getNetworkClient = async () => {
 
   const network = DEFAULT_NETWORK;
 
-  const signer = wallet.ethersProvider.getSigner();
+  const signer = signerOrProvider || wallet.ethersProvider.getSigner();
 
   const reputationOracleUrl = import.meta.env.REPUTATION_ORACLE_ENDPOINT
     ? new URL(import.meta.env.REPUTATION_ORACLE_ENDPOINT)


### PR DESCRIPTION
## Intro Note

This PR is part of the set that will be opened by me to (re)introduce all the changes made to support the Arbitrum deployment, from the `master-arbitrum` branch back into `master` so that the two branches can be _(more or less)_ identical 

We need to run two branches, since AWS enforces one deployment per branch, meaning we can't run both the `Gnosis` and `Arbitrum` deployment from the same branch.

This will get cleaned up, once we get to Multichain and we will be back to only supporting one main deployment _(which itself will support multiple networks, whatever form this might take)_

## Current PR Details

For a long time _(ever since we've introduced the `RetryProvider`)_ revealing your motion vote was broken, but since no one really tested the Gnosis production deployment, people didn't really notice _(this only affects you when you're not in dev mode, and using Metamask)_

This is combination problem. It's due to the way we determine voting sides, and the user of the `RetryProvider`. We cannot know which side the user actually voted for, so in order to know which side to reveal, we basically simulate _(by estimating gas)_ on both sides, and the one that doesn't fail _(using a `try`/`catch`)_, is the side the user voted for. Now the `RetryProvider` comes into play, as it's designed to retry in the event a call to the chain actually fails _(which includes gas estimates as well)_, meaning, our try/catch logic stopped working, as the catch block was never called.

The fix for this required us bypassing the `RetryProvider`, for this saga only, and use the "standard" one as to be able to actually make it fail.

Testing is fairly strait forward, just create a motion, get it to the voting stage, vote, then reveal. All while using Metamask as you wallet. 

![Screenshot from 2024-04-30 17-52-38](https://github.com/JoinColony/colonyCDapp/assets/1193222/f285bd2b-5506-41bc-aca7-3b601cfd7292)
![Screenshot from 2024-04-30 17-52-47](https://github.com/JoinColony/colonyCDapp/assets/1193222/2099ba0b-4f57-408c-aa50-93aefcded25b)
![Screenshot from 2024-04-30 17-53-15](https://github.com/JoinColony/colonyCDapp/assets/1193222/484a3df6-efd5-4f1b-82db-eec9191db86d)
![Screenshot from 2024-04-30 17-53-02](https://github.com/JoinColony/colonyCDapp/assets/1193222/f8bb5473-1b7d-4d6a-8ed8-76dc95a64571)

Fixes #1790 