### PR TITLE
Make sure user is authenticated before sending a Transaction

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -70,9 +70,11 @@ export const authenticateWallet = async (): Promise<void> => {
 
     const signature = await signer.signMessage(message);
 
-    await authProxyRequest('auth', {
+    return authProxyRequest('auth', {
       method: 'POST',
       body: JSON.stringify({ message, signature }),
     });
   }
+
+  return authCheck;
 };

--- a/src/components/shared/Fields/Form/ActionForm.tsx
+++ b/src/components/shared/Fields/Form/ActionForm.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { type FieldValues, type UseFormReturn } from 'react-hook-form';
 
+import { authenticateWallet } from '~auth';
 import useAsyncFunction from '~hooks/useAsyncFunction.ts';
 import { type ActionTypes, type ActionTypeString } from '~redux/index.ts';
 import { type ActionTransformFnType, getFormAction } from '~utils/actions.ts';
@@ -66,6 +67,8 @@ const ActionForm = <V extends Record<string, any>>({
   });
   const handleSubmit: CustomSubmitHandler<V> = async (values, formHelpers) => {
     try {
+      // Force re-auth check to account for loss of auth/connection after the session has been started
+      await authenticateWallet();
       const res = await asyncFunction(values);
       onSuccess?.(values, formHelpers, res);
     } catch (e) {


### PR DESCRIPTION
> ## Disclamer
>
> This PR is part of the set that will be opened by me to (re)introduce all the changes made to support the Arbitrum deployment, from the `master-arbitrum` branch back into `master` so that the two branches can be _(more or less)_ identical 
>
> We need to run two branches, since AWS enforces one deployment per branch, meaning we can't run both the `Gnosis` and `Arbitrum` deployment from the same branch.
>
> This will get cleaned up, once we get to Multichain and we will be back to only supporting one main deployment _(which itself will support multiple networks, whatever form this might take)_

## Current PR Details

This is a simple PR that adds the `authenticateWallet` call inside the `ActionForm` to ensure the user is authenticated before sending a transaction _(and potentially saving metadata)_

NOTE: _Due to the way the `createTransactionChannel` saga logic is set up I was unable to add this on the redux side, so had to resort to adding it on the component side. It's not really ideal, but it's good enough for now_

This is need for cases where the user gets de-authenticated in the middle of their browsing session. The two most common reasons for these are: the session token expires while browsing, or the session token is removed entirely _(auth proxy restarts -- either the service crashes, or the pod auto-scales)_. To account for this, we just make a call to `authenticateWallet`, which internally has logic to check if the user is actually authenticated _(and not attempt to re-authenticate again)_, or they aren't, at which point they'll send out the authentication API call _(and present the user with a message to sign)_

## Testing

To test this, the best way is to start the auth proxy separately, so you can trigger a session token reset. Connect with Metamask, restart auth proxy, then try to send a transaction.

![Screenshot from 2024-05-01 12-58-24](https://github.com/JoinColony/colonyCDapp/assets/1193222/d1c2d3fd-5e3d-4d82-931a-7a9abe46a6de)
![Screenshot from 2024-05-01 12-58-43](https://github.com/JoinColony/colonyCDapp/assets/1193222/d9cb8b9e-674c-49b3-a270-f2f838943c1a)

Before you'll be asked to sign the new transaction, you should be asked to actually sign the authentication message.