### PR TITLE
Fix Colony Balance being subtracted twice for each Payment

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=824b795fa01c03510908d44061a539fffe0f5e7f
+ENV BLOCK_INGESTOR_HASH=23132accc3c3b792042c5f1efc04a4a8ea849d4c
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]


### PR DESCRIPTION
> ## Disclamer
>
> This PR is part of the set that will be opened by me to (re)introduce all the changes made to support the Arbitrum deployment, from the `master-arbitrum` branch back into `master` so that the two branches can be _(more or less)_ identical 
>
> We need to run two branches, since AWS enforces one deployment per branch, meaning we can't run both the `Gnosis` and `Arbitrum` deployment from the same branch.
>
> This will get cleaned up, once we get to Multichain and we will be back to only supporting one main deployment _(which itself will support multiple networks, whatever form this might take)_

## Current PR Details

This fixes a issue where an amount being payed out of the colony would decrease the colony's balance for twice that amount.

This was due to a issue where the simple payment's expenditure _(one tx payment's expenditure)_ was not being updated properly, and showing a negative value. 

Combine that with the balance being fetched by lambdas with the payment value already subtracted, and the expenditure balance "added" to the (already subtracted) balance, and presto change-o you have double the amount removed

Note that the relevant, and actual code fix was done on the ingestor side via https://github.com/JoinColony/block-ingestor/pull/215 this PR just updates the docker commit hash to the relevant one, and it's purpouse is to aid in testing

## Testing

Create a fresh colony, mint a memorable amount _(`100` or `1000`)_. Create a payment for yet another memorable amount _(`10` or something)_.

Look up the expenditure in the database via the graphql explorer, it should have the balance `0`. Any other value in there means this is still broken. _(for one OneTX Payments, other expenditure types, can have non-zero values)_

![Screenshot from 2024-05-01 13-32-14](https://github.com/JoinColony/block-ingestor/assets/1193222/8949f81a-e42b-4756-af59-1cca446012e6)

![Screenshot from 2024-05-01 13-33-58](https://github.com/JoinColony/block-ingestor/assets/1193222/183f3752-7be7-49f9-8585-c12e52db7249)

Look up the colony's balance table, which should should your initial minted amount, minus the payment amount _(if it shows double the payment amount, then this is still broken)_

![Screenshot from 2024-05-01 13-35-23](https://github.com/JoinColony/block-ingestor/assets/1193222/f7d58e83-6a92-47ed-91f8-6fc94fd3927f)

Fixes #2298
