### PR TITLE
Visual indicator if user's wallet is connected to the wrong network

### DIFF
--- a/src/components/common/Extensions/UserNavigation/UserNavigation.tsx
+++ b/src/components/common/Extensions/UserNavigation/UserNavigation.tsx
@@ -1,7 +1,9 @@
 import { Cardholder, GearSix, List, X } from '@phosphor-icons/react';
 import React, { type FC } from 'react';
+import { defineMessages } from 'react-intl';
 import { usePopperTooltip } from 'react-popper-tooltip';
 
+import { DEFAULT_NETWORK_INFO } from '~constants';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useMobile } from '~hooks/index.ts';
 import useDisableBodyScroll from '~hooks/useDisableBodyScroll/index.ts';
@@ -15,6 +17,13 @@ import UserMenu from './partials/UserMenu/index.ts';
 import { type UserNavigationProps } from './types.ts';
 
 const displayName = 'common.Extensions.UserNavigation';
+
+const MSG = defineMessages({
+  wrongNetwork: {
+    id: `${displayName}.unlockedToken`,
+    defaultMessage: `Your wallet is connected to a nework the app was not deployed to yet. ({networkName}).  Please switch your wallet to the "{correctNetworkName}" network.`,
+  },
+});
 
 const UserNavigation: FC<UserNavigationProps> = ({
   extra = null,
@@ -60,7 +69,15 @@ const UserNavigation: FC<UserNavigationProps> = ({
       {isWalletConnected ? (
         <div className="flex gap-1">
           {networkInfo && (
-            <NetworkName size={isMobile ? 18 : 16} networkInfo={networkInfo} />
+            <NetworkName
+              size={isMobile ? 18 : 16}
+              networkInfo={networkInfo}
+              error={networkInfo?.chainId !== DEFAULT_NETWORK_INFO.chainId}
+              errorMessage={formatText(MSG.wrongNetwork, {
+                networkName: networkInfo?.name,
+                correctNetworkName: DEFAULT_NETWORK_INFO.name,
+              })}
+            />
           )}
           {userHub}
         </div>

--- a/src/components/common/Extensions/UserNavigation/UserNavigation.tsx
+++ b/src/components/common/Extensions/UserNavigation/UserNavigation.tsx
@@ -21,7 +21,7 @@ const displayName = 'common.Extensions.UserNavigation';
 const MSG = defineMessages({
   wrongNetwork: {
     id: `${displayName}.unlockedToken`,
-    defaultMessage: `Your wallet is connected to a nework the app was not deployed to yet. ({networkName}).  Please switch your wallet to the "{correctNetworkName}" network.`,
+    defaultMessage: `Please switch your wallet to the {correctNetworkName} network. More chains will be supported in future.`,
   },
 });
 
@@ -74,7 +74,6 @@ const UserNavigation: FC<UserNavigationProps> = ({
               networkInfo={networkInfo}
               error={networkInfo?.chainId !== DEFAULT_NETWORK_INFO.chainId}
               errorMessage={formatText(MSG.wrongNetwork, {
-                networkName: networkInfo?.name,
                 correctNetworkName: DEFAULT_NETWORK_INFO.name,
               })}
             />

--- a/src/components/common/Extensions/UserNavigation/partials/NetworkName/NetworkName.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/NetworkName/NetworkName.tsx
@@ -1,20 +1,45 @@
+import clsx from 'clsx';
 import React, { type FC } from 'react';
 
+import { useMobile } from '~hooks/index.ts';
 import GanacheIcon from '~icons/GanacheIcon.tsx';
+import Tooltip from '~shared/Extensions/Tooltip/Tooltip.tsx';
 
 import { type NetworkNameProps } from './types.ts';
 
 const displayName = 'common.Extensions.UserNavigation.partials.NetworkName';
 
-const NetworkName: FC<NetworkNameProps> = ({ networkInfo, size = 14 }) => {
+const NetworkName: FC<NetworkNameProps> = ({
+  networkInfo,
+  size = 14,
+  error = false,
+  errorMessage,
+}) => {
   const Icon = networkInfo.icon || GanacheIcon;
+  const isMobile = useMobile();
+
   return (
-    <div className="flex min-h-[2.5rem] min-w-[2.625rem] items-center justify-center rounded-full border border-gray-200 bg-base-white px-[0.875rem] py-[0.625rem]">
-      <Icon size={size} />
-      <p className="ml-1 hidden text-gray-700 text-3 md:block">
-        {networkInfo.name}
-      </p>
-    </div>
+    <Tooltip
+      tooltipContent={errorMessage}
+      placement={isMobile ? 'bottom' : 'left'}
+      trigger={error ? 'hover' : null}
+      isError={error}
+    >
+      <div
+        className={clsx(
+          'flex min-h-[2.5rem] min-w-[2.625rem] items-center justify-center rounded-full border border-gray-200 bg-base-white px-[0.875rem] py-[0.625rem]',
+          {
+            'border-negative-400': error,
+            'cursor-pointer': error,
+          },
+        )}
+      >
+        <Icon size={size} />
+        <p className="ml-1 hidden text-gray-700 text-3 md:block">
+          {networkInfo.name}
+        </p>
+      </div>
+    </Tooltip>
   );
 };
 

--- a/src/components/common/Extensions/UserNavigation/partials/NetworkName/NetworkName.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/NetworkName/NetworkName.tsx
@@ -1,3 +1,4 @@
+import { WarningCircle } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { type FC } from 'react';
 
@@ -23,21 +24,22 @@ const NetworkName: FC<NetworkNameProps> = ({
       tooltipContent={errorMessage}
       placement={isMobile ? 'bottom' : 'left'}
       trigger={error ? 'hover' : null}
-      isError={error}
     >
       <div
         className={clsx(
-          'flex min-h-[2.5rem] min-w-[2.625rem] items-center justify-center rounded-full border border-gray-200 bg-base-white px-[0.875rem] py-[0.625rem]',
+          'flex min-h-[2.5rem] min-w-[2.625rem] items-center justify-center gap-1 rounded-full border border-gray-200 bg-base-white px-[0.875rem] py-[0.625rem]',
           {
-            'border-negative-400': error,
+            'border-warning-400': error,
             'cursor-pointer': error,
+            'text-warning-400': error,
           },
         )}
       >
         <Icon size={size} />
-        <p className="ml-1 hidden text-gray-700 text-3 md:block">
+        <p className="hidden text-gray-700 text-3 md:block">
           {networkInfo.name}
         </p>
+        {error && <WarningCircle size={16} />}
       </div>
     </Tooltip>
   );

--- a/src/components/common/Extensions/UserNavigation/partials/NetworkName/types.ts
+++ b/src/components/common/Extensions/UserNavigation/partials/NetworkName/types.ts
@@ -1,6 +1,10 @@
 import { type NetworkInfo } from '~constants/index.ts';
 
+import type React from 'react';
+
 export interface NetworkNameProps {
   networkInfo: NetworkInfo;
   size?: number;
+  error?: boolean;
+  errorMessage?: React.ReactNode;
 }

--- a/src/components/shared/Extensions/Tooltip/Tooltip.tsx
+++ b/src/components/shared/Extensions/Tooltip/Tooltip.tsx
@@ -19,6 +19,7 @@ const Tooltip: FC<PropsWithChildren<TooltipProps>> = ({
   trigger = 'hover',
   isOpen,
   isSuccess = false,
+  isError = false,
   isFullWidthContent,
   className,
   selectTriggerRef = (v) => v,
@@ -63,6 +64,7 @@ const Tooltip: FC<PropsWithChildren<TooltipProps>> = ({
               'tooltip-container',
               {
                 'bg-success-400': isSuccess,
+                'bg-negative-400': isError,
                 'bg-gray-900 [&_a]:underline': !isSuccess,
               },
             ),
@@ -74,6 +76,7 @@ const Tooltip: FC<PropsWithChildren<TooltipProps>> = ({
                 [tooltipClasses.tooltipArrow]: showArrow,
                 'tooltip-arrow': showArrow,
                 'text-success-400': isSuccess,
+                'text-negative-400': isError,
                 'text-gray-900': !isSuccess,
               }),
             })}

--- a/src/components/shared/Extensions/Tooltip/types.ts
+++ b/src/components/shared/Extensions/Tooltip/types.ts
@@ -12,6 +12,7 @@ export interface TooltipProps {
   showArrow?: boolean;
   isOpen?: boolean;
   isSuccess?: boolean;
+  isError?: boolean;
   isFullWidthContent?: boolean;
   className?: string;
   selectTriggerRef?: (ref: HTMLElement | null) => HTMLElement | null;


### PR DESCRIPTION
> ## Disclamer
>
> This PR is part of the set that will be opened by me to (re)introduce all the changes made to support the Arbitrum deployment, from the `master-arbitrum` branch back into `master` so that the two branches can be _(more or less)_ identical 
>
> We need to run two branches, since AWS enforces one deployment per branch, meaning we can't run both the `Gnosis` and `Arbitrum` deployment from the same branch.
>
> This will get cleaned up, once we get to Multichain and we will be back to only supporting one main deployment _(which itself will support multiple networks, whatever form this might take)_

## Current PR Details

This PR implements a visual indication _(network pill lights up)_, if the user's wallet is connected to a network other than the current app is deployed to. This was done in a effort to prevent users reporting "transaction issues" while not sending the transaction on the correct chain to begin with.

This contains both the initial component logic, and the styles done by @davecreaser as part of #2274, but which were merged into the `master-arbitrum` branch, since this piece of logic only existed on that branch.

## Testing

Run the dev environment locally, on "ganache" _(hardhat under the hood)_ and connect your metamask wallet, while being connected to anything other than the local network

![Screenshot from 2024-05-02 19-36-28](https://github.com/JoinColony/colonyCDapp/assets/1193222/77b50874-a7e2-46d7-9007-aa073e7b4dd9)
