### PR TITLE
Fix Colony Creation with Non Colony Tokens

### DIFF
--- a/src/components/common/Onboarding/wizardSteps/CreateColony/TokenSelector.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/TokenSelector.tsx
@@ -52,6 +52,15 @@ const TokenSelector = ({
 
   useEffect(() => {
     if (isFetchingAddress) {
+      setIsLoading(true);
+    }
+    if (data) {
+      setIsLoading(false);
+    }
+  }, [data, isFetchingAddress, setIsLoading]);
+
+  useEffect(() => {
+    if (isFetchingAddress) {
       return;
     }
 

--- a/src/components/common/Onboarding/wizardSteps/CreateColony/TokenSelectorInput.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/TokenSelectorInput.tsx
@@ -4,7 +4,9 @@ import { useFormContext } from 'react-hook-form';
 import { defineMessages, useIntl } from 'react-intl';
 
 import { DEFAULT_NETWORK_INFO } from '~constants';
+import SpinnerLoader from '~shared/Preloaders/SpinnerLoader.tsx';
 import { type Token } from '~types/graphql.ts';
+import { formatText } from '~utils/intl.ts';
 import { getNetworkByChainId } from '~utils/web3/index.ts';
 
 import { getInputError } from '../shared.ts';
@@ -34,6 +36,10 @@ const MSG = defineMessages({
     id: `${displayName}.definitelyCorrectMessage`,
     defaultMessage:
       'If you are certain that the token address is correct, it may not exist on the Gnosis Chain, try switching your wallet’s connected blockchain or continue to the next step.',
+  },
+  loadingToken: {
+    id: `${displayName}.loadingToken`,
+    defaultMessage: `Fetching your token's details ...`,
   },
 });
 
@@ -77,6 +83,15 @@ const TokenSelectorInput = ({
         setIsLoading={setIsLoading}
         isDecoratedError
       />
+
+      {isLoading && (
+        <div className="mt-[5px] text-sm text-gray-600">
+          <SpinnerLoader />
+          <span className="ml-2 align-text-bottom">
+            {formatText(MSG.loadingToken)}
+          </span>
+        </div>
+      )}
 
       {doesTokenExistError && isLoading === false && (
         <div className="mt-14 rounded border border-warning-200 bg-warning-100 px-6 py-3 text-gray-900">

--- a/src/components/v5/common/ActionSidebar/partials/TokenSelect/TokenSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TokenSelect/TokenSelect.tsx
@@ -4,6 +4,7 @@ import React, { type FC, useEffect, useState } from 'react';
 import { useController } from 'react-hook-form';
 
 import { useAdditionalFormOptionsContext } from '~context/AdditionalFormOptionsContext/AdditionalFormOptionsContext.ts';
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useRelativePortalElement from '~hooks/useRelativePortalElement.ts';
 import useToggle from '~hooks/useToggle/index.ts';
 import { formatText } from '~utils/intl.ts';
@@ -16,6 +17,7 @@ import { type TokenSelectProps } from './types.ts';
 const displayName = 'v5.common.ActionsContent.partials.TokenSelect';
 
 const TokenSelect: FC<TokenSelectProps> = ({ name, disabled = false }) => {
+  const { colony } = useColonyContext();
   const [searchError, setSearchError] = useState(false);
   const {
     field,
@@ -37,7 +39,6 @@ const TokenSelect: FC<TokenSelectProps> = ({ name, disabled = false }) => {
     isRemoteTokenAddress,
     renderButtonContent,
     isNativeToken,
-    colonyTokens,
   } = useTokenSelect(field.value);
   const { portalElementRef, relativeElementRef } = useRelativePortalElement<
     HTMLButtonElement,
@@ -91,9 +92,8 @@ const TokenSelect: FC<TokenSelectProps> = ({ name, disabled = false }) => {
                 ) : undefined
               }
               onSearch={(query) => {
-                const isColonyNativeToken = colonyTokens.some(
-                  (token) => token?.token.tokenAddress === query,
-                );
+                const isColonyNativeToken =
+                  colony.nativeToken?.tokenAddress === query;
                 setSearchError(isColonyNativeToken);
 
                 if (isColonyNativeToken) {

--- a/src/components/v5/common/ActionSidebar/partials/TokenSelect/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TokenSelect/hooks.tsx
@@ -17,10 +17,7 @@ export const useTokenSelect = (inputValue: string) => {
   const predefinedTokens = getNetworkTokenList();
   const allTokens = useGetAllTokens();
   const { colony } = useColonyContext();
-  const colonyTokens = colony.tokens?.items || [];
-  const isNativeToken = colonyTokens.some(
-    (token) => token?.token.tokenAddress === inputValue,
-  );
+  const isNativeToken = colony.nativeToken?.tokenAddress === inputValue;
 
   const tokenOptions: SearchSelectOptionProps = {
     key: 'tokens',
@@ -94,6 +91,5 @@ export const useTokenSelect = (inputValue: string) => {
     isRemoteTokenAddress,
     renderButtonContent,
     isNativeToken,
-    colonyTokens,
   };
 };

--- a/src/components/v5/shared/SearchSelect/hooks.ts
+++ b/src/components/v5/shared/SearchSelect/hooks.ts
@@ -32,7 +32,7 @@ export const useSearchSelect = (
             ? [
                 {
                   ...item.options[0],
-                  avatar: item.options[0].showAvatar ? '' : undefined,
+                  avatar: item.options[0]?.showAvatar ? '' : undefined,
                   value: searchValue,
                   label: searchValue,
                   walletAddress: searchValue,

--- a/src/redux/sagas/colony/colonyCreate.ts
+++ b/src/redux/sagas/colony/colonyCreate.ts
@@ -274,6 +274,7 @@ function* colonyCreate({
       },
       {
         timeout: 30000,
+        retryLimit: 0,
       },
     );
 
@@ -335,6 +336,7 @@ function* colonyCreate({
         },
         {
           timeout: 30000,
+          retryLimit: 0,
         },
       );
 

--- a/src/types/rpcMethods.ts
+++ b/src/types/rpcMethods.ts
@@ -16,3 +16,13 @@ export enum RpcMethods {
   SignTypedDataV4 = 'eth_signTypedData_v4', // Only available via Metamask
   WatchAsset = 'wallet_watchAsset', // Metamask method
 }
+
+export enum RetryProviderMethod {
+  Call = 'call',
+}
+
+export enum IColonyContractMethodSignature {
+  Locked = 'locked()',
+  Nonces = 'nonces(address)',
+  GetMetatransactionNonce = 'getMetatransactionNonce(address)',
+}


### PR DESCRIPTION
## Intro Note

This PR is part of the set that will be opened by me to (re)introduce all the changes made to support the Arbitrum deployment, from the `master-arbitrum` branch back into `master` so that the two branches can be _(more or less)_ identical 

We need to run two branches, since AWS enforces one deployment per branch, meaning we can't run both the `Gnosis` and `Arbitrum` deployment from the same branch.

This will get cleaned up, once we get to Multichain and we will be back to only supporting one main deployment _(which itself will support multiple networks, whatever form this might take)_

## Current PR Details

Code for this fix was implemented while pair programming with @area 

This PR introduces a fix to allow colonies to be created with non colony network created tokens _(basically any random token out there, as long as it's ERC-20 standard compliant, however lax that standard might be)_

The problem here is that we were using another "trick" to determine what kind of token we were dealing with, by using a try/catch block, as similarly to the issue we experience with #2306, the `RetryProvider` would kick in and wouldn't actually allow the call to fail.

The `locked()` method on a token is implemented "only" by us, on tokens created via our contracts. And we assume that all tokens who have this method available are `Colony` tokens, while the ones that don't are `ERC-20` tokens.

Since the call to `locked()` failed for `ERC-20` tokens, the `RetryProvider` would kick in trying to retry that call, meaning that piece of code would never fail, and the colony creation saga would time out.

The fix here, involved adding exceptions in the `RetryProvider` for calls we expect to fail, and which we wish the `RetryProvider` would bypass when attempting to retry. The list currently includes only three methods but will most likely grow with time.

## Testing

This is not really strait forward to test, as there's no easy way to deploy a non colony token to the local dev environment.

We actually developed / fixed this while working against QA.

The easiest way to test this for you is to actually deploy this branch to QA and find a random ERC-20 token on Arbitrum Sepolia, and create a colony with that.

Fixes #2264 
