### PR TITLE
Disable Token Actions if Not Available

### DIFF
--- a/src/components/frame/Extensions/layouts/hooks.tsx
+++ b/src/components/frame/Extensions/layouts/hooks.tsx
@@ -106,7 +106,7 @@ export const useCalamityBannerInfo = (): UseCalamityBannerInfoReturnType => {
 
 export const useMainMenuItems = (hasTransactionId: boolean) => {
   const {
-    colony: { metadata },
+    colony: { metadata, status },
   } = useColonyContext();
 
   const {
@@ -293,14 +293,6 @@ export const useMainMenuItems = (hasTransactionId: boolean) => {
                 [ACTION_TYPE_FIELD_NAME]: Action.ManageTokens,
               }),
           },
-          {
-            key: '9',
-            label: formatText({ id: 'actions.mintTokens' }),
-            onClick: () =>
-              toggleActionSidebarOn({
-                [ACTION_TYPE_FIELD_NAME]: Action.MintTokens,
-              }),
-          },
         ],
       },
     },
@@ -386,6 +378,17 @@ export const useMainMenuItems = (hasTransactionId: boolean) => {
       },
     },
   ];
+
+  if (status?.nativeToken?.mintable) {
+    mainMenuItems[3].relatedActionsProps?.items?.push({
+      key: '9',
+      label: formatText({ id: 'actions.mintTokens' }),
+      onClick: () =>
+        toggleActionSidebarOn({
+          [ACTION_TYPE_FIELD_NAME]: Action.MintTokens,
+        }),
+    });
+  }
 
   return mainMenuItems;
 };

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/BalanceTable.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/BalanceTable.tsx
@@ -134,7 +134,7 @@ const BalanceTable: FC = () => {
           ),
           icon: ArrowSquareOut,
         },
-        ...(isTokenNative
+        ...(isTokenNative && nativeTokenStatus?.mintable
           ? [
               {
                 key: 'mint_tokens',

--- a/src/components/v5/common/ActionSidebar/hooks/useActionsList.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useActionsList.ts
@@ -1,11 +1,13 @@
 import { useMemo } from 'react';
 
 import { Action } from '~constants/actions.ts';
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { type SearchSelectOptionProps } from '~v5/shared/SearchSelect/types.ts';
 
 const useActionsList = () => {
-  return useMemo(
-    (): SearchSelectOptionProps[] => [
+  const { colony } = useColonyContext();
+  return useMemo((): SearchSelectOptionProps[] => {
+    const actionsListOptions: SearchSelectOptionProps[] = [
       {
         key: '1',
         title: { id: 'actions.payments' },
@@ -129,9 +131,15 @@ const useActionsList = () => {
           // },
         ],
       },
-    ],
-    [],
-  );
+    ];
+    if (!colony?.status?.nativeToken?.mintable) {
+      actionsListOptions[2].options[1].isDisabled = true;
+    }
+    if (!colony?.status?.nativeToken?.unlockable) {
+      actionsListOptions[2].options[2].isDisabled = true;
+    }
+    return actionsListOptions;
+  }, [colony]);
 };
 
 export default useActionsList;

--- a/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
+++ b/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
@@ -38,6 +38,7 @@ const SearchItem: FC<SearchItemProps> = ({
           label,
           value,
           isDisabled,
+          isComingSoon,
           avatar,
           showAvatar,
           color,
@@ -45,9 +46,7 @@ const SearchItem: FC<SearchItemProps> = ({
           token,
           isVerified,
         }) => {
-          const firstDisabledOption = options.filter(
-            (option) => option.isDisabled,
-          )[0];
+          const comingSoonOption = isComingSoon || (isDisabled && isComingSoon);
           const labelText = formatText(label || '');
 
           const hasAvatar = showAvatar || !!color || !!token;
@@ -122,7 +121,7 @@ const SearchItem: FC<SearchItemProps> = ({
                     />
                   )}
                   {!label && <span className="truncate">{walletAddress}</span>}
-                  {firstDisabledOption?.value === value && (
+                  {comingSoonOption && (
                     <div className="absolute right-0 top-1/2 -translate-y-1/2 transform">
                       <ExtensionsStatusBadge
                         mode="coming-soon"

--- a/src/components/v5/shared/SearchSelect/types.ts
+++ b/src/components/v5/shared/SearchSelect/types.ts
@@ -27,6 +27,7 @@ export interface SearchSelectOption {
   label: MessageDescriptor | string;
   value: string | number;
   isDisabled?: boolean;
+  isComingSoon?: boolean;
   avatar?: string;
   thumbnail?: string;
   showAvatar?: boolean;


### PR DESCRIPTION
## Intro Note

This PR is part of the set that will be opened by me to (re)introduce all the changes made to support the Arbitrum deployment, from the `master-arbitrum` branch back into `master` so that the two branches can be _(more or less)_ identical 

We need to run two branches, since AWS enforces one deployment per branch, meaning we can't run both the `Gnosis` and `Arbitrum` deployment from the same branch.

This will get cleaned up, once we get to Multichain and we will be back to only supporting one main deployment _(which itself will support multiple networks, whatever form this might take)_

## Current PR Details

This PR adds some checks to disable the _"Mint Token"_ and _"Unlock Token"_ actions if the colony doesn't have permissions to do so. This usually happens when you are using an external token, not one created by you, when creating the colony.

## Testing

Testing this is quite easy, just create a new colony, but instead of creating a new token along side it, just bring one from an existing colony _(`planex` for example)_. 

- The actions to unlock and mind should be grayed out in your action selector
- The "mint" option in the Balance page's kebab menu should not be visible
- The "mint tokens" link should not be visible in the "third menu" 

![Screenshot from 2024-04-08 13-18-13](https://github.com/JoinColony/colonyCDapp/assets/1193222/c6540dcb-310c-49a6-9b44-6e50c8d4b9a7)

Resolves #2163 