### PR TITLE
fix: team purpose field text alignment

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/ManageTeam/ManageTeam.tsx
+++ b/src/components/v5/common/CompletedAction/partials/ManageTeam/ManageTeam.tsx
@@ -1,4 +1,4 @@
-import { PaintBucket, Rocket, UserList } from '@phosphor-icons/react';
+import { PaintBucket, UserList } from '@phosphor-icons/react';
 import React from 'react';
 import { defineMessages } from 'react-intl';
 
@@ -18,6 +18,7 @@ import {
   CreatedInRow,
   DecisionMethodRow,
   DescriptionRow,
+  TeamPurpose,
 } from '../rows/index.ts';
 
 const displayName = 'v5.common.CompletedAction.partials.ManageTeam';
@@ -81,18 +82,9 @@ const ManageTeam = ({ action }: CreateNewTeamProps) => {
           })}
           RowIcon={UserList}
         />
-        <ActionData
-          rowLabel={formatText({ id: 'actionSidebar.teamPurpose' })}
-          rowContent={
-            <span className="break-word">
-              {actionDomainMetadata?.description}
-            </span>
-          }
-          tooltipContent={formatText({
-            id: 'actionSidebar.tooltip.createNewTeam.team.purpose',
-          })}
-          RowIcon={Rocket}
-        />
+        {actionDomainMetadata?.description && (
+          <TeamPurpose description={actionDomainMetadata.description} />
+        )}
         <ActionData
           rowLabel={formatText({ id: 'actionSidebar.teamColour' })}
           rowContent={

--- a/src/components/v5/common/CompletedAction/partials/rows/TeamPurpose.tsx
+++ b/src/components/v5/common/CompletedAction/partials/rows/TeamPurpose.tsx
@@ -1,0 +1,28 @@
+import { Rocket } from '@phosphor-icons/react';
+import React from 'react';
+
+import { formatText } from '~utils/intl.ts';
+
+import ActionData from './ActionData.tsx';
+
+const displayName = 'v5.common.CompletedAction.partials.TeamPurpose';
+
+interface TeamPurposeProps {
+  description: string;
+}
+
+const TeamPurpose = ({ description }: TeamPurposeProps) => (
+  <div className="col-span-2 grid grid-cols-subgrid py-[.3125rem]">
+    <ActionData
+      rowLabel={formatText({ id: 'actionSidebar.teamPurpose' })}
+      rowContent={<span className="break-word">{description}</span>}
+      tooltipContent={formatText({
+        id: 'actionSidebar.tooltip.createNewTeam.team.purpose',
+      })}
+      RowIcon={Rocket}
+    />
+  </div>
+);
+
+TeamPurpose.displayName = displayName;
+export default TeamPurpose;

--- a/src/components/v5/common/CompletedAction/partials/rows/index.ts
+++ b/src/components/v5/common/CompletedAction/partials/rows/index.ts
@@ -8,3 +8,4 @@ export { default as PermissionsTableRow } from './PermissionsTable.tsx';
 export { default as SocialLinksTable } from './SocialLinksTable.tsx';
 export { default as ActionData } from './ActionData.tsx';
 export { default as ModificationRow } from './Modification.tsx';
+export { default as TeamPurpose } from './TeamPurpose.tsx';

--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -64,8 +64,8 @@ const actionsMessageDescriptors = {
       ${ColonyActionType.UnlockTokenMotion} {Unlock Token}
       ${ColonyActionType.MintTokens} {Mint Tokens}
       ${ColonyActionType.MintTokensMotion} {Mint Tokens}
-      ${ColonyActionType.CreateDomain} {Create Team}
-      ${ColonyActionType.CreateDomainMotion} {Create Team}
+      ${ColonyActionType.CreateDomain} {Create new team}
+      ${ColonyActionType.CreateDomainMotion} {Create new team}
       ${ColonyActionType.VersionUpgrade} {Version Upgrade}
       ${ColonyActionType.VersionUpgradeMotion} {Version Upgrade}
       ${ColonyActionType.ColonyEdit} {Manage objective}


### PR DESCRIPTION
## Description

The team purpose field looked different in the edit and completed state. The text was aligned differently in both cases. Right now it should be top-aligned all the time.

## Testing

* Step 1. Create a `Create new team` action and add a text to the `team purpose` field that is longer than one line.
* Step 2. Submit the action and open the completed state.

## Diffs

**New stuff** ✨

* 

**Changes** 🏗

* `TeamPurpose` component with `subgrid`

**Deletions** ⚰️

* 

## TODO

Resolves https://github.com/JoinColony/colonyCDapp/issues/2285
