### PR TITLE
Fix: Fund expenditure motion does not get created in the DB

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -2484,6 +2484,23 @@ type ColonyMotion @model {
   Edited expenditure slots associated with the motion, if any
   """
   editedExpenditureSlots: [ExpenditureSlot!]
+
+  """
+  In case of multicall motion funding an expenditure, array containing
+  the details of tokens and amounts to be funded
+  """
+  expenditureFunding: [ExpenditureFundingItem!]
+}
+
+type ExpenditureFundingItem {
+  """
+  The amount of the token to be funded
+  """
+  amount: String!
+  """
+  The token address of the token to be funded
+  """
+  tokenAddress: String!
 }
 
 """

--- a/src/components/v5/common/CompletedAction/CompletedAction.tsx
+++ b/src/components/v5/common/CompletedAction/CompletedAction.tsx
@@ -94,6 +94,9 @@ const CompletedAction = ({ action }: CompletedActionProps) => {
       case ColonyActionType.CreateDecisionMotion:
       case ColonyActionType.SetUserRolesMotion:
       case ColonyActionType.ColonyEditMotion:
+      case ColonyActionType.EditExpenditureMotion:
+      case ColonyActionType.FundExpenditureMotion:
+        // @NOTE: Enabling those 2 above temporarily
         return <Motions transactionId={action.transactionHash} />;
       case ColonyActionType.CreateExpenditure:
         return <PaymentBuilderWidget action={action} />;

--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -24,7 +24,10 @@ import { type EditExpenditureMotionPayload } from '~redux/sagas/motions/expendit
 import { type FinalizeExpenditureMotionPayload } from '~redux/sagas/motions/expenditures/finalizeExpenditureMotion.ts';
 import { type ReleaseExpenditureStageMotionPayload } from '~redux/sagas/motions/expenditures/releaseExpenditureStageMotion.ts';
 import { type CancelStakedExpenditurePayload } from '~redux/types/actions/expenditures.ts';
-import { type ExpenditureCancelMotionPayload } from '~redux/types/actions/motion.ts';
+import {
+  type ExpenditureFundMotionPayload,
+  type ExpenditureCancelMotionPayload,
+} from '~redux/types/actions/motion.ts';
 import { getExpenditureDatabaseId } from '~utils/databaseId.ts';
 import { findDomainByNativeId } from '~utils/domains.ts';
 import { getClaimableExpenditurePayouts } from '~utils/expenditures.ts';
@@ -128,6 +131,11 @@ const TmpAdvancedPayments = () => {
     submit: ActionTypes.MOTION_EXPENDITURE_FINALIZE,
     error: ActionTypes.MOTION_EXPENDITURE_FINALIZE_ERROR,
     success: ActionTypes.MOTION_EXPENDITURE_FINALIZE_SUCCESS,
+  });
+  const fundExpenditureViaMotion = useAsyncFunction({
+    submit: ActionTypes.MOTION_EXPENDITURE_FUND,
+    error: ActionTypes.MOTION_EXPENDITURE_FUND_ERROR,
+    success: ActionTypes.MOTION_EXPENDITURE_FUND_SUCCESS,
   });
 
   const blockTime = useCurrentBlockTime();
@@ -349,6 +357,22 @@ const TmpAdvancedPayments = () => {
     await cancelExpenditure(payload);
   };
 
+  const handleFundViaMotion = async () => {
+    if (!expenditure || !votingReputationAddress) {
+      return;
+    }
+
+    const payload: ExpenditureFundMotionPayload = {
+      colony,
+      expenditure,
+      motionDomainId: Id.RootDomain,
+      fromDomainFundingPotId: 1,
+      fromDomainId: 1,
+    };
+
+    await fundExpenditureViaMotion(payload);
+  };
+
   const handleEditViaMotion = async () => {
     if (!expenditure) {
       return;
@@ -468,6 +492,7 @@ const TmpAdvancedPayments = () => {
           </Button>
           <Button onClick={handleEdit}>Edit</Button>
           <Button onClick={handleCancel}>Cancel</Button>
+          <Button onClick={handleFundViaMotion}>Fund via motion</Button>
           <Button onClick={handleCancelViaMotion}>Cancel via motion</Button>
           <Button onClick={handleEditViaMotion}>Edit via motion</Button>
           <Button onClick={handleFinalizeViaMotion}>Finalize via motion</Button>

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -832,6 +832,11 @@ export type ColonyMotion = {
   createdBy: Scalars['String'];
   /** Edited expenditure slots associated with the motion, if any */
   editedExpenditureSlots?: Maybe<Array<ExpenditureSlot>>;
+  /**
+   * In case of multicall motion funding an expenditure, array containing
+   * the details of tokens and amounts to be funded
+   */
+  expenditureFunding?: Maybe<Array<ExpenditureFundingItem>>;
   /** Expenditure associated with the motion, if any */
   expenditureId?: Maybe<Scalars['ID']>;
   /** Id of the expenditure stage payment to be released if the motion pass, if any */
@@ -1288,6 +1293,7 @@ export type CreateColonyMetadataInput = {
 export type CreateColonyMotionInput = {
   createdBy: Scalars['String'];
   editedExpenditureSlots?: InputMaybe<Array<ExpenditureSlotInput>>;
+  expenditureFunding?: InputMaybe<Array<ExpenditureFundingItemInput>>;
   expenditureId?: InputMaybe<Scalars['ID']>;
   expenditureSlotId?: InputMaybe<Scalars['Int']>;
   gasEstimate: Scalars['String'];
@@ -1979,6 +1985,19 @@ export type ExpenditureBalance = {
 export type ExpenditureBalanceInput = {
   amount: Scalars['String'];
   tokenAddress: Scalars['ID'];
+};
+
+export type ExpenditureFundingItem = {
+  __typename?: 'ExpenditureFundingItem';
+  /** The amount of the token to be funded */
+  amount: Scalars['String'];
+  /** The token address of the token to be funded */
+  tokenAddress: Scalars['String'];
+};
+
+export type ExpenditureFundingItemInput = {
+  amount: Scalars['String'];
+  tokenAddress: Scalars['String'];
 };
 
 export type ExpenditureMetadata = {
@@ -7956,6 +7975,7 @@ export type UpdateColonyMetadataInput = {
 export type UpdateColonyMotionInput = {
   createdBy?: InputMaybe<Scalars['String']>;
   editedExpenditureSlots?: InputMaybe<Array<ExpenditureSlotInput>>;
+  expenditureFunding?: InputMaybe<Array<ExpenditureFundingItemInput>>;
   expenditureId?: InputMaybe<Scalars['ID']>;
   expenditureSlotId?: InputMaybe<Scalars['Int']>;
   gasEstimate?: InputMaybe<Scalars['String']>;

--- a/src/redux/sagas/motions/expenditures/fundExpenditureMotion.ts
+++ b/src/redux/sagas/motions/expenditures/fundExpenditureMotion.ts
@@ -9,7 +9,7 @@ import {
 import { constants } from 'ethers';
 import { call, put, takeEvery } from 'redux-saga/effects';
 
-import { ADDRESS_ZERO } from '~constants/index.ts';
+import { ADDRESS_ZERO, APP_URL } from '~constants/index.ts';
 import { ActionTypes } from '~redux/actionTypes.ts';
 import {
   createGroupTransaction,
@@ -191,6 +191,14 @@ function* fundExpenditureMotion({
         type: ActionTypes.MOTION_EXPENDITURE_FUND_SUCCESS,
         meta,
       });
+
+      // @TODO: Remove during advanced payments UI wiring
+      // eslint-disable-next-line no-console
+      console.log(
+        `Fund Expenditure Motion URL: ${APP_URL}${window.location.pathname.slice(
+          1,
+        )}?tx=${txHash}`,
+      );
     }
   } catch (e) {
     console.error(e);


### PR DESCRIPTION
## Description

This PR fixes a bug outlined in the issue where multicall motions funding an expenditure would not get picked up by block-ingestor. This was due to an overly simplified implementation of handling multicall motions. While my fix is far from getting it where it should be, it fixes the issue for the existing and upcoming UI.

## Testing

TBC

Resolves #2302 
