### PR TITLE
Fix: Edit Colony Details external links truncated

### DIFF
--- a/src/hooks/useSocialLinksTableColumns.tsx
+++ b/src/hooks/useSocialLinksTableColumns.tsx
@@ -48,7 +48,7 @@ export const useSocialLinksTableColumns = (): ColumnDef<
         cell: ({ getValue }) => (
           <span
             className={clsx(
-              'block overflow-hidden overflow-ellipsis whitespace-nowrap text-md font-normal',
+              'block max-w-full overflow-hidden overflow-ellipsis whitespace-nowrap text-md font-normal',
               {
                 'text-gray-700': !hasNoDecisionMethods,
                 'text-gray-300': hasNoDecisionMethods,


### PR DESCRIPTION
## Description

The External Links on the 'Edit Colony Details' action should be truncated on desktop.

This PR adds a max width to the row to ensure the text is properly truncated.

## Testing

Create a new 'Edit Colony Details' action, edit one of the external links so that the text is too long for the row. The text should be truncated.

## Diffs

**Changes** 🏗

* Added max width to external links row to ensure text is truncated

Resolves #2276

<img width="666" alt="Screenshot 2024-05-09 at 11 45 29" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/fb106f65-ed41-4fd7-9b78-3a20f3e9d95b">
