### PR TITLE
Fix: Action process pills overlapping Userhub

### DIFF
--- a/src/components/v5/shared/Modal/Modal.tsx
+++ b/src/components/v5/shared/Modal/Modal.tsx
@@ -61,7 +61,7 @@ const Modal: FC<PropsWithChildren<ModalProps>> = ({
         className="absolute right-4 top-4 text-gray-400 hover:text-gray-600"
       />
       {!isMobile && shouldShowHeader && (
-        <div className="fixed right-4 top-9">
+        <div className="fixed right-4 top-9 z-top">
           <div className="relative">
             <UserNavigationWrapper
               txButtons={txButtons}

--- a/src/components/v5/shared/PopoverBase/PopoverBase.tsx
+++ b/src/components/v5/shared/PopoverBase/PopoverBase.tsx
@@ -19,7 +19,7 @@ const PopoverBase: FC<PropsWithChildren<PopoverBaseProps>> = ({
   <div
     ref={setTooltipRef}
     {...tooltipProps({
-      className: clsx(classNames, 'z-mid', {
+      className: clsx(classNames, 'z-header', {
         'tooltip-container': withTooltipStyles,
       }),
     })}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -145,6 +145,7 @@ module.exports = {
         base: '1',
         mid: '2',
         sidebar: '10',
+        header: '100',
         top: '1000',
       },
     },


### PR DESCRIPTION
## Description

Fixes the issue with z-index between action process pills, modal inputs, and the Userhub.

## Testing

* Step 1. Create an action with the Reputation decision method.
* Step 2. Open the Userhub, ensure the pills of the Action process pills don't overlap.
* Step 3. You can also click the Activate button to open the modal, and open the Userhub again to make sure there is not an overlapping issue there either

![image](https://github.com/JoinColony/colonyCDapp/assets/33682027/713cc4e8-fb54-48eb-886f-c4ff3db75c15)


## Diffs

**New stuff** ✨

* Added addition z-index to tailwind config.
* Added z-index to modal

**Changes** 🏗

* Changed popover z-index to newly added one for the header.

Also fixes this issue:

![image](https://github.com/JoinColony/colonyCDapp/assets/33682027/abe4c737-719f-4f84-946d-b85fb84ec643)


Resolves #2277
