### PR TITLE
Fix: useHasNoDecisionMethods hook causes edit colony details completed action to crash

### DIFF
--- a/src/components/v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts
@@ -22,7 +22,12 @@ const useHasNoDecisionMethods = () => {
   const { user } = useAppContext();
   const { isVotingReputationEnabled } = useEnabledExtensions();
 
-  const { watch } = useFormContext();
+  const { watch } = useFormContext() || {};
+
+  if (!watch) {
+    return false;
+  }
+
   const actionType = watch(ACTION_TYPE_FIELD_NAME);
 
   if (!user) {


### PR DESCRIPTION
## Description

The CDapp was crashing when loading the completed action for edit colony details.

This PR adds a check to the `useHasNoDecisionMethods` hook so that if `watch` is undefined it will return false. `watch` will only ever be undefined if the `useHasNoDecisionMethods` hook is called outside of a form (as is the case on the edit colony details completed action screen).

## Testing

Create a new edit colony details action. The completed action screen should show without issue.

## Diffs

**Changes** 🏗

* The `useHasNoDecisionMethods` hook returns false if `watch` is undefined.

Resolves #2278 
