### PR TITLE
Removes usage of the payment token decimal in staking

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/hooks.ts
@@ -39,7 +39,7 @@ export const useStakingForm = () => {
   const { colony, motionData } = motionAction || {};
   const { nativeToken } = colony || {};
   const { nativeTokenDecimals, tokenAddress } = nativeToken || {};
-  const tokenDecimals = nativeTokenDecimals || 18;
+  const tokenDecimals = getTokenDecimalsWithFallback(nativeTokenDecimals);
 
   const { motionId, remainingStakes } = motionData;
   const [opposeRemaining, supportRemaining] = remainingStakes || [];
@@ -59,9 +59,7 @@ export const useStakingForm = () => {
             }
 
             try {
-              const amount = BigNumber.from(
-                moveDecimal(value, getTokenDecimalsWithFallback(tokenDecimals)),
-              );
+              const amount = BigNumber.from(moveDecimal(value, tokenDecimals));
 
               return amount.gt(0);
             } catch {
@@ -83,9 +81,7 @@ export const useStakingForm = () => {
                 : opposeRemaining;
 
             try {
-              const amount = BigNumber.from(
-                moveDecimal(value, getTokenDecimalsWithFallback(tokenDecimals)),
-              );
+              const amount = BigNumber.from(moveDecimal(value, tokenDecimals));
 
               return amount.lte(remainingTokens);
             } catch {
@@ -102,9 +98,7 @@ export const useStakingForm = () => {
             }
 
             try {
-              const amount = BigNumber.from(
-                moveDecimal(value, getTokenDecimalsWithFallback(tokenDecimals)),
-              );
+              const amount = BigNumber.from(moveDecimal(value, tokenDecimals));
 
               return amount.lte(userAvailableTokens);
             } catch {

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/hooks.ts
@@ -36,11 +36,10 @@ export const useStakingForm = () => {
   const { motionAction, setIsRefetching, startPollingAction } =
     useMotionContext();
 
-  const { token, colony, motionData } = motionAction || {};
-  const { decimals } = token || {};
+  const { colony, motionData } = motionAction || {};
   const { nativeToken } = colony || {};
   const { nativeTokenDecimals, tokenAddress } = nativeToken || {};
-  const tokenDecimals = decimals || nativeTokenDecimals || 0;
+  const tokenDecimals = nativeTokenDecimals || 18;
 
   const { motionId, remainingStakes } = motionData;
   const [opposeRemaining, supportRemaining] = remainingStakes || [];


### PR DESCRIPTION
## Description

This fixes the issue when the decimals of the token being used for payment is different to the decimals of the native token of a colony, which is being used for staking.

## Testing

* Step 1. Transfer a 6 decimal token to a colony that has an 18 decimal native token.
   - This can be done locally, but it is a little bit of a pain. Ask me if you wish to pursue it and I will provide scripts and instructions, as messy as it was.
* Step 2. Create a motion where the different tokens are used one for the payment and one for staking.
* Step 3. You should be able to stake the max without validation appearing.
* Step 4. You should be able to complete staking without any issues.

## Diffs

**Changes** 🏗

* Removed payment token decimal from staking.

Resolves #2354
