### PR TITLE
Fix: Use StaticJsonRpcProvider where appropriate

### DIFF
--- a/amplify/backend/function/fetchColonyBalances/src/index.js
+++ b/amplify/backend/function/fetchColonyBalances/src/index.js
@@ -54,7 +54,7 @@ exports.handler = async ({ source: { id: colonyAddress } }) => {
       return { items: [] };
     }
 
-    const provider = new providers.JsonRpcProvider(rpcURL);
+    const provider = new providers.StaticJsonRpcProvider(rpcURL);
     const networkClient = getColonyNetworkClient(network, provider, {
       networkAddress,
     });

--- a/amplify/backend/function/fetchColonyNativeFundsClaim/src/index.js
+++ b/amplify/backend/function/fetchColonyNativeFundsClaim/src/index.js
@@ -18,7 +18,7 @@ exports.handler = async ({ source: { id: colonyAddress } }) => {
     throw new Error('Unable to set environment variables. Reason:', e);
   }
 
-  const provider = new providers.JsonRpcProvider(rpcURL);
+  const provider = new providers.StaticJsonRpcProvider(rpcURL);
 
   const providerNetwork = await provider.getNetwork();
   const chainId = String(providerNetwork.chainId);

--- a/amplify/backend/function/fetchMotionState/src/utils.js
+++ b/amplify/backend/function/fetchMotionState/src/utils.js
@@ -52,7 +52,7 @@ const setEnvVariables = async () => {
 };
 
 const getNetworkClient = () => {
-  const provider = new providers.JsonRpcProvider(rpcURL);
+  const provider = new providers.StaticJsonRpcProvider(rpcURL);
 
   const networkClient = getColonyNetworkClient(network, provider, {
     networkAddress,

--- a/amplify/backend/function/fetchMotionTimeoutPeriods/src/index.js
+++ b/amplify/backend/function/fetchMotionTimeoutPeriods/src/index.js
@@ -41,7 +41,7 @@ exports.handler = async (event) => {
   } catch (e) {
     throw Error('Unable to set environment variables. Reason:', e);
   }
-  const provider = new providers.JsonRpcProvider(rpcURL);
+  const provider = new providers.StaticJsonRpcProvider(rpcURL);
   const networkClient = getColonyNetworkClient(network, provider, {
     networkAddress,
     reputationOracleEndpoint,

--- a/amplify/backend/function/fetchTokenFromChain/src/index.js
+++ b/amplify/backend/function/fetchTokenFromChain/src/index.js
@@ -98,7 +98,7 @@ exports.handler = async (event) => {
        * Attempt to fetch it from the chain
        */
       const checksummedAddress = utils.getAddress(tokenAddress);
-      const provider = new providers.JsonRpcProvider(rpcURL);
+      const provider = new providers.StaticJsonRpcProvider(rpcURL);
       const tokenFromChain = new Contract(
         checksummedAddress,
         basicTokenAbi,

--- a/amplify/backend/function/fetchVoterRewards/src/utils.js
+++ b/amplify/backend/function/fetchVoterRewards/src/utils.js
@@ -45,7 +45,7 @@ const setEnvVariables = async () => {
 };
 
 const getNetworkClient = () => {
-  const provider = new providers.JsonRpcProvider(rpcURL);
+  const provider = new providers.StaticJsonRpcProvider(rpcURL);
   const networkClient = getColonyNetworkClient(network, provider, {
     networkAddress,
     reputationOracleEndpoint,

--- a/amplify/backend/function/getSafeTransactionStatus/src/index.js
+++ b/amplify/backend/function/getSafeTransactionStatus/src/index.js
@@ -36,7 +36,7 @@ exports.handler = async (event) => {
     return [];
   }
 
-  const provider = new providers.JsonRpcProvider(rpcURL);
+  const provider = new providers.StaticJsonRpcProvider(rpcURL);
   const transactionReceipt =
     await provider.getTransactionReceipt(transactionHash);
 

--- a/amplify/backend/function/getSafeTransactionStatus/src/utils.js
+++ b/amplify/backend/function/getSafeTransactionStatus/src/utils.js
@@ -144,7 +144,7 @@ const getHomeProvider = async () => {
     [rpcURL] = await getParams(['chainRpcEndpoint']);
   }
 
-  return new providers.JsonRpcProvider(rpcURL);
+  return new providers.StaticJsonRpcProvider(rpcURL);
 };
 
 const getForeignProvider = (safeChainId) => {
@@ -158,7 +158,7 @@ const getForeignProvider = (safeChainId) => {
     );
   }
 
-  return new providers.JsonRpcProvider(
+  return new providers.StaticJsonRpcProvider(
     isDev ? LOCAL_FOREIGN_CHAIN : network.rpcUrl,
   );
 };

--- a/amplify/backend/function/getUserReputation/src/index.js
+++ b/amplify/backend/function/getUserReputation/src/index.js
@@ -48,7 +48,7 @@ exports.handler = async (event) => {
   const domainId = input?.domainId;
   const rootHash = input?.rootHash;
 
-  const provider = new providers.JsonRpcProvider(rpcURL);
+  const provider = new providers.StaticJsonRpcProvider(rpcURL);
 
   const networkClient = getColonyNetworkClient(network, provider, {
     networkAddress,

--- a/amplify/backend/function/getUserTokenBalance/src/index.js
+++ b/amplify/backend/function/getUserTokenBalance/src/index.js
@@ -53,7 +53,7 @@ const setEnvVariables = async () => {
 
     const { walletAddress, tokenAddress, colonyAddress } =
       event.arguments?.input || {};
-    const provider = new providers.JsonRpcProvider(rpcURL);
+    const provider = new providers.StaticJsonRpcProvider(rpcURL);
 
     if (tokenAddress === constants.AddressZero) {
       // Get chain native token balance

--- a/amplify/backend/function/qaSSMtest/src/index.js
+++ b/amplify/backend/function/qaSSMtest/src/index.js
@@ -41,7 +41,7 @@ const setEnvVariables = async () => {
 
 exports.handler = async ({ walletAddress, colonyAddress }) => {
   await setEnvVariables();
-  const provider = new providers.JsonRpcProvider(rpcURL);
+  const provider = new providers.StaticJsonRpcProvider(rpcURL);
 
   const networkClient = getColonyNetworkClient(network, provider, {
     networkAddress,

--- a/amplify/backend/function/updateContributorsWithReputation/src/index.js
+++ b/amplify/backend/function/updateContributorsWithReputation/src/index.js
@@ -83,7 +83,7 @@ exports.handler = async (event) => {
       return true;
     }
 
-    const provider = new providers.JsonRpcProvider(rpcURL);
+    const provider = new providers.StaticJsonRpcProvider(rpcURL);
 
     const networkClient = getColonyNetworkClient(network, provider, {
       networkAddress,

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=b502a80cf03030ad2cc7982dad75252b7d94900d
+ENV BLOCK_INGESTOR_HASH=2481f5909026d2c1261c1c4fbcc638839b73933b
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/frame/v5/pages/UserAdvancedPage/partials/RpcForm/helpers.ts
+++ b/src/components/frame/v5/pages/UserAdvancedPage/partials/RpcForm/helpers.ts
@@ -24,7 +24,7 @@ export const isValidURL = (url: string) => {
 };
 
 async function validateCustomRPC(rpcURL: string, expectedChainId: string) {
-  const provider = new ethers.providers.JsonRpcProvider(rpcURL);
+  const provider = new ethers.providers.StaticJsonRpcProvider(rpcURL);
   try {
     const chainId = await provider.send('net_version', []);
     if (chainId === expectedChainId) {

--- a/src/redux/sagas/motions/revealVoteMotion.ts
+++ b/src/redux/sagas/motions/revealVoteMotion.ts
@@ -37,7 +37,7 @@ function* revealVoteMotion({
      */
     const provider = (() => {
       if (isDev) {
-        return new providers.JsonRpcProvider(GANACHE_LOCAL_RPC_URL);
+        return new providers.StaticJsonRpcProvider(GANACHE_LOCAL_RPC_URL);
       }
       return new providers.Web3Provider(window.ethereum!);
     })();


### PR DESCRIPTION
## Description

[Related block-ingestor PR](https://github.com/JoinColony/block-ingestor/pull/221)

We currently use [JsonRPCProvider](https://docs.ethers.org/v5/api/providers/jsonrpc-provider/#JsonRpcProvider) everywhere, which makes a lot of sense, but as we are paying per-request currently, it would be a benefit to use [StaticJsonRPCProvider](https://docs.ethers.org/v5/api/providers/jsonrpc-provider/#StaticJsonRpcProvider) where appropriate. That means in lambdas, and in the block ingestor - nowhere in the frontend, where a user can change the network their metamask or equivalent is connected to.

This PR changes JsonRPCProvider to StaticJsonRPCProvider in the lambdas and block-ingestor.

## Testing

Perform some actions which utilise the lambdas (and block-ingestor) and ensure nothing has broken.

## Diffs

**Changes** 🏗

* Changed JsonRPCProvider to StaticJsonRPCProvider in the lambdas and block-ingestor.

Resolves #2319