### PR TITLE
Strip headers in minimised descriptions

### DIFF
--- a/src/components/v5/shared/RichText/hooks.ts
+++ b/src/components/v5/shared/RichText/hooks.ts
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react';
 import { useController } from 'react-hook-form';
 
 import { formatText } from '~utils/intl.ts';
+import { stripAndremoveHeadingsFromHTML } from '~utils/strings.ts';
 
 export const useRichText = (
   name: string,
@@ -119,8 +120,11 @@ export const useRichText = (
   useEffect(() => {
     if (field.value && editor && !isDecriptionFieldExpanded) {
       editor?.setEditable(false);
+
+      const strippedContent = stripAndremoveHeadingsFromHTML(editor.getHTML());
+
       setNotFormattedContent(
-        editor?.getText() || formatText({ id: 'placeholder.enterDescription' }),
+        strippedContent || formatText({ id: 'placeholder.enterDescription' }),
       );
     }
   }, [editor, isDecriptionFieldExpanded, field.value]);
@@ -146,13 +150,16 @@ export const useRichText = (
   }, [editor, field.value, name]);
 
   useEffect(() => {
-    if (editor?.getHTML() === field.value) {
+    if (!editor || editor.getHTML() === field.value) {
       return;
     }
 
-    editor?.commands.setContent(field.value);
+    editor.commands.setContent(field.value);
+
+    const strippedContent = stripAndremoveHeadingsFromHTML(editor.getHTML());
+
     setNotFormattedContent(
-      editor?.getText() || formatText({ id: 'placeholder.enterDescription' }),
+      strippedContent || formatText({ id: 'placeholder.enterDescription' }),
     );
   }, [editor, field.value]);
 

--- a/src/components/v5/shared/RichTextDisplay/RichTextDisplay.tsx
+++ b/src/components/v5/shared/RichTextDisplay/RichTextDisplay.tsx
@@ -1,7 +1,10 @@
 import clsx from 'clsx';
 import React from 'react';
 
-import { sanitizeHTML, stripHTML } from '~utils/strings.ts';
+import {
+  stripAndremoveHeadingsFromHTML,
+  sanitizeHTML,
+} from '~utils/strings.ts';
 
 import styles from './RichTextDisplay.module.css';
 
@@ -22,7 +25,7 @@ const RichTextDisplay = ({
 }: RichTextDisplayProps) => {
   const cleanContent = shouldFormat
     ? sanitizeHTML(content)
-    : stripHTML(content);
+    : stripAndremoveHeadingsFromHTML(content);
 
   return (
     <div

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -168,3 +168,25 @@ export const sanitizeHTML = (content: string) => DOMPurify.sanitize(content);
 
 export const stripHTML = (content: string) =>
   DOMPurify.sanitize(content, { ALLOWED_TAGS: [], KEEP_CONTENT: true });
+
+export const stripAndremoveHeadingsFromHTML = (content: string) => {
+  // When stripHTML is called, it removes all of the HTML tags, but does not leave a space between the content of paragraphs.
+  // This hook ensures that there is a space between paragraphs.
+  DOMPurify.addHook('uponSanitizeElement', (node) => {
+    if (node.tagName?.toLowerCase() === 'p') {
+      // eslint-disable-next-line no-param-reassign
+      node.innerHTML = !node.innerHTML ? '' : `${node.innerHTML} `;
+    }
+  });
+
+  const string = stripHTML(
+    DOMPurify.sanitize(content, {
+      FORBID_TAGS: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+      KEEP_CONTENT: false,
+    }),
+  );
+
+  DOMPurify.removeHook('uponSanitizeElement');
+
+  return string;
+};


### PR DESCRIPTION
## Description

- Ensure that in descriptions in a collapsed state (actions and agreements) do not show header elements.

Details here: https://github.com/JoinColony/colonyCDapp/issues/2273

## Testing

- Open any action type
- Use the WYSIWYG or markup to add headings into the description field and add a regular block of content
- Complete the action
- View the description field in the collapsed state and check that the headings don't show

- Open the agreement action type
- Use the WYSIWYG or markup to add headings into the description field and add a regular block of content
- Save it as a draft or complete the agreement flow
- Visit the agreements page and view the draft or completed agreement card, and check that the headings don't show

## Diffs

**New stuff** ✨

* New strings util `stripAndremoveHeadingsFromHTML`

**Changes** 🏗

* Remove headings from collapsed descriptions

Resolves #2273
