### PR TITLE
Remove reputation weighted step validation

### DIFF
--- a/src/components/frame/Extensions/pages/LazyConsensusPage/consts.tsx
+++ b/src/components/frame/Extensions/pages/LazyConsensusPage/consts.tsx
@@ -94,7 +94,7 @@ export const initialExtensionContent = [
           name: 'params.totalStakeFraction',
           min: 1,
           max: 50,
-          step: 1,
+          step: 'any',
         },
         accordionItem: [
           {


### PR DESCRIPTION
## Description

- Remove reputation weighted step validation

## Testing

- Install the Reputation Weighted extension.
- On the settings screen, set the value for "Required Stake" to a fraction of a percent.
- Click the Enable button.
- The form should allow you to do it.

Resolves #2284
