### PR TITLE
feat: action sidebar close button

### DIFF
--- a/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
@@ -127,17 +127,16 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
       ref={registerContainerRef}
     >
       <div className="flex w-full items-center justify-between border-b border-gray-200 px-6 py-4">
-        {isMobile ? (
+        <div className="flex items-center gap-2">
           <button
             type="button"
-            className="flex items-center justify-center py-2.5 text-gray-400"
+            className="flex items-center justify-center py-2.5 text-gray-400 transition sm:hover:text-blue-400"
             onClick={closeSidebarClick}
             aria-label={formatText({ id: 'ariaLabel.closeModal' })}
           >
             <X size={18} />
           </button>
-        ) : (
-          <>
+          {!isMobile && (
             <button
               type="button"
               className="flex items-center justify-center py-2.5 text-gray-400 transition sm:hover:text-blue-400"
@@ -150,10 +149,9 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
                 <ArrowsOutSimple size={18} />
               )}
             </button>
-
-            <MotionOutcomeBadge motionState={motionState} />
-          </>
-        )}
+          )}
+        </div>
+        {!isMobile && <MotionOutcomeBadge motionState={motionState} />}
         <div>{children}</div>
       </div>
       {getSidebarContent()}


### PR DESCRIPTION
## Description

Adding close feature within the side panel on desktop and tablet will enable uses to close the side panel via the header. This adds an extra close mechanism to the side panel giving greater usability control for users within the CDapp.

The close icon should be available to the user in all states of the side panel including:

During the active action stage where a user is creating a new action;
When the transaction is completed; and
And when the transaction is in a motion state.
When the side panel is in the full width state.
If the user selects the close icon during the active action stage and has changed content within the action type chosen, the closing modal should be triggered (which matches the current modal trigger).

For all other states, the side panel should close when selected by the user without the modal triggering.

## Testing

Scenario 1:
* Step 1. Open sidepanel
* Step 2. Close without updating any form field

Scenario 2:
* Step 1. Open again and edit any field
* Step 2. Click on close button - modal with confirmation message should appear

Scenario 3:
* Step 1. Click on the completed action (from activity table on dashboard page)
* Step 2. Close the sidebar

## Diffs

**New stuff** ✨

* 

**Changes** 🏗

* close button now visible on desktop

**Deletions** ⚰️

* 

## TODO


Resolves https://github.com/JoinColony/colonyCDapp/issues/2287
