### PR TITLE
fix: show loader until expenditure status is updated

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
@@ -171,6 +171,9 @@ const UserSelect: FC<UserSelectProps> = ({
           // }}
           trigger={!isUserAddressValid ? 'hover' : undefined}
           placement={isUserAddressValid ? 'top' : 'bottom'}
+          popperOptions={{
+            strategy: 'fixed',
+          }}
         >
           {toggler}
         </Tooltip>

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/FundingModal.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/FundingModal.tsx
@@ -1,6 +1,6 @@
 import { Wallet } from '@phosphor-icons/react';
 import { BigNumber } from 'ethers';
-import React, { useState, type FC } from 'react';
+import React, { type FC } from 'react';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useAsyncFunction from '~hooks/useAsyncFunction.ts';
@@ -24,10 +24,9 @@ import { type FundingModalProps, type TokenItemProps } from './types.ts';
 const FundingModal: FC<FundingModalProps> = ({
   onClose,
   expenditure,
-  refetchExpenditure,
+  onSuccess,
   ...rest
 }) => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const { colony } = useColonyContext();
 
   const fundingItems = expenditure.slots.reduce<TokenItemProps[]>(
@@ -67,7 +66,6 @@ const FundingModal: FC<FundingModalProps> = ({
   });
 
   const handleFundExpenditure = async () => {
-    setIsSubmitting(true);
     try {
       if (!expenditure) {
         return;
@@ -80,14 +78,11 @@ const FundingModal: FC<FundingModalProps> = ({
       };
 
       await fundExpenditure(payload);
-      await refetchExpenditure({
-        expenditureId: expenditure.id,
-      });
 
-      setIsSubmitting(false);
+      onSuccess();
+
       onClose();
     } catch (err) {
-      setIsSubmitting(false);
       onClose();
     }
   };
@@ -100,7 +95,7 @@ const FundingModal: FC<FundingModalProps> = ({
         validationSchema={validationSchema}
         defaultValues={{ decisionMethod: {} }}
       >
-        {({ watch }) => {
+        {({ watch, formState: { isSubmitting } }) => {
           const method = watch('decisionMethod');
 
           return (

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/types.ts
@@ -2,11 +2,9 @@ import { type ExpenditurePayout } from '~gql';
 import { type Expenditure } from '~types/graphql.ts';
 import { type ModalProps } from '~v5/shared/Modal/types.ts';
 
-import { type RefetchExpenditureType } from '../../types.ts';
-
 export type TokenItemProps = Omit<ExpenditurePayout, 'isClaimed'>;
 
 export interface FundingModalProps extends ModalProps {
   expenditure: Expenditure;
-  refetchExpenditure: RefetchExpenditureType;
+  onSuccess: () => void;
 }

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/PaymentStepDetailsBlock.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/PaymentStepDetailsBlock.tsx
@@ -20,7 +20,6 @@ import { getSummedTokens } from './utils.ts';
 
 const PaymentStepDetailsBlock: FC<PaymentStepDetailsBlockProps> = ({
   expenditure,
-  refetchExpenditure,
 }) => {
   const { colony } = useColonyContext();
   const { currentBlockTime: blockTime, fetchCurrentBlockTime } =
@@ -140,7 +139,6 @@ const PaymentStepDetailsBlock: FC<PaymentStepDetailsBlockProps> = ({
                 values={claimPayload}
                 text={formatText({ id: 'expenditure.paymentStage.button' })}
                 onSuccess={() => {
-                  refetchExpenditure();
                   fetchCurrentBlockTime();
                 }}
               />

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/types.ts
@@ -2,5 +2,4 @@ import { type Expenditure } from '~types/graphql.ts';
 
 export interface PaymentStepDetailsBlockProps {
   expenditure: Expenditure | null | undefined;
-  refetchExpenditure: () => void;
 }

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/ReleasePaymentModal/ReleasePaymentModal.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/ReleasePaymentModal/ReleasePaymentModal.tsx
@@ -1,5 +1,5 @@
 import { Wallet } from '@phosphor-icons/react';
-import React, { useState, type FC } from 'react';
+import React, { type FC } from 'react';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
@@ -24,12 +24,11 @@ const ReleasePaymentModal: FC<ReleasePaymentModalProps> = ({
   expenditure,
   isOpen,
   onClose,
-  refetchExpenditure,
+  onSuccess,
   ...rest
 }) => {
   const { colony } = useColonyContext();
   const { user } = useAppContext();
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const releaseDecisionMethodItems =
     useGetReleaseDecisionMethodItems(expenditure);
 
@@ -40,7 +39,6 @@ const ReleasePaymentModal: FC<ReleasePaymentModalProps> = ({
   });
 
   const handleFinalizeExpenditure = async () => {
-    setIsSubmitting(true);
     try {
       if (!expenditure) {
         return;
@@ -53,11 +51,11 @@ const ReleasePaymentModal: FC<ReleasePaymentModalProps> = ({
       };
 
       await finalizeExpenditure(finalizePayload);
-      await refetchExpenditure({ expenditureId: expenditure.id });
-      setIsSubmitting(false);
+
+      onSuccess();
+
       onClose();
     } catch (err) {
-      setIsSubmitting(false);
       onClose();
     }
   };
@@ -70,7 +68,7 @@ const ReleasePaymentModal: FC<ReleasePaymentModalProps> = ({
         validationSchema={validationSchema}
         defaultValues={{ decisionMethod: {} }}
       >
-        {({ watch }) => {
+        {({ watch, formState: { isSubmitting } }) => {
           const method = watch('decisionMethod');
 
           return (

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/ReleasePaymentModal/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/ReleasePaymentModal/types.ts
@@ -1,9 +1,7 @@
 import { type Expenditure } from '~types/graphql.ts';
 import { type ModalProps } from '~v5/shared/Modal/types.ts';
 
-import { type RefetchExpenditureType } from '../../types.ts';
-
 export interface ReleasePaymentModalProps extends ModalProps {
   expenditure: Expenditure;
-  refetchExpenditure: RefetchExpenditureType;
+  onSuccess: () => void;
 }


### PR DESCRIPTION
## Description

Showing loader until expenditure status is updated after each step

## Testing

* Step 1. Create a Payment Builder action.
* Step 2. Get to the Fund step.
* Step 3. Click and fund the payment and complete the transactions.
* Step 4. Check if the Fund button will still be clickable.

## Diffs

**New stuff** ✨

* 

**Changes** 🏗

* `onSuccess` prop instead of `refetchExpenditure` passed to modals and payment step
* `isLoading` state added to show loader instead of clickable button on action success
* `strategy: 'fixed'` added to `UserSelect` component, so that the tooltip is visible when inside the table

**Deletions** ⚰️

* removed `refetchExpenditure` from each modal and payment step

## TODO



Resolves https://github.com/JoinColony/colonyCDapp/issues/2372
