### PR TITLE
Fix: Motion widgets UI regressions

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
@@ -147,7 +147,7 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
                 content: (
                   <p className="text-sm">{formatText(MSG.finalizeError)}</p>
                 ),
-                className: 'bg-negative-100 text-negative-400',
+                className: 'bg-negative-100 text-negative-400 !py-3',
               },
             ]
           : []),

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/OutcomeStep/partials/VoteStatuses/VoteStatuses.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/OutcomeStep/partials/VoteStatuses/VoteStatuses.tsx
@@ -36,14 +36,14 @@ const VoteStatuses: FC<VoteStatusesProps> = ({ items, voters }) => {
               <Icon
                 className={clsx('h-[1em] w-[1em] text-[1.125rem]', {
                   'text-purple-400': status === MotionVote.Yay,
-                  'text-red-400': status === MotionVote.Nay,
+                  'text-negative-400': status === MotionVote.Nay,
                 })}
                 size={20}
               />
               <span
                 className={clsx('text-3', {
                   'text-purple-400': status === MotionVote.Yay,
-                  'text-red-400': status === MotionVote.Nay,
+                  'text-negative-400': status === MotionVote.Nay,
                 })}
               >
                 {label}
@@ -55,7 +55,7 @@ const VoteStatuses: FC<VoteStatusesProps> = ({ items, voters }) => {
               additionalText="%"
               barClassName={clsx({
                 'bg-purple-200': status === MotionVote.Yay,
-                'bg-red-300': status === MotionVote.Nay,
+                'bg-negative-300': status === MotionVote.Nay,
               })}
             />
           </div>

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/RevealStep/RevealStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/RevealStep/RevealStep.tsx
@@ -71,18 +71,20 @@ const RevealStep: FC<RevealStepProps> = ({
         textClassName: 'text-4',
         content: (
           <div className="mt-1 flex flex-col gap-2">
-            <ProgressBar
-              progress={revealProgress}
-              max={totalVoters}
-              additionalText={formatText({
-                id:
-                  revealProgress === 1
-                    ? 'motion.revealStep.voteRevealed'
-                    : 'motion.revealStep.votesRevealed',
-              })}
-              className="ml-1"
-              isTall
-            />
+            <div className="ml-[1.375rem]">
+              <ProgressBar
+                progress={revealProgress}
+                max={totalVoters}
+                additionalText={formatText({
+                  id:
+                    revealProgress === 1
+                      ? 'motion.revealStep.voteRevealed'
+                      : 'motion.revealStep.votesRevealed',
+                })}
+                className="ml-1"
+                isTall
+              />
+            </div>
             {!revealPhaseEnded && canInteract && (
               <StatusText
                 status={StatusTypes.Warning}

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/RevealStep/RevealStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/RevealStep/RevealStep.tsx
@@ -105,7 +105,7 @@ const RevealStep: FC<RevealStepProps> = ({
               onSuccess={handleSuccess}
             >
               {hasUserVoted ? (
-                <>
+                <div className="mb-1.5">
                   <div className={clsx({ 'mb-6': !userVoteRevealed })}>
                     <div className="mb-2 flex items-center justify-between gap-2">
                       <h4 className="text-2">
@@ -132,13 +132,13 @@ const RevealStep: FC<RevealStepProps> = ({
                       text={formatText({ id: 'motion.revealStep.submit' })}
                     />
                   )}
-                </>
+                </div>
               ) : (
                 <>
                   <h4 className="mb-2 text-1">
                     {formatText({ id: 'motion.revealStep.emptyTitle' })}
                   </h4>
-                  <p className="text-sm text-gray-600">
+                  <p className="mb-1.5 text-sm text-gray-600">
                     {formatText({ id: 'motion.revealStep.emptyDescription' })}
                   </p>
                 </>

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/RevealStep/partials/RevealInformationItem/RevealInformationItem.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/RevealStep/partials/RevealInformationItem/RevealInformationItem.tsx
@@ -14,7 +14,7 @@ const RevealInformationItem: FC<RevealInformationListItem> = ({
 }) => {
   return (
     <div className="flex items-center justify-between gap-2 text-gray-900">
-      <UserPopover size={20} walletAddress={address} />
+      <UserPopover size={20} walletAddress={address} textClassName="text-sm" />
       <div className="flex items-center gap-2 text-gray-900">
         {hasRevealed ? <Eye size={14} /> : <EyeClosed size={14} />}
         <span className="text-sm">{hasRevealed ? 'Revealed' : 'Hidden'}</span>

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/StakingStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/StakingStep.tsx
@@ -112,8 +112,9 @@ const StakingStep: FC<StakingStepProps> = ({ className, isActive }) => {
             </StatusText>
           ) : undefined,
           status:
-            objectingStakesPercentageValue === 100 ||
-            supportingStakesPercentageValue === 100
+            (objectingStakesPercentageValue === 100 ||
+              supportingStakesPercentageValue === 100) &&
+            !isFullyStaked
               ? StatusTypes.Warning
               : StatusTypes.Info,
         }}

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/StakingStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/StakingStep.tsx
@@ -132,7 +132,7 @@ const StakingStep: FC<StakingStepProps> = ({ className, isActive }) => {
                       )}
                     </p>
                   ),
-                  className: 'bg-negative-100 text-negative-400',
+                  className: 'bg-negative-100 text-negative-400 !py-3',
                 },
               ]
             : []),
@@ -143,33 +143,36 @@ const StakingStep: FC<StakingStepProps> = ({ className, isActive }) => {
                 {
                   key: '1',
                   content: <NotEnoughTokensInfo />,
-                  className: 'bg-negative-100 text-negative-400',
+                  className: 'bg-negative-100 text-negative-400 !py-3',
                 },
               ]
             : []),
           {
             key: '2',
-            content:
-              isFullyStaked || !isActive ? (
-                <StakingChart
-                  chartProps={{
-                    percentageVotesAgainst: objectingStakesPercentageValue,
-                    percentageVotesFor: supportingStakesPercentageValue,
-                  }}
-                  tokenDecimals={decimals || nativeTokenDecimals}
-                  tokenSymbol={symbol || nativeTokenSymbol}
-                  requiredStake={requiredStake}
-                />
-              ) : (
-                <StakingForm
-                  disableForm={
-                    !enoughReputationToStakeMinimum ||
-                    !enoughTokensToStakeMinimum
-                  }
-                  userActivatedTokens={userActivatedTokens}
-                  userInactivatedTokens={userInactivatedTokens}
-                />
-              ),
+            content: (
+              <div className={clsx({ 'mb-1.5': isStaked })}>
+                {isFullyStaked || !isActive ? (
+                  <StakingChart
+                    chartProps={{
+                      percentageVotesAgainst: objectingStakesPercentageValue,
+                      percentageVotesFor: supportingStakesPercentageValue,
+                    }}
+                    tokenDecimals={decimals || nativeTokenDecimals}
+                    tokenSymbol={symbol || nativeTokenSymbol}
+                    requiredStake={requiredStake}
+                  />
+                ) : (
+                  <StakingForm
+                    disableForm={
+                      !enoughReputationToStakeMinimum ||
+                      !enoughTokensToStakeMinimum
+                    }
+                    userActivatedTokens={userActivatedTokens}
+                    userInactivatedTokens={userInactivatedTokens}
+                  />
+                )}
+              </div>
+            ),
           },
           ...(isStaked
             ? [

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakesList/StakesList.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakesList/StakesList.tsx
@@ -64,7 +64,11 @@ const StakesList = ({ userStakes }: StakesListProps) => {
                       key={stake.address}
                       className="flex w-full items-center justify-between gap-4"
                     >
-                      <UserPopover size={20} walletAddress={stake.address} />
+                      <UserPopover
+                        size={20}
+                        walletAddress={stake.address}
+                        textClassName="text-sm"
+                      />
                       <div className="flex-shrink-0 text-right text-sm text-gray-900">
                         {formatText(
                           { id: 'motion.staking.staked' },

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/VotingStep/VotingStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/VotingStep/VotingStep.tsx
@@ -74,14 +74,16 @@ const VotingStep: FC<VotingStepProps> = ({
         textClassName: 'text-4',
         iconAlignment: 'top',
         content: (
-          <ProgressBar
-            progress={currentReputationPercent}
-            threshold={thresholdPercent}
-            additionalText={formatText({
-              id: 'motion.votingStep.additionalText',
-            })}
-            isTall
-          />
+          <div className="ml-[1.375rem] mt-1">
+            <ProgressBar
+              progress={currentReputationPercent}
+              threshold={thresholdPercent}
+              additionalText={formatText({
+                id: 'motion.votingStep.additionalText',
+              })}
+              isTall
+            />
+          </div>
         ),
       }}
       sections={[

--- a/src/components/v5/shared/MenuWithSections/MenuWithSections.tsx
+++ b/src/components/v5/shared/MenuWithSections/MenuWithSections.tsx
@@ -19,16 +19,14 @@ const MenuWithSections: React.FC<MenuWithSectionsProps> = ({
           key={key}
           className={clsx(
             className,
-            'border-b border-gray-200 px-[1.125rem] py-3 last:border-b-0',
+            'border-b border-gray-200 p-[1.125rem] last:border-b-0',
           )}
         >
           {content}
         </div>
       ))}
       {footer && (
-        <div className={clsx(footerClassName, 'px-[1.125rem] py-3')}>
-          {footer}
-        </div>
+        <div className={clsx(footerClassName, 'p-[1.125rem]')}>{footer}</div>
       )}
     </MenuContainer>
   ) : null;

--- a/src/components/v5/shared/UserPopover/UserPopover.tsx
+++ b/src/components/v5/shared/UserPopover/UserPopover.tsx
@@ -17,6 +17,7 @@ const UserPopover: FC<UserPopoverProps> = ({
   size,
   popperOptions,
   walletAddress,
+  textClassName = 'text-md',
 }) => {
   const {
     colony: { colonyAddress },
@@ -48,11 +49,11 @@ const UserPopover: FC<UserPopoverProps> = ({
           userName={displayName ?? undefined}
           userAddress={walletAddress}
         />
-        <p className="ml-2 truncate text-md font-medium">
+        <p className={clsx('ml-2 truncate font-medium', textClassName)}>
           {userDisplayName ?? (
             <MaskedAddress
               address={walletAddress}
-              className="!text-md !font-medium"
+              className={`!${textClassName} !font-medium`}
             />
           )}
         </p>

--- a/src/components/v5/shared/UserPopover/types.ts
+++ b/src/components/v5/shared/UserPopover/types.ts
@@ -4,4 +4,5 @@ export interface UserPopoverProps {
   size: number;
   walletAddress: string;
   popperOptions?: PopperOptions;
+  textClassName?: string;
 }


### PR DESCRIPTION
## Description

This PR resolves a number of UI regressions in the motion widgets.

1. Username fonts are now the correct size in staking information and reveal information.

<img width="291" alt="Screenshot 2024-05-16 at 12 08 12" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/a8663c45-6fc8-47a7-9e92-45c03b863e56">
<img width="289" alt="Screenshot 2024-05-16 at 12 08 18" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/d432e88f-4467-47cd-a721-8c3d5f4aaac0">

2. Padding between all motion widgets is now 18px increased from 12px.

<img width="829" alt="Screenshot 2024-05-16 at 12 08 50" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/682d9a83-352e-4b75-913a-9c4a111df7ac">

3 + 4. Icon in completed state is now correct.

<img width="360" alt="Screenshot 2024-05-16 at 12 06 43" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/0fb55053-a320-41a2-9877-b7a367a14d2d">

5 + 6. Progress bar is now correctly aligned with the start of the text, and padding has been increased between the text and the progress bar.

<img width="351" alt="Screenshot 2024-05-16 at 12 09 13" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/dad7c515-f3cc-4de5-a3c8-e0b31f2a4c06">

7. Outcome widget now has the correct colour for oppose.

<img width="360" alt="Screenshot 2024-05-16 at 12 10 27" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/aadb0e6c-21a6-4d27-8226-827cbddad776">

## Testing

Create a new motion and check the changes listed above.

## Diffs

**Changes** 🏗

* Various small UI changes as detailed above

Resolves #2288
