### PR TITLE
Fix: Release expenditure stage via motion

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -687,6 +687,10 @@ enum ColonyActionType {
   """
   EDIT_EXPENDITURE_MOTION
   """
+  An action related to a motion to release a staged payment
+  """
+  RELEASE_STAGED_PAYMENT_MOTION
+  """
   An action related to the creation of safe transactions via Safe Control
   """
   MAKE_ARBITRARY_TRANSACTION

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=68cee46ff28c4a24054e87633172e51cf406be7f
+ENV BLOCK_INGESTOR_HASH=0c4e0e1ee607a875b3b7abe22e2dfca84b8f87fa
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/v5/common/CompletedAction/CompletedAction.tsx
+++ b/src/components/v5/common/CompletedAction/CompletedAction.tsx
@@ -104,6 +104,7 @@ const CompletedAction = ({ action }: CompletedActionProps) => {
       case ColonyActionType.CreateDecisionMotion:
       case ColonyActionType.SetUserRolesMotion:
       case ColonyActionType.ColonyEditMotion:
+      case ColonyActionType.ReleaseStagedPaymentMotion:
       case ColonyActionType.EditExpenditureMotion:
       case ColonyActionType.FundExpenditureMotion:
         // @NOTE: Enabling those 2 above temporarily

--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -164,7 +164,22 @@ const TmpAdvancedPayments = () => {
   };
 
   const createStagedExpenditurePayload: CreateExpenditurePayload = {
-    payouts,
+    payouts: [
+      {
+        amount: transactionAmount,
+        tokenAddress,
+        recipientAddress: user?.walletAddress ?? '',
+        claimDelay: '0',
+        tokenDecimals: tokenDecimalAmount,
+      },
+      {
+        amount: '500',
+        tokenAddress,
+        recipientAddress: user?.walletAddress ?? '',
+        claimDelay: '0',
+        tokenDecimals: tokenDecimalAmount,
+      },
+    ],
     colonyAddress: colony.colonyAddress,
     createdInDomain: rootDomain,
     fundFromDomainId: 1,
@@ -296,18 +311,24 @@ const TmpAdvancedPayments = () => {
   };
 
   const handleReleaseExpenditureStageMotion = async () => {
-    if (!expenditure || !releaseStage || !stagedExpenditureAddress) {
+    if (
+      !expenditure ||
+      !releaseStage ||
+      !stagedExpenditureAddress ||
+      !votingReputationAddress
+    ) {
       return;
     }
 
     const payload: ReleaseExpenditureStageMotionPayload = {
       colonyAddress: colony.colonyAddress,
       colonyName: colony.name,
+      stagedExpenditureAddress,
+      votingReputationAddress,
       expenditure,
       slotId: Number(releaseStage),
       motionDomainId: expenditure.nativeDomainId,
       tokenAddresses: [colony.nativeToken.tokenAddress],
-      stagedExpenditureAddress,
     };
 
     await releaseExpenditureStageMotion(payload);

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -455,6 +455,8 @@ export enum ColonyActionType {
   PaymentMotion = 'PAYMENT_MOTION',
   /** An action related to the recovery functionality of a Colony */
   Recovery = 'RECOVERY',
+  /** An action related to a motion to release a staged payment */
+  ReleaseStagedPaymentMotion = 'RELEASE_STAGED_PAYMENT_MOTION',
   /** An action related to removing verified members */
   RemoveVerifiedMembers = 'REMOVE_VERIFIED_MEMBERS',
   RemoveVerifiedMembersMotion = 'REMOVE_VERIFIED_MEMBERS_MOTION',

--- a/src/hooks/useActivityFeed/helpers.ts
+++ b/src/hooks/useActivityFeed/helpers.ts
@@ -103,6 +103,7 @@ const ACTION_TYPES_TO_HIDE = [
   ColonyActionType.SetExpenditureStateMotion,
   ColonyActionType.EditExpenditure,
   ColonyActionType.EditExpenditureMotion,
+  ColonyActionType.ReleaseStagedPaymentMotion,
 ];
 
 export const filterByActionTypes = (

--- a/src/redux/sagas/motions/expenditures/releaseExpenditureStageMotion.ts
+++ b/src/redux/sagas/motions/expenditures/releaseExpenditureStageMotion.ts
@@ -1,9 +1,9 @@
 import {
-  type AnyVotingReputationClient,
   ClientType,
   ColonyRole,
   getPermissionProofs,
   Id,
+  getChildIndex,
 } from '@colony/colony-js';
 import { call, put, takeEvery } from 'redux-saga/effects';
 
@@ -16,7 +16,6 @@ import {
   waitForTxResult,
 } from '~redux/sagas/transactions/index.ts';
 import {
-  getMulticallDataForStageRelease,
   getColonyManager,
   initiateTransaction,
 } from '~redux/sagas/utils/index.ts';
@@ -30,6 +29,8 @@ function* releaseExpenditureStageMotion({
   payload: {
     colonyAddress,
     colonyName,
+    stagedExpenditureAddress,
+    votingReputationAddress,
     expenditure,
     slotId,
     motionDomainId,
@@ -50,25 +51,34 @@ function* releaseExpenditureStageMotion({
   );
 
   try {
+    const stagedExpenditureClient = yield colonyManager.getClient(
+      ClientType.StagedExpenditureClient,
+      colonyAddress,
+    );
+
     if (expenditure.status !== ExpenditureStatus.Finalized) {
       throw new Error(
         'Expenditure must be finalized in order to release expenditure stage',
       );
     }
 
-    const votingReputationClient: AnyVotingReputationClient = yield call(
-      [colonyManager, colonyManager.getClient],
-      ClientType.VotingReputationClient,
-      colonyAddress,
-    );
+    const [userPermissionDomainId, userChildSkillIndex] =
+      yield getPermissionProofs(
+        colonyClient.networkClient,
+        colonyClient,
+        expenditure.nativeDomainId,
+        ColonyRole.Arbitration,
+        votingReputationAddress,
+      );
 
-    const [permissionDomainId, childSkillIndex] = yield getPermissionProofs(
-      colonyClient.networkClient,
-      colonyClient,
-      expenditure.nativeDomainId,
-      ColonyRole.Arbitration,
-      votingReputationClient.address,
-    );
+    const [extensionPermissionDomainId, extensionChildSkillIndex] =
+      yield getPermissionProofs(
+        colonyClient.networkClient,
+        colonyClient,
+        expenditure.nativeDomainId,
+        ColonyRole.Arbitration,
+        stagedExpenditureAddress,
+      );
 
     const { skillId } = yield call(
       [colonyClient, colonyClient.getDomain],
@@ -81,21 +91,28 @@ function* releaseExpenditureStageMotion({
       ADDRESS_ZERO,
     );
 
-    const encodedMulticallData: string[] = getMulticallDataForStageRelease(
-      expenditure,
-      slotId,
+    const childSkillIndex = yield call(
+      getChildIndex,
+      colonyClient.networkClient,
       colonyClient,
-      permissionDomainId,
-      childSkillIndex,
-      tokenAddresses,
+      motionDomainId,
+      expenditure.nativeDomainId,
     );
 
-    const encodedReleaseStagedPaymentAction =
-      yield colonyClient.interface.encodeFunctionData('multicall', [
-        encodedMulticallData,
-      ]);
+    const encodedAction = stagedExpenditureClient.interface.encodeFunctionData(
+      'releaseStagedPaymentViaArbitration',
+      [
+        userPermissionDomainId,
+        userChildSkillIndex,
+        extensionPermissionDomainId,
+        extensionChildSkillIndex,
+        expenditure.nativeId,
+        slotId,
+        tokenAddresses,
+      ],
+    );
 
-    const batchKey = 'motion-release-expenditure-stage';
+    const batchKey = 'createMotion';
 
     yield createGroupTransaction(createMotion, batchKey, meta, {
       context: ClientType.VotingReputationClient,
@@ -104,18 +121,17 @@ function* releaseExpenditureStageMotion({
       params: [
         motionDomainId,
         childSkillIndex,
-        ADDRESS_ZERO,
-        encodedReleaseStagedPaymentAction,
+        stagedExpenditureAddress,
+        encodedAction,
         key,
         value,
         branchMask,
         siblings,
       ],
       group: {
-        title: { id: 'transaction.group.createMotion.title' },
-        description: {
-          id: 'transaction.group.createMotion.description',
-        },
+        key: batchKey,
+        id: meta.id,
+        index: 1,
       },
     });
 

--- a/src/redux/sagas/utils/setExpenditureStateHelpers.ts
+++ b/src/redux/sagas/utils/setExpenditureStateHelpers.ts
@@ -22,44 +22,6 @@ const EXPENDITURESLOTS_SLOT = toB32(BigNumber.from(26));
 const EXPENDITURESLOT_RECIPIENT = toB32(BigNumber.from(0));
 const EXPENDITURESLOT_CLAIMDELAY = toB32(BigNumber.from(1));
 
-const MAPPING = false;
-const ARRAY = true;
-
-export const getMulticallDataForStageRelease = (
-  expenditure: Expenditure,
-  slotId: number,
-  colonyClient: AnyColonyClient,
-  permissionDomainId: BigNumber,
-  childSkillIndex: BigNumber,
-  tokenAddresses: string[],
-) => {
-  const encodedMulticallData: string[] = [];
-
-  encodedMulticallData.push(
-    colonyClient.interface.encodeFunctionData('setExpenditureState', [
-      permissionDomainId,
-      childSkillIndex,
-      expenditure.nativeId,
-      EXPENDITURESLOTS_SLOT,
-      [MAPPING, ARRAY],
-      [toB32(slotId), EXPENDITURESLOT_CLAIMDELAY],
-      toB32(0),
-    ]),
-  );
-
-  for (const tokenAddress of tokenAddresses) {
-    encodedMulticallData.push(
-      colonyClient.interface.encodeFunctionData('claimExpenditurePayout', [
-        expenditure.nativeId,
-        slotId,
-        tokenAddress,
-      ]),
-    );
-  }
-
-  return encodedMulticallData;
-};
-
 /**
  * Helper function returning an array of encoded multicall data containing transactions
  * needed to update expenditure payouts

--- a/src/redux/types/actions/motion.ts
+++ b/src/redux/types/actions/motion.ts
@@ -370,6 +370,7 @@ export type MotionActionTypes =
         slotId: number;
         tokenAddresses: Address[];
         stagedExpenditureAddress: Address;
+        votingReputationAddress: Address;
         motionDomainId: number;
       },
       MetaWithSetter<object>


### PR DESCRIPTION
## Description

This PR modifies the release expenditure stage via motion saga and block-ingestor handler to take advantage of the `releaseStagedPaymentViaArbitration` contract method in order to make the release stage flow functional again.

[block-ingestor counterpart](https://github.com/JoinColony/block-ingestor/pull/224)

## Testing

1. Install both the weighted reputation extension and the staged payments extension.
2. Enter a transaction amount greater than 0 and create a new staged payment via the temporary dashboard UI. (The expenditure ID will be logged to the console).
3. Lock, fund and finalize the payment.
4. Refetch the expenditure, and enter the stage to release (1 or 2) into 'stage to release' input and submit.
5. Run the following query to check the current state of the database:

```
query MyQuery {
  listExpenditures(filter: {nativeId: {eq: 33}}) {
    items {
      metadata {
        stages {
          isReleased
          name
          slotId
        }
      }
      motions {
        items {
          action {
            type
          }
        }
      }
      slots {
        id
        claimDelay
        payouts {
          isClaimed
        }
      }
    }
  }
}
```

`isReleased` should be false for both stages. The `claimDelay` should be set for both slots and `isClaimed` should be false for both slots. You should also be able to see a motion linked to this expenditure.

7. Open the URL logged to the console and follow the motion flow.
8. Finalize the motion and run the query again. `isReleased` should now be true for the stage you released. The `claimDelay` should be 0 and `isClaimed` should be true for the slot you released.

## Diffs

**Changes** 🏗

*  `releaseExpenditureStageMotion` saga now uses the `releaseStagedPaymentViaArbitration` contract method instead of multicall

Resolves #2333
