### PR TITLE
Advanced Payments API: Use multicall wherever possible

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=68cee46ff28c4a24054e87633172e51cf406be7f
+ENV BLOCK_INGESTOR_HASH=7b0bb2b12523ea027b207d9c633924adac7342ec
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -364,6 +364,8 @@
     "transaction.group.createExpenditure.description": "Create Expenditure",
     "transaction.ColonyClient.makeExpenditure.title": "Make Expenditure",
     "transaction.ColonyClient.makeExpenditure.description": "Make Expenditure",
+    "transaction.ColonyClient.multicall.title": "Multicall",
+    "transaction.ColonyClient.multicall.description": "Multicall",
     "transaction.ColonyClient.setExpenditureValues.title": "Set Expenditure Values",
     "transaction.ColonyClient.setExpenditureValues.description": "Set Expenditure Values",
     "transaction.ColonyClient.lockExpenditure.title": "Lock Expenditure",

--- a/src/redux/sagas/expenditures/claimExpenditure.ts
+++ b/src/redux/sagas/expenditures/claimExpenditure.ts
@@ -1,8 +1,13 @@
+import { ClientType } from '@colony/colony-js';
 import { takeEvery, put } from 'redux-saga/effects';
 
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 
-import { claimExpenditurePayouts, putError } from '../utils/index.ts';
+import {
+  claimExpenditurePayouts,
+  getColonyManager,
+  putError,
+} from '../utils/index.ts';
 
 export type ClaimExpenditurePayload =
   Action<ActionTypes.EXPENDITURE_CLAIM>['payload'];
@@ -12,11 +17,18 @@ export function* claimExpenditure({
   payload: { colonyAddress, nativeExpenditureId, claimablePayouts },
 }: Action<ActionTypes.EXPENDITURE_CLAIM>) {
   try {
+    const colonyManager = yield getColonyManager();
+    const colonyClient = yield colonyManager.getClient(
+      ClientType.ColonyClient,
+      colonyAddress,
+    );
+
     yield claimExpenditurePayouts({
       colonyAddress,
       claimablePayouts,
       metaId: meta.id,
       nativeExpenditureId,
+      colonyClient,
     });
 
     yield put<AllActions>({

--- a/src/redux/sagas/expenditures/finalizeExpenditure.ts
+++ b/src/redux/sagas/expenditures/finalizeExpenditure.ts
@@ -95,6 +95,7 @@ function* finalizeExpenditureAction({
       claimablePayouts,
       metaId: meta.id,
       nativeExpenditureId: expenditure.nativeId,
+      colonyClient,
     });
 
     yield put<AllActions>({

--- a/src/redux/sagas/expenditures/fundExpenditure.ts
+++ b/src/redux/sagas/expenditures/fundExpenditure.ts
@@ -1,10 +1,7 @@
 import { ClientType } from '@colony/colony-js';
-import { all, fork, put, takeEvery } from 'redux-saga/effects';
+import { fork, put, takeEvery } from 'redux-saga/effects';
 
-import {
-  transactionAddParams,
-  transactionPending,
-} from '~redux/actionCreators/index.ts';
+import { transactionPending } from '~redux/actionCreators/index.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 
 import {
@@ -15,6 +12,7 @@ import {
 } from '../transactions/index.ts';
 import { getExpenditureBalancesByTokenAddress } from '../utils/expenditures.ts';
 import {
+  getColonyManager,
   getMoveFundsPermissionProofs,
   initiateTransaction,
   putError,
@@ -34,6 +32,12 @@ function* fundExpenditure({
   },
   meta,
 }: Action<ActionTypes.EXPENDITURE_FUND>) {
+  const colonyManager = yield getColonyManager();
+  const colonyClient = yield colonyManager.getClient(
+    ClientType.ColonyClient,
+    colonyAddress,
+  );
+
   const { nativeFundingPotId: expenditureFundingPotId } = expenditure;
 
   const batchKey = 'fundExpenditure';
@@ -46,29 +50,51 @@ function* fundExpenditure({
   // Create channel for each token, using its address as channel id
   const {
     annotateFundExpenditure,
-    ...channels
+    fundMulticall,
   }: Record<string, ChannelDefinition> = yield createTransactionChannels(
     meta.id,
-    [...balancesByTokenAddresses.keys(), 'annotateFundExpenditure'],
+    ['fundMulticall', 'annotateFundExpenditure'],
   );
 
   try {
-    yield all(
-      [...balancesByTokenAddresses.keys()].map((tokenAddress, index) =>
-        fork(createTransaction, channels[tokenAddress].id, {
-          context: ClientType.ColonyClient,
-          methodName:
-            'moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)',
-          identifier: colonyAddress,
-          group: {
-            key: batchKey,
-            id: meta.id,
-            index,
-          },
-          ready: false,
-        }),
-      ),
+    const [permissionDomainId, fromChildSkillIndex, toChildSkillIndex] =
+      yield getMoveFundsPermissionProofs(
+        colonyAddress,
+        fromDomainFundingPotId,
+        expenditureFundingPotId,
+      );
+
+    const multicallData = [...balancesByTokenAddresses.entries()].map(
+      ([tokenAddress, amount]) =>
+        colonyClient.interface.encodeFunctionData(
+          'moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)',
+          [
+            permissionDomainId,
+            fromChildSkillIndex,
+            permissionDomainId,
+            fromChildSkillIndex,
+            toChildSkillIndex,
+            fromDomainFundingPotId,
+            expenditureFundingPotId,
+            amount,
+            tokenAddress,
+          ],
+        ),
     );
+
+    yield fork(createTransaction, fundMulticall.id, {
+      context: ClientType.ColonyClient,
+      methodName: 'multicall',
+      identifier: colonyAddress,
+      group: {
+        key: batchKey,
+        id: meta.id,
+        index: 0,
+      },
+      ready: false,
+      params: [multicallData],
+    });
+
     if (annotationMessage) {
       yield fork(createTransaction, annotateFundExpenditure.id, {
         context: ClientType.ColonyClient,
@@ -77,66 +103,39 @@ function* fundExpenditure({
         group: {
           key: batchKey,
           id: meta.id,
-          index: Object.keys(balancesByTokenAddresses).length,
+          index: 1,
         },
         ready: false,
       });
     }
 
-    for (const [tokenAddress, amount] of [
-      ...balancesByTokenAddresses.entries(),
-    ]) {
+    yield takeFrom(fundMulticall.channel, ActionTypes.TRANSACTION_CREATED);
+    if (annotationMessage) {
       yield takeFrom(
-        channels[tokenAddress].channel,
+        annotateFundExpenditure.channel,
         ActionTypes.TRANSACTION_CREATED,
       );
-      if (annotationMessage) {
-        yield takeFrom(
-          annotateFundExpenditure.channel,
-          ActionTypes.TRANSACTION_CREATED,
-        );
-      }
+    }
 
-      yield put(transactionPending(channels[tokenAddress].id));
+    yield put(transactionPending(fundMulticall.id));
 
-      const [permissionDomainId, fromChildSkillIndex, toChildSkillIndex] =
-        yield getMoveFundsPermissionProofs(
-          colonyAddress,
-          fromDomainFundingPotId,
-          expenditureFundingPotId,
-        );
-      yield put(
-        transactionAddParams(channels[tokenAddress].id, [
-          permissionDomainId,
-          fromChildSkillIndex,
-          permissionDomainId,
-          fromChildSkillIndex,
-          toChildSkillIndex,
-          fromDomainFundingPotId,
-          expenditureFundingPotId,
-          amount,
-          tokenAddress,
-        ]),
-      );
+    yield initiateTransaction({ id: fundMulticall.id });
 
-      yield initiateTransaction({ id: channels[tokenAddress].id });
+    const {
+      payload: { hash: txHash },
+    } = yield takeFrom(
+      fundMulticall.channel,
+      ActionTypes.TRANSACTION_HASH_RECEIVED,
+    );
 
-      const {
-        payload: { hash: txHash },
-      } = yield takeFrom(
-        channels[tokenAddress].channel,
-        ActionTypes.TRANSACTION_HASH_RECEIVED,
-      );
+    yield waitForTxResult(fundMulticall.channel);
 
-      yield waitForTxResult(channels[tokenAddress].channel);
-
-      if (annotationMessage) {
-        yield uploadAnnotation({
-          txChannel: annotateFundExpenditure,
-          message: annotationMessage,
-          txHash,
-        });
-      }
+    if (annotationMessage) {
+      yield uploadAnnotation({
+        txChannel: annotateFundExpenditure,
+        message: annotationMessage,
+        txHash,
+      });
     }
 
     yield put<AllActions>({
@@ -147,9 +146,7 @@ function* fundExpenditure({
   } catch (error) {
     return yield putError(ActionTypes.EXPENDITURE_FUND_ERROR, error, meta);
   } finally {
-    [...balancesByTokenAddresses.keys()].forEach((tokenAddress) =>
-      channels[tokenAddress].channel.close(),
-    );
+    fundMulticall.channel.close();
     annotateFundExpenditure.channel.close();
   }
 

--- a/src/redux/sagas/expenditures/releaseExpenditureStage.ts
+++ b/src/redux/sagas/expenditures/releaseExpenditureStage.ts
@@ -131,6 +131,7 @@ function* releaseExpenditureStage({
       claimablePayouts: payoutsWithSlotIds,
       metaId: meta.id,
       nativeExpenditureId: expenditure.nativeId,
+      colonyClient,
     });
 
     yield put<AllActions>({


### PR DESCRIPTION
## Description

This PR refactors funding and claiming expenditure to use multicall instead of many transactions.

## Testing

Check that funding expenditure still works, and that finalizing expenditure claims payouts automatically.

Resolves #2391 
