### PR TITLE
fix: remove the Learn More link from the permissions tooltip

### DIFF
--- a/src/components/frame/v5/pages/VerifiedPage/partials/PermissionRow/PermissionRow.tsx
+++ b/src/components/frame/v5/pages/VerifiedPage/partials/PermissionRow/PermissionRow.tsx
@@ -27,18 +27,11 @@ const PermissionRow: FC<PermissionRowProps> = ({ contributorAddress }) => {
               { id: 'role.description' },
               { role: permissionRole.name },
             )}
-            <ul className="mb-4 list-disc pl-4 font-medium">
+            <ul className="list-disc pl-4 font-medium">
               {permissionRole.permissions.map((permission) => (
                 <li key={permission}>{ColonyRole[permission]}</li>
               ))}
             </ul>
-            <a
-              href="https://docs.colony.io/learn/advanced-concepts/permissions"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {formatText({ id: 'learn.more' })}
-            </a>
           </>
         }
       >


### PR DESCRIPTION
## Description

This will remove the "Learn more" link from the Permission tooltip.

## Testing

The "Learn more" link should not be included in the Permission tooltip. 

1. Create an activity in your Colony if it doesn't already have one
2. Visit your Colony's Activity page
3. Click on an Activity
4. On the right drawer, hover on the member's role to bring up the permissions tooltip
5. Verify that:
  a.) the "Learn more" link doesn't exist anymore
  b.) the bottom spacing of the tooltip matches the top spacing 

**Deletions** ⚰️

The "Learn more" link has been removed from the Permissions tooltip

Resolves #2401 