### PR TITLE
fix: Fix popover menu distances from their anchors

### DIFF
--- a/src/components/v5/common/ActionSidebar/ActionTypeSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionTypeSelect.tsx
@@ -38,7 +38,9 @@ const ActionTypeSelect: FC<ActionTypeSelectProps> = ({ className }) => {
   const { portalElementRef, relativeElementRef } = useRelativePortalElement<
     HTMLButtonElement,
     HTMLDivElement
-  >([isSelectVisible]);
+  >([isSelectVisible], {
+    top: 8,
+  });
   const { formState, reset, watch } = useFormContext();
   const { readonly } = useAdditionalFormOptionsContext();
 

--- a/src/components/v5/common/ActionSidebar/partials/NonVerifiedMembersSelect/NonVerifiedMembersSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/NonVerifiedMembersSelect/NonVerifiedMembersSelect.tsx
@@ -51,6 +51,7 @@ const NonVerifiedMembersSelect: FC<NonVerifiedMembersSelectProps> = ({
     withMaxHeight: false,
     withAutoTopPlacement: true,
     withLeftPosition: !isMobile,
+    top: 8,
   });
   const { getValues, setValue } = useFormContext();
   const checkedItems = getValues('members')

--- a/src/components/v5/common/ActionSidebar/partials/TeamsSelect/TeamsSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TeamsSelect/TeamsSelect.tsx
@@ -47,7 +47,9 @@ const TeamsSelect: FC<TeamSelectProps> = ({
   const { portalElementRef, relativeElementRef } = useRelativePortalElement<
     HTMLButtonElement,
     HTMLDivElement
-  >([isTeamSelectVisible]);
+  >([isTeamSelectVisible], {
+    top: 8,
+  });
 
   useEffect(() => {
     if (!selectedOption && field.value) {

--- a/src/components/v5/common/ActionSidebar/partials/TokenSelect/TokenSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TokenSelect/TokenSelect.tsx
@@ -43,7 +43,9 @@ const TokenSelect: FC<TokenSelectProps> = ({ name, disabled = false }) => {
   const { portalElementRef, relativeElementRef } = useRelativePortalElement<
     HTMLButtonElement,
     HTMLDivElement
-  >([isTokenSelectVisible]);
+  >([isTokenSelectVisible], {
+    top: 8,
+  });
   const { readonly } = useAdditionalFormOptionsContext();
 
   useEffect(() => {

--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
@@ -52,7 +52,9 @@ const UserSelect: FC<UserSelectProps> = ({
   const { portalElementRef, relativeElementRef } = useRelativePortalElement<
     HTMLButtonElement,
     HTMLDivElement
-  >([isUserSelectVisible]);
+  >([isUserSelectVisible], {
+    top: 8,
+  });
 
   const selectedUserOption = (options || usersOptions).options.find(
     (option) => option.value === field.value,

--- a/src/components/v5/common/ActionSidebar/partials/VerifiedMembersSelect/VerifiedMembersSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/VerifiedMembersSelect/VerifiedMembersSelect.tsx
@@ -51,6 +51,7 @@ const VerifiedMembersSelect: FC<VerifiedMembersSelectProps> = ({
     withMaxHeight: false,
     withAutoTopPlacement: true,
     withLeftPosition: !isMobile,
+    top: 8,
   });
   const { getValues, setValue } = useFormContext();
   const checkedItems = getValues()


### PR DESCRIPTION
## Description

This PR aims to make the distance between popover menus and their respective anchors consistent.

## Testing

Please inspect the follow fields and verify that their distance from the popover menus they open are consistent:

- Action type
- Non-verified member
- Verified member
- Team selection
- User selection
- Token selection

## Diffs

**Changes** 🏗

Followed the current standard of 8px as the distance between popover menus and their anchors.

Resolves #2385 
