### PR TITLE
fix: Preserve Avatar Skeleton's Aspect Ratio

### DIFF
--- a/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
@@ -49,7 +49,7 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
   return (
     <div className="flex w-full items-center gap-2 sm:gap-4">
       {loading ? (
-        <div className="aspect-square h-[26px] w-[26px] rounded-full skeleton before:rounded-full" />
+        <div className="aspect-square h-[26px] w-auto rounded-full skeleton before:rounded-full" />
       ) : (
         <UserAvatar
           size={26}

--- a/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
@@ -49,7 +49,7 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
   return (
     <div className="flex w-full items-center gap-2 sm:gap-4">
       {loading ? (
-        <div className="h-[26px] w-[26px] rounded-full skeleton before:rounded-full" />
+        <div className="aspect-square h-[26px] w-[26px] rounded-full skeleton before:rounded-full" />
       ) : (
         <UserAvatar
           size={26}


### PR DESCRIPTION
## Description

Ensures that the Avatar components skeleton always preserves its 1:1 aspect ratio.

## Testing

1. Visit a Colony you've joined
2. Make sure there's at least 1 action available in the activity widget
3. Toggle the device toolbar
4. Set the dimensions to "Galaxy Fold"
![Screenshot 2024-05-21 at 14 04 39](https://github.com/JoinColony/colonyCDapp/assets/50642296/201bc95c-abc1-4c1e-8cdf-d5a42fb46fa0)
5. Throttle the network speed and choose "Low-end mobile"
![Screenshot 2024-05-21 at 14 02 45](https://github.com/JoinColony/colonyCDapp/assets/50642296/6101072b-92fe-4a62-aa03-c5d4b4a15f13)
6. Reload the page
7. Wait for the content to load and verify that the Skeleton for the Avatar is round as per designs

## Diffs

**Changes** 🏗

Keep the Avatar Skeleton's aspect ratio in tact.

Resolves #2290 
