### PR TITLE
Fix userhub positioning on mobile

### DIFF
--- a/src/components/v5/frame/PageLayout/PageLayout.tsx
+++ b/src/components/v5/frame/PageLayout/PageLayout.tsx
@@ -43,10 +43,9 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
         contentRect: { height },
       } = entry;
 
-      wrapperRef?.current?.style.setProperty(
-        '--top-content-height',
-        `${height}px`,
-      );
+      // Must set this css variable on the body so that any elements rendered in portals outside of the
+      // wrapper in the DOM will still have the correct variable value.
+      document.body.style.setProperty('--top-content-height', `${height}px`);
     });
 
     observer.observe(topContentWrapperRef.current);


### PR DESCRIPTION
## Description

- Fix the position of the userhub on mobile when the action sidebar is open

## Testing

* Step 1. Open the app on mobile screen size
* Step 2. Open the action sidebar / start creating a new action
* Step 3. Open the userhub
* Step 4. Check that the userhub is positioned correctly in relation to the top of the screen, and you can close it / navigate away as needed.

## Diffs

**Changes** 🏗

* CSS variable changes to position the userhub menu properly on mobile

Resolves #2286
