### PR TITLE
fix: Disable token selection when mint form is active

### DIFF
--- a/src/components/v5/common/ActionSidebar/ActionTypeSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionTypeSelect.tsx
@@ -1,7 +1,7 @@
 import { FilePlus, WarningCircle } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { type FC, useState } from 'react';
-import { useController, useFormContext, useWatch } from 'react-hook-form';
+import { useController, useFormContext } from 'react-hook-form';
 
 import { useAdditionalFormOptionsContext } from '~context/AdditionalFormOptionsContext/AdditionalFormOptionsContext.ts';
 import useRelativePortalElement from '~hooks/useRelativePortalElement.ts';
@@ -14,6 +14,7 @@ import ActionFormRow from '../ActionFormRow/index.ts';
 
 import { ACTION_TYPE_FIELD_NAME, NON_RESETTABLE_FIELDS } from './consts.ts';
 import useActionsList from './hooks/useActionsList.ts';
+import { useActiveActionType } from './hooks/useActiveActionType.ts';
 import { translateAction } from './utils.ts';
 
 const displayName = 'v5.common.ActionTypeSelect';
@@ -31,7 +32,7 @@ const ActionTypeSelect: FC<ActionTypeSelectProps> = ({ className }) => {
     isSelectVisible,
     { toggle: toggleSelect, toggleOff: toggleSelectOff, registerContainerRef },
   ] = useToggle();
-  const actionType = useWatch({ name: ACTION_TYPE_FIELD_NAME });
+  const actionType = useActiveActionType();
   const {
     field: { onChange },
   } = useController({ name: ACTION_TYPE_FIELD_NAME });

--- a/src/components/v5/common/ActionSidebar/hooks/useActiveActionType.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useActiveActionType.ts
@@ -1,0 +1,13 @@
+import { useWatch } from 'react-hook-form';
+
+import { type Action } from '~constants/actions.ts';
+
+import { ACTION_TYPE_FIELD_NAME } from '../consts.ts';
+
+export const useActiveActionType = () => {
+  const activeActionType: Action | undefined = useWatch({
+    name: ACTION_TYPE_FIELD_NAME,
+  });
+
+  return activeActionType;
+};

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/NoPermissionsError.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/NoPermissionsError.tsx
@@ -1,12 +1,11 @@
 import { WarningCircle } from '@phosphor-icons/react';
 import React from 'react';
-import { useWatch } from 'react-hook-form';
 import { defineMessages, useIntl } from 'react-intl';
 
 import { Action } from '~constants/actions.ts';
-import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import useHasActionPermissions from '~v5/common/ActionSidebar/hooks/permissions/useHasActionPermissions.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
+import { useActiveActionType } from '~v5/common/ActionSidebar/hooks/useActiveActionType.ts';
 import NotificationBanner from '~v5/shared/NotificationBanner/index.ts';
 
 const displayName =
@@ -22,9 +21,7 @@ const MSG = defineMessages({
 const NoPermissionsError = () => {
   const { formatMessage } = useIntl();
 
-  const actionType: Action | undefined = useWatch({
-    name: ACTION_TYPE_FIELD_NAME,
-  });
+  const actionType = useActiveActionType();
 
   const hasPermissions = useHasActionPermissions();
   const hasNoDecisionMethods = useHasNoDecisionMethods();

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/ActionSidebarDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/ActionSidebarDescription.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { useWatch } from 'react-hook-form';
 
 import { Action } from '~constants/actions.ts';
 
-import { ACTION_TYPE_FIELD_NAME } from '../../consts.ts';
+import { useActiveActionType } from '../../hooks/useActiveActionType.ts';
 
 import CreateDecisionDescription from './partials/CreateDecisionDescription.tsx';
 import CreateNewDomainDescription from './partials/CreateNewDomainDescription.tsx';
@@ -26,9 +25,7 @@ const displayName =
   'v5.common.ActionsSidebar.partials.ActionSidebarDescription';
 
 const ActionSidebarDescription = () => {
-  const selectedAction: Action | undefined = useWatch({
-    name: ACTION_TYPE_FIELD_NAME,
-  });
+  const selectedAction = useActiveActionType();
 
   switch (selectedAction) {
     case Action.MintTokens:

--- a/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
@@ -33,6 +33,7 @@ const AmountField: FC<AmountFieldProps> = ({
   isDisabled,
   placeholder,
   tokenAddressFieldName = 'tokenAddress',
+  isTokenSelectionDisabled,
 }) => {
   const {
     field,
@@ -167,12 +168,12 @@ const AmountField: FC<AmountFieldProps> = ({
             {
               'text-gray-900': selectedToken?.symbol,
               'text-gray-500': !selectedToken?.symbol,
-              'md:hover:text-blue-400': !readonly,
+              'md:hover:text-blue-400': !readonly && !isTokenSelectionDisabled,
             },
           )}
           onClick={toggleTokenSelect}
           aria-label={formatText({ id: 'ariaLabel.selectToken' })}
-          disabled={readonly || isDisabled}
+          disabled={readonly || isDisabled || isTokenSelectionDisabled}
         >
           {selectedTokenContent}
         </button>

--- a/src/components/v5/common/ActionSidebar/partials/AmountField/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/types.ts
@@ -7,4 +7,5 @@ export interface AmountFieldProps {
   domainId?: number;
   isDisabled?: boolean;
   placeholder?: string;
+  isTokenSelectionDisabled?: boolean;
 }

--- a/src/components/v5/common/ActionSidebar/partials/AmountRow/AmountRow.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/AmountRow/AmountRow.tsx
@@ -1,10 +1,12 @@
 import { Coins } from '@phosphor-icons/react';
 import React from 'react';
 
+import { Action } from '~constants/actions.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
 
 import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
+import { useActiveActionType } from '../../hooks/useActiveActionType.ts';
 import AmountField from '../AmountField/index.ts';
 
 import { type AmountRowProps } from './types.ts';
@@ -13,6 +15,8 @@ const displayName = 'v5.common.ActionSidebar.partials.AmountRow';
 
 const AmountRow = ({ domainId, title, tooltips }: AmountRowProps) => {
   const hasNoDecisionMethods = useHasNoDecisionMethods();
+
+  const activeActionType = useActiveActionType();
 
   return (
     <ActionFormRow
@@ -27,6 +31,7 @@ const AmountRow = ({ domainId, title, tooltips }: AmountRowProps) => {
         maxWidth={270}
         domainId={domainId}
         isDisabled={hasNoDecisionMethods}
+        isTokenSelectionDisabled={activeActionType === Action.MintTokens}
       />
     </ActionFormRow>
   );

--- a/src/components/v5/common/ActionSidebar/partials/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/hooks.ts
@@ -1,6 +1,5 @@
 import { Extension } from '@colony/colony-js';
 import { useMemo } from 'react';
-import { useWatch } from 'react-hook-form';
 
 import { Action } from '~constants/actions.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
@@ -10,7 +9,7 @@ import { canColonyBeUpgraded } from '~utils/checks/index.ts';
 import { isInstalledExtensionData } from '~utils/extensions.ts';
 import { formatText } from '~utils/intl.ts';
 
-import { ACTION_TYPE_FIELD_NAME } from '../consts.ts';
+import { useActiveActionType } from '../hooks/useActiveActionType.ts';
 
 const SUBMIT_BUTTON_TEXT_MAP: Partial<Record<Action, string>> = {
   [Action.PaymentBuilder]: 'button.createPayment',
@@ -37,9 +36,7 @@ const SUBMIT_BUTTON_TEXT_MAP: Partial<Record<Action, string>> = {
 };
 
 export const useSubmitButtonText = () => {
-  const selectedAction: Action | undefined = useWatch({
-    name: ACTION_TYPE_FIELD_NAME,
-  });
+  const selectedAction = useActiveActionType();
   const selectedActionText =
     selectedAction && SUBMIT_BUTTON_TEXT_MAP[selectedAction];
 
@@ -58,9 +55,7 @@ export const useSubmitButtonDisabled = () => {
   const canUpgrade = canColonyBeUpgraded(colony, colonyContractVersion);
 
   const isNativeTokenUnlocked = !!colony.status?.nativeToken?.unlocked;
-  const selectedAction: Action | undefined = useWatch({
-    name: ACTION_TYPE_FIELD_NAME,
-  });
+  const selectedAction = useActiveActionType();
 
   switch (selectedAction) {
     case Action.UnlockToken:
@@ -74,9 +69,7 @@ export const useSubmitButtonDisabled = () => {
 
 export const useIsFieldDisabled = () => {
   const { extensionData } = useExtensionData(Extension.VotingReputation);
-  const selectedAction: Action | undefined = useWatch({
-    name: ACTION_TYPE_FIELD_NAME,
-  });
+  const selectedAction = useActiveActionType();
   const isExtensionEnabled =
     extensionData &&
     isInstalledExtensionData(extensionData) &&

--- a/src/components/v5/common/ActionSidebar/utils.ts
+++ b/src/components/v5/common/ActionSidebar/utils.ts
@@ -1,6 +1,8 @@
-export const translateAction = (action: string) => {
+import { type Action } from '~constants/actions.ts';
+
+export const translateAction = (action?: Action) => {
   const actionName = action
-    .split('-')
+    ?.split('-')
     .map((word, index) => {
       if (index === 0) {
         return word.toLowerCase();


### PR DESCRIPTION
## Description

This will disable the token selection when the mint form is presented to the user.

## Testing

1. Visit a Colony you've joined
2. Bring up the Action form
3. Set the Action type field to "Mint tokens"
4.  Verify that:
  a.) Hovering on the token symbol doesn't do anything
  b.) Clicking the token symbol doesn't do anything

## Diffs

**New stuff** ✨

I noticed that the `ACTION_TYPE_FIELD_NAME` action is being tracked in multiple places so I made a new hook called `useActionActionType` to keep things dry.

**Changes** 🏗

Token selection should now be disabled when the mint form is active.

Resolves #2383 
