### PR TITLE
[Advanced payments] Switch sagas away from `setExpenditureValues`

### DIFF
--- a/src/redux/sagas/expenditures/createStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/createStakedExpenditure.ts
@@ -16,11 +16,11 @@ import {
   getColonyManager,
   putError,
   takeFrom,
-  getSetExpenditureValuesFunctionParams,
   saveExpenditureMetadata,
   initiateTransaction,
   uploadAnnotation,
   getPayoutsWithSlotIds,
+  getExpenditureValuesMulticallData,
 } from '../utils/index.ts';
 
 export type CreateStakedExpenditurePayload =
@@ -95,7 +95,7 @@ function* createStakedExpenditure({
 
     yield fork(createTransaction, setExpenditureValues.id, {
       context: ClientType.ColonyClient,
-      methodName: 'setExpenditureValues',
+      methodName: 'multicall',
       identifier: colonyAddress,
       group: {
         key: batchKey,
@@ -192,17 +192,15 @@ function* createStakedExpenditure({
       setExpenditureValues.channel,
       ActionTypes.TRANSACTION_CREATED,
     );
-    yield put(
-      transactionAddParams(
-        setExpenditureValues.id,
-        getSetExpenditureValuesFunctionParams(
-          expenditureId,
-          payoutsWithSlotIds,
-          networkInverseFee,
-          isStaged,
-        ),
-      ),
+
+    const multicallData = getExpenditureValuesMulticallData(
+      colonyClient,
+      expenditureId,
+      payoutsWithSlotIds,
+      networkInverseFee,
     );
+
+    yield put(transactionAddParams(setExpenditureValues.id, [multicallData]));
     yield initiateTransaction({ id: setExpenditureValues.id });
     yield waitForTxResult(setExpenditureValues.channel);
 

--- a/src/redux/sagas/expenditures/editExpenditure.ts
+++ b/src/redux/sagas/expenditures/editExpenditure.ts
@@ -2,7 +2,6 @@ import { type AnyColonyClient, ClientType } from '@colony/colony-js';
 import { fork, put, takeEvery } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context';
-import { ExpenditureStatus, ExpenditureType } from '~gql';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 
 import {
@@ -13,13 +12,13 @@ import {
 } from '../transactions/index.ts';
 import {
   putError,
-  getSetExpenditureValuesFunctionParams,
   initiateTransaction,
   takeFrom,
   uploadAnnotation,
   getColonyManager,
-  getMulticallDataForUpdatedPayouts,
   getResolvedPayouts,
+  getExpenditureValuesMulticallData,
+  getPayoutsWithSlotIds,
 } from '../utils/index.ts';
 
 export type EditExpenditurePayload =
@@ -32,7 +31,6 @@ function* editExpenditureAction({
     payouts,
     networkInverseFee,
     annotationMessage,
-    userAddress,
   },
   meta,
 }: Action<ActionTypes.EXPENDITURE_EDIT>) {
@@ -55,47 +53,26 @@ function* editExpenditureAction({
   );
 
   try {
-    if (
-      expenditure.ownerAddress === userAddress &&
-      expenditure.status === ExpenditureStatus.Draft
-    ) {
-      // `setExpenditureValues` can only be used if the user is the owner and the expenditure is draft
-      yield fork(createTransaction, editExpenditure.id, {
-        context: ClientType.ColonyClient,
-        methodName: 'setExpenditureValues',
-        identifier: colonyAddress,
-        group: {
-          key: batchKey,
-          id: meta.id,
-          index: 0,
-        },
-        params: getSetExpenditureValuesFunctionParams(
-          expenditure.nativeId,
-          resolvedPayouts,
-          networkInverseFee,
-          expenditure.type === ExpenditureType.Staged,
-        ),
-      });
-    } else {
-      const multicallData = yield getMulticallDataForUpdatedPayouts(
-        expenditure,
-        resolvedPayouts,
-        colonyClient,
-        networkInverseFee,
-      );
+    const resolvedPayoutsWithSlotIds = getPayoutsWithSlotIds(resolvedPayouts);
 
-      yield fork(createTransaction, editExpenditure.id, {
-        context: ClientType.ColonyClient,
-        methodName: 'multicall',
-        identifier: colonyAddress,
-        group: {
-          key: batchKey,
-          id: meta.id,
-          index: 0,
-        },
-        params: [multicallData],
-      });
-    }
+    const multicallData = getExpenditureValuesMulticallData(
+      colonyClient,
+      expenditure.nativeId,
+      resolvedPayoutsWithSlotIds,
+      networkInverseFee,
+    );
+
+    yield fork(createTransaction, editExpenditure.id, {
+      context: ClientType.ColonyClient,
+      methodName: 'multicall',
+      identifier: colonyAddress,
+      group: {
+        key: batchKey,
+        id: meta.id,
+        index: 0,
+      },
+      params: [multicallData],
+    });
 
     if (annotationMessage) {
       yield fork(createTransaction, annotateEditExpenditure.id, {

--- a/src/redux/sagas/utils/setExpenditureStateHelpers.ts
+++ b/src/redux/sagas/utils/setExpenditureStateHelpers.ts
@@ -144,3 +144,55 @@ export const getMulticallDataForUpdatedPayouts = async (
 
   return encodedMulticallData;
 };
+
+/**
+ * Helper function returning an array of encoded multicall data to set
+ * expenditure values when creating or editing expenditures
+ */
+export const getExpenditureValuesMulticallData = (
+  colonyClient: any,
+  expenditureId: any,
+  payoutsWithSlotIds: ExpenditurePayoutFieldValue[],
+  networkInverseFee: string,
+) => {
+  const encodedMulticallData: string[] = [];
+  encodedMulticallData.push(
+    colonyClient.interface.encodeFunctionData('setExpenditureRecipients', [
+      expenditureId,
+      payoutsWithSlotIds.map((payout) => payout.slotId),
+      payoutsWithSlotIds.map((payout) => payout.recipientAddress),
+    ]),
+  );
+
+  encodedMulticallData.push(
+    colonyClient.interface.encodeFunctionData('setExpenditureClaimDelays', [
+      expenditureId,
+      payoutsWithSlotIds.map((payout) => payout.slotId),
+      payoutsWithSlotIds.map((payout) => payout.claimDelay),
+    ]),
+  );
+
+  const tokenAddresses = new Set(
+    payoutsWithSlotIds.map((payout) => payout.tokenAddress),
+  );
+
+  tokenAddresses.forEach((tokenAddress) => {
+    const tokenPayouts = payoutsWithSlotIds.filter(
+      (payout) => payout.tokenAddress === tokenAddress,
+    );
+    const tokenAmounts = tokenPayouts.map((payout) =>
+      getPayoutAmount(payout, networkInverseFee),
+    );
+
+    encodedMulticallData.push(
+      colonyClient.interface.encodeFunctionData('setExpenditurePayouts', [
+        expenditureId,
+        tokenPayouts.map((payout) => payout.slotId),
+        tokenAddress,
+        tokenAmounts,
+      ]),
+    );
+  });
+
+  return encodedMulticallData;
+};


### PR DESCRIPTION
## Description

Instead of calling `setExpenditureValues`, both `createStakedExpenditure` and `editExpenditure` sagas should send a multicall of `setExpenditureRecipients`, `setExpenditureClaimDelays` and `setExpenditurePayouts`.

This PR extracts the logic from `createExpenditure` into a helper function and adjusts `createExpenditure`, `createStakedExpenditure` and `editExpenditure` to use the new function.

## Testing

* Step 1 - Open the `ColonyHome.tsx` file and uncomment line `17` and lines `48-50`.
* Step 2 - Enter an amount greater than 0 into the amount field
* Step 3 - Create a new expenditure (ensure the `createExpenditure` saga is unaffected)
* Step 4 - Run the following query in graphiql to confirm the expenditure has been properly created

```
query MyQuery {
  listExpenditures(filter: {nativeId: {eq: 33}}) {
    items {
      nativeId
      slots {
        claimDelay
        payouts {
          amount
          networkFee
          tokenAddress
        }
        recipientAddress
      }
    }
  }
}
```

* Step 5 - Enter the expenditure native ID into the field and click edit
* Step 6 - Run the query again and confirm the expenditure has been edited
* Step 7 - Create a staked expenditure. Confirm this has been created properly in the database.

## Diffs

**Changes** 🏗

* `createExpenditure`, `createStakedExpenditure` and `editExpenditure` use new `getExpenditureValuesMulticallData` helper function.

Resolves #2387
