### PR TITLE
fix: missing validation for funds available to fund an expenditure

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/hooks.ts
@@ -27,7 +27,7 @@ import { getSimplePaymentPayload } from './utils.tsx';
 export const useValidationSchema = () => {
   const { colony } = useColonyContext();
   const { watch } = useFormContext();
-  const selectedTeam: string | undefined = watch('from');
+  const selectedTeam: number | undefined = watch('from');
 
   const validationSchema = useMemo(
     () =>

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/FundingModal.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/FundingModal.tsx
@@ -1,12 +1,15 @@
 import { Wallet } from '@phosphor-icons/react';
 import { BigNumber } from 'ethers';
-import React, { useState, type FC } from 'react';
+import React, { useEffect, type FC } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { defineMessages } from 'react-intl';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useAsyncFunction from '~hooks/useAsyncFunction.ts';
 import { ActionTypes } from '~redux';
 import { type FundExpenditurePayload } from '~redux/sagas/expenditures/fundExpenditure.ts';
 import { Form } from '~shared/Fields/index.ts';
+import { findDomainByNativeId } from '~utils/domains.ts';
 import { formatText } from '~utils/intl.ts';
 import Button from '~v5/shared/Button/Button.tsx';
 import Modal from '~v5/shared/Modal/index.ts';
@@ -16,10 +19,112 @@ import DecisionMethodSelect from '../DecisionMethodSelect/DecisionMethodSelect.t
 import {
   fundingDecisionMethodDescriptions,
   fundingDecisionMethodItems,
-  validationSchema,
+  getValidationSchema,
 } from './consts.ts';
 import TokenItem from './TokenItem.tsx';
-import { type FundingModalProps, type TokenItemProps } from './types.ts';
+import {
+  type FundingModalContentProps,
+  type FundingModalProps,
+  type TokenItemProps,
+} from './types.ts';
+
+const displayName =
+  'v5.common.CompletedAction.partials.PaymentBuilder.partials.FundingModal';
+
+const MSG = defineMessages({
+  notEnoughTokens: {
+    id: `${displayName}.notEnoughTokens`,
+    defaultMessage:
+      'There are not enough funds in {team} to fund this payment. Ensure there are enough funds in the team before trying again.',
+  },
+});
+
+const FundingModalContent: FC<FundingModalContentProps> = ({
+  fundingItems,
+  onClose,
+  teamName,
+}) => {
+  const {
+    watch,
+    formState: { isSubmitting, errors },
+    trigger,
+  } = useFormContext();
+  const method = watch('decisionMethod');
+
+  useEffect(() => {
+    trigger('fundingItems');
+  }, [trigger]);
+
+  const hasEnoughFunds = !errors.fundingItems;
+
+  return (
+    <>
+      <h5 className="mb-2 heading-5">
+        {formatText({ id: 'fundingModal.title' })}
+      </h5>
+      <p className="mb-6 text-md text-gray-600">
+        {formatText({ id: 'fundingModal.description' })}
+      </p>
+      <h6 className="mb-2 text-2">
+        {formatText({ id: 'fundingModal.fundsRequired' })}
+      </h6>
+      <div className="mb-4 rounded bg-gray-50 px-3.5 py-3">
+        <div className="mb-4 flex items-center justify-between uppercase text-gray-600 text-4">
+          <span>{formatText({ id: 'fundingModal.asset' })}</span>
+          <span>{formatText({ id: 'fundingModal.amount' })}</span>
+        </div>
+        {fundingItems.map(({ tokenAddress, amount, networkFee }) => (
+          <div key={tokenAddress} className="mb-4 last:mb-0">
+            <TokenItem
+              tokenAddress={tokenAddress}
+              amount={amount}
+              networkFee={networkFee}
+            />
+          </div>
+        ))}
+      </div>
+
+      <div className="mb-8">
+        <DecisionMethodSelect
+          options={fundingDecisionMethodItems}
+          name="decisionMethod"
+        />
+        {method && method.value && (
+          <div className="mt-4 rounded border border-gray-300 bg-base-bg p-[1.125rem]">
+            <p className="text-sm text-gray-600">
+              <span className="font-medium">
+                {formatText({ id: 'fundingModal.note' })}
+              </span>
+              {fundingDecisionMethodDescriptions[method.value]}
+            </p>
+          </div>
+        )}
+        {!hasEnoughFunds && (
+          <div className="mt-4 rounded-[.25rem] border border-negative-300 bg-negative-100 p-[1.125rem] text-sm text-negative-400">
+            {formatText(MSG.notEnoughTokens, {
+              team: teamName,
+            })}
+          </div>
+        )}
+      </div>
+      <div className="mt-auto flex flex-col-reverse items-center justify-between gap-3 sm:flex-row">
+        <Button mode="primaryOutline" isFullSize onClick={onClose}>
+          {formatText({ id: 'button.cancel' })}
+        </Button>
+        <div className="flex w-full justify-center">
+          <Button
+            mode="primarySolid"
+            isFullSize
+            type="submit"
+            loading={isSubmitting}
+          >
+            {formatText({ id: 'fundingModal.accept' })}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+};
 
 const FundingModal: FC<FundingModalProps> = ({
   onClose,
@@ -27,38 +132,39 @@ const FundingModal: FC<FundingModalProps> = ({
   onSuccess,
   ...rest
 }) => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const { colony } = useColonyContext();
-
-  const fundingItems = expenditure.slots.reduce<TokenItemProps[]>(
-    (acc, item) => {
-      if (!item.payouts) return acc;
-
-      item.payouts.forEach((payout) => {
-        const existingItemIndex = acc.findIndex(
-          (existingItem) => existingItem.tokenAddress === payout.tokenAddress,
-        );
-        if (existingItemIndex !== -1) {
-          const existingItem = acc[existingItemIndex];
-
-          existingItem.amount = BigNumber.from(existingItem.amount)
-            .add(BigNumber.from(payout.amount))
-            .toString();
-          existingItem.networkFee = BigNumber.from(existingItem.networkFee)
-            .add(BigNumber.from(payout.networkFee))
-            .toString();
-        } else {
-          acc.push({
-            tokenAddress: payout.tokenAddress,
-            amount: payout.amount,
-            networkFee: payout.networkFee,
-          });
-        }
-      });
-      return acc;
-    },
-    [],
+  const { slots, metadata } = expenditure;
+  const selectedTeam = findDomainByNativeId(
+    metadata?.fundFromDomainNativeId,
+    colony,
   );
+
+  const fundingItems = slots.reduce<TokenItemProps[]>((acc, item) => {
+    if (!item.payouts) return acc;
+
+    item.payouts.forEach((payout) => {
+      const existingItemIndex = acc.findIndex(
+        (existingItem) => existingItem.tokenAddress === payout.tokenAddress,
+      );
+      if (existingItemIndex !== -1) {
+        const existingItem = acc[existingItemIndex];
+
+        existingItem.amount = BigNumber.from(existingItem.amount)
+          .add(BigNumber.from(payout.amount))
+          .toString();
+        existingItem.networkFee = BigNumber.from(existingItem.networkFee)
+          .add(BigNumber.from(payout.networkFee))
+          .toString();
+      } else {
+        acc.push({
+          tokenAddress: payout.tokenAddress,
+          amount: payout.amount,
+          networkFee: payout.networkFee,
+        });
+      }
+    });
+    return acc;
+  }, []);
 
   const fundExpenditure = useAsyncFunction({
     submit: ActionTypes.EXPENDITURE_FUND,
@@ -67,7 +173,6 @@ const FundingModal: FC<FundingModalProps> = ({
   });
 
   const handleFundExpenditure = async () => {
-    setIsSubmitting(true);
     try {
       if (!expenditure) {
         return;
@@ -81,14 +186,14 @@ const FundingModal: FC<FundingModalProps> = ({
 
       await fundExpenditure(payload);
 
-      setIsSubmitting(false);
       onSuccess();
       onClose();
     } catch (err) {
-      setIsSubmitting(false);
       onClose();
     }
   };
+
+  const validationSchema = getValidationSchema(selectedTeam?.nativeId, colony);
 
   return (
     <Modal {...rest} onClose={onClose} icon={Wallet}>
@@ -96,71 +201,13 @@ const FundingModal: FC<FundingModalProps> = ({
         className="flex h-full flex-col"
         onSubmit={handleFundExpenditure}
         validationSchema={validationSchema}
-        defaultValues={{ decisionMethod: {} }}
+        defaultValues={{ decisionMethod: {}, fundingItems }}
       >
-        {({ watch }) => {
-          const method = watch('decisionMethod');
-
-          return (
-            <>
-              <h5 className="mb-2 heading-5">
-                {formatText({ id: 'fundingModal.title' })}
-              </h5>
-              <p className="mb-6 text-md text-gray-600">
-                {formatText({ id: 'fundingModal.description' })}
-              </p>
-              <h6 className="mb-2 text-2">
-                {formatText({ id: 'fundingModal.fundsRequired' })}
-              </h6>
-              <div className="mb-4 rounded bg-gray-50 px-3.5 py-3">
-                <div className="mb-4 flex items-center justify-between uppercase text-gray-600 text-4">
-                  <span>{formatText({ id: 'fundingModal.asset' })}</span>
-                  <span>{formatText({ id: 'fundingModal.amount' })}</span>
-                </div>
-                {fundingItems.map(({ tokenAddress, amount, networkFee }) => (
-                  <div key={tokenAddress} className="mb-4 last:mb-0">
-                    <TokenItem
-                      tokenAddress={tokenAddress}
-                      amount={amount}
-                      networkFee={networkFee}
-                    />
-                  </div>
-                ))}
-              </div>
-              <div className="mb-8">
-                <DecisionMethodSelect
-                  options={fundingDecisionMethodItems}
-                  name="decisionMethod"
-                />
-                {method && method.value && (
-                  <div className="mt-4 rounded border border-gray-300 bg-base-bg p-[1.125rem]">
-                    <p className="text-sm text-gray-600">
-                      <span className="font-medium">
-                        {formatText({ id: 'fundingModal.note' })}
-                      </span>
-                      {fundingDecisionMethodDescriptions[method.value]}
-                    </p>
-                  </div>
-                )}
-              </div>
-              <div className="mt-auto flex flex-col-reverse items-center justify-between gap-3 sm:flex-row">
-                <Button mode="primaryOutline" isFullSize onClick={onClose}>
-                  {formatText({ id: 'button.cancel' })}
-                </Button>
-                <div className="flex w-full justify-center">
-                  <Button
-                    mode="primarySolid"
-                    isFullSize
-                    type="submit"
-                    loading={isSubmitting}
-                  >
-                    {formatText({ id: 'fundingModal.accept' })}
-                  </Button>
-                </div>
-              </div>
-            </>
-          );
-        }}
+        <FundingModalContent
+          fundingItems={fundingItems}
+          onClose={onClose}
+          teamName={selectedTeam?.metadata?.name || ''}
+        />
       </Form>
     </Modal>
   );

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/types.ts
@@ -8,3 +8,9 @@ export interface FundingModalProps extends ModalProps {
   expenditure: Expenditure;
   onSuccess: () => void;
 }
+
+export interface FundingModalContentProps
+  extends Pick<FundingModalProps, 'onClose'> {
+  fundingItems: TokenItemProps[];
+  teamName: string;
+}

--- a/src/utils/validation/hasEnoughFundsValidation.ts
+++ b/src/utils/validation/hasEnoughFundsValidation.ts
@@ -13,7 +13,7 @@ import {
 export const hasEnoughFundsValidation = (
   value: string | null | undefined,
   context: TestContext<object>,
-  selectedTeam: string | undefined,
+  selectedTeam: number | undefined,
   colony: ColonyFragment,
   tokenAddress?: string,
 ) => {
@@ -41,7 +41,7 @@ export const hasEnoughFundsValidation = (
   const tokenBalance = getBalanceForTokenAndDomain(
     colony?.balances,
     selectedToken?.tokenAddress,
-    Number(selectedTeam) || Id.RootDomain,
+    selectedTeam || Id.RootDomain,
   );
 
   return !BigNumber.from(


### PR DESCRIPTION
## Description

Validation to check if there are enough funds in the team to fund an expenditure

## Testing

* Step 1. Mint tokens for a colony. E.g. 100 CLNY
* Step 2. Create a Payment builder action, but don't fund it. E.g. for 80 CLNY
* Step 3. Make a Simple payment from the from team used in the first step. E.g. 50 CLNY, leaving the balance at 50 CLNY.
* Step 4. Return to the Payment builder action and try to fund it.

## Diffs

**New stuff** ✨

* `FundingModalContent` component to trigger validation on modal opening

**Changes** 🏗

* `fundingItems` added to validation schema

**Deletions** ⚰️

* 

Resolves https://github.com/JoinColony/colonyCDapp/issues/2415
