### PR TITLE
fix: Update the total balances currency conversion arithmetic

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/TokenBalance/hooks.ts
+++ b/src/components/v5/frame/ColonyHome/partials/TokenBalance/hooks.ts
@@ -17,7 +17,7 @@ const calculateTotalFunds = async (
     ?.filter(notNull)
     .filter(({ domain }) => !!domain?.isRoot)
     .reduce(
-      async (total, { balance, token: { tokenAddress } }) => {
+      async (total, { balance, token: { tokenAddress, decimals } }) => {
         const currentPrice = await fetchCurrentPrice({
           contractAddress: tokenAddress,
           conversionDenomination: currency,
@@ -27,7 +27,11 @@ const calculateTotalFunds = async (
           isError = true;
         }
 
-        return (await total).add(new Decimal(balance).mul(currentPrice ?? 0));
+        const balanceInWeiToToken = new Decimal(balance).div(10 ** decimals);
+
+        return (await total).add(
+          new Decimal(balanceInWeiToToken).mul(currentPrice ?? 0),
+        );
       },
       Promise.resolve(new Decimal(0)),
     );

--- a/src/components/v5/frame/ColonyHome/partials/TokenBalance/hooks.ts
+++ b/src/components/v5/frame/ColonyHome/partials/TokenBalance/hooks.ts
@@ -27,10 +27,10 @@ const calculateTotalFunds = async (
           isError = true;
         }
 
-        const balanceInWeiToToken = new Decimal(balance).div(10 ** decimals);
+        const balanceInWeiToEth = new Decimal(balance).div(10 ** decimals);
 
         return (await total).add(
-          new Decimal(balanceInWeiToToken).mul(currentPrice ?? 0),
+          new Decimal(balanceInWeiToEth).mul(currentPrice ?? 0),
         );
       },
       Promise.resolve(new Decimal(0)),


### PR DESCRIPTION
## Description

Previously, we were converting the wei version of the balance by its currency equivalent which was producing a "wei-like" format of the conversion price.

In this PR, it is now first converting the wei version of the balance to its unit version before applying the final currency conversion.
 
## Testing

1. Visit your Colony's Balances page
2. Take note of the "Total funds" value
3. Click on the the Total Funds cell
4. Verify that it matches the "Balance" value for ETH

## Diffs

**Changes** 🏗

Added an extra step to first derive the non-wei value of the token's balance prior to finalising its currency conversion.

| before | after |
| ------ | ------ |
| ![Screenshot 2024-05-23 at 00 15 39](https://github.com/JoinColony/colonyCDapp/assets/50642296/dd433db7-b13d-4ae9-bd47-02560068d7d0) | ![image](https://github.com/JoinColony/colonyCDapp/assets/50642296/6a9db1c5-6c08-42a1-b1de-199fd3ef4118) |

Resolves #2334 