### PR TITLE
Fix activity table empty state on firefox

### DIFF
--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -285,7 +285,7 @@ const Table = <T,>({
               {shouldShowEmptyContent ? (
                 <tr className="[&:not(:last-child)>td]:border-b [&:not(:last-child)>td]:border-gray-100">
                   <td colSpan={totalColumnsCount} className="h-full">
-                    <div className="flex h-full flex-col items-start justify-center px-[1.1rem] py-4 text-md text-gray-500">
+                    <div className="flex flex-col items-start justify-center px-[1.1rem] py-4 text-md text-gray-500">
                       {emptyContent}
                     </div>
                   </td>


### PR DESCRIPTION
## Description

- Fix the activity table empty state heights on firefox.

## Testing

Test on firefox

* Step 1. Create a new colony
* Step 2. Check the dashboard / activity page to see the activity table in it's empty state
* Step 3. The table should have a normal height, and not be all squished up like it was before

## Diffs

**Changes** 🏗

* UI fixes to activity table empty states

Resolves #2357
