### PR TITLE
fix: Update Completed Action Amount Row Spacings

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/rows/Amount.tsx
+++ b/src/components/v5/common/CompletedAction/partials/rows/Amount.tsx
@@ -27,10 +27,10 @@ const AmountRow = ({ amount, token }: AmountRowProps) => {
       })}
       RowIcon={Coins}
       rowContent={
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-3">
           {formattedAmount}
           {token && (
-            <>
+            <div className="flex gap-1">
               <TokenAvatar
                 size={18}
                 tokenName={token.name}
@@ -38,7 +38,7 @@ const AmountRow = ({ amount, token }: AmountRowProps) => {
                 tokenAvatarSrc={token.avatar ?? undefined}
               />
               <span className="text-md">{token.symbol}</span>
-            </>
+            </div>
           )}
         </div>
       }


### PR DESCRIPTION
## Description

Set the correct distance between the amount and the token logo as per [Figma designs](https://www.figma.com/design/5V8pr7iMwXsT9L3VAZsmUt/Colony-v5?node-id=2890-260049&t=b7jtBZGZUw2X2nMm-0).

## Testing

1. .Make a Simple payment
2. Verify that the distance between the amount and the token value follows the [Figma designs](https://www.figma.com/design/5V8pr7iMwXsT9L3VAZsmUt/Colony-v5?node-id=2890-260049&t=b7jtBZGZUw2X2nMm-0) 

## Diffs

**Changes** 🏗

- Update the gap between the amount and the token logo to 12px on the the Completed Actions component

Resolves #2439 

## Todo

- Request for PR review once this issue enters a cycle