### PR TITLE
Update incoming funds schemas

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -1906,7 +1906,7 @@ type DomainMetadataChangelog {
 """
 Represents a Colony Funds Claim for all ERC20 tokens (except native chain tokens)
 """
-type ColonyFundsClaim @model {
+type ColonyFundsClaim @model @searchable {
   """
   Unique identifier for the Colony Funds Claim
   """
@@ -1927,6 +1927,10 @@ type ColonyFundsClaim @model {
   Amount claimed in the Colony Funds Claim
   """
   amount: String!
+  """
+  Boolean to indicate whether the claim has been claimed or not
+  """
+  isClaimed: Boolean
 }
 
 # This is really not elegant, but there's no other proper solution, as you can't # return the Token @hadOne relationship from the lambda function # Note that we don't need token details for the values that we're fetching (since # it's implied), but it would have been nice not to have to basically repeat the type
@@ -1955,6 +1959,10 @@ type ColonyChainFundsClaim {
   Amount claimed in the Colony Chain Funds Claim
   """
   amount: String!
+  """
+  Boolean to indicate whether the claim has been claimed or not
+  """
+  isClaimed: Boolean
 }
 
 # This is not a @model since it will only be returned by a lambda function # so don't need to create tables for them

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -524,6 +524,8 @@ export type ColonyChainFundsClaim = {
   createdAtBlock: Scalars['Int'];
   /** Unique identifier for the Colony Chain Funds Claim */
   id: Scalars['ID'];
+  /** Boolean to indicate whether the claim has been claimed or not */
+  isClaimed?: Maybe<Scalars['Boolean']>;
   /** Timestamp when the Chain Funds Claim was last updated */
   updatedAt: Scalars['AWSDateTime'];
 };
@@ -533,6 +535,7 @@ export type ColonyChainFundsClaimInput = {
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
   createdAtBlock: Scalars['Int'];
   id?: InputMaybe<Scalars['ID']>;
+  isClaimed?: InputMaybe<Scalars['Boolean']>;
   updatedAt?: InputMaybe<Scalars['AWSDateTime']>;
 };
 
@@ -650,6 +653,8 @@ export type ColonyFundsClaim = {
   createdAtBlock: Scalars['Int'];
   /** Unique identifier for the Colony Funds Claim */
   id: Scalars['ID'];
+  /** Boolean to indicate whether the claim has been claimed or not */
+  isClaimed?: Maybe<Scalars['Boolean']>;
   /** Token associated with the Colony Funds Claim */
   token: Token;
   updatedAt: Scalars['AWSDateTime'];
@@ -1223,6 +1228,7 @@ export type CreateColonyFundsClaimInput = {
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
   createdAtBlock: Scalars['Int'];
   id?: InputMaybe<Scalars['ID']>;
+  isClaimed?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type CreateColonyHistoricRoleInput = {
@@ -2553,6 +2559,7 @@ export type ModelColonyFundsClaimConditionInput = {
   colonyFundsClaimsId?: InputMaybe<ModelIdInput>;
   createdAt?: InputMaybe<ModelStringInput>;
   createdAtBlock?: InputMaybe<ModelIntInput>;
+  isClaimed?: InputMaybe<ModelBooleanInput>;
   not?: InputMaybe<ModelColonyFundsClaimConditionInput>;
   or?: InputMaybe<Array<InputMaybe<ModelColonyFundsClaimConditionInput>>>;
 };
@@ -2571,6 +2578,7 @@ export type ModelColonyFundsClaimFilterInput = {
   createdAt?: InputMaybe<ModelStringInput>;
   createdAtBlock?: InputMaybe<ModelIntInput>;
   id?: InputMaybe<ModelIdInput>;
+  isClaimed?: InputMaybe<ModelBooleanInput>;
   not?: InputMaybe<ModelColonyFundsClaimFilterInput>;
   or?: InputMaybe<Array<InputMaybe<ModelColonyFundsClaimFilterInput>>>;
 };
@@ -3582,6 +3590,7 @@ export type ModelSubscriptionColonyFundsClaimFilterInput = {
   createdAt?: InputMaybe<ModelSubscriptionStringInput>;
   createdAtBlock?: InputMaybe<ModelSubscriptionIntInput>;
   id?: InputMaybe<ModelSubscriptionIdInput>;
+  isClaimed?: InputMaybe<ModelSubscriptionBooleanInput>;
   or?: InputMaybe<Array<InputMaybe<ModelSubscriptionColonyFundsClaimFilterInput>>>;
 };
 
@@ -5604,6 +5613,7 @@ export type Query = {
   listUsers?: Maybe<ModelUserConnection>;
   searchColonyActions?: Maybe<SearchableColonyActionConnection>;
   searchColonyContributors?: Maybe<SearchableColonyContributorConnection>;
+  searchColonyFundsClaims?: Maybe<SearchableColonyFundsClaimConnection>;
 };
 
 
@@ -6538,6 +6548,17 @@ export type QuerySearchColonyContributorsArgs = {
   sort?: InputMaybe<Array<InputMaybe<SearchableColonyContributorSortInput>>>;
 };
 
+
+/** Root query type */
+export type QuerySearchColonyFundsClaimsArgs = {
+  aggregates?: InputMaybe<Array<InputMaybe<SearchableColonyFundsClaimAggregationInput>>>;
+  filter?: InputMaybe<SearchableColonyFundsClaimFilterInput>;
+  from?: InputMaybe<Scalars['Int']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  nextToken?: InputMaybe<Scalars['String']>;
+  sort?: InputMaybe<Array<InputMaybe<SearchableColonyFundsClaimSortInput>>>;
+};
+
 export type RemoveMemberFromColonyWhitelistInput = {
   /** The colony address */
   colonyAddress: Scalars['ID'];
@@ -6835,6 +6856,61 @@ export enum SearchableColonyContributorSortableFields {
   Id = 'id',
   IsVerified = 'isVerified',
   IsWatching = 'isWatching',
+  UpdatedAt = 'updatedAt'
+}
+
+export enum SearchableColonyFundsClaimAggregateField {
+  Amount = 'amount',
+  ColonyFundsClaimTokenId = 'colonyFundsClaimTokenId',
+  ColonyFundsClaimsId = 'colonyFundsClaimsId',
+  CreatedAt = 'createdAt',
+  CreatedAtBlock = 'createdAtBlock',
+  Id = 'id',
+  IsClaimed = 'isClaimed',
+  UpdatedAt = 'updatedAt'
+}
+
+export type SearchableColonyFundsClaimAggregationInput = {
+  field: SearchableColonyFundsClaimAggregateField;
+  name: Scalars['String'];
+  type: SearchableAggregateType;
+};
+
+export type SearchableColonyFundsClaimConnection = {
+  __typename?: 'SearchableColonyFundsClaimConnection';
+  aggregateItems: Array<Maybe<SearchableAggregateResult>>;
+  items: Array<Maybe<ColonyFundsClaim>>;
+  nextToken?: Maybe<Scalars['String']>;
+  total?: Maybe<Scalars['Int']>;
+};
+
+export type SearchableColonyFundsClaimFilterInput = {
+  amount?: InputMaybe<SearchableStringFilterInput>;
+  and?: InputMaybe<Array<InputMaybe<SearchableColonyFundsClaimFilterInput>>>;
+  colonyFundsClaimTokenId?: InputMaybe<SearchableIdFilterInput>;
+  colonyFundsClaimsId?: InputMaybe<SearchableIdFilterInput>;
+  createdAt?: InputMaybe<SearchableStringFilterInput>;
+  createdAtBlock?: InputMaybe<SearchableIntFilterInput>;
+  id?: InputMaybe<SearchableIdFilterInput>;
+  isClaimed?: InputMaybe<SearchableBooleanFilterInput>;
+  not?: InputMaybe<SearchableColonyFundsClaimFilterInput>;
+  or?: InputMaybe<Array<InputMaybe<SearchableColonyFundsClaimFilterInput>>>;
+  updatedAt?: InputMaybe<SearchableStringFilterInput>;
+};
+
+export type SearchableColonyFundsClaimSortInput = {
+  direction?: InputMaybe<SearchableSortDirection>;
+  field?: InputMaybe<SearchableColonyFundsClaimSortableFields>;
+};
+
+export enum SearchableColonyFundsClaimSortableFields {
+  Amount = 'amount',
+  ColonyFundsClaimTokenId = 'colonyFundsClaimTokenId',
+  ColonyFundsClaimsId = 'colonyFundsClaimsId',
+  CreatedAt = 'createdAt',
+  CreatedAtBlock = 'createdAtBlock',
+  Id = 'id',
+  IsClaimed = 'isClaimed',
   UpdatedAt = 'updatedAt'
 }
 
@@ -7978,6 +8054,7 @@ export type UpdateColonyFundsClaimInput = {
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
   createdAtBlock?: InputMaybe<Scalars['Int']>;
   id: Scalars['ID'];
+  isClaimed?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type UpdateColonyHistoricRoleInput = {


### PR DESCRIPTION
## Description

- Update the ColonyFundsClaim and ColonyChainFundsClaim models to include an `isClaimed` flag.

## Testing

* Check that in your amplify graphql explorer you can query those properties.

Here's a handy query for you:

```
query MyQuery {
  getColonyByName(name: "planex") {
    items {
      fundsClaims {
        items {
          amount
          isClaimed
        }
      }
      chainFundsClaim {
        amount
        isClaimed
      }
    }
  }
}
```

## Diffs

**Changes** 🏗

* Updated schemas and generated code.

Resolves #2444
