### PR TITLE
fix: add verified member from user popover

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
@@ -10,10 +10,12 @@ import useRelativePortalElement from '~hooks/useRelativePortalElement.ts';
 import useToggle from '~hooks/useToggle/index.ts';
 import useUserByAddress from '~hooks/useUserByAddress.ts';
 import Tooltip from '~shared/Extensions/Tooltip/Tooltip.tsx';
+import { type User } from '~types/graphql.ts';
 import { formatText } from '~utils/intl.ts';
 import { splitWalletAddress } from '~utils/splitWalletAddress.ts';
 import SearchSelect from '~v5/shared/SearchSelect/SearchSelect.tsx';
 import UserAvatar from '~v5/shared/UserAvatar/index.ts';
+import UserInfoPopover from '~v5/shared/UserInfoPopover/UserInfoPopover.tsx';
 
 import { useUserSelect } from './hooks.ts';
 import { type UserSelectProps } from './types.ts';
@@ -91,68 +93,79 @@ const UserSelect: FC<UserSelectProps> = ({
   const isUserAddressValid = isAddress(field.value);
 
   const toggler = (
-    <button
-      type="button"
-      ref={relativeElementRef}
-      className={clsx('flex items-center text-md transition-colors', {
-        'text-gray-400': !isError && !isUserSelectVisible && !disabled,
-        'text-gray-300': disabled,
-        'text-negative-400': isError,
-        'text-blue-400': isUserSelectVisible,
-        'md:hover:text-blue-400': !disabled,
-      })}
-      onClick={toggleUserSelect}
-      aria-label={formatText({ id: 'ariaLabel.selectUser' })}
-      disabled={disabled}
-    >
-      {selectedUser || field.value ? (
-        <>
-          {isUserAddressValid ? (
-            <>
-              <UserAvatar
-                userName={
-                  selectedUser?.profile?.displayName?.toString() ?? undefined
-                }
-                userAddress={userWalletAddress}
-                userAvatarSrc={selectedUser?.profile?.avatar ?? undefined}
-                size={20}
-              />
-              <p
-                className={clsx('ml-2 truncate text-md font-medium', {
-                  'text-warning-400': !selectedUser?.isVerified,
-                  'text-gray-900': selectedUser?.isVerified,
-                })}
-              >
-                {formatText(userName || '')}
-              </p>
-              {selectedUser?.isVerified && (
-                <CircleWavyCheck
-                  size={14}
-                  className="ml-1 flex-shrink-0 text-blue-400"
+    <>
+      <button
+        type="button"
+        ref={relativeElementRef}
+        className={clsx('flex items-center text-md transition-colors', {
+          'text-gray-400': !isError && !isUserSelectVisible && !disabled,
+          'text-gray-300': disabled,
+          'text-negative-400': isError,
+          'text-blue-400': isUserSelectVisible,
+          'md:hover:text-blue-400': !disabled,
+        })}
+        onClick={toggleUserSelect}
+        aria-label={formatText({ id: 'ariaLabel.selectUser' })}
+        disabled={disabled}
+      >
+        {selectedUser || field.value ? (
+          <>
+            {isUserAddressValid ? (
+              <>
+                <UserAvatar
+                  userName={
+                    selectedUser?.profile?.displayName?.toString() ?? undefined
+                  }
+                  userAddress={userWalletAddress}
+                  userAvatarSrc={selectedUser?.profile?.avatar ?? undefined}
+                  size={20}
                 />
-              )}
-              {!selectedUser?.isVerified && (
-                <WarningCircle
-                  size={14}
-                  className="ml-1 flex-shrink-0 text-warning-400"
-                />
-              )}
-            </>
-          ) : (
-            <div className="flex items-center gap-1 text-negative-400">
-              <WarningCircle size={16} />
-              <span className="text-md">
-                {formatText({
-                  id: 'actionSidebar.addressError',
-                })}
-              </span>
-            </div>
-          )}
-        </>
-      ) : (
-        formatText({ id: 'actionSidebar.selectMember' })
-      )}
-    </button>
+                <p
+                  className={clsx('ml-2 truncate text-md font-medium', {
+                    'text-warning-400': !selectedUser?.isVerified,
+                    'text-gray-900': selectedUser?.isVerified,
+                  })}
+                >
+                  {formatText(userName || '')}
+                </p>
+                {selectedUser?.isVerified && (
+                  <CircleWavyCheck
+                    size={14}
+                    className="ml-1 flex-shrink-0 text-blue-400"
+                  />
+                )}
+              </>
+            ) : (
+              <div className="flex items-center gap-1 text-negative-400">
+                <WarningCircle size={16} />
+                <span className="text-md">
+                  {formatText({
+                    id: 'actionSidebar.addressError',
+                  })}
+                </span>
+              </div>
+            )}
+          </>
+        ) : (
+          formatText({ id: 'actionSidebar.selectMember' })
+        )}
+      </button>
+      {(selectedUser || field.value) &&
+        !selectedUser?.isVerified &&
+        isUserAddressValid && (
+          <UserInfoPopover
+            walletAddress={userWalletAddress}
+            user={selectedUser as User}
+            withVerifiedBadge={false}
+            className="flex w-auto max-w-full flex-col items-center justify-between gap-2 text-gray-900"
+          >
+            <WarningCircle
+              size={14}
+              className="ml-1 flex-shrink-0 text-warning-400"
+            />
+          </UserInfoPopover>
+        )}
+    </>
   );
 
   const selectedUserContent = (

--- a/src/components/v5/shared/UserInfoPopover/UserInfoPopover.tsx
+++ b/src/components/v5/shared/UserInfoPopover/UserInfoPopover.tsx
@@ -13,6 +13,7 @@ import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { ContributorType, useGetColonyContributorQuery } from '~gql';
 import { useMobile } from '~hooks/index.ts';
 import useContributorBreakdown from '~hooks/members/useContributorBreakdown.ts';
+import useToggle from '~hooks/useToggle/index.ts';
 import { getColonyContributorId } from '~utils/members.ts';
 import Modal from '~v5/shared/Modal/index.ts';
 import PopoverBase from '~v5/shared/PopoverBase/index.ts';
@@ -63,22 +64,30 @@ const UserInfoPopover: FC<PropsWithChildren<UserInfoPopoverProps>> = ({
     setIsOpen(false);
   }, []);
 
-  const { getTooltipProps, setTooltipRef, setTriggerRef, visible } =
-    usePopperTooltip({
-      delayShow: 200,
-      delayHide: 200,
-      placement: popperOptions?.placement || 'bottom-end',
-      trigger: ['click'],
-      interactive: true,
-    });
+  const [
+    isTooltipVisible,
+    {
+      toggleOn: toggleOnTooltip,
+      toggleOff: toggleOffTooltip,
+      registerContainerRef,
+    },
+  ] = useToggle();
+
+  const { getTooltipProps, setTooltipRef, setTriggerRef } = usePopperTooltip({
+    delayShow: 200,
+    delayHide: 200,
+    placement: popperOptions?.placement || 'bottom-end',
+    trigger: ['click'],
+    interactive: true,
+  });
 
   const button = (
     <button
-      onClick={isMobile ? onOpenModal : noop}
+      ref={setTriggerRef}
+      onClick={isMobile ? onOpenModal : toggleOnTooltip}
       onMouseEnter={isMobile ? noop : () => onOpenModal()}
       onMouseLeave={isMobile ? noop : () => onCloseModal()}
       type="button"
-      ref={setTriggerRef}
       className={clsx(
         'inline-flex flex-shrink-0 items-center transition-all duration-normal hover:text-blue-400',
         className,
@@ -111,6 +120,7 @@ const UserInfoPopover: FC<PropsWithChildren<UserInfoPopoverProps>> = ({
       additionalContent={
         !isVerified ? (
           <UserNotVerified
+            onClick={toggleOffTooltip}
             walletAddress={walletAddress}
             description={
               <div className="mt-2 break-words pb-2 text-sm font-semibold">
@@ -139,26 +149,28 @@ const UserInfoPopover: FC<PropsWithChildren<UserInfoPopoverProps>> = ({
         </Modal>
       ) : (
         <>
-          {visible && (
-            <PopoverBase
-              setTooltipRef={setTooltipRef}
-              tooltipProps={getTooltipProps}
-              classNames="max-w-[20rem]"
-              withTooltipStyles={false}
-              cardProps={{
-                rounded: 's',
-                className: clsx('bg-base-white', {
-                  'overflow-hidden border-2 border-purple-200 ':
-                    isTopSectionWithBackground,
-                }),
-                hasShadow: true,
-              }}
-              isTopSectionWithBackground={
-                isTopSectionWithBackground && isMobile
-              }
-            >
-              {content}
-            </PopoverBase>
+          {isTooltipVisible && (
+            <div ref={registerContainerRef}>
+              <PopoverBase
+                setTooltipRef={setTooltipRef}
+                tooltipProps={getTooltipProps}
+                classNames="max-w-[20rem]"
+                withTooltipStyles={false}
+                cardProps={{
+                  rounded: 's',
+                  className: clsx('bg-base-white', {
+                    'overflow-hidden border-2 border-purple-200 ':
+                      isTopSectionWithBackground,
+                  }),
+                  hasShadow: true,
+                }}
+                isTopSectionWithBackground={
+                  isTopSectionWithBackground && isMobile
+                }
+              >
+                {content}
+              </PopoverBase>
+            </div>
           )}
         </>
       )}

--- a/src/components/v5/shared/UserInfoPopover/UserInfoPopover.tsx
+++ b/src/components/v5/shared/UserInfoPopover/UserInfoPopover.tsx
@@ -111,9 +111,10 @@ const UserInfoPopover: FC<PropsWithChildren<UserInfoPopoverProps>> = ({
       additionalContent={
         !isVerified ? (
           <UserNotVerified
+            walletAddress={walletAddress}
             description={
               <div className="mt-2 break-words pb-2 text-sm font-semibold">
-                {user?.walletAddress}
+                {walletAddress}
               </div>
             }
           />

--- a/src/components/v5/shared/UserInfoPopover/partials/UserNotVerified.tsx
+++ b/src/components/v5/shared/UserInfoPopover/partials/UserNotVerified.tsx
@@ -22,7 +22,7 @@ const UserNotVerified: FC<UserNotVerifiedProps> = ({
 }) => {
   const {
     actionSidebarToggle: [
-      ,
+      isActionSidebarOpen,
       { toggleOn: toggleActionSidebarOn, toggleOff: toggleActionSidebarOff },
     ],
   } = useActionSidebarContext();
@@ -35,7 +35,11 @@ const UserNotVerified: FC<UserNotVerifiedProps> = ({
         <button
           type="button"
           onClick={() => {
-            toggleActionSidebarOff();
+            const timeout = isActionSidebarOpen ? 500 : 0;
+
+            if (isActionSidebarOpen) {
+              toggleActionSidebarOff();
+            }
 
             setTimeout(() => {
               onClick?.();
@@ -44,7 +48,7 @@ const UserNotVerified: FC<UserNotVerifiedProps> = ({
                 members: [{ value: walletAddress }],
                 manageMembers: ManageMembersType.Add,
               });
-            }, 500);
+            }, timeout);
           }}
         >
           {formatText({ id: 'add.verified.member' })}

--- a/src/components/v5/shared/UserInfoPopover/partials/UserNotVerified.tsx
+++ b/src/components/v5/shared/UserInfoPopover/partials/UserNotVerified.tsx
@@ -12,11 +12,13 @@ const displayName = 'v5.UserInfoPopover.partials.UserNotVerified';
 export interface UserNotVerifiedProps {
   description?: React.ReactNode;
   walletAddress: string;
+  onClick?: () => void;
 }
 
 const UserNotVerified: FC<UserNotVerifiedProps> = ({
   description,
   walletAddress,
+  onClick,
 }) => {
   const {
     actionSidebarToggle: [
@@ -36,6 +38,7 @@ const UserNotVerified: FC<UserNotVerifiedProps> = ({
             toggleActionSidebarOff();
 
             setTimeout(() => {
+              onClick?.();
               toggleActionSidebarOn({
                 [ACTION_TYPE_FIELD_NAME]: Action.ManageVerifiedMembers,
                 members: [{ value: walletAddress }],

--- a/src/components/v5/shared/UserInfoPopover/partials/UserNotVerified.tsx
+++ b/src/components/v5/shared/UserInfoPopover/partials/UserNotVerified.tsx
@@ -1,22 +1,49 @@
 import React, { type FC } from 'react';
 
+import { Action } from '~constants/actions.ts';
+import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { formatText } from '~utils/intl.ts';
+import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
+import { ManageMembersType } from '~v5/common/ActionSidebar/partials/forms/ManageVerifiedMembersForm/consts.ts';
 import NotificationBanner from '~v5/shared/NotificationBanner/index.ts';
 
 const displayName = 'v5.UserInfoPopover.partials.UserNotVerified';
 
 export interface UserNotVerifiedProps {
   description?: React.ReactNode;
+  walletAddress: string;
 }
-// rename to UserNotVerified??
-const UserNotVerified: FC<UserNotVerifiedProps> = ({ description }) => {
+
+const UserNotVerified: FC<UserNotVerifiedProps> = ({
+  description,
+  walletAddress,
+}) => {
+  const {
+    actionSidebarToggle: [
+      ,
+      { toggleOn: toggleActionSidebarOn, toggleOff: toggleActionSidebarOff },
+    ],
+  } = useActionSidebarContext();
+
   return (
     <NotificationBanner
       status="warning"
       description={description}
       callToAction={
-        <button type="button">
-          {/* @TODO: add action */}
+        <button
+          type="button"
+          onClick={() => {
+            toggleActionSidebarOff();
+
+            setTimeout(() => {
+              toggleActionSidebarOn({
+                [ACTION_TYPE_FIELD_NAME]: Action.ManageVerifiedMembers,
+                members: [{ value: walletAddress }],
+                manageMembers: ManageMembersType.Add,
+              });
+            }, 500);
+          }}
+        >
           {formatText({ id: 'add.verified.member' })}
         </button>
       }


### PR DESCRIPTION
## Testing

Members page

* Go to the members page.
* Click on a member who is not verified to open their Memberpopover.
* Click on the Add as verified member link.

Action panel

* Create a new action.
* Select the Simple payments action type.
* Select a member who is not verified.
* Click on the yellow warning icon.

## Diffs

**Changes** 🏗

* `Add as verified member` button will now open sidebar with selected action and member.

Resolves [#2117](https://github.com/JoinColony/colonyCDapp/issues/2117)
