### PR TITLE
Fix: Prevent app crash when initiating a Simple Payment/Funds Transfer via the Balances page

### DIFF
--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/BalanceTable.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/BalanceTable.tsx
@@ -153,9 +153,7 @@ const BalanceTable: FC = () => {
           onClick: () => {
             toggleActionSidebarOn({
               [ACTION_TYPE_FIELD_NAME]: Action.TransferFunds,
-              amount: {
-                tokenAddress: selectedTokenData?.tokenAddress,
-              },
+              tokenAddress: selectedTokenData?.tokenAddress,
             });
           },
           label: formatMessage(MSG.labelTransferFunds),
@@ -166,9 +164,7 @@ const BalanceTable: FC = () => {
           onClick: () => {
             toggleActionSidebarOn({
               [ACTION_TYPE_FIELD_NAME]: Action.SimplePayment,
-              amount: {
-                tokenAddress: selectedTokenData?.tokenAddress,
-              },
+              tokenAddress: selectedTokenData?.tokenAddress,
             });
           },
           label: formatMessage(MSG.labelMakePayment),


### PR DESCRIPTION
## Description

An object was being passed to the `amount` field via the `toggleActionSidebarOn()` function which was then causing the `formatNumeral()` function within the `AmountField` component to throw an exception. So I'm now just passing an expected payload to `toggleActionSidebarOn()` function. The same crash scenario happens when initiating a "Transfer Funds" action from the Balances page so I fixed both under this PR.

![2424](https://github.com/JoinColony/colonyCDapp/assets/50642296/a353dfa7-0d21-43fc-a973-907e50921dab)

## Testing

### Simple Payment via the Balances page

1. Visit the Balances page
2. Click the meatball menu button for a token row
3. Click "Make payment using this token"
4. Verify that:
  a.) The app does not crash
  b.) The Action Sidebar Menu opens and is set to the Simple Payment action
  c.) The token is correctly set

### Transfer Funds via the Balances page

1. Visit the Balances page
2. Click the meatball menu button for a token row
3. Click "Transfer funds"
4. Verify that:
  a.) The app does not crash
  b.) The Action Sidebar Menu opens and is set to the Transfer Funds action
  c.) The token is correctly set

## Diffs

**Changes** 🏗

* A payload change for the `toggleActionSidebarOn()` function.

Resolves #2424 
