### PR TITLE
Fix UI issues with userhub transactions

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransaction.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransaction.tsx
@@ -44,6 +44,7 @@ const GroupedTransaction: FC<GroupedTransactionProps> = ({
   isContentOpened,
   onToggleExpand,
   hideSummary = false,
+  isClickable = true,
 }) => {
   const { formatMessage } = useIntl();
   const isMobile = useMobile();
@@ -54,6 +55,7 @@ const GroupedTransaction: FC<GroupedTransactionProps> = ({
   const values = getGroupValues<TransactionType>(transactionGroup);
 
   const canLinkToAction =
+    isClickable &&
     values.group?.key &&
     !GROUP_KEYS_WHICH_CANNOT_LINK.includes(
       values.group.key as TRANSACTION_METHODS,
@@ -131,14 +133,16 @@ const GroupedTransaction: FC<GroupedTransactionProps> = ({
               <div className="flex w-full items-center justify-between gap-4">
                 <div className="flex flex-col items-start">
                   <div className="flex items-center gap-2">
-                    <h4 className="text-1">{value}</h4>
+                    <h4 className="truncate text-left text-1 sm:w-[190px]">
+                      {value}
+                    </h4>
                     {createdAt && (
                       <span className="mt-0.5 block text-xs text-gray-400">
                         {createdAt}
                       </span>
                     )}
                   </div>
-                  <p className="text-left text-xs text-gray-600 break-word">
+                  <p className="truncate text-left text-xs text-gray-600 sm:w-[250px]">
                     <FormattedMessage
                       {...defaultTransactionGroupMessageDescriptorDescriptionId}
                       {...values.group?.description}
@@ -190,9 +194,9 @@ const GroupedTransaction: FC<GroupedTransactionProps> = ({
               exit="hidden"
               variants={accordionAnimation}
               transition={{ duration: 0.4, ease: 'easeOut' }}
-              className="w-full overflow-hidden pt-2 text-md text-gray-600"
+              className="w-full overflow-hidden text-md text-gray-600"
             >
-              <ul className="sm:px-6">
+              <ul className="pt-2 sm:px-6">
                 {transactionGroup.map((transaction, idx) => (
                   <GroupedTransactionContent
                     key={transaction.id}

--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/types.ts
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/types.ts
@@ -55,6 +55,7 @@ export interface GroupedTransactionProps {
   isContentOpened: boolean;
   onToggleExpand?: (id?: string) => void;
   hideSummary?: boolean;
+  isClickable?: boolean;
 }
 
 export interface TransactionStatusProps {

--- a/src/components/common/Onboarding/wizardSteps/CreateColony/ConfirmTransactions.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/ConfirmTransactions.tsx
@@ -35,6 +35,7 @@ const ConfirmTransactions = ({
           transactionGroup={transactionGroup as TransactionType[]}
           isContentOpened
           hideSummary
+          isClickable={false}
         />
         {transactionGroupStatus === TransactionStatus.Succeeded && (
           <div className="mt-8 text-center text-sm text-gray-600">

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -530,6 +530,8 @@
     "metatransaction.group.enableExtensions.description": "Enable Colony Extension",
     "metatransaction.group.unistallExtensions.title": "Uninstall Colony Extension",
     "metatransaction.group.unistallExtensions.description": "Uninstall Colony Extension",
+    "metatransaction.ColonyClient.installExtension.title": "Install Colony Extension",
+    "metatransaction.ColonyClient.installExtension.description": "Install Colony Extension",
     "metatransaction.ColonyClient.uninstallExtension.title": "Uninstall Colony Extension",
     "metatransaction.ColonyClient.uninstallExtension.description": "Uninstall Colony Extension",
     "metatransaction.ColonyClient.deprecateExtension.title": "Deprecate Colony Extension",


### PR DESCRIPTION
## Description

- Fix issues with userhub transactions overflowing.
- Fix issues with grouped transactions having a hover / click state during colony creation. (Userhub components being reused across the app 🤔)
- Add missing translation keys.

## Testing

- Perform some transactions (especially adding an extension with metacolony transactions enabled).
- Open up the UserHub Transactions tab.
- Check that the transactions items are not overflowing the Userhub container.

---

- Make a new colony.
- During the final creation stage, try to hover over the grouped transactions as they are loading.
- They should not have a flickering grey background hover state.

## Diffs

**Changes** 🏗

* UI fixes in userhub

Resolves #2457
