### PR TITLE
Fix: Correctly show staking information for the Manage Verified Members action

### DIFF
--- a/src/components/v5/common/CompletedAction/CompletedAction.tsx
+++ b/src/components/v5/common/CompletedAction/CompletedAction.tsx
@@ -95,6 +95,7 @@ const CompletedAction = ({ action }: CompletedActionProps) => {
   const getSidebarWidgetContent = () => {
     switch (actionType) {
       case ColonyActionType.AddVerifiedMembersMotion:
+      case ColonyActionType.RemoveVerifiedMembersMotion:
       case ColonyActionType.PaymentMotion:
       case ColonyActionType.MintTokensMotion:
       case ColonyActionType.MoveFundsMotion:

--- a/src/components/v5/common/CompletedAction/CompletedAction.tsx
+++ b/src/components/v5/common/CompletedAction/CompletedAction.tsx
@@ -94,6 +94,7 @@ const CompletedAction = ({ action }: CompletedActionProps) => {
 
   const getSidebarWidgetContent = () => {
     switch (actionType) {
+      case ColonyActionType.AddVerifiedMembersMotion:
       case ColonyActionType.PaymentMotion:
       case ColonyActionType.MintTokensMotion:
       case ColonyActionType.MoveFundsMotion:


### PR DESCRIPTION
## Description

I just added the `AddVerifiedMembersMotion` Colony Action type to the list of action types that the `Motions` component can handle.

| Verified a member via Reputation decision method | Viewing it from the Activities table |
| ---- | ---- |
| ![2452_a](https://github.com/JoinColony/colonyCDapp/assets/50642296/c102e195-0183-4249-b202-f6dad1cb8479) | ![2452_b](https://github.com/JoinColony/colonyCDapp/assets/50642296/5ed6a159-d922-49f6-848a-90c660676d24) |

## Testing

1. Install the Reputation Weighted extension
2. Bring up the Manage Verified Members form
3. Set the decision method to Reputation
4. Set the add/remove field to Add members
5. Fill in the other required fields
6. Submit the form and wait for the Completed Action component to come up
7. Verify that you can see the Motions component
8. Dismiss the Completed Actions component
9. Visit the Dashboard page
10. Click the action you just made from the Activities table
11. Verify that you can see the Motions component

Please repeat steps 2 - 11 but this time, set the add/remove field to Remove members.

## Diffs

**New stuff** ✨

* Added `AddVerifiedMembersMotion` to the list of actions that the Motions component can handle. 

Resolves #2452 
