### PR TITLE
Fix: Team colour picker mobile view UI adjustments

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/TeamColorField/TeamColorField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TeamColorField/TeamColorField.tsx
@@ -41,6 +41,7 @@ const TeamColorField: FC<TeamColourFieldProps> = ({ name, disabled }) => {
     HTMLDivElement
   >([isTeamColourSelectVisible], {
     top: 8,
+    withAutoTopPlacement: true,
   });
 
   return (

--- a/src/components/v5/common/ActionSidebar/partials/TeamColorField/TeamColorField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TeamColorField/TeamColorField.tsx
@@ -81,7 +81,7 @@ const TeamColorField: FC<TeamColourFieldProps> = ({ name, disabled }) => {
                   registerContainerRef(ref);
                   portalElementRef.current = ref;
                 }}
-                className="absolute z-sidebar w-full max-w-[calc(100%-2.25rem)] p-6 sm:w-auto sm:max-w-none"
+                className="absolute z-sidebar w-full max-w-[calc(100%-2.25rem)] px-0 py-6 sm:w-auto sm:max-w-none sm:px-6"
                 hasShadow
                 rounded="s"
               >

--- a/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
+++ b/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
@@ -28,7 +28,7 @@ const SearchItem: FC<SearchItemProps> = ({
     <ul
       className={clsx({
         'w-full': isLabelVisible,
-        '-mx-2 flex flex-wrap items-center gap-y-4 sm:w-[8.75rem]':
+        '-mx-2 flex flex-wrap items-center gap-y-6 sm:w-[8.75rem]':
           !isLabelVisible,
         'sm:w-[12.75rem]': !isLabelVisible && isMobile,
       })}
@@ -64,13 +64,13 @@ const SearchItem: FC<SearchItemProps> = ({
               <button
                 type="button"
                 className={clsx(
-                  'flex w-full items-center rounded px-2 py-1.5 text-left text-md transition-colors',
+                  'flex w-full items-center rounded px-2 text-left text-md transition-colors',
                   {
                     'justify-between': !hasAvatar,
                     'justify-start': hasAvatar,
                     'pointer-events-none gap-1 text-gray-400': isDisabled,
-
                     'justify-center': !isLabelVisible,
+                    'py-1.5': isLabelVisible,
                   },
                 )}
                 name={value.toString()}
@@ -81,9 +81,9 @@ const SearchItem: FC<SearchItemProps> = ({
                 <div className="relative flex w-full items-center">
                   {color && !isLabelVisible && (
                     <div
-                      className={clsx(teamColor, 'mx-auto shrink-0 rounded', {
+                      className={clsx(teamColor, 'mx-auto rounded sm:mx-0', {
                         'h-[1.125rem] w-[1.125rem]': !isMobile,
-                        'h-7 w-7': isMobile,
+                        'aspect-square h-auto w-7': isMobile,
                       })}
                     />
                   )}

--- a/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
+++ b/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
@@ -81,7 +81,7 @@ const SearchItem: FC<SearchItemProps> = ({
                 <div className="relative flex w-full items-center">
                   {color && !isLabelVisible && (
                     <div
-                      className={clsx(teamColor, 'shrink-0 rounded', {
+                      className={clsx(teamColor, 'mx-auto shrink-0 rounded', {
                         'h-[1.125rem] w-[1.125rem]': !isMobile,
                         'h-7 w-7': isMobile,
                       })}


### PR DESCRIPTION
## Description

It's not pixel perfect compared to the [Figma designs](https://www.figma.com/design/l1dOM5qiQYwF0ElvKDqqjg/Design-System---Colony-v3?node-id=1782-177&t=I6SkwLY4baMEi24f-4) when it comes to non-mobile phone specific viewports below the 768px width breakpoint but hopefully this satisfies the AC when it comes to actual phone dimensions like the iPhone SE or the iPhone 14 Pro Max.

As a side note, this `SearchItem` component seems to manage various scenarios, resulting in a couple of conditional and shared styles that can be challenging to maintain over time. Ideally, in the future, we should create a dedicated component specifically for the colour picker.

| Before (iPhone SE) | (After) iPhone SE |
| ---- | ---- |
| ![Screenshot 2024-06-04 at 19 18 24](https://github.com/JoinColony/colonyCDapp/assets/50642296/384ff2a4-769e-4e12-b9e1-7152affc5c47) | ![Screenshot 2024-06-04 at 18 56 18](https://github.com/JoinColony/colonyCDapp/assets/50642296/5f556cf8-80d3-4bb2-b7a4-ee129f1def7e) |

I also added a bonus fix for making sure that the colour picker popover is fully shown when it's mount origin is near the bottom part of the viewport 😄 

![2417_bonus](https://github.com/JoinColony/colonyCDapp/assets/50642296/40b0434b-df1d-469d-a64d-3299ff2ce5a9)

## Testing

1. Set your browser to mobile view i.e. iPhone 14 Pro
2. Open the 'Create team' or 'Edit team' action form
3. Click the 'Team colour' field
4. Verify that the colour picker layout matches the [Figma designs](https://www.figma.com/design/l1dOM5qiQYwF0ElvKDqqjg/Design-System---Colony-v3?node-id=1782-177&t=I6SkwLY4baMEi24f-4). I do remember @melyndav telling me that the aim is not to be super pixel perfect so hopefully that's all right as far as the actual mobile viewport goes.

Resolves #2417 