### PR TITLE
Fix: Show the Expenditure's description on the Completed Action component

### DIFF
--- a/src/components/v5/common/ActionSidebar/hooks/useGetColonyAction.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useGetColonyAction.ts
@@ -51,6 +51,14 @@ const useGetColonyAction = (transactionHash?: string) => {
 
   const action = actionData?.getColonyAction;
 
+  const clearPollingCancellationTimer = () => {
+    if (pollTimerRef.current) {
+      clearTimeout(pollTimerRef.current);
+
+      pollTimerRef.current = null;
+    }
+  };
+
   useEffect(() => {
     const shouldPool = !isInvalidTx && !action;
 
@@ -68,11 +76,7 @@ const useGetColonyAction = (transactionHash?: string) => {
       return;
     }
 
-    if (pollTimerRef.current) {
-      clearTimeout(pollTimerRef.current);
-
-      pollTimerRef.current = null;
-    }
+    clearPollingCancellationTimer();
 
     pollTimerRef.current = setTimeout(stopPollingForAction, POLLING_TIMEOUT);
 
@@ -95,9 +99,7 @@ const useGetColonyAction = (transactionHash?: string) => {
       // This effect should receive an empty array dependency to ensure that
       // it only ever calls the return statement when its node unmounts,
       // and not when any other state gets updated.
-      if (pollTimerRef.current) {
-        clearTimeout(pollTimerRef.current);
-      }
+      clearPollingCancellationTimer();
 
       stopPollingForAction();
     };

--- a/src/components/v5/common/ActionSidebar/hooks/useGetColonyAction.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useGetColonyAction.ts
@@ -73,9 +73,11 @@ const useGetColonyAction = (transactionHash?: string) => {
   }, [stopPolling]);
 
   useEffect(() => {
-    const shouldPool = !isInvalidTx && !action;
+    const shouldPoll = !isInvalidTx && !action;
 
-    if (!shouldPool) {
+    setIsPolling(shouldPoll);
+
+    if (!shouldPoll) {
       if (action) {
         if (action.type === ColonyActionType.Payment) {
           refetchTokenBalances();

--- a/src/components/v5/common/ActionSidebar/hooks/useGetColonyAction.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useGetColonyAction.ts
@@ -1,5 +1,5 @@
 import { MotionState as NetworkMotionState } from '@colony/colony-js';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useUserTokenBalanceContext } from '~context/UserTokenBalanceContext/UserTokenBalanceContext.ts';
@@ -38,8 +38,8 @@ const useGetColonyAction = (transactionHash?: string) => {
   const {
     data: actionData,
     loading: loadingAction,
-    startPolling: startPollingForAction,
-    stopPolling: stopPollingForAction,
+    startPolling,
+    stopPolling,
     refetch: refetchAction,
   } = useGetColonyActionQuery({
     skip: isInvalidTx,
@@ -59,10 +59,21 @@ const useGetColonyAction = (transactionHash?: string) => {
     }
   };
 
+  const startPollingForAction = useCallback(
+    (interval: number = pollInterval) => {
+      startPolling(interval);
+      setIsPolling(true);
+    },
+    [pollInterval, startPolling],
+  );
+
+  const stopPollingForAction = useCallback(() => {
+    stopPolling();
+    setIsPolling(false);
+  }, [stopPolling]);
+
   useEffect(() => {
     const shouldPool = !isInvalidTx && !action;
-
-    setIsPolling(shouldPool);
 
     if (!shouldPool) {
       if (action) {


### PR DESCRIPTION
## Description

Currently, there's a bit of a race condition that occurs whereby polling for a Colony Action gets cancelled prematurely even though the intention is to only stop it when the Action Sidebar unmounts.

This PR ensures the original intent of stopping a poll only when the component unmounts is respected.

![2373_asap](https://github.com/JoinColony/colonyCDapp/assets/50642296/a05a153a-17db-4186-b152-91da73c95120)

## Testing

**Prerequisite**: If you don't currently have a network monitoring tool for GraphQL queries, install the [GraphQL Network Inspector browser add-on](https://chromewebstore.google.com/detail/graphql-network-inspector/ndlbedplllcgconngcnfmkadhokfaaln?hl=en-GB)

1. Bring up the Payment Builder action form
2. Fill in all required fields
3. Make sure to enter a description
4. Submit the form
5. Open your GraphQL monitoring tool
6. When the Completed Action component mounts, verify that the description field comes up without the need for a browser reload and that this behaviour is consistent with how a Simple Payment action behaves on production
7. Close the Completed Action component
8. Verify that the `GetColonyAction` GraphQL requests have stopped

## Diffs

**Changes** 🏗

I isolated the concern of stopping the poll in a separate effect and gave that effect an empty array dependency to ensure that its return statement only ever gets called when the component unmounts, and not when there's a state change elsewhere.

Resolves #2373 
