### PR TITLE
Fix: Handle image upload error due to fingerprint blocking

### DIFF
--- a/src/components/v5/common/AvatarUploader/hooks.ts
+++ b/src/components/v5/common/AvatarUploader/hooks.ts
@@ -47,6 +47,12 @@ export const useAvatarUploader = ({ updateFn }: UseAvatarUploaderProps) => {
     } catch (e) {
       if (e.message.includes('exceeded the maximum')) {
         setUploadAvatarError(DropzoneErrors.TOO_LARGE);
+      } else if (
+        e.message.includes(
+          "Pica: cannot use getImageData on canvas, make sure fingerprinting protection isn't enabled",
+        )
+      ) {
+        setUploadAvatarError(DropzoneErrors.FINGERPRINT_ENABLED);
       } else {
         setUploadAvatarError(DropzoneErrors.DEFAULT);
       }

--- a/src/components/v5/common/AvatarUploader/partials/ErrorContent.tsx
+++ b/src/components/v5/common/AvatarUploader/partials/ErrorContent.tsx
@@ -29,7 +29,7 @@ const ErrorContent: FC<ErrorContentProps> = ({
         </div>
       </div>
       <div className="flex w-full flex-col gap-1">
-        <div className="items-top flex justify-between">
+        <div className="items-top flex justify-between gap-2">
           <span className=" text-left text-negative-400 text-1">
             {formatMessage(errorMessage)}
           </span>

--- a/src/components/v5/common/AvatarUploader/utils.ts
+++ b/src/components/v5/common/AvatarUploader/utils.ts
@@ -16,7 +16,7 @@ const MSG = defineMessages({
   fingerprintError: {
     id: `${displayName}.fingerprintError`,
     defaultMessage:
-      'You currently have fingerprint blocking enabled. Please disable it before selecting a file.',
+      'Your browser currently have fingerprint blocking enabled. Please disable it before selecting a file.',
   },
   fileSizeError: {
     id: `${displayName}.fileSizeError`,

--- a/src/components/v5/common/AvatarUploader/utils.ts
+++ b/src/components/v5/common/AvatarUploader/utils.ts
@@ -16,7 +16,7 @@ const MSG = defineMessages({
   fingerprintError: {
     id: `${displayName}.fingerprintError`,
     defaultMessage:
-      'Your browser currently have fingerprint blocking enabled. Please disable it before selecting a file.',
+      'Your browser currently has fingerprint blocking enabled. Please disable it before selecting a file.',
   },
   fileSizeError: {
     id: `${displayName}.fileSizeError`,

--- a/src/components/v5/common/AvatarUploader/utils.ts
+++ b/src/components/v5/common/AvatarUploader/utils.ts
@@ -16,7 +16,7 @@ const MSG = defineMessages({
   fingerprintError: {
     id: `${displayName}.fingerprintError`,
     defaultMessage:
-      'Your browser currently has fingerprint blocking enabled. Please disable it before selecting a file.',
+      'Your browser blocked the upload. Check if fingerprint blocking is enabled and temporarily disable it before trying again.',
   },
   fileSizeError: {
     id: `${displayName}.fileSizeError`,

--- a/src/components/v5/common/AvatarUploader/utils.ts
+++ b/src/components/v5/common/AvatarUploader/utils.ts
@@ -13,6 +13,11 @@ const MSG = defineMessages({
     defaultMessage:
       'File could not be uploaded and may be corrupted. Try again with a different file.',
   },
+  fingerprintError: {
+    id: `${displayName}.fingerprintError`,
+    defaultMessage:
+      'You currently have fingerprint blocking enabled. Please disable it before selecting a file.',
+  },
   fileSizeError: {
     id: `${displayName}.fileSizeError`,
     defaultMessage: 'File size is too large, it should not exceed 1MB',
@@ -48,6 +53,7 @@ export enum DropzoneErrors {
   STRUCTURE = 'wrong-structure',
   CUSTOM = 'custom-error',
   DEFAULT = 'default',
+  FINGERPRINT_ENABLED = 'fingerprint-enabled',
 }
 
 /**
@@ -68,6 +74,9 @@ export const getErrorMessage = (errorCode: DropzoneErrors) => {
     }
     case DropzoneErrors.STRUCTURE: {
       return MSG.wrongStructure;
+    }
+    case DropzoneErrors.FINGERPRINT_ENABLED: {
+      return MSG.fingerprintError;
     }
 
     /* Extend here with too-small and too-many as needed */


### PR DESCRIPTION
## Description

There's currently an error being thrown by the `pica` lib whenever a file is being selected in our image uploader due to Brave's fingerprint blocking mechanism which is enabled when the Brave Shields are up.

![image](https://github.com/JoinColony/colonyCDapp/assets/50642296/3276aef0-8089-4afb-bcc2-d598659570ac)

I'm waiting for Arren's thoughts on this but last time I discussed this with Raul & Chris, it was decided that the most optimal solution **for now** is to describe to the user what the error is. Because the preferred fix is much more complex and will take up a lot of time. Here's a proposal for the error message:

<div align="center">

![image](https://github.com/JoinColony/colonyCDapp/assets/50642296/4b4b29ff-86b7-4714-b830-8dd061b79c41)

</div>

## Testing

I will need @rdig's or @chmanie's thoughts with this one. I am unable to find a way to replicate it locally. From what I understand, the on-demand qa environment isn't set up yet so I'm guessing we should just take a gamble and test this once it's deployed to the QA environment 🎲 

But for the actual steps:

1. Install the Brave browser if you don't have it already
2. Make sure Brave Shields are up and "Block fingerprinting" is enabled
![Screenshot 2024-06-07 at 10 47 44](https://github.com/JoinColony/colonyCDapp/assets/50642296/4e858447-fae2-476c-b4b2-57462c033477)
3. Go to Manage Profile page
4. Select a file to upload as your avatar
5. Verify that you can see the following error message: `"Your browser blocked the upload. Check if fingerprint blocking is enabled and temporarily disable it before trying again."`
![image](https://github.com/JoinColony/colonyCDapp/assets/50642296/4b4b29ff-86b7-4714-b830-8dd061b79c41)

## Diffs

**New stuff** ✨

* A new error message to display when we capture a fingerprint blocking related error whenever a user selects an file to upload.

Resolves #2262 