### PR TITLE
Feat: Conditionally auto activate tokens when processing a Staked Expenditure

### DIFF
--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -286,7 +286,7 @@ const TmpAdvancedPayments = () => {
       stakedExpenditureAddress,
       networkInverseFee,
       tokenAddress,
-      activeAmount: tokenBalanceData?.activeBalance ?? '0',
+      activeBalance: tokenBalanceData?.activeBalance ?? '0',
     };
 
     await createStakedExpenditure(payload);

--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -1,8 +1,10 @@
 import { Id } from '@colony/colony-js';
+import { BigNumber } from 'ethers';
 import React, { useState } from 'react';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { useUserTokenBalanceContext } from '~context/UserTokenBalanceContext/UserTokenBalanceContext.ts';
 import { StreamingPaymentEndCondition, useGetExpenditureQuery } from '~gql';
 import useAsyncFunction from '~hooks/useAsyncFunction.ts';
 import useCurrentBlockTime from '~hooks/useCurrentBlockTime.ts';
@@ -41,6 +43,8 @@ const TmpAdvancedPayments = () => {
   const { votingReputationAddress, stagedExpenditureAddress } =
     useEnabledExtensions();
   const { networkInverseFee = '0' } = useNetworkInverseFee();
+
+  const { tokenBalanceData } = useUserTokenBalanceContext();
 
   const [tokenAddress, setTokenAddress] = useState(
     colony.nativeToken.tokenAddress,
@@ -278,9 +282,11 @@ const TmpAdvancedPayments = () => {
       colonyAddress: colony.colonyAddress,
       createdInDomain: rootDomain,
       fundFromDomainId: 1,
-      stakeAmount,
+      stakeAmount: BigNumber.from(stakeAmount),
       stakedExpenditureAddress,
       networkInverseFee,
+      tokenAddress,
+      activeAmount: tokenBalanceData?.activeBalance ?? '0',
     };
 
     await createStakedExpenditure(payload);

--- a/src/redux/sagas/expenditures/createStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/createStakedExpenditure.ts
@@ -87,35 +87,37 @@ function* createStakedExpenditure({
   );
 
   try {
-    const missingActiveTokens = stakeAmount.sub(activeAmount);
+    if (stakeAmount.gt(activeAmount)) {
+      const missingActiveTokens = stakeAmount.sub(activeAmount);
 
-    yield createGroupTransaction(approve, batchKey, meta, {
-      context: ClientType.TokenClient,
-      methodName: 'approve',
-      identifier: tokenAddress,
-      params: [tokenLockingClient.address, missingActiveTokens],
-      ready: false,
-    });
+      yield createGroupTransaction(approve, batchKey, meta, {
+        context: ClientType.TokenClient,
+        methodName: 'approve',
+        identifier: tokenAddress,
+        params: [tokenLockingClient.address, missingActiveTokens],
+        ready: false,
+      });
 
-    yield createGroupTransaction(deposit, batchKey, meta, {
-      context: ClientType.TokenLockingClient,
-      methodName: 'deposit(address,uint256,bool)',
-      identifier: colonyAddress,
-      params: [tokenAddress, missingActiveTokens, false],
-      ready: false,
-    });
+      yield createGroupTransaction(deposit, batchKey, meta, {
+        context: ClientType.TokenLockingClient,
+        methodName: 'deposit(address,uint256,bool)',
+        identifier: colonyAddress,
+        params: [tokenAddress, missingActiveTokens, false],
+        ready: false,
+      });
 
-    yield takeFrom(approve.channel, ActionTypes.TRANSACTION_CREATED);
+      yield takeFrom(approve.channel, ActionTypes.TRANSACTION_CREATED);
 
-    yield takeFrom(deposit.channel, ActionTypes.TRANSACTION_CREATED);
+      yield takeFrom(deposit.channel, ActionTypes.TRANSACTION_CREATED);
 
-    yield initiateTransaction({ id: approve.id });
+      yield initiateTransaction({ id: approve.id });
 
-    yield waitForTxResult(approve.channel);
+      yield waitForTxResult(approve.channel);
 
-    yield initiateTransaction({ id: deposit.id });
+      yield initiateTransaction({ id: deposit.id });
 
-    yield waitForTxResult(deposit.channel);
+      yield waitForTxResult(deposit.channel);
+    }
 
     yield createGroupTransaction(approveStake, batchKey, meta, {
       context: ClientType.ColonyClient,

--- a/src/redux/sagas/expenditures/createStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/createStakedExpenditure.ts
@@ -270,6 +270,8 @@ function* createStakedExpenditure({
     return yield putError(ActionTypes.EXPENDITURE_CREATE_ERROR, error, meta);
   } finally {
     [
+      approve,
+      deposit,
       approveStake,
       makeExpenditure,
       setExpenditureValues,

--- a/src/redux/sagas/expenditures/createStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/createStakedExpenditure.ts
@@ -4,7 +4,7 @@ import {
   type TokenLockingClient,
   getChildIndex,
 } from '@colony/colony-js';
-import { takeEvery, call, put, all } from 'redux-saga/effects';
+import { takeEvery, call, put } from 'redux-saga/effects';
 
 import { ADDRESS_ZERO } from '~constants/index.ts';
 import { type ColonyManager } from '~context/index.ts';
@@ -152,26 +152,15 @@ function* createStakedExpenditure({
       );
     }
 
-    yield all(
-      [
-        approve,
-        deposit,
-        approveStake,
-        makeExpenditure,
-        setExpenditureValues,
-        setExpenditureStaged,
-        annotateMakeStagedExpenditure,
-      ].map((channelDefinition) =>
-        takeFrom(channelDefinition.channel, ActionTypes.TRANSACTION_CREATED),
-      ),
-    );
-
+    yield takeFrom(approve.channel, ActionTypes.TRANSACTION_CREATED);
     yield initiateTransaction({ id: approve.id });
     yield waitForTxResult(approve.channel);
 
+    yield takeFrom(deposit.channel, ActionTypes.TRANSACTION_CREATED);
     yield initiateTransaction({ id: deposit.id });
     yield waitForTxResult(deposit.channel);
 
+    yield takeFrom(approveStake.channel, ActionTypes.TRANSACTION_CREATED);
     yield initiateTransaction({ id: approveStake.id });
     yield waitForTxResult(approveStake.channel);
 

--- a/src/redux/sagas/expenditures/createStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/createStakedExpenditure.ts
@@ -105,18 +105,6 @@ function* createStakedExpenditure({
         params: [tokenAddress, missingActiveTokens, false],
         ready: false,
       });
-
-      yield takeFrom(approve.channel, ActionTypes.TRANSACTION_CREATED);
-
-      yield takeFrom(deposit.channel, ActionTypes.TRANSACTION_CREATED);
-
-      yield initiateTransaction({ id: approve.id });
-
-      yield waitForTxResult(approve.channel);
-
-      yield initiateTransaction({ id: deposit.id });
-
-      yield waitForTxResult(deposit.channel);
     }
 
     yield createGroupTransaction(approveStake, batchKey, meta, {
@@ -166,6 +154,8 @@ function* createStakedExpenditure({
 
     yield all(
       [
+        approve,
+        deposit,
         approveStake,
         makeExpenditure,
         setExpenditureValues,
@@ -175,6 +165,12 @@ function* createStakedExpenditure({
         takeFrom(channelDefinition.channel, ActionTypes.TRANSACTION_CREATED),
       ),
     );
+
+    yield initiateTransaction({ id: approve.id });
+    yield waitForTxResult(approve.channel);
+
+    yield initiateTransaction({ id: deposit.id });
+    yield waitForTxResult(deposit.channel);
 
     yield initiateTransaction({ id: approveStake.id });
     yield waitForTxResult(approveStake.channel);

--- a/src/redux/sagas/expenditures/createStakedExpenditure.ts
+++ b/src/redux/sagas/expenditures/createStakedExpenditure.ts
@@ -46,7 +46,7 @@ function* createStakedExpenditure({
     networkInverseFee,
     annotationMessage,
     distributionType,
-    activeAmount = '0',
+    activeBalance = '0',
     tokenAddress,
   },
 }: Action<ActionTypes.STAKED_EXPENDITURE_CREATE>) {
@@ -87,8 +87,8 @@ function* createStakedExpenditure({
   );
 
   try {
-    if (stakeAmount.gt(activeAmount)) {
-      const missingActiveTokens = stakeAmount.sub(activeAmount);
+    if (stakeAmount.gt(activeBalance)) {
+      const missingActiveTokens = stakeAmount.sub(activeBalance);
 
       yield createGroupTransaction(approve, batchKey, meta, {
         context: ClientType.TokenClient,

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -140,7 +140,7 @@ export type ExpendituresActionTypes =
         networkInverseFee: string;
         annotationMessage?: string;
         distributionType?: SplitPaymentDistributionType;
-        activeAmount: string;
+        activeAmount: string | undefined;
         tokenAddress: string;
       },
       MetaWithSetter<object>

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -140,7 +140,7 @@ export type ExpendituresActionTypes =
         networkInverseFee: string;
         annotationMessage?: string;
         distributionType?: SplitPaymentDistributionType;
-        activeAmount: string | undefined;
+        activeBalance: string | undefined;
         tokenAddress: string;
       },
       MetaWithSetter<object>

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -1,3 +1,5 @@
+import { type BigNumber } from 'ethers';
+
 import {
   type SplitPaymentDistributionType,
   type StreamingPaymentEndCondition,
@@ -131,13 +133,15 @@ export type ExpendituresActionTypes =
         createdInDomain: Domain;
         // id of the domain to fund the expenditure from
         fundFromDomainId: number;
-        stakeAmount: string;
+        stakeAmount: BigNumber;
         stakedExpenditureAddress: Address;
         isStaged?: boolean;
         stages?: ExpenditureStageFieldValue[];
         networkInverseFee: string;
         annotationMessage?: string;
         distributionType?: SplitPaymentDistributionType;
+        activeAmount: string;
+        tokenAddress: string;
       },
       MetaWithSetter<object>
     >


### PR DESCRIPTION
## Description

This will allow the `createStakedExpenditure` saga to handle Payment Builder actions that were made using the "Reputation" decision method.

![2483_proof](https://github.com/JoinColony/colonyCDapp/assets/50642296/3c191f17-643a-4ac4-a8f6-52f20341023a)

## Testing

I was using @jakubcolony's local API debugger while developing this. 

![Screenshot 2024-06-05 at 17 36 39](https://github.com/JoinColony/colonyCDapp/assets/50642296/0616a79c-f253-4740-849a-da187afa8397)

1. Enter an amount in the Transaction Amount field
2. Click the "Create staked expenditure" button
3. Reload the page ( important❗)
4. Click the most recent transaction in the Activities table
5. Ignore the Title, just make sure that:
  a.) The amount field value is correct
  b.) The staking information is correct
6. Open the User Hub popover and click on the Transactions tab
7. Expand the first Transaction in the list
8. Verify that the information is correct and the step indices (1. 2. 3. 4. 5.) are sequentially correct

## Diffs

**Changes** 🏗

The `createStakedExpenditure` can now automatically activate a token when needed.

Resolves #2483