### PR TITLE
Fix: Correctly show members and their role categorisations based on the Team filter

### DIFF
--- a/src/components/frame/Extensions/pages/PermissionsPage/IndividualPermissionsPage.tsx
+++ b/src/components/frame/Extensions/pages/PermissionsPage/IndividualPermissionsPage.tsx
@@ -12,6 +12,7 @@ import PermissionsPageRow from './partials/PermissionsPageRow.tsx';
 
 const IndividualPermissionsPage = () => {
   const { itemsByRole, filters, isLoading } = useGetMembersForPermissions();
+
   const emptyMembers = Object.keys(itemsByRole).every(
     (role) => itemsByRole[role].length === 0,
   );

--- a/src/components/frame/Extensions/pages/PermissionsPage/hooks.tsx
+++ b/src/components/frame/Extensions/pages/PermissionsPage/hooks.tsx
@@ -151,6 +151,7 @@ export const useGetMembersForPermissions = () => {
     () => getMembersList(pagedMembers, selectedDomain?.nativeId, colony),
     [colony, pagedMembers, selectedDomain],
   );
+
   const allExtensions: AnyExtensionData[] = useMemo(
     () => [...availableExtensionsData, ...installedExtensionsData],
     [availableExtensionsData, installedExtensionsData],
@@ -212,6 +213,7 @@ export const useGetMembersForPermissions = () => {
       ),
     [allExtensions, colony.name, isMobile],
   );
+
   const mappedMembers = useMemo<Record<string, MemberCardItem>>(
     () =>
       membersList.reduce(
@@ -424,6 +426,7 @@ export const useGetMembersForPermissions = () => {
     const memberItems = searchedMembers.reduce((acc, memberCard) => {
       if (memberCard.member.role) {
         const roleName = memberCard.member.role.name.toLowerCase();
+
         if (!acc[roleName]) {
           acc[roleName] = [];
         }

--- a/src/components/frame/v5/pages/MembersPage/utils.ts
+++ b/src/components/frame/v5/pages/MembersPage/utils.ts
@@ -2,7 +2,7 @@ import { ColonyRole, Id } from '@colony/colony-js';
 
 import { getRole } from '~constants/permissions.ts';
 import { type ColonyContributorFragment, type ColonyFragment } from '~gql';
-import { getAllUserRoles } from '~transformers/index.ts';
+import { getAllUserRoles } from '~transformers';
 
 import { type MemberItem } from './types.ts';
 
@@ -11,6 +11,8 @@ export const getMembersList = (
   selectedTeamId: number | undefined,
   colony: ColonyFragment,
 ): MemberItem[] => {
+  const isAllTeamsSelected = selectedTeamId === undefined;
+
   return members.map((contributor) => {
     const {
       contributorAddress,
@@ -20,38 +22,42 @@ export const getMembersList = (
       roles,
       reputation,
       type,
+      hasPermissions,
     } = contributor;
-    const { items } = roles || {};
-    const hasRoleInTeam = items?.some((item) => {
-      const { domain } = item || {};
 
-      return (
-        domain?.nativeId === selectedTeamId ||
-        domain?.nativeId === Id.RootDomain
-      );
+    const hasRoleInTeam = roles?.items?.some((item) => {
+      const domainId = item?.domain?.nativeId;
+
+      return isAllTeamsSelected
+        ? hasPermissions
+        : domainId === selectedTeamId || domainId === Id.RootDomain;
     });
+
     const allRoles = getAllUserRoles(colony, contributorAddress);
-    const allRolesFiltered =
+
+    const filteredRoles =
       hasRoleInTeam && (!selectedTeamId || selectedTeamId === Id.RootDomain)
         ? allRoles
         : allRoles?.filter(
             (role) => role !== ColonyRole.Root && role !== ColonyRole.Recovery,
           );
+
     const permissionRole =
-      hasRoleInTeam && allRolesFiltered?.length
-        ? getRole(allRolesFiltered)
+      hasRoleInTeam && filteredRoles?.length
+        ? getRole(filteredRoles)
         : undefined;
+
+    const teamReputation = reputation?.items?.find(
+      (item) => item?.domain?.nativeId === selectedTeamId,
+    )?.reputationPercentage;
 
     return {
       user,
       walletAddress: contributorAddress,
       isVerified,
-      reputation: selectedTeamId
-        ? reputation?.items?.find((item) => {
-            const { domain } = item || {};
-            return domain?.nativeId === selectedTeamId;
-          })?.reputationPercentage
-        : colonyReputationPercentage,
+      reputation: isAllTeamsSelected
+        ? colonyReputationPercentage
+        : teamReputation,
       role: permissionRole,
       contributorType: type ?? undefined,
     };

--- a/src/components/frame/v5/pages/MembersPage/utils.ts
+++ b/src/components/frame/v5/pages/MembersPage/utils.ts
@@ -47,7 +47,7 @@ export const getMembersList = (
         ? getRole(filteredRoles)
         : undefined;
 
-    const teamReputation = reputation?.items?.find(
+    const teamReputationPercentage = reputation?.items?.find(
       (item) => item?.domain?.nativeId === selectedTeamId,
     )?.reputationPercentage;
 
@@ -57,7 +57,7 @@ export const getMembersList = (
       isVerified,
       reputation: isAllTeamsSelected
         ? colonyReputationPercentage
-        : teamReputation,
+        : teamReputationPercentage,
       role: permissionRole,
       contributorType: type ?? undefined,
     };


### PR DESCRIPTION
## Description

When the "All teams" filter is toggled, the selected team ID is `undefined` which was throwing off the logic. This PR handles that scenario so members are correctly filtered when the "All teams" filter is enabled.

| Amy shown as Admin in Serenity | Amy shown as Admin in All teams |
| ---- | ---- |
| ![Screenshot 2024-06-05 at 20 44 01](https://github.com/JoinColony/colonyCDapp/assets/50642296/27ee832d-85f4-4439-b46a-c9254cc2a127) | ![Screenshot 2024-06-05 at 20 43 40](https://github.com/JoinColony/colonyCDapp/assets/50642296/01e228a4-3639-47b5-93ef-cfb1d063a552) |

## Testing

1. Give a user, let's call them USER, Admin permissions for the Serenity team
2. Reload the page ( important ❗️)
3. Head over to the Permissions page `http://localhost:9091/{colonyName}/permissions`
4. Set the teams filter to "ALL TEAMS"
5. Verify you can see USER under the Admin section
6. Set the teams filter to "Serenity"
7. Make sure you still see USER under the Admin section

## Diffs

**Changes** 🏗

Just little refactor for the `getMembersList` function to make it easier to follow. Maybe this is too subjective 😅 

Resolves #2469 
