### PR TITLE
[Multi-sig] feat: uninstallation of multi-sig extension

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -2423,6 +2423,10 @@ type ColonyMultiSig @model {
   Colony address the multiSig belongs to
   """
   colonyAddress: ID!
+    @index(
+      name: "byColonyAddress"
+      queryField: "getMultiSigByColonyAddress"
+    )
   """
   The on chain id of the multiSig
   """
@@ -3234,6 +3238,11 @@ type ColonyRole @model {
   The colony in which the role was set
   """
   colonyAddress: ID!
+    @index(
+      name: "byColonyAddress"
+      queryField: "getRoleByColony"
+      sortKeyFields: ["domainId"]
+    )
   """
   Block at which permissions were update last
   """

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=10468c4aebd2b533e5df814fd07aa00acfb0416f
+ENV BLOCK_INGESTOR_HASH=042d04e1e9d3e331008d8da6dd974c8f18149ab4
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/frame/v5/pages/MembersPage/utils.ts
+++ b/src/components/frame/v5/pages/MembersPage/utils.ts
@@ -52,6 +52,7 @@ export const getMembersList = (
     const teamReputationPercentage = reputation?.items?.find(
       (item) => item?.domain?.nativeId === selectedTeamId,
     )?.reputationPercentage;
+
     const allMultiSigRoles = getAllUserRoles(
       extractColonyRoles(colony.roles),
       contributorAddress,

--- a/src/context/ColonyManager.ts
+++ b/src/context/ColonyManager.ts
@@ -9,6 +9,7 @@ import {
   type TokenLockingClient,
   type ExtensionClient,
   type AnyColonyClient,
+  type AnyMultisigPermissionsClient,
 } from '@colony/colony-js';
 import { type Signer, type providers } from 'ethers';
 
@@ -81,6 +82,17 @@ export default class ColonyManager {
     return client as Promise<ExtensionClient>;
   }
 
+  public async removeColonyExtensionClient(
+    identifier: Address,
+    extensionId: Extension,
+  ): Promise<void> {
+    if (!isAddress(identifier)) {
+      throw new Error('A colony address must be provided');
+    }
+    const key = `${identifier}-${extensionId}`;
+    this.extensionClients.delete(key);
+  }
+
   async setColonyClient(address: Address): Promise<AnyColonyClient> {
     const clientPromise = this.getColonyPromise(address);
     this.colonyClients.set(address, clientPromise);
@@ -115,6 +127,11 @@ export default class ColonyManager {
     type: ClientType.OneTxPaymentClient,
     identifier?: Address,
   ): Promise<AnyOneTxPaymentClient>;
+
+  async getClient(
+    type: ClientType.MultisigPermissionsClient,
+    identifier?: Address,
+  ): Promise<AnyMultisigPermissionsClient>;
 
   async getClient(
     type: ClientType,

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -5863,6 +5863,7 @@ export type Query = {
   getMotionState: Scalars['Int'];
   /** Get the timeout for the current period of a motion */
   getMotionTimeoutPeriods?: Maybe<GetMotionTimeoutPeriodsReturn>;
+  getMultiSigByColonyAddress?: Maybe<ModelColonyMultiSigConnection>;
   getMultiSigByTransactionHash?: Maybe<ModelColonyMultiSigConnection>;
   getMultiSigUserSignature?: Maybe<MultiSigUserSignature>;
   getMultiSigUserSignatureByMultiSigId?: Maybe<ModelMultiSigUserSignatureConnection>;
@@ -5871,6 +5872,7 @@ export type Query = {
   getProfileByEmail?: Maybe<ModelProfileConnection>;
   getProfileByUsername?: Maybe<ModelProfileConnection>;
   getReputationMiningCycleMetadata?: Maybe<ReputationMiningCycleMetadata>;
+  getRoleByColony?: Maybe<ModelColonyRoleConnection>;
   getRoleByDomainAndColony?: Maybe<ModelColonyRoleConnection>;
   getRoleByTargetAddressAndColony?: Maybe<ModelColonyRoleConnection>;
   getSafeTransaction?: Maybe<SafeTransaction>;
@@ -6359,6 +6361,16 @@ export type QueryGetMotionTimeoutPeriodsArgs = {
 
 
 /** Root query type */
+export type QueryGetMultiSigByColonyAddressArgs = {
+  colonyAddress: Scalars['ID'];
+  filter?: InputMaybe<ModelColonyMultiSigFilterInput>;
+  limit?: InputMaybe<Scalars['Int']>;
+  nextToken?: InputMaybe<Scalars['String']>;
+  sortDirection?: InputMaybe<ModelSortDirection>;
+};
+
+
+/** Root query type */
 export type QueryGetMultiSigByTransactionHashArgs = {
   filter?: InputMaybe<ModelColonyMultiSigFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -6419,6 +6431,17 @@ export type QueryGetProfileByUsernameArgs = {
 /** Root query type */
 export type QueryGetReputationMiningCycleMetadataArgs = {
   id: Scalars['ID'];
+};
+
+
+/** Root query type */
+export type QueryGetRoleByColonyArgs = {
+  colonyAddress: Scalars['ID'];
+  domainId?: InputMaybe<ModelIdKeyConditionInput>;
+  filter?: InputMaybe<ModelColonyRoleFilterInput>;
+  limit?: InputMaybe<Scalars['Int']>;
+  nextToken?: InputMaybe<Scalars['String']>;
+  sortDirection?: InputMaybe<ModelSortDirection>;
 };
 
 

--- a/src/redux/sagas/extensions/extensionUninstall.ts
+++ b/src/redux/sagas/extensions/extensionUninstall.ts
@@ -1,6 +1,7 @@
 import { ClientType, getExtensionHash } from '@colony/colony-js';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
+import { type ColonyManager } from '~context';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 
 import {
@@ -8,13 +9,19 @@ import {
   getTxChannel,
   waitForTxResult,
 } from '../transactions/index.ts';
-import { initiateTransaction, putError, takeFrom } from '../utils/index.ts';
+import {
+  getColonyManager,
+  initiateTransaction,
+  putError,
+  takeFrom,
+} from '../utils/index.ts';
 
 export function* extensionUninstall({
   meta,
   payload: { colonyAddress, extensionId },
 }: Action<ActionTypes.EXTENSION_UNINSTALL>) {
   const txChannel = yield call(getTxChannel, meta.id);
+  const colonyManager: ColonyManager = yield getColonyManager();
 
   try {
     yield fork(createTransaction, meta.id, {
@@ -31,6 +38,7 @@ export function* extensionUninstall({
     const { type } = yield waitForTxResult(txChannel);
 
     if (type === ActionTypes.TRANSACTION_SUCCEEDED) {
+      colonyManager.removeColonyExtensionClient(colonyAddress, extensionId);
       yield put<AllActions>({
         type: ActionTypes.EXTENSION_UNINSTALL_SUCCESS,
         payload: {},


### PR DESCRIPTION
## Description

This PR adds the functionality to deprecate and uninstall the multi sig extension.
The heavy lifting is done by the block-ingestor :)
[Block ingestor PR](https://github.com/JoinColony/block-ingestor/pull/236)

## Testing

This is gonna be a lot to test, but here are 2 handy queries
Getting multisig motions:
```
listColonyMultiSigs(
    filter: {colonyAddress: {eq: "YOUR_COLONY_ADDRESS"}}
  ) {
    items {
      action {
        type
      }
      colonyAddress
      createdAt
      isExecuted
      isRejected
      isSuccess
      nativeMultiSigId
      signatures {
        items {
          colonyAddress
          multiSigId
          role
          userAddress
          vote
          user {
            profile {
              displayName
            }
          }
        }
      }
    }
  }
```
Get multisig roles:
```
listColonyRoles(
    filter: {isMultiSig: {eq: true}, colonyAddress: {eq: "YOUR_COLONY_ADDRESS"}}
  ) {
    items {
      colonyAddress
      id
      isMultiSig
      targetUser {
        profile {
          displayName
        }
      }
      targetAddress
    }
  }
```

Prerequisite: 2 users, both with owner multiSig permissions in the colony of your choice. I'll be using `leela` and `amy` respectively.

**a) Finalization and voting when the extension is deprecated**
1. Enable the multisig extension as leela
2. Set the global threshold to 2
3. Give amy owner permissions with `Take actions via Multi-Sig`
4. Create a mint tokens motion, copy the URL and open it in another browser as amy
5. Deprecate the extension
6. Approve the motion as amy and then finalize it as any user
7. The motion should be finalized

Verify by running the `listColonyMultisigs` query, you should see a motion with `isExecuted` and `isSuccess` to `true`.
![image](https://github.com/JoinColony/colonyCDapp/assets/23449297/e50272d9-26ac-49e8-b19c-a4179af7d48f)

Run the roles query and verify that both `amy` and `leela` still have their multi sig roles (2 items should display in the array).

**b) Uninstalling the extension with open motions**
1. Enable the multisig extension as leela
2. Set the global threshold to 2
3. Give amy owner permissions with `Take actions via Multi-Sig`
4. Create a mint tokens motion, copy the URL and open it in another browser as amy
5. Deprecate the extension and then uninstall it
6. Look at the motion as amy/leela, you should get temporary text that the extension is uninstalled
![image](https://github.com/JoinColony/colonyCDapp/assets/23449297/ab439265-7d01-45b1-90d6-19a76e243993)

Verify by running `listColonyMultisigs`, the last motion should be rejected.
![image](https://github.com/JoinColony/colonyCDapp/assets/23449297/d0df5bf3-df1d-449e-95c5-9683a23d7e0f)
and the `listColonyRoles` shouldn't display any multiSig roles.

## Diffs

**New stuff** ✨

* Upon multiSig uninstall, we reject all open motions and remove all role entries

Resolves #2141
