### PR TITLE
Fix: Don't allow user to stake while a previous stake is loading

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/StakingForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/StakingForm.tsx
@@ -51,7 +51,8 @@ const StakingForm: FC<StakingFormProps> = ({
     userInactivatedTokens,
   );
 
-  const { handleSuccess, transform, validationSchema } = useStakingForm();
+  const { handleSuccess, transform, validationSchema, isRefetching } =
+    useStakingForm();
 
   const { percentage } = motionStakes;
   const { nay, yay } = percentage;
@@ -220,7 +221,7 @@ const StakingForm: FC<StakingFormProps> = ({
                   />
                   <Button
                     isFullSize
-                    disabled={isSubmitting || !isValid}
+                    disabled={isSubmitting || !isValid || isRefetching}
                     type="submit"
                   >
                     {formatText({ id: 'motion.staking.button.submit' })}

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/StakingForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/StakingForm.tsx
@@ -130,7 +130,7 @@ const StakingForm: FC<StakingFormProps> = ({
                             checked && !disabled,
                         }),
                       icon: ThumbsDown,
-                      disabled: isFullyObjected,
+                      disabled: isFullyObjected || isRefetching,
                     },
                     {
                       label: formatText({ id: 'motion.support' }),
@@ -146,7 +146,7 @@ const StakingForm: FC<StakingFormProps> = ({
                             checked && !disabled,
                         }),
                       icon: ThumbsUp,
-                      disabled: isFullySupported,
+                      disabled: isFullySupported || isRefetching,
                     },
                   ]}
                   disabled={disableForm}

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/hooks.ts
@@ -33,7 +33,7 @@ export const useStakingForm = () => {
   const { user } = useAppContext();
   const { pollLockedTokenBalance, tokenBalanceData } =
     useUserTokenBalanceContext();
-  const { motionAction, setIsRefetching, startPollingAction } =
+  const { motionAction, setIsRefetching, startPollingAction, isRefetching } =
     useMotionContext();
 
   const { colony, motionData } = motionAction || {};
@@ -127,6 +127,7 @@ export const useStakingForm = () => {
   );
 
   return {
+    isRefetching,
     transform,
     handleSuccess,
     validationSchema,


### PR DESCRIPTION
## Description

- Fix issue where the user could fully stake for support twice

## Testing

- Create a simple payment action and select the reputation decision method.
- Create and sign action
- Fully stake and support
- Try to immediately stake and support again. The buttons should be disabled and not allow you to.

Video of original issue can be found here: https://github.com/JoinColony/colonyCDapp/issues/2416

## Diffs

**Changes** 🏗

* Disable staking buttons while a motion is being refetched.

Resolves #2416
