### PR TITLE
Fix: Inconsistent balances across the ui

### DIFF
--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/BalanceTable.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/BalanceTable.tsx
@@ -89,8 +89,10 @@ const BalanceTable: FC = () => {
 
   const columns = useBalanceTableColumns(nativeToken, nativeTokenStatus);
   const getMenuProps: TableProps<BalanceTableFieldModel>['getMenuProps'] = ({
-    original: { token: selectedTokenData },
+    original: { token: selectedTokenData, loading },
   }) => {
+    if (loading) return undefined;
+
     const isTokenNative =
       selectedTokenData?.tokenAddress === nativeToken?.tokenAddress;
 

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/hooks.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/hooks.tsx
@@ -123,8 +123,9 @@ export const useBalanceTableColumns = (
         cell: ({ row }) => {
           if (!row.original.token) return [];
 
-          if (row.original.loading)
+          if (row.original.loading) {
             return <div className="h-4 w-40 skeleton" />;
+          }
 
           return (
             <TokenCell
@@ -141,8 +142,10 @@ export const useBalanceTableColumns = (
         header: () => formatText({ id: 'table.row.symbol' }),
         headCellClassName: isMobile ? 'pr-2 pl-0' : undefined,
         cell: ({ row }) => {
-          if (row.original.loading)
+          if (row.original.loading) {
             return <div className="h-4 w-12 skeleton" />;
+          }
+
           return (
             <span className="text-gray-600">
               {multiLineTextEllipsis(row.original.token?.symbol ?? '', 5)}
@@ -155,8 +158,9 @@ export const useBalanceTableColumns = (
         size: 130,
         header: () => formatText({ id: 'table.row.type' }),
         cell: ({ row }) => {
-          if (row.original.loading)
+          if (row.original.loading) {
             return <div className="h-4 w-12 skeleton" />;
+          }
 
           const isTokenNative =
             row.original.token?.tokenAddress === nativeToken.tokenAddress;
@@ -182,8 +186,9 @@ export const useBalanceTableColumns = (
         cell: ({ row }) => {
           const currentTokenBalance = row.original.balance;
 
-          if (row.original.loading)
+          if (row.original.loading) {
             return <div className="ml-auto h-4 w-24 skeleton" />;
+          }
 
           return (
             <div className="ml-auto text-right">

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/hooks.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/hooks.tsx
@@ -31,7 +31,7 @@ export const useBalancesData = (): BalanceTableFieldModel[] => {
   } = useColonyContext();
   const selectedDomain = useGetSelectedDomainFilter();
   const { attributeFilters, tokenTypes, searchFilter } = useFiltersContext();
-  const { balancesByToken: expenditureBalances } =
+  const { balancesByToken: expenditureBalances, loading } =
     useColonyExpenditureBalances();
 
   const tokensData = useMemo(
@@ -55,9 +55,16 @@ export const useBalancesData = (): BalanceTableFieldModel[] => {
         return {
           ...item,
           balance: totalBalance,
+          loading,
         };
       }) ?? [],
-    [colonyTokens?.items, balances, selectedDomain, expenditureBalances],
+    [
+      colonyTokens?.items,
+      balances,
+      selectedDomain,
+      expenditureBalances,
+      loading,
+    ],
   );
 
   const filteredTokens = tokensData?.filter((token) => {
@@ -116,6 +123,9 @@ export const useBalanceTableColumns = (
         cell: ({ row }) => {
           if (!row.original.token) return [];
 
+          if (row.original.loading)
+            return <div className="h-4 w-40 skeleton" />;
+
           return (
             <TokenCell
               token={row.original.token}
@@ -130,17 +140,24 @@ export const useBalanceTableColumns = (
         size: isMobile ? 60 : 100,
         header: () => formatText({ id: 'table.row.symbol' }),
         headCellClassName: isMobile ? 'pr-2 pl-0' : undefined,
-        cell: ({ row }) => (
-          <span className="text-gray-600">
-            {multiLineTextEllipsis(row.original.token?.symbol ?? '', 5)}
-          </span>
-        ),
+        cell: ({ row }) => {
+          if (row.original.loading)
+            return <div className="h-4 w-12 skeleton" />;
+          return (
+            <span className="text-gray-600">
+              {multiLineTextEllipsis(row.original.token?.symbol ?? '', 5)}
+            </span>
+          );
+        },
       }),
       columnHelper.display({
         id: 'type',
         size: 130,
         header: () => formatText({ id: 'table.row.type' }),
         cell: ({ row }) => {
+          if (row.original.loading)
+            return <div className="h-4 w-12 skeleton" />;
+
           const isTokenNative =
             row.original.token?.tokenAddress === nativeToken.tokenAddress;
 
@@ -164,6 +181,9 @@ export const useBalanceTableColumns = (
         }),
         cell: ({ row }) => {
           const currentTokenBalance = row.original.balance;
+
+          if (row.original.loading)
+            return <div className="ml-auto h-4 w-24 skeleton" />;
 
           return (
             <div className="ml-auto text-right">

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/types.ts
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/types.ts
@@ -5,4 +5,5 @@ import { type TokenFragment } from '~gql';
 export interface BalanceTableFieldModel {
   balance: BigNumber;
   token?: TokenFragment;
+  loading?: boolean;
 }


### PR DESCRIPTION
## Description

- Fix an issue where the balance was not being consistent in different places across the UI
- Add loading state to balance table

## Testing

- Go to the balances page note the balance.
- Create a Payment builder action (while still on balances page in the background) and fund it, but don't release it.
- Close the sidebar to go back to the balances page. The balance should still be the same.
- Start to create a new simple payment action (don't actually create it).
- Check the available funds from token drop down. This should be equal to the balance shown in the balance table minus the amounts currently held in expenditure funding.
- Close the sidebar to go back to the balances page.
- Refresh the page and be ready to check the loading state.
- Once the page reloads it should show a skeleton loader, and then the balances. These balances should not flicker between two numbers at all.

## Diffs

**New stuff** ✨

* New skeleton loader state in the balances page.

**Changes** 🏗

* Changes to handle cache updates when expenditures are funded.

Resolves #2408
