### PR TITLE
Fix: Use correct asset platform when calling CoinGecko

### DIFF
--- a/src/components/shared/CurrencyConversion/CurrencyConversion.tsx
+++ b/src/components/shared/CurrencyConversion/CurrencyConversion.tsx
@@ -9,7 +9,7 @@ import useCurrency from '~hooks/useCurrency.ts';
 import Numeral, {
   type Props as NumeralProps,
 } from '~shared/Numeral/Numeral.tsx';
-import { Network } from '~types/network.ts';
+import { type Network } from '~types/network.ts';
 import { type FetchCurrentPriceArgs } from '~utils/currency/index.ts';
 
 const displayName = 'CurrencyConversion';
@@ -47,9 +47,7 @@ const CurrencyConversion = ({
   tokenBalance,
   tokenDecimals,
   contractAddress,
-  chainId = DEFAULT_NETWORK in Network
-    ? (DEFAULT_NETWORK as Network)
-    : undefined,
+  chainId = DEFAULT_NETWORK as Network,
   className,
   ...rest
 }: Props) => {

--- a/src/components/shared/CurrencyConversion/CurrencyConversion.tsx
+++ b/src/components/shared/CurrencyConversion/CurrencyConversion.tsx
@@ -3,11 +3,13 @@ import { type BigNumber } from 'ethers';
 import moveDecimal from 'move-decimal-point';
 import React from 'react';
 
+import { DEFAULT_NETWORK } from '~constants';
 import { useCurrencyContext } from '~context/CurrencyContext/CurrencyContext.ts';
 import useCurrency from '~hooks/useCurrency.ts';
 import Numeral, {
   type Props as NumeralProps,
 } from '~shared/Numeral/Numeral.tsx';
+import { Network } from '~types/network.tsx';
 import { type FetchCurrentPriceArgs } from '~utils/currency/index.ts';
 
 const displayName = 'CurrencyConversion';
@@ -45,7 +47,9 @@ const CurrencyConversion = ({
   tokenBalance,
   tokenDecimals,
   contractAddress,
-  chainId,
+  chainId = DEFAULT_NETWORK in Network
+    ? (DEFAULT_NETWORK as Network)
+    : undefined,
   className,
   ...rest
 }: Props) => {

--- a/src/components/shared/CurrencyConversion/CurrencyConversion.tsx
+++ b/src/components/shared/CurrencyConversion/CurrencyConversion.tsx
@@ -9,7 +9,7 @@ import useCurrency from '~hooks/useCurrency.ts';
 import Numeral, {
   type Props as NumeralProps,
 } from '~shared/Numeral/Numeral.tsx';
-import { Network } from '~types/network.tsx';
+import { Network } from '~types/network.ts';
 import { type FetchCurrentPriceArgs } from '~utils/currency/index.ts';
 
 const displayName = 'CurrencyConversion';

--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import { Network, SupportedCurrencies } from '~gql';
+import { SupportedCurrencies } from '~gql';
+import { Network } from '~types/network.ts';
 import {
   fetchCurrentPrice,
   type FetchCurrentPriceArgs,
@@ -8,7 +9,7 @@ import {
 
 const useCurrency = ({
   contractAddress,
-  chainId = Network.Gnosis,
+  chainId = Network.ArbitrumOne,
   conversionDenomination = SupportedCurrencies.Usd,
 }: FetchCurrentPriceArgs) => {
   const [price, setPrice] = useState<number | null>(0);

--- a/src/utils/currency/config.ts
+++ b/src/utils/currency/config.ts
@@ -1,5 +1,6 @@
 import { ETHER_TOKEN, XDAI_TOKEN } from '~constants';
-import { Network, SupportedCurrencies } from '~gql';
+import { SupportedCurrencies } from '~gql';
+import { Network } from '~types/network.ts';
 
 // For walkthrough, see: https://apiguide.coingecko.com/getting-started/10-min-tutorial-guide/1-get-data-by-id-or-address
 export const currencyApiConfig = {
@@ -23,6 +24,22 @@ export const currencyApiConfig = {
   },
   attribution: 'https://www.coingecko.com/',
 };
+
+// This is a map between our internal reference to the current network, and the asset platform
+// we should call the coingecko api with.
+// For full list: https://api.coingecko.com/api/v3/asset_platforms
+const coinGeckoAssetPlatforms: { [key in Network]: string } = {
+  [Network.Amoy]: 'polygon-pos',
+  [Network.ArbitrumOne]: 'arbitrum-one',
+  [Network.ArbitrumSepolia]: 'arbitrum-one',
+  [Network.Ganache]: 'arbitrum-one',
+  [Network.Gnosis]: 'xdai',
+  [Network.GnosisFork]: 'xdai',
+  [Network.Goerli]: 'ethereum',
+  [Network.Mainnet]: 'ethereum',
+  [Network.Polygon]: 'polygon-pos',
+};
+
 export const coinGeckoMappings = {
   // This is a map between our internal reference to a supported currency, and the reference the api uses.
   // For full list: https://api.coingecko.com/api/v3/simple/supported_vs_currencies
@@ -37,11 +54,7 @@ export const coinGeckoMappings = {
     [SupportedCurrencies.Brl]: 'brl',
     [SupportedCurrencies.Eth]: 'eth',
   },
-  // For full list: https://api.coingecko.com/api/v3/asset_platforms
-  chains: {
-    [Network.Gnosis]: 'xdai',
-    [Network.Mainnet]: 'ethereum',
-  },
+  chains: coinGeckoAssetPlatforms,
   networkTokens: {
     [ETHER_TOKEN.symbol]: 'ethereum',
     [XDAI_TOKEN.symbol]: 'xdai',

--- a/src/utils/currency/currency.ts
+++ b/src/utils/currency/currency.ts
@@ -1,7 +1,8 @@
 import { Tokens } from '@colony/colony-js';
 
 import { ADDRESS_ZERO, DEFAULT_NETWORK_TOKEN } from '~constants';
-import { Network, SupportedCurrencies } from '~gql';
+import { SupportedCurrencies } from '~gql';
+import { Network } from '~types/network.ts';
 
 import { coinGeckoMappings } from './config.ts';
 import { getSavedPrice, savePrice } from './memo.ts';
@@ -15,7 +16,7 @@ import { convertTokenToCLNY } from './utils.ts';
 
 const fetchPriceFromCoinGecko = async ({
   contractAddress,
-  chainId = Network.Gnosis,
+  chainId = Network.ArbitrumOne,
   conversionDenomination,
 }: Pick<FetchCurrentPriceArgs, 'chainId' | 'contractAddress'> & {
   conversionDenomination: CoinGeckoSupportedCurrencies;
@@ -61,7 +62,7 @@ const getCLNYPriceInUSD = async () => {
  */
 export const fetchCurrentPrice = async ({
   contractAddress,
-  chainId = Network.Gnosis,
+  chainId = Network.ArbitrumOne,
   conversionDenomination = SupportedCurrencies.Usd,
 }: FetchCurrentPriceArgs): Promise<number | null> => {
   const savedPrice = getSavedPrice({

--- a/src/utils/currency/tokenPriceByAddress.ts
+++ b/src/utils/currency/tokenPriceByAddress.ts
@@ -1,4 +1,5 @@
-import { Network, SupportedCurrencies } from '~gql';
+import { SupportedCurrencies } from '~gql';
+import { Network } from '~types/network.ts';
 
 import { currencyApiConfig, coinGeckoMappings } from './config.ts';
 import {
@@ -16,7 +17,7 @@ import { buildAPIEndpoint, fetchData, mapToAPIFormat } from './utils.ts';
 const { chains, currencies } = coinGeckoMappings;
 const buildTokenAddressCoinGeckoURL = (
   contractAddress: string,
-  chainId: SupportedChains = Network.Gnosis,
+  chainId: SupportedChains = Network.ArbitrumOne,
   conversionDenomination: CoinGeckoSupportedCurrencies = SupportedCurrencies.Usd,
 ) => {
   const chain = mapToAPIFormat(chains, chainId);
@@ -64,7 +65,7 @@ const isAddressPriceSuccessResponse = (
 
 export const fetchTokenPriceByAddress = async ({
   contractAddress,
-  chainId = Network.Gnosis,
+  chainId = Network.ArbitrumOne,
   conversionDenomination = SupportedCurrencies.Usd,
 }: Pick<FetchCurrentPriceArgs, 'chainId' | 'contractAddress'> & {
   conversionDenomination: CoinGeckoSupportedCurrencies;


### PR DESCRIPTION
## Description

- Use the network_id environment variable to determine which asset platform should be used while calling the CoinGecko api.

## Testing

A little trickier to test properly, but there's some things you can do:

- Go to the balances table and refresh the page with the network tab open in dev tools.
- If you check the network tab you should find some calls to the CoinGecko api:

<img width="654" alt="Screenshot 2024-06-12 at 17 30 58" src="https://github.com/JoinColony/colonyCDapp/assets/38098203/b0a527c8-901c-4c6c-9fe9-321a08e4f928">

- Change`NETWORK_ID="ganache"` in your .env.local file to be `NETWORK_ID="gnosis"`
- Repeat the first two steps
- You should now see the call being made with `xdai` instead of `arbitrum-one` as the asset platform

<img width="655" alt="Screenshot 2024-06-12 at 17 38 30" src="https://github.com/JoinColony/colonyCDapp/assets/38098203/da54290b-6edd-4104-b078-f0427c98fdc0">

The main idea here is that on production, it is currently incorrectly calling with `xdai` as the asset platform, whereas it should be using `arbitrum-one`. The network_id environment variable on production is `arbitrumOne`.

## Diffs

**Changes** 🏗

* Update the CoinGecko config to use the network_id environment variable to determine which asset platform should be used when calling the api.

Resolves #2418
