### PR TITLE
Fix: Correctly show user permission groupings on the Permissions page

### DIFF
--- a/src/components/frame/Extensions/pages/PermissionsPage/hooks.tsx
+++ b/src/components/frame/Extensions/pages/PermissionsPage/hooks.tsx
@@ -139,7 +139,9 @@ export const useGetMembersForPermissions = () => {
     loading: extensionLoading,
   } = useExtensionsData();
   const isMobile = useMobile();
-  const { pagedMembers, loading } = useMemberContext();
+  const { loading, filteredMembers: filteredMembersFromContext } =
+    useMemberContext();
+
   const { colony } = useColonyContext();
   const selectedDomain = useGetSelectedDomainFilter();
   const { handleClipboardCopy, isCopied } = useCopyToClipboard();
@@ -148,8 +150,13 @@ export const useGetMembersForPermissions = () => {
   } = useActionSidebarContext();
 
   const membersList = useMemo(
-    () => getMembersList(pagedMembers, selectedDomain?.nativeId, colony),
-    [colony, pagedMembers, selectedDomain],
+    () =>
+      getMembersList(
+        filteredMembersFromContext,
+        selectedDomain?.nativeId,
+        colony,
+      ),
+    [colony, filteredMembersFromContext, selectedDomain?.nativeId],
   );
 
   const allExtensions: AnyExtensionData[] = useMemo(


### PR DESCRIPTION
## Description

This PR will now show the correct member list when the "All teams" filter is set on the Permissions page.

![Screenshot 2024-06-12 at 20 00 41](https://github.com/JoinColony/colonyCDapp/assets/50642296/e83b31fb-0f2b-4b39-84e9-b014fedc9114)

## Testing

**Testing steps**
> I'm choosing `adam-advent` because he doesn't appear in the first chunk of a paginated members list
>
> For anyone else testing: `adam-advent` won't necessarily appear outside of the first chunk of the paginated members list (the order in which users are generated is different each time the create-data script is ran) pick a member low down the list when giving them permissions
1. Using the Manage Permissions action, give user `adam-advent` Owner permissions
2. Reload the page
3. Visit the Permissions page
4. Verify that you can see `adam-advent` under the Owner group

I guess for an easy comparison:
1. Checkout to the `master` branch
2. Reload the Permissions page
3. You can see that `adam-advent` doesn't appear on the Permissions page

Resolves #2512 