### PR TITLE
Fx: Remove staking form for users who are not allowed to stake

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/StakingForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/StakingForm.tsx
@@ -6,7 +6,6 @@ import moveDecimal from 'move-decimal-point';
 import React, { type FC } from 'react';
 
 import { accordionAnimation } from '~constants/accordionAnimation.ts';
-import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { ActionTypes } from '~redux/index.ts';
 import { ActionForm } from '~shared/Fields/index.ts';
 import Numeral from '~shared/Numeral/index.ts';
@@ -32,7 +31,6 @@ const StakingForm: FC<StakingFormProps> = ({
   userInactivatedTokens,
   disableForm,
 }) => {
-  const { canInteract } = useAppContext();
   const { motionAction } = useMotionContext();
 
   const thresholdPercentValue = 10;
@@ -107,11 +105,11 @@ const StakingForm: FC<StakingFormProps> = ({
                   voteTypeValue === MotionVote.Yay
                     ? predictedPercentage
                     : undefined,
-                className: 'mb-6',
+                ...(!disableForm && { className: 'mb-6' }),
               }}
             />
             <div>
-              {canInteract && (
+              {!disableForm && (
                 <FormButtonRadioButtons
                   name="voteType"
                   allowUnselect={!isFullySupported && !isFullyObjected}


### PR DESCRIPTION
## Description

This PR simply unmounts the the staking form if the user is not allowed to stake.

![Screenshot 2024-06-13 at 14 59 20](https://github.com/JoinColony/colonyCDapp/assets/50642296/655d22b1-546d-4f12-8d3a-0230b1a7d6eb)

## Testing

**Prerequisites:**
1. Visit the GraphQL playground and run the following query to generate an invite code for the "planex" Colony
```
query MyQuery {
  getColonyByName(name: "newcolony") {
    items {
      colonyMemberInviteCode
    }
  }
}
```
2. Copy the invite code i.e. `bf7ebc5a-ccff-4d14-a195-dc6b88cb72a3`

**Steps**
1. `*incognito window*` Connect Dev Wallet 16 and create a profile
3. `*incognito window*` Visit the invite page for the "planex" Colony at http://localhost:9091/invite/planex/{yourInviteCode}
4. `*non-incognito window*` Log in as Leela (Dev wallet 1)
5. `*non-incognito window*` Install and Enable the "Reputation weighted" extension http://localhost:9091/planex/extensions/VotingReputation
6. `*non-incognito window*` Create an agreement via the Action Form and wait for the action to be completed
7. `*incognito window*` Reload the page
8. `*incognito window*` Go to the Dashboard and open the Agreement
9. `*incognito window*` When the action form shows up, verify that you don't see the Approve and Support buttons

## Diffs

**Changes** 🏗

- The staking form is now unmounted if the user is not allowed to stake.

Resolves #2521 