### PR TITLE
Chore: Rename payment builder action

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/PaymentBuilder.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/PaymentBuilder.tsx
@@ -50,7 +50,7 @@ const displayName = 'v5.common.CompletedAction.partials.PaymentBuilder';
 const MSG = defineMessages({
   defaultTitle: {
     id: `${displayName}.defaultTitle`,
-    defaultMessage: 'Payment builder',
+    defaultMessage: 'Advanced payment',
   },
 });
 

--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -85,7 +85,7 @@ const actionsMessageDescriptors = {
       ${ColonyActionType.AddVerifiedMembersMotion} {Manage verified members}
       ${ColonyActionType.RemoveVerifiedMembers} {Manage verified members}
       ${ColonyActionType.RemoveVerifiedMembersMotion} {Manage verified members}
-      ${ColonyActionType.CreateExpenditure} {Payment Builder}
+      ${ColonyActionType.CreateExpenditure} {Advanced payment}
       ${ExtendedColonyActionType.UpdateTokens} {Update Tokens}
       ${ExtendedColonyActionType.AddSafe} {Add Safe}
       ${ExtendedColonyActionType.RemoveSafe} {Remove Safe}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -893,7 +893,7 @@
     "actions.selectActionType": "Select action type",
     "actions.payments": "Payments",
     "actions.simplePayment": "Simple payment",
-    "actions.paymentBuilder": "Payment builder",
+    "actions.paymentBuilder": "Advanced payment",
     "actions.batchPayment": "Batch payment",
     "actions.splitPayment": "Split payment",
     "actions.stagedPayment": "Staged payment",


### PR DESCRIPTION
Rename Payment Builder action to Advanced Payment

## Description

Refactor 'Payment Builder' action to 'Advanced payment'

## Testing

* Step 1. Create new payment builder action 
* Step 2. Check naming is 'Advanced payment'


Resolves #2493
