### PR TITLE
Fix: remove comments number from agreement

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/Agreements/Agreements.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/Agreements/Agreements.tsx
@@ -16,7 +16,6 @@ import { formatText } from '~utils/intl.ts';
 import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import WidgetBox from '~v5/common/WidgetBox/index.ts';
 import EmptyWidgetState from '~v5/common/WidgetBox/partials/index.ts';
-import MessageNumber from '~v5/shared/MessageNumber/index.ts';
 import RichTextDisplay from '~v5/shared/RichTextDisplay/index.ts';
 import TitleWithNumber from '~v5/shared/TitleWithNumber/index.ts';
 
@@ -72,7 +71,8 @@ const Agreements = () => {
                 <span className="text-3">
                   {newestAgreement.decisionData?.title}
                 </span>
-                <MessageNumber message={1} />
+                {/* @TODO Re-enable once a Motion supports the comments feature */}
+                {/* <MessageNumber message={1} /> */}
               </div>
               {newestAgreement.decisionData?.description && (
                 <RichTextDisplay

--- a/src/components/v5/frame/ColonyHome/partials/Agreements/Agreements.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/Agreements/Agreements.tsx
@@ -71,8 +71,6 @@ const Agreements = () => {
                 <span className="text-3">
                   {newestAgreement.decisionData?.title}
                 </span>
-                {/* @TODO Re-enable once a Motion supports the comments feature */}
-                {/* <MessageNumber message={1} /> */}
               </div>
               {newestAgreement.decisionData?.description && (
                 <RichTextDisplay


### PR DESCRIPTION
Remove comments number from colony home agreement card

## Description

- Remove comments number from colony home agreement card
- Add TODO to re-enable the comment number once this feature is implemented

## Testing

TODO: Check is comments number still shows for an agreement on the colony home page

* Step 1. Create an agreement
* Step 2. Go to colony dashboard
* Step 3. Check agreements section

Resolves #2505
