### PR TITLE
fix: User avatar shrinks on mobile when action is submitting

### DIFF
--- a/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
+++ b/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
@@ -151,7 +151,7 @@ const UserHubButton: FC = () => {
           {
             '!border-blue-400': visible || isUserHubOpen,
           },
-          ' flex min-w-[3rem] md:hover:!border-blue-400',
+          'min-w-[3rem] md:hover:!border-blue-400',
         )}
         onClick={handleButtonClick}
       >

--- a/src/components/v5/frame/NavigationSidebar/NavigationSidebar.tsx
+++ b/src/components/v5/frame/NavigationSidebar/NavigationSidebar.tsx
@@ -117,7 +117,7 @@ const NavigationSidebarContent: FC<NavigationSidebarProps> = ({
             md:gap-9
           `}
         >
-          <div className="flex gap-3 md:flex-col md:gap-9">
+          <div className="flex gap-6 md:flex-col md:gap-9">
             <div className="flex justify-center md:w-full">
               <button
                 type="button"


### PR DESCRIPTION
## Description
Fix user avatar shrinks on mobile when action is submitting

## Testing
* Step 1. Set screen size to mobile
* Step 2. Create a new action and submit
* Step 3. See that user avatar is visible
<img width="380" alt="image" src="https://github.com/JoinColony/colonyCDapp/assets/15706494/60089753-4724-40d8-8032-0dfa1dfaf79b">

Resolves #2546
