### PR TITLE
fix: Unable to open settings menu on mobile when action sidebar is open

### DIFF
--- a/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
@@ -235,49 +235,51 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
       )}
       ref={registerContainerRef}
     >
-      <div className="flex w-full items-center justify-between border-b border-gray-200 px-6 py-4">
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            className="flex items-center justify-center py-2.5 text-gray-400 transition sm:hover:text-blue-400"
-            onClick={closeSidebarClick}
-            aria-label={formatText({ id: 'ariaLabel.closeModal' })}
-          >
-            <X size={18} />
-          </button>
-          {!isMobile && (
-            <div className="flex items-center gap-4">
-              <button
-                type="button"
-                className="flex items-center justify-center py-2.5 text-gray-400 transition sm:hover:text-blue-400"
-                onClick={toggleIsSidebarFullscreen}
-                aria-label={formatText({ id: 'ariaLabel.fullWidth' })}
-              >
-                {isSidebarFullscreen ? (
-                  <ArrowLineRight size={18} />
-                ) : (
-                  <ArrowsOutSimple size={18} />
-                )}
-              </button>
-              {action && !isMotion && !expenditure && (
-                <PillsBase
-                  className="bg-success-100 text-success-400"
-                  isCapitalized={false}
+      <div className="relative">
+        <div className="flex w-full items-center justify-between border-b border-gray-200 px-6 py-4">
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="flex items-center justify-center py-2.5 text-gray-400 transition sm:hover:text-blue-400"
+              onClick={closeSidebarClick}
+              aria-label={formatText({ id: 'ariaLabel.closeModal' })}
+            >
+              <X size={18} />
+            </button>
+            {!isMobile && (
+              <div className="flex items-center gap-4">
+                <button
+                  type="button"
+                  className="flex items-center justify-center py-2.5 text-gray-400 transition sm:hover:text-blue-400"
+                  onClick={toggleIsSidebarFullscreen}
+                  aria-label={formatText({ id: 'ariaLabel.fullWidth' })}
                 >
-                  {formatText({ id: 'action.passed' })}
-                </PillsBase>
-              )}
-              {!!expenditure && (
-                <ExpenditureActionStatusBadge
-                  expenditure={expenditure}
-                  withAdditionalStatuses
-                />
-              )}
-              <MotionOutcomeBadge motionState={motionState} />
-            </div>
-          )}
+                  {isSidebarFullscreen ? (
+                    <ArrowLineRight size={18} />
+                  ) : (
+                    <ArrowsOutSimple size={18} />
+                  )}
+                </button>
+                {action && !isMotion && !expenditure && (
+                  <PillsBase
+                    className="bg-success-100 text-success-400"
+                    isCapitalized={false}
+                  >
+                    {formatText({ id: 'action.passed' })}
+                  </PillsBase>
+                )}
+                {!!expenditure && (
+                  <ExpenditureActionStatusBadge
+                    expenditure={expenditure}
+                    withAdditionalStatuses
+                  />
+                )}
+                <MotionOutcomeBadge motionState={motionState} />
+              </div>
+            )}
+          </div>
+          <div>{children}</div>
         </div>
-        <div>{children}</div>
       </div>
       {getSidebarContent()}
       <Modal


### PR DESCRIPTION
## Description
Fixed opening settings in action sidebar. The problem was that the settings had top: `100% !important`, which helped position it under the header. However, in the case of the action sidebar, the "relative"-fixed value was higher on the wrapper with the header plus action form, so the settings screen was positioned down, under the action form.

Position: relative on the correct div fixed that.

## Testing

* Step 1 Set screen size to mobile
* Step 2 Create a new action to open the action sidebar
* Step 3 Attempt to open the settings menu

<img width="404" alt="image" src="https://github.com/JoinColony/colonyCDapp/assets/15706494/8cdab7ff-6696-4131-9b4f-4ab64768c9b5">


(Resolves | Contributes to) #2548
