### PR TITLE
Fix: prevent app crash on mobile view when viewing a transaction that's ready to be finalized

### DIFF
--- a/src/components/v5/shared/Stepper/Stepper.tsx
+++ b/src/components/v5/shared/Stepper/Stepper.tsx
@@ -195,7 +195,7 @@ function Stepper<TKey extends React.Key>({
           </button>
         )}
       </div>
-      {isMobile && !!openedItem.content && (
+      {isMobile && !!openedItem?.content && (
         <div className="pt-4">{openedItem.content}</div>
       )}
     </>


### PR DESCRIPTION
## Description

![null guard](https://github.com/JoinColony/colonyCDapp/assets/50642296/d88d770a-311e-4c0d-975b-ab4945e51e8a)

## Testing

1. Enable the "Reputation weighted" extension and use the "Testing governance" preset
2. Create a Simple Payment and choose the "Reputation" decision method
3. Support the stake and submit the Max staking amount
4. Run the following commands to forward the time:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"evm_increaseTime","params":[3600],"id":1}' localhost:8545
curl -X POST --data '{"jsonrpc":"2.0","method":"evm_mine","params":[],"id":1}' localhost:8545
```
5. Reload the page
6. Make sure the app doesn't crash

## Diffs

* Just a good ol' optional chaining to make sure we're not extracting a field from an undefined object.

Resolves #2538