### PR TITLE
Fix: Show correct funds amount per team in the total funds widget

### DIFF
--- a/src/utils/currency/currency.ts
+++ b/src/utils/currency/currency.ts
@@ -1,6 +1,6 @@
 import { Tokens } from '@colony/colony-js';
 
-import { ADDRESS_ZERO, DEFAULT_NETWORK_TOKEN } from '~constants';
+import { ADDRESS_ZERO, DEFAULT_NETWORK_TOKEN, isDev } from '~constants';
 import { SupportedCurrencies } from '~gql';
 import { Network } from '~types/network.ts';
 
@@ -65,6 +65,10 @@ export const fetchCurrentPrice = async ({
   chainId = Network.ArbitrumOne,
   conversionDenomination = SupportedCurrencies.Usd,
 }: FetchCurrentPriceArgs): Promise<number | null> => {
+  // It is useful to have a mock price for tokens in our dev environments, this ensures every token price
+  // is equal to 1 unit of your local currency when running the app locally, since calls to coinGecko won't work.
+  if (isDev) return 1;
+
   const savedPrice = getSavedPrice({
     contractAddress,
     chainId,


### PR DESCRIPTION
## Description

- Ensure that the total funds widget on the dashboard updates when the team filter is changed.

## Testing

* Go to the balances page and take note of the balances for all teams, and for a specific team by changing the team filter at the top.
  * For example, here under `all teams`, the total balance is 12.9996M EUR, but under `serenity`, the total balance is 168 EUR.
<img width="1728" alt="Screenshot 2024-06-18 at 16 01 36" src="https://github.com/JoinColony/colonyCDapp/assets/38098203/54bcbf3f-6073-4b3a-b2f6-cb42b8b83492">
<img width="1728" alt="Screenshot 2024-06-18 at 16 01 44" src="https://github.com/JoinColony/colonyCDapp/assets/38098203/e106823c-a422-4fe3-baf6-5d3a6768b9c7">

* Go to the dashboard, and check the total funds widget to ensure that the funds are correct for `all teams` and the team you looked at before.
<img width="1728" alt="Screenshot 2024-06-18 at 16 04 55" src="https://github.com/JoinColony/colonyCDapp/assets/38098203/ca7ea490-7c09-44ab-ab3d-f3ce7849a05a">
<img width="1728" alt="Screenshot 2024-06-18 at 16 05 02" src="https://github.com/JoinColony/colonyCDapp/assets/38098203/a6232a1a-0288-46ba-b8e1-2416c32aecaa">

## Diffs

**New stuff** ✨

* Added a new dev mode mock when the current price of a token is fetched.

**Changes** 🏗

* Fix the total funds widget to take the currently selected domain into account.

Resolves #2503
