### PR TITLE
Fix: show the correct team members count when a team filter is applied on the Dasbhoard

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/Members/Members.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/Members/Members.tsx
@@ -19,10 +19,11 @@ const Members = () => {
     totalMembers: members,
     totalMemberCount,
     loading: membersLoading,
+    filteredMembers,
   } = useMemberContext();
 
   const domainMembers = nativeDomainId
-    ? members.filter(
+    ? filteredMembers.filter(
         ({ roles, reputation }) =>
           roles?.items?.find(
             (role) => role?.domain.nativeId === nativeDomainId,
@@ -39,7 +40,9 @@ const Members = () => {
   }));
 
   // Either all or just filtered by domain
-  const membersCount = !nativeDomainId ? totalMemberCount : allMembers.length;
+  const membersCount = !nativeDomainId
+    ? totalMemberCount
+    : filteredMembers.length;
 
   return (
     <WidgetBox


### PR DESCRIPTION
## Description

![2502](https://github.com/JoinColony/colonyCDapp/assets/50642296/e53deeb7-cb6b-4b64-8f3d-54653d8af6f8)

## Testing

1. Create a new team
2. Go to the Dashboard
3. Filter the view by the team you just made
4. Keep track of the Members count
5. Click on the Members widget
6. Verify that the number of members you see corresponds to the number shown on the Members widget from the Dashboard

## Diffs

**Changes** 🏗

* Updated the members array being used to show the number of members per team on the Dashboard

Resolves #2502