### PR TITLE
Feat: Add `forward-time` script advancing EVM time

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "upgrade-colony-js": "./scripts/upgrade-colony-js.sh",
     "prepare": "if [ -z \"$SKIP_HOOKS\" ]; then import-meta-env-typescript -x .env.example -o src/typedefs; fi",
     "postinstall": "if [ -z \"$SKIP_HOOKS\" ]; then ./scripts/lambda-functions-dependencies.sh && scripts/generate-amplify-local-config.sh; fi",
-    "watch-amplify": "node scripts/watchAmplifyFiles"
+    "watch-amplify": "node scripts/watchAmplifyFiles",
+    "forward-time": "node scripts/forward-time"
   },
   "repository": {
     "type": "git",

--- a/scripts/forward-time.js
+++ b/scripts/forward-time.js
@@ -1,0 +1,59 @@
+/**
+ * Script forwarding the local blockchain time by a given number of hours
+ */
+const fetch = require('node-fetch');
+
+const args = process.argv.slice(2);
+if (args.length !== 1) {
+  console.error('Usage: npm run forward-time -- <hours>');
+  process.exit(1);
+}
+
+const hours = parseFloat(args[0]);
+if (isNaN(hours) || hours <= 0) {
+  console.error('Please provide a valid number of hours.');
+  process.exit(1);
+}
+
+const seconds = hours * 60 * 60;
+
+const forwardTime = async () => {
+  try {
+    let response = await fetch('http://localhost:8545', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'evm_increaseTime',
+        params: [seconds],
+        id: 1,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error('Request failed');
+    }
+
+    response = await fetch('http://localhost:8545', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'evm_mine',
+        params: [],
+        id: 1,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error('Request failed');
+    }
+
+    console.log(`Forwarded block time by ${seconds} seconds`);
+  } catch (e) {
+    console.error('Error forwarding time: ', e);
+    process.exit(1);
+  }
+};
+
+forwardTime();


### PR DESCRIPTION
## Description

This is a cherry-pick of a commit from #2513 as I want to make it available before it gets merged. 

The days of manually copying curls from https://www.notion.so/colony/Time-in-development-f1283a43c09e46bb97f15accd438069b and adjusting the params (pity if you pasted into console before doing so!) are finally gone, as now you can simply run:

```
npm run forward-time -- <number_of_hours>
```

Which will do all the "heavy" lifting for you. 

On a side note, I really don't like the `--` bit but it's necessary when you run a script using npm run.

**Note:** as @rdig mentioned, advancing time when reputation monitor is on will not work properly, and similarly any time-bound features such as staking won't function, so please make sure to disable it before adjusting time manually.

## Testing

Navigate to some time-sensitive feature, e.g. motion staking. Run the script and it should advance the time as expected.
