### PR TITLE
Fix Local Dev Env Docker NPM Flakiness 

### DIFF
--- a/docker/colony-cdapp-dev-env-base
+++ b/docker/colony-cdapp-dev-env-base
@@ -91,4 +91,6 @@ RUN pip install pipenv
 # This counteracts the fact that you need a GH account in order to use ssh keys
 RUN git config --global url."https://github".insteadOf ssh://git@github
 
+RUN npm install -g npm@10.8
+
 WORKDIR /colonyCDapp


### PR DESCRIPTION
For a while now, we've been plagued by our docker builds failing at the `npm ci` step intermittently 

https://discord.com/channels/@me/1184783345406705766/1250770038194180167
https://discord.com/channels/@me/1184783345406705766/1251124500792213615
https://discord.com/channels/@me/1184783345406705766/1252368133046665271

Some of us just brute forced our way through, by re-running the build until it succeeded, others used VPN while building _(which strangely helped)_, and for others, like me, this would actually saturate my load balancer and kill my network

![Screenshot from 2024-06-19 00-28-06](https://github.com/JoinColony/colonyCDapp/assets/1193222/e88514f9-0624-4cb3-a1d5-0dc352bfe733)

The issue _seems_ to be related to an old version of `npm` that we were running inside the docker images, so the obvious solution here was to just update it to the latest version.

Current latest is `10.8.1`, and while I want the latest, I also don't want it changing drastically in the background and ending up in a month or two with the environment broken again. To retain some control, I've fixed in place the `MAJOR` and the `MINOR` version, while letting the `PATCH` be upgraded freely whenever new releases get pushed out.

I can't 100% promise this will work, as the issues were themselves pretty spotty, affecting just some of us, but from the preliminary reports, everything seems to be "back to normal" with the updated `npm` version.

Do note that the change was applied to the `base` docker image, since all others inherit from it.

### Testing 

Testing isn't really a thing here, as most of us experienced this through our work day.

However, if you do want to be thorough:
- discard the changes in this PR !!! _(basically checkout a clean `master`)_
- stop your dev environment
- Remove all the `exited` containers: `docker rm $(docker ps -qa --no-trunc --filter "status=exited")` _(which in this case will be the various docker images that make up our dev environment)_
- Remove all the CDapp dev env images: `docker rmi --force $(docker images | grep colony)`
- Re-run / re-build your images and dev environment: `npm run dev`

Chances are that you'll run into a similar `npm ci` failure either in the `block-ingestor` image or in the `amplify` one

![image](https://github.com/JoinColony/colonyCDapp/assets/1193222/962109cc-9beb-4ccd-8192-4c30f0b7be76)
![image-2](https://github.com/JoinColony/colonyCDapp/assets/1193222/70b482fe-2e04-4d5a-9f9e-bee409426cd8)
![image-3](https://github.com/JoinColony/colonyCDapp/assets/1193222/ff00de11-e1e1-4676-985a-b964dddaab47)

Now, do the exact same thing in reverse, to confirm the fix is actually working:
- checkout this branch, basically applying the fix
- stop the dev environment
- Remove all the `exited` containers: `docker rm $(docker ps -qa --no-trunc --filter "status=exited")`
- Remove all the CDapp dev env images: `docker rmi --force $(docker images | grep colony)`
- Rebuild everything: `npm run dev`

You should now have clean build from start to finish, with no connection errors being thrown in either image