### PR TITLE
Fix: update action input fields placeholders

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/ManageReputationTable.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/ManageReputationTable.tsx
@@ -85,7 +85,7 @@ const ManageReputationTable: FC = () => {
           'bg-transparent placeholder:text-gray-300': isChangeFieldDisabled,
           'placeholder:text-gray-400': !isChangeFieldDisabled && !error,
         })}
-        placeholder="0"
+        placeholder={formatText({ id: 'actionSidebar.enterValue' })}
         value={value}
         autoComplete="off"
         onChange={handleFieldChange}

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/hooks.tsx
@@ -71,7 +71,7 @@ export const useRecipientsFieldTableColumns = (
               name={`${name}.${row.index}.amount`}
               tokenAddressFieldName={`${name}.${row.index}.tokenAddress`}
               domainId={selectedTeam}
-              placeholder="0"
+              placeholder={formatText({ id: 'actionSidebar.enterAmount' })}
             />
           ),
           footer: hasMoreThanOneToken
@@ -92,7 +92,7 @@ export const useRecipientsFieldTableColumns = (
           cell: ({ row }) => (
             <FormInputBase
               message={false}
-              placeholder="0"
+              placeholder={formatText({ id: 'actionSidebar.enterValue' })}
               autoWidth
               inputWrapperClassName="flex-row flex items-center gap-2"
               min={0}

--- a/src/components/v5/common/Fields/InputBase/hooks.ts
+++ b/src/components/v5/common/Fields/InputBase/hooks.ts
@@ -26,7 +26,7 @@ export const useAdjustInputWidth = (
 
     const input = inputRef.current;
     const changeHandler = () => {
-      input.style.width = `${getInputTextWidth(input)}px`;
+      input.style.width = `${getInputTextWidth(input, { usePlaceholderAsFallback: true })}px`;
     };
 
     input.addEventListener('input', changeHandler);

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1128,6 +1128,7 @@
     "actionSidebar.selectTeamColor": "Select team colour",
     "actionSidebar.selectMember": "Select member",
     "actionSidebar.enterAmount": "Enter amount",
+    "actionSidebar.enterValue": "Enter value",
     "actionSidebar.addressError": "Address error",
     "actionSidebar.addressErrorTooltip": "The address is not valid. \n \n Click to manually select the user.",
     "actionSidebar.tokenError": "Token error",


### PR DESCRIPTION
## Description

Update payment builder action input placeholder values 
Update manage reputation action input placeholder value 
Use usePlaceholderAsFallback flag for InputBase width 
Add translations

## Testing

* Step 1. Create Payment builder/Advanced Payment action
* Step 2. Check the placeholder for the Amount field is 'Enter amount'
* Step 3. Check the placeholder for the Claim delay field is 'Enter value'
* Step 4. Create Manage Reputation action
* Step 5. Check the placeholder for the Change field is 'Enter value'


Resolves #2507
