### PR TITLE
Fix: update permissions upon member field change

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx
@@ -10,6 +10,7 @@ import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
 import { FormCardSelect } from '~v5/common/Fields/CardSelect/index.ts';
 
+import { DECISION_METHOD_FIELD_NAME } from '../../consts.ts';
 import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
 
 import {
@@ -65,7 +66,7 @@ const DecisionMethodField = ({
   return (
     <ActionFormRow
       icon={Scales}
-      fieldName="decisionMethod"
+      fieldName={DECISION_METHOD_FIELD_NAME}
       tooltips={{
         label: {
           tooltipContent: formatText({
@@ -77,7 +78,7 @@ const DecisionMethodField = ({
       isDisabled={disabled || hasNoDecisionMethods}
     >
       <FormCardSelect
-        name="decisionMethod"
+        name={DECISION_METHOD_FIELD_NAME}
         options={getDecisionMethods()}
         title={formatText({ id: 'actionSidebar.availableDecisions' })}
         placeholder={formatText({

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/ManagePermissionsForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/ManagePermissionsForm.tsx
@@ -25,7 +25,11 @@ import Description from '../../Description/index.ts';
 import TeamsSelect from '../../TeamsSelect/index.ts';
 import UserSelect from '../../UserSelect/index.ts';
 
-import { AuthorityOptions, RemoveRoleOptionValue } from './consts.ts';
+import {
+  AuthorityOptions,
+  FIELD_NAME,
+  RemoveRoleOptionValue,
+} from './consts.ts';
 import { useManagePermissions } from './hooks.ts';
 import PermissionsModal from './partials/PermissionsModal/index.ts';
 import PermissionsTable from './partials/PermissionsTable/index.ts';
@@ -88,7 +92,7 @@ const ManagePermissionsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       />
       <ActionFormRow
         icon={UserFocus}
-        fieldName="member"
+        fieldName={FIELD_NAME.MEMBER}
         tooltips={{
           label: {
             tooltipContent: formatText({
@@ -99,11 +103,11 @@ const ManagePermissionsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
         title={formatText({ id: 'actionSidebar.member' })}
         isDisabled={hasNoDecisionMethods}
       >
-        <UserSelect name="member" disabled={hasNoDecisionMethods} />
+        <UserSelect name={FIELD_NAME.MEMBER} disabled={hasNoDecisionMethods} />
       </ActionFormRow>
       <ActionFormRow
         icon={UsersThree}
-        fieldName="team"
+        fieldName={FIELD_NAME.TEAM}
         tooltips={{
           label: {
             tooltipContent: formatText({
@@ -114,11 +118,11 @@ const ManagePermissionsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
         title={formatText({ id: 'actionSidebar.managePermissions.team' })}
         isDisabled={hasNoDecisionMethods}
       >
-        <TeamsSelect name="team" disabled={hasNoDecisionMethods} />
+        <TeamsSelect name={FIELD_NAME.TEAM} disabled={hasNoDecisionMethods} />
       </ActionFormRow>
       <ActionFormRow
         icon={Shield}
-        fieldName="role"
+        fieldName={FIELD_NAME.ROLE}
         tooltips={{
           label: {
             tooltipContent: formatText({
@@ -130,7 +134,7 @@ const ManagePermissionsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
         isDisabled={hasNoDecisionMethods}
       >
         <FormCardSelect
-          name="role"
+          name={FIELD_NAME.ROLE}
           cardClassName="max-w-[calc(100vw-2.5rem)] md:max-w-sm md:px-4 md:[&_.section-title]:px-2"
           renderSelectedValue={(option, placeholder) =>
             getRoleLabel(option?.value) || placeholder
@@ -147,7 +151,7 @@ const ManagePermissionsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       </ActionFormRow>
       <ActionFormRow
         icon={Signature}
-        fieldName="authority"
+        fieldName={FIELD_NAME.AUTHORITY}
         tooltips={{
           label: {
             tooltipContent: formatText({
@@ -174,7 +178,7 @@ const ManagePermissionsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       >
         <FormCardSelect
           disabled={isModeRoleSelected || hasNoDecisionMethods}
-          name="authority"
+          name={FIELD_NAME.AUTHORITY}
           options={AuthorityOptions}
           title={formatText({
             id: 'actionSidebar.managePermissions.authoritySelect.title',
@@ -188,7 +192,11 @@ const ManagePermissionsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       <CreatedIn filterOptionsFn={createdInFilterFn} />
       <Description />
       {role !== RemoveRoleOptionValue.remove && (
-        <PermissionsTable name="permissions" role={role} className="mt-7" />
+        <PermissionsTable
+          name={FIELD_NAME.PERMISSIONS}
+          role={role}
+          className="mt-7"
+        />
       )}
     </>
   );

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/ManagePermissionsForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/ManagePermissionsForm.tsx
@@ -136,8 +136,8 @@ const ManagePermissionsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
         <FormCardSelect
           name={FIELD_NAME.ROLE}
           cardClassName="max-w-[calc(100vw-2.5rem)] md:max-w-sm md:px-4 md:[&_.section-title]:px-2"
-          renderSelectedValue={(option, placeholder) =>
-            getRoleLabel(option?.value) || placeholder
+          renderSelectedValue={(_, placeholder) =>
+            getRoleLabel(role) || placeholder
           }
           options={ALLOWED_PERMISSION_OPTIONS}
           title={formatText({ id: 'actionSidebar.permissions' })}

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/consts.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/consts.ts
@@ -3,7 +3,10 @@ import { type InferType, mixed, object, string, number } from 'yup';
 
 import { CUSTOM_USER_ROLE } from '~constants/permissions.ts';
 import { formatText } from '~utils/intl.ts';
-import { ACTION_BASE_VALIDATION_SCHEMA } from '~v5/common/ActionSidebar/consts.ts';
+import {
+  ACTION_BASE_VALIDATION_SCHEMA,
+  DECISION_METHOD_FIELD_NAME,
+} from '~v5/common/ActionSidebar/consts.ts';
 import { type CardSelectOption } from '~v5/common/Fields/CardSelect/types.ts';
 
 export const FIELD_NAME = {
@@ -13,17 +16,21 @@ export const FIELD_NAME = {
   ROLE: 'role',
   AUTHORITY: 'authority',
   PERMISSIONS: 'permissions',
-  DECISION_METHOD: 'decisionMethod',
+  DECISION_METHOD: DECISION_METHOD_FIELD_NAME,
 } as const;
+
+type PermissionRole = `role_${(typeof AVAILABLE_ROLES)[number]}`;
 
 export const validationSchema = object()
   .shape({
-    member: string().required(),
-    team: number().required(),
-    createdIn: number().required(),
-    role: string().required(),
-    authority: string().required(),
-    permissions: mixed<Partial<Record<string, boolean>>>().test(
+    [FIELD_NAME.MEMBER]: string().required(),
+    [FIELD_NAME.TEAM]: number().required(),
+    [FIELD_NAME.CREATED_IN]: number().required(),
+    [FIELD_NAME.ROLE]: string().required(),
+    [FIELD_NAME.AUTHORITY]: string().required(),
+    [FIELD_NAME.PERMISSIONS]: mixed<
+      Partial<Record<PermissionRole, boolean>>
+    >().test(
       'permissions',
       'You have to select at least one permission.',
       (value, { parent }) => {
@@ -34,7 +41,7 @@ export const validationSchema = object()
         return Object.values(value || {}).some(Boolean);
       },
     ),
-    decisionMethod: string().defined(),
+    [FIELD_NAME.DECISION_METHOD]: string().defined(),
   })
   .defined()
   .concat(ACTION_BASE_VALIDATION_SCHEMA);

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/consts.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/consts.ts
@@ -6,6 +6,16 @@ import { formatText } from '~utils/intl.ts';
 import { ACTION_BASE_VALIDATION_SCHEMA } from '~v5/common/ActionSidebar/consts.ts';
 import { type CardSelectOption } from '~v5/common/Fields/CardSelect/types.ts';
 
+export const FIELD_NAME = {
+  MEMBER: 'member',
+  TEAM: 'team',
+  CREATED_IN: 'createdIn',
+  ROLE: 'role',
+  AUTHORITY: 'authority',
+  PERMISSIONS: 'permissions',
+  DECISION_METHOD: 'decisionMethod',
+} as const;
+
 export const validationSchema = object()
   .shape({
     member: string().required(),

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/hooks.ts
@@ -72,6 +72,7 @@ export const useManagePermissions = (
 
       setValue(FIELD_NAME.ROLE, roleValue, {
         shouldValidate: !!roleValue || (isSubmitted && !isValid),
+        shouldDirty: true,
       });
 
       if (userRole.role !== UserRole.Custom) {

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/hooks.ts
@@ -12,7 +12,6 @@ import { getUserRolesForDomain } from '~transformers/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { mapPayload, pipe } from '~utils/actions.ts';
 import { notMaybe } from '~utils/arrays/index.ts';
-import { DECISION_METHOD_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 
 import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
 import { type ActionFormBaseProps } from '../../../types.ts';
@@ -23,6 +22,7 @@ import {
   type ManagePermissionsFormValues,
   type RemoveRoleOptionValue,
   validationSchema,
+  FIELD_NAME,
 } from './consts.ts';
 import { getManagePermissionsPayload } from './utils.ts';
 
@@ -30,7 +30,7 @@ export const useManagePermissions = (
   getFormOptions: ActionFormBaseProps['getFormOptions'],
 ) => {
   const decisionMethod: DecisionMethod | undefined = useWatch({
-    name: DECISION_METHOD_FIELD_NAME,
+    name: FIELD_NAME.DECISION_METHOD,
   });
   const { setValue, watch } =
     useFormContext<Partial<ManagePermissionsFormValues>>();
@@ -38,13 +38,13 @@ export const useManagePermissions = (
   const { user } = useAppContext();
   const navigate = useNavigate();
   const role: UserRole | RemoveRoleOptionValue | undefined = useWatch({
-    name: 'role',
+    name: FIELD_NAME.ROLE,
   });
   const isModeRoleSelected = role === UserRole.Mod;
 
   useEffect(() => {
     if (isModeRoleSelected) {
-      setValue('authority', Authority.Own);
+      setValue(FIELD_NAME.AUTHORITY, Authority.Own);
     }
   }, [isModeRoleSelected, setValue]);
 
@@ -52,7 +52,7 @@ export const useManagePermissions = (
     const { unsubscribe } = watch(({ member, team }, { name }) => {
       if (
         !name ||
-        !['team', 'member'].includes(name) ||
+        name !== FIELD_NAME.TEAM ||
         !notMaybe(team) ||
         !notMaybe(member)
       ) {
@@ -66,7 +66,10 @@ export const useManagePermissions = (
       });
       const userRole = getRole(userPermissions);
 
-      setValue('role', userRole.permissions.length ? userRole.role : undefined);
+      setValue(
+        FIELD_NAME.ROLE,
+        userRole.permissions.length ? userRole.role : undefined,
+      );
 
       if (userRole.role !== UserRole.Custom) {
         return;

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/partials/PermissionsTable/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/partials/PermissionsTable/hooks.tsx
@@ -13,7 +13,7 @@ const customPermissionsColumnHelper =
 export const useCustomPermissionsTableColumns = (name: string) => {
   const isMobile = useMobile();
 
-  return useMemo(
+  const memoizedTableColumns = useMemo(
     () => [
       customPermissionsColumnHelper.accessor('type', {
         staticSize: isMobile ? '6.125rem' : '8.25rem',
@@ -52,15 +52,19 @@ export const useCustomPermissionsTableColumns = (name: string) => {
           <span className="text-md text-gray-600">{getValue()}</span>
         ),
       }),
-      customPermissionsColumnHelper.display({
-        staticSize: '4.375rem',
-        id: 'enabled',
-        header: formatText({ id: 'table.column.enable' }),
-        cell: ({ row }) => (
-          <FormSwitch name={`${name}.role_${row.original.name}`} />
-        ),
-      }),
     ],
     [isMobile, name],
   );
+
+  return [
+    ...memoizedTableColumns,
+    customPermissionsColumnHelper.display({
+      staticSize: '4.375rem',
+      id: 'enabled',
+      header: formatText({ id: 'table.column.enable' }),
+      cell: ({ row }) => (
+        <FormSwitch name={`${name}.role_${row.original.name}`} />
+      ),
+    }),
+  ];
 };

--- a/src/components/v5/common/Fields/CardSelect/FormCardSelect.tsx
+++ b/src/components/v5/common/Fields/CardSelect/FormCardSelect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useController } from 'react-hook-form';
+import { useController, useWatch } from 'react-hook-form';
 
 import { useAdditionalFormOptionsContext } from '~context/AdditionalFormOptionsContext/AdditionalFormOptionsContext.ts';
 
@@ -17,17 +17,18 @@ function FormCardSelect<TValue = string>({
 }: FormCardSelectProps<TValue>): JSX.Element {
   const { readonly } = useAdditionalFormOptionsContext();
   const {
-    field: { onChange: onFieldChange, value },
+    field: { onChange: onFieldChange },
     fieldState: { invalid, error },
   } = useController({
     name,
   });
+  const watchedValue = useWatch({ name });
 
   return (
     <CardSelect<TValue>
       {...rest}
       readonly={readonly}
-      value={value}
+      value={watchedValue}
       onChange={(onChangeValue) => {
         onChange?.(onChangeValue);
         onFieldChange(onChangeValue);


### PR DESCRIPTION
## Description

- Update permissions upon member field change in Manage Permissions action

## Testing

TODO: Check permissions are updated when changing the member in the Manage Permissions action

* Step 1. Create a Manage Permissions action
* Step 2. Select a member
* Step 3. Select permissions
* Step 4. Select another member
* Step 5.1. Check permissions are reset if user has no permissions already set
* Step 5.2. Check permissions are set based on existing user permissions
* Step 6. Check you can continue to next step without getting an error message for the permissions field if it's already filled

Resolves #2547
