### PR TITLE
fix: Update members pages tabbed menu padding

### DIFF
--- a/src/components/frame/v5/pages/MembersPage/partials/MembersTabContent/MembersTabContentWrapper.tsx
+++ b/src/components/frame/v5/pages/MembersPage/partials/MembersTabContent/MembersTabContentWrapper.tsx
@@ -18,7 +18,7 @@ const MembersTabContentWrapper: FC<
   );
 
   return (
-    <div className="pt-2">
+    <div className="pt-6">
       <div
         className={clsx('mb-6 flex w-full flex-col', {
           'gap-4 sm:gap-1': additionalActions,


### PR DESCRIPTION
## Description
Fixed padding for members tabbed menu.

## Testing
| Before | After |
| ---- | ---- |
| <img width="600" alt="image" src="https://github.com/JoinColony/colonyCDapp/assets/15706494/cc760500-0dd4-4a44-951c-fd2f379a041e"> | <img width="600" alt="image" src="https://github.com/JoinColony/colonyCDapp/assets/15706494/51f427a8-8872-40a6-ba0b-b40a6a8d3387"> | 



(Resolves | Contributes to) #2504