### PR TITLE
Fix: Keep z-index for mobile navigation sidebar regardless of open state

### DIFF
--- a/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarMobileContentWrapper/NavigationSidebarMobileContentWrapper.tsx
+++ b/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarMobileContentWrapper/NavigationSidebarMobileContentWrapper.tsx
@@ -26,14 +26,12 @@ const NavigationSidebarMobileContentWrapper: FC<
         left-0
         right-0
         top-full
+        z-base
         h-[calc(100vh-var(--top-content-height))]
         w-full
         overflow-hidden
         bg-base-white
       `,
-      {
-        'z-base': isOpen,
-      },
     )}
   >
     <div className="inner flex h-full flex-col gap-6 !p-6">


### PR DESCRIPTION
## Description

Keep z-index for NavigationSidebarMobileContentWrapper component regardless of open state
The navigation sidebar was getting behind the other elements on the page upon closing, causing it to appear as if it was losing it's background color.

## Testing

* Step 1. Adjust viewport to mobile
* Step 2. Open navigation sidebar
* Step 3. Close navigation sidebar 
* Step 4. Check styling

Resolves [#2539](https://github.com/JoinColony/colonyCDapp/issues/2539)
