### PR TITLE
fix: UserHub Missing transaction text and should not be clickable for claimFunds transaction

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransaction.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransaction.tsx
@@ -36,6 +36,7 @@ const GROUP_KEYS_WHICH_CANNOT_LINK = [
   TRANSACTION_METHODS.FinalizeMotion,
   TRANSACTION_METHODS.EscalateMotion,
   TRANSACTION_METHODS.EnableExtension,
+  TRANSACTION_METHODS.ClaimColonyFunds,
 ];
 
 const GroupedTransaction: FC<GroupedTransactionProps> = ({

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -511,6 +511,8 @@
     "metatransaction.ColonyClient.upgrade.description": "Colony Version Upgrade",
     "metatransaction.group.upgrade.title": "Colony Version Upgrade",
     "metatransaction.group.upgrade.description": "Colony Version Upgrade",
+    "metatransaction.group.claimColonyFunds.title": "Claim Pending Transactions",
+    "metatransaction.group.claimColonyFunds.description": "Claim Pending Transactions",
     "metatransaction.ColonyClient.claimColonyFunds.title": "Claim Pending Transactions",
     "metatransaction.ColonyClient.claimColonyFunds.description": "Claim Pending Transactions",
     "metatransaction.ColonyClient.moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address).title": "Move Funds Between Pots",


### PR DESCRIPTION
## Description
- Fixed: missing title for claim funds if it was a meta transaction
- Fixed: no links for claim funds transactions 

## Testing
1. Create two colonies.
2. Ensure you have MetaTransactions enabled. (this will likely require some trickery with local dev)
3. Transfer funds from one colony to another.
4. Go to the Incoming funds page.
5. Claim the incoming funds.
6. Check the Transactions tab in the UserHub.
7. Notice that the translation is missing for the claim incoming funds transaction when using MetaTransactions.

| Before | After |
| ---- | ---- |
| ![image](https://github.com/JoinColony/colonyCDapp/assets/15706494/5a8d537e-808f-46d8-8033-f8d2a81b7786) | <img width="466" alt="image" src="https://github.com/JoinColony/colonyCDapp/assets/15706494/6dcc7feb-fb83-4555-89be-3b0e9484ca87"> |

8. Click on the "Claim pending transaction" title
Before: redirect to http://localhost:9091/wayne/incoming?tx=0xa1ee3ad572afdabcf6f849f9c8808659f69b006dcc2aa44f1b107e5982df937f
Now: nothing has happened

Resolves #2508 