### PR TITLE
fix: Select member incorrect tooltip on actions

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
@@ -89,8 +89,6 @@ const UserSelect: FC<UserSelectProps> = ({
 
   const userName = getUserName();
   const isUserAddressValid = isAddress(field.value);
-  const isUserAddressInvalid =
-    !isUserAddressValid && (selectedUser || field.value);
 
   const toggler = (
     <button
@@ -159,13 +157,9 @@ const UserSelect: FC<UserSelectProps> = ({
 
   const selectedUserContent = (
     <>
-      {tooltipContent || isUserAddressInvalid ? (
+      {tooltipContent ? (
         <Tooltip
-          tooltipContent={
-            isUserAddressInvalid
-              ? formatText({ id: 'actionSidebar.addressErrorTooltip' })
-              : tooltipContent
-          }
+          tooltipContent={tooltipContent}
           placement="top"
           // selectTriggerRef={(triggerRef) => {
           //   if (!triggerRef) {

--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
@@ -89,6 +89,8 @@ const UserSelect: FC<UserSelectProps> = ({
 
   const userName = getUserName();
   const isUserAddressValid = isAddress(field.value);
+  const isUserAddressInvalid =
+    !isUserAddressValid && (selectedUser || field.value);
 
   const toggler = (
     <button
@@ -157,12 +159,12 @@ const UserSelect: FC<UserSelectProps> = ({
 
   const selectedUserContent = (
     <>
-      {tooltipContent || !isUserAddressValid ? (
+      {tooltipContent || isUserAddressInvalid ? (
         <Tooltip
           tooltipContent={
-            isUserAddressValid
-              ? tooltipContent
-              : formatText({ id: 'actionSidebar.addressErrorTooltip' })
+            isUserAddressInvalid
+              ? formatText({ id: 'actionSidebar.addressErrorTooltip' })
+              : tooltipContent
           }
           // selectTriggerRef={(triggerRef) => {
           //   if (!triggerRef) {
@@ -171,8 +173,8 @@ const UserSelect: FC<UserSelectProps> = ({
 
           //   return triggerRef.querySelector(`.${LABEL_CLASSNAME}`);
           // }}
-          trigger={!isUserAddressValid ? 'hover' : undefined}
-          placement={isUserAddressValid ? 'top' : 'bottom'}
+          trigger={isUserAddressInvalid ? 'hover' : undefined}
+          placement={isUserAddressInvalid ? 'bottom' : 'top'}
         >
           {toggler}
         </Tooltip>

--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
@@ -166,6 +166,7 @@ const UserSelect: FC<UserSelectProps> = ({
               ? formatText({ id: 'actionSidebar.addressErrorTooltip' })
               : tooltipContent
           }
+          placement="top"
           // selectTriggerRef={(triggerRef) => {
           //   if (!triggerRef) {
           //     return null;
@@ -173,8 +174,6 @@ const UserSelect: FC<UserSelectProps> = ({
 
           //   return triggerRef.querySelector(`.${LABEL_CLASSNAME}`);
           // }}
-          trigger={isUserAddressInvalid ? 'hover' : undefined}
-          placement={isUserAddressInvalid ? 'bottom' : 'top'}
         >
           {toggler}
         </Tooltip>

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/UserSelectRow.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/UserSelectRow.tsx
@@ -1,22 +1,27 @@
+import { type Row } from '@tanstack/react-table';
 import { isAddress } from 'ethers/lib/utils';
-import React from 'react';
+import React, { type FC } from 'react';
 import { useController } from 'react-hook-form';
 
 import { formatText } from '~utils/intl.ts';
 import UserSelect from '~v5/common/ActionSidebar/partials/UserSelect/index.ts';
 
-export const UserSelectRow = ({ row, name }: any) => {
-  const userSelectName = `${name}.${row.index}.recipient`;
+import { type PaymentBuilderRecipientsTableModel } from './types.ts';
 
+interface UserSelectRowProps {
+  name: string;
+  row: Row<PaymentBuilderRecipientsTableModel>;
+}
+export const UserSelectRow: FC<UserSelectRowProps> = ({ row, name }) => {
   const { field } = useController({
-    name: userSelectName,
+    name,
   });
 
   const isUserAddressValid = isAddress(field.value);
   return (
     <div key={row.id}>
       <UserSelect
-        name={userSelectName}
+        name={name}
         tooltipContent={
           !isUserAddressValid &&
           formatText({ id: 'actionSidebar.addressErrorTooltip' })

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/UserSelectRow.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/UserSelectRow.tsx
@@ -1,0 +1,27 @@
+import { isAddress } from 'ethers/lib/utils';
+import React from 'react';
+import { useController } from 'react-hook-form';
+
+import { formatText } from '~utils/intl.ts';
+import UserSelect from '~v5/common/ActionSidebar/partials/UserSelect/index.ts';
+
+export const UserSelectRow = ({ row, name }: any) => {
+  const userSelectName = `${name}.${row.index}.recipient`;
+
+  const { field } = useController({
+    name: userSelectName,
+  });
+
+  const isUserAddressValid = isAddress(field.value);
+  return (
+    <div key={row.id}>
+      <UserSelect
+        name={userSelectName}
+        tooltipContent={
+          !isUserAddressValid &&
+          formatText({ id: 'actionSidebar.addressErrorTooltip' })
+        }
+      />
+    </div>
+  );
+};

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/hooks.tsx
@@ -6,7 +6,6 @@ import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useWrapWithRef from '~hooks/useWrapWithRef.ts';
 import { formatText } from '~utils/intl.ts';
 import AmountField from '~v5/common/ActionSidebar/partials/AmountField/index.ts';
-import UserSelect from '~v5/common/ActionSidebar/partials/UserSelect/index.ts';
 import FormInputBase from '~v5/common/Fields/InputBase/FormInputBase.tsx';
 
 import PaymentBuilderPayoutsTotal from '../PaymentBuilderPayoutsTotal/index.ts';
@@ -15,6 +14,7 @@ import {
   type PaymentBuilderRecipientsFieldModel,
   type PaymentBuilderRecipientsTableModel,
 } from './types.ts';
+import { UserSelectRow } from './UserSelectRow.tsx';
 
 export const useRecipientsFieldTableColumns = (
   name: string,
@@ -44,11 +44,7 @@ export const useRecipientsFieldTableColumns = (
         columnHelper.display({
           id: 'recipient',
           header: () => formatText({ id: 'table.row.recipient' }),
-          cell: ({ row }) => (
-            <div key={row.id}>
-              <UserSelect name={`${name}.${row.index}.recipient`} />
-            </div>
-          ),
+          cell: ({ row }) => <UserSelectRow row={row} name={name} />,
           footer: hasMoreThanOneToken
             ? () => (
                 <span className="flex min-h-[1.875rem] items-center text-xs text-gray-400">

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/hooks.tsx
@@ -44,7 +44,9 @@ export const useRecipientsFieldTableColumns = (
         columnHelper.display({
           id: 'recipient',
           header: () => formatText({ id: 'table.row.recipient' }),
-          cell: ({ row }) => <UserSelectRow row={row} name={name} />,
+          cell: ({ row }) => (
+            <UserSelectRow row={row} name={`${name}.${row.index}.recipient`} />
+          ),
           footer: hasMoreThanOneToken
             ? () => (
                 <span className="flex min-h-[1.875rem] items-center text-xs text-gray-400">

--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -104,12 +104,7 @@ const Table = <T,>({
   const shouldShowEmptyContent = emptyContent && data.length === 0;
 
   return (
-    <div
-      className={clsx(
-        className,
-        'overflow-hidden rounded-lg border border-gray-200',
-      )}
-    >
+    <div className={className}>
       <table
         className={`
           h-px
@@ -117,6 +112,9 @@ const Table = <T,>({
           table-fixed
           border-separate
           border-spacing-0
+          rounded-lg
+          border
+          border-gray-200
         `}
         cellPadding="0"
         cellSpacing="0"
@@ -160,6 +158,8 @@ const Table = <T,>({
                             text-left
                             text-sm
                             font-normal
+                            first:rounded-tl-lg
+                            last:rounded-tr-lg
                           `}
                           style={{
                             width:
@@ -231,7 +231,7 @@ const Table = <T,>({
                       key={header.id}
                       className={clsx(
                         header.column.columnDef.headCellClassName,
-                        'border-b border-b-gray-200 bg-gray-50 px-[1.125rem] py-2.5 text-left text-sm font-normal text-gray-600 empty:p-0',
+                        'border-b border-b-gray-200 bg-gray-50 px-[1.125rem] py-2.5 text-left text-sm font-normal text-gray-600 first:rounded-tl-lg last:rounded-tr-lg empty:p-0',
                         {
                           'cursor-pointer':
                             header.column.getCanSort() &&


### PR DESCRIPTION
## Description
Fix: Select member incorrect tooltip on actions

## Testing
1. Open any action type that has a select member input field
2. Hover over the placeholder
3. The tooltip will NOT show

<img width="516" alt="image" src="https://github.com/JoinColony/colonyCDapp/assets/15706494/fbfba1cd-41bc-4a7b-a226-c19e66268533">


4. The tooltip will show only for error state

<img width="369" alt="image" src="https://github.com/JoinColony/colonyCDapp/assets/15706494/124f8422-1c32-4c92-b07a-50457363eeaa">


Resolves #2514 