### PR TITLE
Fix/15955924 funding step

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
@@ -103,6 +103,14 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
     };
   }
 
+  let title = 'motion.finalizeStep.title';
+
+  if (isMotionClaimable) {
+    title = 'motion.finalizeStep.claimable.statusText';
+  } else if (isMotionFailedNotFinalizable) {
+    title = 'motion.finalizeStep.failed.statusText';
+  }
+
   /*
    * @NOTE This is just needed until we properly save motion data in the db
    * For now, we just fetch it live from chain, so when we uninstall the extension
@@ -115,9 +123,7 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
       statusTextSectionProps={{
         status: StatusTypes.Info,
         children: formatText({
-          id: isMotionFailedNotFinalizable
-            ? 'motion.finalizeStep.failed.statusText'
-            : 'motion.finalizeStep.statusText',
+          id: title,
         }),
         textClassName: 'text-4',
         iconAlignment: 'top',

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/PaymentBuilderWidget.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/PaymentBuilderWidget.tsx
@@ -217,7 +217,8 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
   useEffect(() => {
     if (
       !hasEveryMotionEnded &&
-      motionState === MotionState.FailedNotFinalizable
+      (motionState === MotionState.FailedNotFinalizable ||
+        motionState === MotionState.Invalid)
     ) {
       setSelectedTransaction(fundingMotions?.[0]?.transactionHash);
     }
@@ -227,6 +228,10 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
     motionState,
     setSelectedTransaction,
   ]);
+
+  useEffect(() => {
+    setSelectedTransaction(fundingMotions?.[0]?.transactionHash);
+  }, [fundingMotions, fundingMotions.length, setSelectedTransaction]);
 
   const items: StepperItem<ExpenditureStep>[] = [
     {
@@ -311,7 +316,7 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
           !isFundingMotionFailed &&
           motionStakes ? (
             <MotionCountDownTimer
-              key={motionAction?.transactionHash}
+              key={`${motionAction?.transactionHash}-${motionState}-${motionId}}`}
               motionState={motionState}
               motionId={motionId}
               motionStakes={motionStakes}

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/PaymentBuilderWidget.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/PaymentBuilderWidget.tsx
@@ -10,6 +10,7 @@ import { ActionTypes } from '~redux';
 import { type LockExpenditurePayload } from '~redux/sagas/expenditures/lockExpenditure.ts';
 import SpinnerLoader from '~shared/Preloaders/SpinnerLoader.tsx';
 import { notNull } from '~utils/arrays/index.ts';
+import { MotionState } from '~utils/colonyMotions.ts';
 import { formatText } from '~utils/intl.ts';
 import { getSafePollingInterval } from '~utils/queries.ts';
 import useGetColonyAction from '~v5/common/ActionSidebar/hooks/useGetColonyAction.ts';
@@ -102,12 +103,16 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
     }
   }, [expectedStepKey, expenditureStep]);
 
-  const lockExpenditurePayload: LockExpenditurePayload | null = expenditure
-    ? {
-        colonyAddress: colony.colonyAddress,
-        nativeExpenditureId: expenditure.nativeId,
-      }
-    : null;
+  const lockExpenditurePayload: LockExpenditurePayload | null = useMemo(
+    () =>
+      expenditure
+        ? {
+            colonyAddress: colony.colonyAddress,
+            nativeExpenditureId: expenditure.nativeId,
+          }
+        : null,
+    [colony.colonyAddress, expenditure],
+  );
 
   const cancelItem: StepperItem<ExpenditureStep> = {
     key: ExpenditureStep.Cancel,
@@ -208,6 +213,20 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
       setExpectedStepKey(null);
     }
   }, [expectedStepKey, hasEveryMotionEnded, fundingMotions]);
+
+  useEffect(() => {
+    if (
+      !hasEveryMotionEnded &&
+      motionState === MotionState.FailedNotFinalizable
+    ) {
+      setSelectedTransaction(fundingMotions?.[0]?.transactionHash);
+    }
+  }, [
+    fundingMotions,
+    hasEveryMotionEnded,
+    motionState,
+    setSelectedTransaction,
+  ]);
 
   const items: StepperItem<ExpenditureStep>[] = [
     {

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/RequestBox/RequestBox.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/RequestBox/RequestBox.tsx
@@ -25,17 +25,19 @@ const RequestBox: FC<RequestBoxProps> = ({
       withPadding={false}
     >
       <h5 className="mb-2 text-1">{title}</h5>
-      <ul className="max-h-[6.25rem] overflow-y-auto overflow-x-hidden">
-        {items.map(({ date, transactionHash }) => (
-          <li className="mb-2 w-full last:mb-0" key={transactionHash}>
-            <RequestBoxItem
-              date={date}
-              transactionHash={transactionHash}
-              isSingleItem={items.length === 1}
-            />
-          </li>
-        ))}
-      </ul>
+      <div className="max-h-[6.25rem] overflow-x-hidden overflow-y-scroll">
+        <ul className="flex flex-col gap-2 overflow-hidden">
+          {items.map(({ date, transactionHash }) => (
+            <li className="w-full" key={transactionHash}>
+              <RequestBoxItem
+                date={date}
+                transactionHash={transactionHash}
+                isSingleItem={items.length === 1}
+              />
+            </li>
+          ))}
+        </ul>
+      </div>
     </MenuContainer>
   );
 };

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/RequestBox/partials/RequestBoxItem.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/RequestBox/partials/RequestBoxItem.tsx
@@ -31,7 +31,7 @@ const RequestBoxItem: FC<RequestBoxItemProps> = ({
     <button
       type="button"
       className={clsx(
-        'flex w-full items-center justify-between text-gray-600 outline-none transition-colors',
+        'relative flex w-full items-center justify-between text-gray-600 outline-none transition-colors',
         {
           'hover:text-blue-400': isMotionFailed || !isSingleItem,
         },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1431,6 +1431,7 @@
     "motion.staking.accordion.title.hide": "Hide staking information",
     "motion.finalize.label": "Finalize",
     "motion.finalizeStep.statusText": "Finalize to execute the agreed transactions and return stakes.",
+    "motion.finalizeStep.claimable.statusText": "Action has passed and has been executed.",
     "motion.finalizeStep.failed.statusText": "Action failed due to not achieving required stake.",
     "motion.finalizeStep.title": "Staking overview",
     "motion.finalizeStep.staked": "Staked",


### PR DESCRIPTION
## Description

Makes various updates to fix the funding with a motion flow, please refer to complete descriptions as of the linked issues.

## Testing

1. Ensure Reputation decision method is active with low timer (e.g. 0.04, can be lower in local dev) for periods.
2. Create an Advanced payment action.
3. Disconnect and switch to a user who does not have permissions.
4. On the funding step, you should not see the permissions option as a decision method.
5. Check the timer that should appear next to the Funding pill, it will be stuck in a loading state.
6. Pay attention to the loader before the status of the motion appears.
7. Don't stake the payment and let it fail.
8. The UI should auto update with the failed motion and allow you to try and fund again.
9. Fund again using reputation.
10. Trigger a vote, but staking both in Oppose and Support fully.
11. Vote either way.
12. Reveal, then Finalize.
13. You should get a smooth transition to the reveal step.
15. Click on the previous Funding step.
16. The details should be correct and match the design.

Resolves [2562](https://github.com/JoinColony/colonyCDapp/issues/2562), [2561](https://github.com/JoinColony/colonyCDapp/issues/2561), [2558](https://github.com/JoinColony/colonyCDapp/issues/2558), [2557](https://github.com/JoinColony/colonyCDapp/issues/2557), [2556](https://github.com/JoinColony/colonyCDapp/issues/2556)
