### PR TITLE
Fix: Modal input: active state styling issue in Firefox

### DIFF
--- a/src/components/v5/common/Fields/InputBase/FormattedInput.tsx
+++ b/src/components/v5/common/Fields/InputBase/FormattedInput.tsx
@@ -85,7 +85,7 @@ const FormattedInput: FC<FormattedInputProps> = ({
           className={clsx(
             className,
             state ? stateClassNames[state] : undefined,
-            'w-full pr-[var(--button-width)] text-md outline-0 placeholder:text-gray-400',
+            'w-full pr-[var(--button-width)] text-md outline-0 placeholder:text-gray-400 focus:outline-none',
             {
               'pointer-events-none text-gray-400': disabled,
               'rounded border border-gray-300 bg-base-white py-3 pl-3.5 focus:border-blue-200 focus:shadow-light-blue':


### PR DESCRIPTION
## Description
Fix: Unnecessary outline styles for withdrawing modal input
Bug related only to the Firefox browser 
Issue: https://github.com/w3c/csswg-drafts/issues/4925

## Testing
| Before | After |
| ---- | ---- |
| ![image](https://github.com/JoinColony/colonyCDapp/assets/15706494/b96cb36e-a56b-4ba3-9877-1ee9a9f1f6f8) |  ![image](https://github.com/JoinColony/colonyCDapp/assets/15706494/b7d585e8-8713-40f8-af5d-08d5af6e9a6c") |

Resolves #2550 
