### PR TITLE
fix: unified date format

### DIFF
--- a/src/components/common/ColonyActionsTable/hooks/useColonyActionsTableColumns.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useColonyActionsTableColumns.tsx
@@ -1,15 +1,14 @@
 import { CaretDown } from '@phosphor-icons/react';
 import { createColumnHelper } from '@tanstack/react-table';
 import clsx from 'clsx';
-import { format } from 'date-fns';
 import React, { useMemo } from 'react';
 import { defineMessages } from 'react-intl';
 
 import { useMobile } from '~hooks';
 import { type ActivityFeedColonyAction } from '~hooks/useActivityFeed/types.ts';
 import { type RefetchMotionStates } from '~hooks/useNetworkMotionStates.ts';
+import { getFormattedDateFrom } from '~utils/getFormattedDateFrom.ts';
 import { formatText } from '~utils/intl.ts';
-import { DEFAULT_DATE_FORMAT } from '~v5/common/Fields/datepickers/common/consts.ts';
 import TeamBadge from '~v5/common/Pills/TeamBadge/index.ts';
 
 import ActionBadge from '../partials/ActionBadge/ActionBadge.tsx';
@@ -84,7 +83,7 @@ const useColonyActionsTableColumns = (
           id: 'activityFeedTable.table.header.date',
         }),
         cell: ({ getValue }) => {
-          const date = format(new Date(getValue()), DEFAULT_DATE_FORMAT);
+          const date = getFormattedDateFrom(new Date(getValue()));
 
           return (
             <span

--- a/src/components/common/ColonyActionsTable/hooks/useColonyActionsTableColumns.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useColonyActionsTableColumns.tsx
@@ -9,6 +9,7 @@ import { useMobile } from '~hooks';
 import { type ActivityFeedColonyAction } from '~hooks/useActivityFeed/types.ts';
 import { type RefetchMotionStates } from '~hooks/useNetworkMotionStates.ts';
 import { formatText } from '~utils/intl.ts';
+import { DEFAULT_DATE_FORMAT } from '~v5/common/Fields/datepickers/common/consts.ts';
 import TeamBadge from '~v5/common/Pills/TeamBadge/index.ts';
 
 import ActionBadge from '../partials/ActionBadge/ActionBadge.tsx';
@@ -83,7 +84,7 @@ const useColonyActionsTableColumns = (
           id: 'activityFeedTable.table.header.date',
         }),
         cell: ({ getValue }) => {
-          const date = format(new Date(getValue()), 'dd MMMM yyyy');
+          const date = format(new Date(getValue()), DEFAULT_DATE_FORMAT);
 
           return (
             <span

--- a/src/components/common/ColonyActionsTable/partials/ActionMobileDescription/ActionMobileDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionMobileDescription/ActionMobileDescription.tsx
@@ -1,14 +1,13 @@
 import clsx from 'clsx';
-import format from 'date-fns/format';
 import React, { type FC } from 'react';
 
 import getActionTitleValues from '~common/ColonyActions/helpers/getActionTitleValues.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useShouldDisplayMotionCountdownTime from '~hooks/useShouldDisplayMotionCountdownTime.ts';
+import { getFormattedDateFrom } from '~utils/getFormattedDateFrom.ts';
 import { formatText } from '~utils/intl.ts';
 import { useGetExpenditureData } from '~v5/common/ActionSidebar/hooks/useGetExpenditureData.ts';
 import MotionCountDownTimer from '~v5/common/ActionSidebar/partials/Motions/partials/MotionCountDownTimer/index.ts';
-import { DEFAULT_DATE_FORMAT } from '~v5/common/Fields/datepickers/common/consts.ts';
 import TeamBadge from '~v5/common/Pills/TeamBadge/index.ts';
 import MeatBallMenu from '~v5/shared/MeatBallMenu/index.ts';
 
@@ -61,7 +60,7 @@ const ActionMobileDescription: FC<ActionMobileDescriptionProps> = ({
     }),
   );
   const team = fromDomain?.metadata || motionData?.motionDomain.metadata;
-  const date = format(new Date(createdAt), DEFAULT_DATE_FORMAT);
+  const date = getFormattedDateFrom(createdAt);
   const meatBallMenuProps = getMenuProps(actionRow);
   const textClassName = 'font-normal text-sm';
 

--- a/src/components/common/ColonyActionsTable/partials/ActionMobileDescription/ActionMobileDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionMobileDescription/ActionMobileDescription.tsx
@@ -8,6 +8,7 @@ import useShouldDisplayMotionCountdownTime from '~hooks/useShouldDisplayMotionCo
 import { formatText } from '~utils/intl.ts';
 import { useGetExpenditureData } from '~v5/common/ActionSidebar/hooks/useGetExpenditureData.ts';
 import MotionCountDownTimer from '~v5/common/ActionSidebar/partials/Motions/partials/MotionCountDownTimer/index.ts';
+import { DEFAULT_DATE_FORMAT } from '~v5/common/Fields/datepickers/common/consts.ts';
 import TeamBadge from '~v5/common/Pills/TeamBadge/index.ts';
 import MeatBallMenu from '~v5/shared/MeatBallMenu/index.ts';
 
@@ -60,7 +61,7 @@ const ActionMobileDescription: FC<ActionMobileDescriptionProps> = ({
     }),
   );
   const team = fromDomain?.metadata || motionData?.motionDomain.metadata;
-  const date = format(new Date(createdAt), 'dd MMMM yyyy');
+  const date = format(new Date(createdAt), DEFAULT_DATE_FORMAT);
   const meatBallMenuProps = getMenuProps(actionRow);
   const textClassName = 'font-normal text-sm';
 

--- a/src/components/common/ColonyActionsTable/utils.ts
+++ b/src/components/common/ColonyActionsTable/utils.ts
@@ -1,4 +1,3 @@
-import format from 'date-fns/format';
 import sub from 'date-fns/sub';
 
 import {
@@ -11,7 +10,7 @@ import {
   type ActivityFeedFilters,
   type ActivityFeedColonyAction,
 } from '~hooks/useActivityFeed/types.ts';
-import { DEFAULT_DATE_FORMAT } from '~v5/common/Fields/datepickers/common/consts.ts';
+import { getFormattedDateFrom } from '~utils/getFormattedDateFrom.ts';
 
 import { type DateOptions } from './partials/ActionsTableFilters/types.ts';
 
@@ -117,8 +116,5 @@ export const getCustomDateLabel = (dateRange?: DateOptions['custom']) => {
   const startDate = new Date(startDateString);
   const endDate = new Date(endDateString);
 
-  return `${format(startDate, DEFAULT_DATE_FORMAT)} - ${format(
-    endDate,
-    DEFAULT_DATE_FORMAT,
-  )}`;
+  return `${getFormattedDateFrom(startDate)} - ${getFormattedDateFrom(endDate)}`;
 };

--- a/src/components/common/Extensions/SpecificSidePanel/hooks.tsx
+++ b/src/components/common/Extensions/SpecificSidePanel/hooks.tsx
@@ -8,6 +8,7 @@ import {
   type InstalledExtensionData,
 } from '~types/extensions.ts';
 import { isInstalledExtensionData } from '~utils/extensions.ts';
+import { DEFAULT_DATE_FORMAT } from '~v5/common/Fields/datepickers/common/consts.ts';
 import { type ExtensionStatusBadgeMode } from '~v5/common/Pills/types.ts';
 import UserAvatar from '~v5/shared/UserAvatar/index.ts';
 
@@ -27,7 +28,7 @@ export const useSpecificSidePanel = (extensionData: AnyExtensionData) => {
       new Date(
         ((extensionData as InstalledExtensionData)?.installedAt ?? 0) * 1000,
       ),
-      'dd MMMM yyyy',
+      DEFAULT_DATE_FORMAT,
     );
 
   const { user } = useUserByNameOrAddress(
@@ -35,7 +36,7 @@ export const useSpecificSidePanel = (extensionData: AnyExtensionData) => {
   );
   const createdAtDate =
     extensionData &&
-    format(new Date(extensionData?.createdAt ?? 0 * 1000), 'dd MMMM yyyy');
+    format(new Date(extensionData?.createdAt ?? 0 * 1000), DEFAULT_DATE_FORMAT);
 
   const isExtensionDeprecatedAndDisabled = !!(
     !!user &&

--- a/src/components/common/Extensions/SpecificSidePanel/hooks.tsx
+++ b/src/components/common/Extensions/SpecificSidePanel/hooks.tsx
@@ -1,4 +1,3 @@
-import { format } from 'date-fns';
 import React, { useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 
@@ -8,7 +7,7 @@ import {
   type InstalledExtensionData,
 } from '~types/extensions.ts';
 import { isInstalledExtensionData } from '~utils/extensions.ts';
-import { DEFAULT_DATE_FORMAT } from '~v5/common/Fields/datepickers/common/consts.ts';
+import { getFormattedDateFrom } from '~utils/getFormattedDateFrom.ts';
 import { type ExtensionStatusBadgeMode } from '~v5/common/Pills/types.ts';
 import UserAvatar from '~v5/shared/UserAvatar/index.ts';
 
@@ -24,19 +23,17 @@ export const useSpecificSidePanel = (extensionData: AnyExtensionData) => {
     extensionData && isInstalledExtensionData(extensionData);
   const installedAtDate =
     extensionData &&
-    format(
+    getFormattedDateFrom(
       new Date(
         ((extensionData as InstalledExtensionData)?.installedAt ?? 0) * 1000,
       ),
-      DEFAULT_DATE_FORMAT,
     );
 
   const { user } = useUserByNameOrAddress(
     (extensionData as InstalledExtensionData)?.installedBy,
   );
   const createdAtDate =
-    extensionData &&
-    format(new Date(extensionData?.createdAt ?? 0 * 1000), DEFAULT_DATE_FORMAT);
+    extensionData && getFormattedDateFrom(extensionData?.createdAt ?? 0 * 1000);
 
   const isExtensionDeprecatedAndDisabled = !!(
     !!user &&

--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransaction.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransaction.tsx
@@ -13,6 +13,7 @@ import { TX_SEARCH_PARAM } from '~routes';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { arrayToObject } from '~utils/arrays/index.ts';
 import { formatText } from '~utils/intl.ts';
+import { DEFAULT_DATE_FORMAT } from '~v5/common/Fields/datepickers/common/consts.ts';
 
 import {
   getActiveTransactionIdx,
@@ -95,7 +96,7 @@ const GroupedTransaction: FC<GroupedTransactionProps> = ({
 
   const createdAt =
     transactionGroup?.[0].createdAt &&
-    format(new Date(transactionGroup[0].createdAt), 'dd MMMM yyyy');
+    format(new Date(transactionGroup[0].createdAt), DEFAULT_DATE_FORMAT);
 
   const handleNavigateToAction = () => {
     if (canLinkToAction) {

--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransaction.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransaction.tsx
@@ -1,6 +1,5 @@
 import { CaretDown, CaretUp } from '@phosphor-icons/react';
 import clsx from 'clsx';
-import { format } from 'date-fns';
 import { AnimatePresence, motion } from 'framer-motion';
 import React, { type FC } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -12,8 +11,8 @@ import { type TransactionType } from '~redux/immutable/index.ts';
 import { TX_SEARCH_PARAM } from '~routes';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { arrayToObject } from '~utils/arrays/index.ts';
+import { getFormattedDateFrom } from '~utils/getFormattedDateFrom.ts';
 import { formatText } from '~utils/intl.ts';
-import { DEFAULT_DATE_FORMAT } from '~v5/common/Fields/datepickers/common/consts.ts';
 
 import {
   getActiveTransactionIdx,
@@ -96,7 +95,7 @@ const GroupedTransaction: FC<GroupedTransactionProps> = ({
 
   const createdAt =
     transactionGroup?.[0].createdAt &&
-    format(new Date(transactionGroup[0].createdAt), DEFAULT_DATE_FORMAT);
+    getFormattedDateFrom(new Date(transactionGroup[0].createdAt));
 
   const handleNavigateToAction = () => {
     if (canLinkToAction) {

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementCard/AgreementCard.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementCard/AgreementCard.tsx
@@ -1,6 +1,5 @@
 import { FilePlus, ShareNetwork } from '@phosphor-icons/react';
 import clsx from 'clsx';
-import { format } from 'date-fns';
 import React, { type FC, useEffect } from 'react';
 import { generatePath, useNavigate } from 'react-router-dom';
 
@@ -13,10 +12,10 @@ import {
   TX_SEARCH_PARAM,
 } from '~routes/index.ts';
 import { MotionState } from '~utils/colonyMotions.ts';
+import { getFormattedDateFrom } from '~utils/getFormattedDateFrom.ts';
 import { formatText } from '~utils/intl.ts';
 import useGetColonyAction from '~v5/common/ActionSidebar/hooks/useGetColonyAction.ts';
 import MotionCountDownTimer from '~v5/common/ActionSidebar/partials/Motions/partials/MotionCountDownTimer/MotionCountDownTimer.tsx';
-import { DEFAULT_DATE_FORMAT } from '~v5/common/Fields/datepickers/common/consts.ts';
 import MotionStateBadge from '~v5/common/Pills/MotionStateBadge/MotionStateBadge.tsx';
 import TeamBadge from '~v5/common/Pills/TeamBadge/TeamBadge.tsx';
 import MeatBallMenu from '~v5/shared/MeatBallMenu/MeatBallMenu.tsx';
@@ -145,7 +144,7 @@ const AgreementCard: FC<AgreementCardProps> = ({ transactionId }) => {
               )}
               {createdAt && (
                 <p className="text-sm text-gray-600">
-                  {format(new Date(createdAt), DEFAULT_DATE_FORMAT)}
+                  {getFormattedDateFrom(new Date(createdAt))}
                 </p>
               )}
               <MeatBallMenu

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementCard/AgreementCard.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementCard/AgreementCard.tsx
@@ -16,6 +16,7 @@ import { MotionState } from '~utils/colonyMotions.ts';
 import { formatText } from '~utils/intl.ts';
 import useGetColonyAction from '~v5/common/ActionSidebar/hooks/useGetColonyAction.ts';
 import MotionCountDownTimer from '~v5/common/ActionSidebar/partials/Motions/partials/MotionCountDownTimer/MotionCountDownTimer.tsx';
+import { DEFAULT_DATE_FORMAT } from '~v5/common/Fields/datepickers/common/consts.ts';
 import MotionStateBadge from '~v5/common/Pills/MotionStateBadge/MotionStateBadge.tsx';
 import TeamBadge from '~v5/common/Pills/TeamBadge/TeamBadge.tsx';
 import MeatBallMenu from '~v5/shared/MeatBallMenu/MeatBallMenu.tsx';
@@ -144,7 +145,7 @@ const AgreementCard: FC<AgreementCardProps> = ({ transactionId }) => {
               )}
               {createdAt && (
                 <p className="text-sm text-gray-600">
-                  {format(new Date(createdAt), 'd MMMM yyyy')}
+                  {format(new Date(createdAt), DEFAULT_DATE_FORMAT)}
                 </p>
               )}
               <MeatBallMenu

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/utils.ts
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/utils.ts
@@ -1,7 +1,6 @@
-import format from 'date-fns/format';
 import sub from 'date-fns/sub';
 
-import { DEFAULT_DATE_FORMAT } from '~v5/common/Fields/datepickers/common/consts.ts';
+import { getFormattedDateFrom } from '~utils/getFormattedDateFrom.ts';
 
 import { type AgreementsPageFilters, type DateOptions } from './types.ts';
 
@@ -79,8 +78,5 @@ export const getCustomDateLabel = (dateRange?: DateOptions['custom']) => {
   const startDate = new Date(startDateString);
   const endDate = new Date(endDateString);
 
-  return `${format(startDate, DEFAULT_DATE_FORMAT)} - ${format(
-    endDate,
-    DEFAULT_DATE_FORMAT,
-  )}`;
+  return `${getFormattedDateFrom(startDate)} - ${getFormattedDateFrom(endDate)}`;
 };

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/PermissionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/PermissionSidebar.tsx
@@ -1,8 +1,9 @@
 import { isToday, isYesterday } from 'date-fns';
 import React, { type FC } from 'react';
-import { FormattedDate, FormattedDateParts, defineMessages } from 'react-intl';
+import { FormattedDate, defineMessages } from 'react-intl';
 
 import PermissionRow from '~frame/v5/pages/VerifiedPage/partials/PermissionRow/index.ts';
+import { getFormattedDateFrom } from '~utils/getFormattedDateFrom.ts';
 import { formatText } from '~utils/intl.ts';
 import useGetColonyAction from '~v5/common/ActionSidebar/hooks/useGetColonyAction.ts';
 import MenuWithStatusText from '~v5/shared/MenuWithStatusText/index.ts';
@@ -55,19 +56,7 @@ const formatDate = (value: string | undefined) => {
 
   return (
     <>
-      <FormattedDateParts
-        value={date}
-        day="numeric"
-        month="short"
-        year="numeric"
-      >
-        {(parts) => (
-          <span>
-            {parts[2].value} {parts[0].value} {parts[4].value}
-          </span>
-        )}
-      </FormattedDateParts>{' '}
-      {formatText(MSG.at)}{' '}
+      {getFormattedDateFrom(value)} {formatText(MSG.at)}{' '}
       <FormattedDate value={date} hour="numeric" minute="numeric" />
     </>
   );

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/PermissionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/PermissionSidebar.tsx
@@ -1,6 +1,6 @@
 import { isToday, isYesterday } from 'date-fns';
 import React, { type FC } from 'react';
-import { FormattedDate, defineMessages } from 'react-intl';
+import { FormattedDate, FormattedDateParts, defineMessages } from 'react-intl';
 
 import PermissionRow from '~frame/v5/pages/VerifiedPage/partials/PermissionRow/index.ts';
 import { formatText } from '~utils/intl.ts';
@@ -55,7 +55,18 @@ const formatDate = (value: string | undefined) => {
 
   return (
     <>
-      <FormattedDate value={date} day="numeric" month="short" year="numeric" />{' '}
+      <FormattedDateParts
+        value={date}
+        day="numeric"
+        month="short"
+        year="numeric"
+      >
+        {(parts) => (
+          <span>
+            {parts[2].value} {parts[0].value} {parts[4].value}
+          </span>
+        )}
+      </FormattedDateParts>{' '}
       {formatText(MSG.at)}{' '}
       <FormattedDate value={date} hour="numeric" minute="numeric" />
     </>

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizeWithPermissionsInfo/FinalizeWithPermissionsInfo.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizeWithPermissionsInfo/FinalizeWithPermissionsInfo.tsx
@@ -1,8 +1,9 @@
 import { isToday, isYesterday } from 'date-fns';
 import React, { type FC } from 'react';
-import { FormattedDate, FormattedDateParts, defineMessages } from 'react-intl';
+import { FormattedDate, defineMessages } from 'react-intl';
 
 import PermissionRow from '~frame/v5/pages/VerifiedPage/partials/PermissionRow/index.ts';
+import { getFormattedDateFrom } from '~utils/getFormattedDateFrom.ts';
 import { formatText } from '~utils/intl.ts';
 import MenuWithStatusText from '~v5/shared/MenuWithStatusText/index.ts';
 import { StatusTypes } from '~v5/shared/StatusText/consts.ts';
@@ -55,19 +56,7 @@ const formatDate = (value: string | undefined) => {
 
   return (
     <>
-      <FormattedDateParts
-        value={date}
-        day="numeric"
-        month="short"
-        year="numeric"
-      >
-        {(parts) => (
-          <span>
-            {parts[2].value} {parts[0].value} {parts[4].value}
-          </span>
-        )}
-      </FormattedDateParts>{' '}
-      {formatText(MSG.at)}{' '}
+      {getFormattedDateFrom(value)} {formatText(MSG.at)}{' '}
       <FormattedDate value={date} hour="numeric" minute="numeric" />
     </>
   );

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizeWithPermissionsInfo/FinalizeWithPermissionsInfo.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizeWithPermissionsInfo/FinalizeWithPermissionsInfo.tsx
@@ -1,6 +1,6 @@
 import { isToday, isYesterday } from 'date-fns';
 import React, { type FC } from 'react';
-import { FormattedDate, defineMessages } from 'react-intl';
+import { FormattedDate, FormattedDateParts, defineMessages } from 'react-intl';
 
 import PermissionRow from '~frame/v5/pages/VerifiedPage/partials/PermissionRow/index.ts';
 import { formatText } from '~utils/intl.ts';
@@ -55,7 +55,18 @@ const formatDate = (value: string | undefined) => {
 
   return (
     <>
-      <FormattedDate value={date} day="numeric" month="short" year="numeric" />{' '}
+      <FormattedDateParts
+        value={date}
+        day="numeric"
+        month="short"
+        year="numeric"
+      >
+        {(parts) => (
+          <span>
+            {parts[2].value} {parts[0].value} {parts[4].value}
+          </span>
+        )}
+      </FormattedDateParts>{' '}
       {formatText(MSG.at)}{' '}
       <FormattedDate value={date} hour="numeric" minute="numeric" />
     </>

--- a/src/components/v5/common/Fields/datepickers/common/consts.ts
+++ b/src/components/v5/common/Fields/datepickers/common/consts.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_DATE_FORMAT = 'MMM d, yyyy';
+export const DEFAULT_DATE_FORMAT = 'dd MMM yyyy';
 export const DATEPICKER_PORTAL_ID = 'datepicker-portal';

--- a/src/utils/getFormattedDateFrom.ts
+++ b/src/utils/getFormattedDateFrom.ts
@@ -1,0 +1,6 @@
+import { format } from 'date-fns';
+
+import { DEFAULT_DATE_FORMAT } from '~v5/common/Fields/datepickers/common/consts.ts';
+
+export const getFormattedDateFrom = (value: number | string | Date) =>
+  format(new Date(value), DEFAULT_DATE_FORMAT);


### PR DESCRIPTION
## Description

- Date formatting in the app should be with months in shorthand, such as 14 Sep 2024

## Testing

* Click through page and check if months are in shorthand (`14 Sep 2024`)

Resolves [https://github.com/JoinColony/colonyCDapp/issues/2349](https://github.com/JoinColony/colonyCDapp/issues/2349)
