### PR TITLE
Fix: Create random users in batches in create-data script

### DIFF
--- a/scripts/create-data.js
+++ b/scripts/create-data.js
@@ -86,7 +86,8 @@ const CHAR_LIMITS = {
   },
   COLONY: {
     MAX_COLONY_DISPLAY_NAME: 20,
-    MAX_COLONY_OBJECTIVE_TITLE: 60
+    MAX_COLONY_OBJECTIVE_TITLE: 60,
+    MAX_COLONY_OBJECTIVE_DESCRIPTION: 200,
   }
 };
 
@@ -525,6 +526,7 @@ const createColony = async (
     metadata.objective = {
       ...colonyObjective,
       title: colonyObjective.title.slice(0, CHAR_LIMITS.COLONY.MAX_COLONY_OBJECTIVE_TITLE),
+      description: colonyObjective.description.slice(0, CHAR_LIMITS.COLONY.MAX_COLONY_OBJECTIVE_DESCRIPTION),
     };
   }
 


### PR DESCRIPTION
## Description

Refactored the create-data script in order to minimise failure while creating too many users all at once.
The random users creation is batched in chunks of 3.

Also, added a new method  `graphqlRequestPreconfigured` to enclose the `GRAPHQL_URI` and `API_KEY` used for the `graphqlRequest`

Add character limits for 
- user fields: displayName, bio and location
- colony fields: displayName and objective.title

## Testing

* Step 1. Run `npm ci`
* Step 2. Run `npm run dev`
* Step 3. Run `node ./scripts/create-data.js --yes`
* Step 4. Check if there are any errors while creating the data

Resolves #[2606](https://github.com/JoinColony/colonyCDapp/issues/2606)
