### PR TITLE
Feat: Refactor manage permissions motion to handle multi-sig

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=1fff5b26280ef56a9577ea18dab3307441074de9
+ENV BLOCK_INGESTOR_HASH=49696d123612ff3066768c0a41e725fb9088f4d1
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=8ef5e84debb011a1f63471c7b986527ce1505d7e
+ENV BLOCK_INGESTOR_HASH=cf8346facc3445cdbd0078bbba2a85719a49bfaf
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=49696d123612ff3066768c0a41e725fb9088f4d1
+ENV BLOCK_INGESTOR_HASH=75683b00a9ffca90c95636e19da58a3de1a96169
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=c1add192eac8c1762a4c5fdbad5808ba50fbd9b7
+ENV BLOCK_INGESTOR_HASH=1fff5b26280ef56a9577ea18dab3307441074de9
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=cf8346facc3445cdbd0078bbba2a85719a49bfaf
+ENV BLOCK_INGESTOR_HASH=c1add192eac8c1762a4c5fdbad5808ba50fbd9b7
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/common/ColonyActions/helpers/getActionTitleValues.ts
+++ b/src/components/common/ColonyActions/helpers/getActionTitleValues.ts
@@ -22,6 +22,7 @@ export enum ActionTitleMessageKeys {
   Amount = 'amount',
   Direction = 'direction',
   FromDomain = 'fromDomain',
+  MultiSigAuthority = 'multiSigAuthority',
   Initiator = 'initiator',
   Members = 'members',
   NewVersion = 'newVersion',
@@ -107,6 +108,7 @@ const getMessageDescriptorKeys = (actionType: AnyActionType) => {
         ActionTitleMessageKeys.FromDomain,
         ActionTitleMessageKeys.Recipient,
         ActionTitleMessageKeys.Initiator,
+        ActionTitleMessageKeys.MultiSigAuthority,
       ];
     case actionType.includes(ColonyActionType.CreateExpenditure):
       return [

--- a/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
+++ b/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
@@ -18,7 +18,7 @@ import {
 } from '~types/graphql.ts';
 import { notMaybe } from '~utils/arrays/index.ts';
 import { formatRolesTitle } from '~utils/colonyActions.ts';
-import { intl } from '~utils/intl.ts';
+import { formatText, intl } from '~utils/intl.ts';
 import { formatReputationChange } from '~utils/reputation.ts';
 import { getAddedSafeChainName } from '~utils/safes/index.ts';
 import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
@@ -275,5 +275,10 @@ export const mapColonyActionToExpectedFormat = ({
         (slot) => slot.payouts?.map((payout) => payout.tokenAddress) ?? [],
       ),
     ).size,
+    [ActionTitleMessageKeys.MultiSigAuthority]: actionData.rolesAreMultiSig
+      ? `${formatText({
+          id: 'decisionMethod.multiSig',
+        })} `
+      : '',
   };
 };

--- a/src/components/v5/common/ActionSidebar/hooks/permissions/helpers.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/helpers.ts
@@ -37,7 +37,7 @@ export const getPermissionsNeededForAction = (
       }
       return undefined;
     case Action.ManagePermissions: {
-      return formValues.team === Id.RootDomain
+      return formValues.createdIn === Id.RootDomain
         ? PERMISSIONS_NEEDED_FOR_ACTION.ManagePermissionsInRootDomain
         : PERMISSIONS_NEEDED_FOR_ACTION.ManagePermissionsInSubDomain;
     }

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/ManagePermissionsDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/ManagePermissionsDescription.tsx
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { type ColonyActionRoles, ColonyActionType } from '~gql';
+import { Authority } from '~types/authority.ts';
 import { formatRolesTitle } from '~utils/colonyActions.ts';
 import { formatText } from '~utils/intl.ts';
 
@@ -21,7 +22,7 @@ export const ManagePermissionsDescription = () => {
     colony: { domains },
   } = useColonyContext();
   const formValues = useFormContext<ManagePermissionsFormValues>().getValues();
-  const { member, role, permissions, team } = formValues;
+  const { member, role, permissions, team, authority } = formValues;
 
   const selectedDomain = domains?.items.find(
     (domain) => domain?.nativeId === team,
@@ -80,6 +81,12 @@ export const ManagePermissionsDescription = () => {
           : formatText({
               id: 'actionSidebar.metadataDescription.team',
             }),
+        multiSigAuthority:
+          authority === Authority.ViaMultiSig
+            ? `${formatText({
+                id: 'decisionMethod.multiSig',
+              })} `
+            : '',
         initiator: <CurrentUser />,
       }}
     />

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/MultiSigWidget.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/MultiSigWidget.tsx
@@ -43,9 +43,11 @@ const MultiSigWidget: FC<MultiSigWidgetProps> = ({
   action,
   initiatorAddress,
 }) => {
-  const actionType = action.type;
-  const { multiSigData } = action;
-  const requiredRoles = getRolesNeededForMultiSigAction(action.type);
+  const { type: actionType, multiSigData } = action;
+  const requiredRoles = getRolesNeededForMultiSigAction({
+    actionType,
+    createdIn: Number(multiSigData.nativeMultiSigDomainId),
+  });
 
   const { isLoading, thresholdPerRole } = useDomainThreshold({
     domainId: Number(multiSigData.nativeMultiSigDomainId),

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
@@ -105,7 +105,10 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
 
   const isOwner = user?.walletAddress === initiatorAddress;
 
-  const requiredRoles = getRolesNeededForMultiSigAction(actionType);
+  const requiredRoles = getRolesNeededForMultiSigAction({
+    actionType,
+    createdIn: Number(multiSigData.nativeMultiSigDomainId),
+  });
   const { uniqueEligibleSignees } = useEligibleSignees({
     domainId: Number(multiSigData.nativeMultiSigDomainId),
     requiredRoles,

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/RemoveVoteButton/RemoveVoteButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/RemoveVoteButton/RemoveVoteButton.tsx
@@ -51,7 +51,10 @@ const RemoveVoteButton: FC<RemoveVoteButtonProps> = ({
     vote: MultiSigVote.None,
     domainId: multiSigDomainId,
     multiSigId,
-    requiredRoles: getRolesNeededForMultiSigAction(actionType) || [],
+    requiredRoles: getRolesNeededForMultiSigAction({
+      actionType,
+      createdIn: multiSigDomainId,
+    }) || [],
   }));
 
   return (

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/VoteButton/VoteButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/VoteButton/VoteButton.tsx
@@ -58,7 +58,7 @@ const VoteButton: FC<VoteButtonProps> = ({
   const buttonText = {
     [MultiSigVote.Approve]: MSG.approve,
     [MultiSigVote.Reject]: MSG.reject,
-  };
+  }
 
   const transform = mapPayload(() => ({
     colonyAddress: colony.colonyAddress,
@@ -67,7 +67,10 @@ const VoteButton: FC<VoteButtonProps> = ({
     vote: voteType,
     domainId: multiSigDomainId,
     multiSigId,
-    requiredRoles: getRolesNeededForMultiSigAction(actionType) || [],
+    requiredRoles: getRolesNeededForMultiSigAction({
+      actionType,
+      createdIn: multiSigDomainId,
+    }) || [],
   }));
 
   return (

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/hooks.ts
@@ -95,9 +95,10 @@ export const useManagePermissions = (
     getFormOptions,
     validationSchema,
     actionType:
-      decisionMethod === DecisionMethod.Permissions
-        ? ActionTypes.ACTION_USER_ROLES_SET
-        : ActionTypes.MOTION_USER_ROLES_SET,
+      decisionMethod === DecisionMethod.Reputation ||
+      decisionMethod === DecisionMethod.MultiSig
+        ? ActionTypes.MOTION_USER_ROLES_SET
+        : ActionTypes.ACTION_USER_ROLES_SET,
     defaultValues: useMemo<DeepPartial<ManagePermissionsFormValues>>(
       () => ({
         createdIn: Id.RootDomain,

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/utils.ts
@@ -7,10 +7,9 @@ import {
 } from '~constants/permissions.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { type Colony } from '~types/graphql.ts';
-import { extractColonyRoles } from '~utils/colonyRoles.ts';
-import { extractColonyDomains } from '~utils/domains.ts';
 import { getEnumValueFromKey } from '~utils/getEnumValueFromKey.ts';
 import { formatText } from '~utils/intl.ts';
+import { getMotionPayload } from '~utils/motions.ts';
 import { sanitizeHTML } from '~utils/strings.ts';
 
 import {
@@ -116,9 +115,10 @@ export const getManagePermissionsPayload = (
     return {
       ...commonPayload,
       motionDomainId: Number(createdIn),
-      colonyRoles: extractColonyRoles(colony.roles),
-      colonyDomains: extractColonyDomains(colony.domains),
-      isMultiSig: decisionMethod === DecisionMethod.MultiSig,
+      ...getMotionPayload(
+        values.decisionMethod === DecisionMethod.MultiSig,
+        colony,
+      ),
     };
   }
 

--- a/src/components/v5/common/CompletedAction/CompletedAction.tsx
+++ b/src/components/v5/common/CompletedAction/CompletedAction.tsx
@@ -69,6 +69,7 @@ const CompletedAction = ({ action }: CompletedActionProps) => {
         return <CreateDecision action={action} />;
       case ColonyActionType.SetUserRoles:
       case ColonyActionType.SetUserRolesMotion:
+      case ColonyActionType.SetUserRolesMultisig:
         return <SetUserRoles action={action} />;
       case ColonyActionType.AddVerifiedMembers:
       case ColonyActionType.AddVerifiedMembersMotion:

--- a/src/components/v5/common/CompletedAction/partials/MintTokens/MintTokens.tsx
+++ b/src/components/v5/common/CompletedAction/partials/MintTokens/MintTokens.tsx
@@ -77,6 +77,10 @@ const MintTokens = ({ action }: MintTokensProps) => {
 
   const isOwner = initiatorUser?.walletAddress === user?.walletAddress;
 
+  const metadata =
+    action.motionData?.motionDomain.metadata ??
+    action.multiSigData?.multiSigDomain.metadata;
+
   return (
     <>
       <div className="flex items-center justify-between gap-2">
@@ -132,11 +136,7 @@ const MintTokens = ({ action }: MintTokensProps) => {
           isMultisig={action.isMultiSig || false}
         />
 
-        {action.motionData?.motionDomain.metadata && (
-          <CreatedInRow
-            motionDomainMetadata={action.motionData.motionDomain.metadata}
-          />
-        )}
+        {metadata && <CreatedInRow motionDomainMetadata={metadata} />}
       </ActionDataGrid>
       {action.annotation?.message && (
         <DescriptionRow description={action.annotation.message} />

--- a/src/components/v5/common/CompletedAction/partials/SetUserRoles/SetUserRoles.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SetUserRoles/SetUserRoles.tsx
@@ -167,6 +167,12 @@ const SetUserRoles = ({ action }: Props) => {
           { id: 'action.title' },
           {
             direction: rolesTitle,
+            multiSigAuthority:
+              roleAuthority === Authority.ViaMultiSig
+                ? `${formatText({
+                    id: 'decisionMethod.multiSig',
+                  })} `
+                : '',
             actionType: ColonyActionType.SetUserRoles,
             fromDomain: action.fromDomain?.metadata?.name,
             initiator: initiatorUser ? (

--- a/src/components/v5/common/CompletedAction/partials/SetUserRoles/SetUserRoles.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SetUserRoles/SetUserRoles.tsx
@@ -129,6 +129,10 @@ const SetUserRoles = ({ action }: Props) => {
     ? Authority.ViaMultiSig
     : Authority.Own;
 
+  const metadata =
+    action.motionData?.motionDomain.metadata ??
+    action.multiSigData?.multiSigDomain.metadata;
+
   return (
     <>
       <div className="flex items-center justify-between gap-2">
@@ -238,11 +242,7 @@ const SetUserRoles = ({ action }: Props) => {
           isMotion={action.isMotion || false}
           isMultisig={action.isMultiSig || false}
         />
-        {action.motionData?.motionDomain.metadata && (
-          <CreatedInRow
-            motionDomainMetadata={action.motionData.motionDomain.metadata}
-          />
-        )}
+        {metadata && <CreatedInRow motionDomainMetadata={metadata} />}
       </ActionDataGrid>
       {action.annotation?.message && (
         <DescriptionRow description={action.annotation.message} />

--- a/src/components/v5/common/CompletedAction/partials/SetUserRoles/SetUserRoles.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SetUserRoles/SetUserRoles.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { ADDRESS_ZERO } from '~constants';
 import { Action } from '~constants/actions.ts';
 import { getRole } from '~constants/permissions.ts';
+import { useAppContext } from '~context/AppContext/AppContext.ts';
 import {
   ColonyActionType,
   type ColonyActionRoles,
@@ -33,6 +34,7 @@ import {
   ActionTitle,
 } from '../Blocks/index.ts';
 import MeatballMenu from '../MeatballMenu/MeatballMenu.tsx';
+import MultiSigMeatballMenu from '../MultiSigMeatballMenu/MultiSigMeatballMenu.tsx';
 import {
   ActionData,
   ActionTypeRow,
@@ -89,6 +91,7 @@ const SetUserRoles = ({ action }: Props) => {
       { actionType: ColonyActionType.SetUserRoles },
     ),
   } = action.metadata || {};
+  const { user } = useAppContext();
   const {
     initiatorUser,
     recipientUser,
@@ -101,7 +104,12 @@ const SetUserRoles = ({ action }: Props) => {
     blockNumber,
     colonyAddress,
     rolesAreMultiSig,
+    isMultiSig,
+    multiSigData,
+    type: actionType,
   } = action;
+
+  const isOwner = initiatorUser?.walletAddress === user?.walletAddress;
 
   const { data: historicRoles } = useGetColonyHistoricRoleRolesQuery({
     variables: {
@@ -125,21 +133,30 @@ const SetUserRoles = ({ action }: Props) => {
     <>
       <div className="flex items-center justify-between gap-2">
         <ActionTitle>{customTitle}</ActionTitle>
-        <MeatballMenu
-          transactionHash={transactionHash}
-          defaultValues={{
-            [TITLE_FIELD_NAME]: customTitle,
-            [ACTION_TYPE_FIELD_NAME]: Action.ManagePermissions,
-            member: recipientAddress,
-            authority: roleAuthority,
-            role,
-            [TEAM_FIELD_NAME]: fromDomain?.nativeId,
-            [DECISION_METHOD_FIELD_NAME]: isMotion
-              ? DecisionMethod.Reputation
-              : DecisionMethod.Permissions,
-            [DESCRIPTION_FIELD_NAME]: annotation?.message,
-          }}
-        />
+        {isMultiSig && multiSigData ? (
+          <MultiSigMeatballMenu
+            transactionHash={transactionHash}
+            multiSigData={multiSigData}
+            isOwner={isOwner}
+            actionType={actionType}
+          />
+        ) : (
+          <MeatballMenu
+            transactionHash={transactionHash}
+            defaultValues={{
+              [TITLE_FIELD_NAME]: customTitle,
+              [ACTION_TYPE_FIELD_NAME]: Action.ManagePermissions,
+              member: recipientAddress,
+              authority: roleAuthority,
+              role,
+              [TEAM_FIELD_NAME]: fromDomain?.nativeId,
+              [DECISION_METHOD_FIELD_NAME]: isMotion
+                ? DecisionMethod.Reputation
+                : DecisionMethod.Permissions,
+              [DESCRIPTION_FIELD_NAME]: annotation?.message,
+            }}
+          />
+        )}
       </div>
       <ActionSubtitle>
         {formatText(

--- a/src/components/v5/common/CompletedAction/partials/rows/TeamFrom.tsx
+++ b/src/components/v5/common/CompletedAction/partials/rows/TeamFrom.tsx
@@ -18,6 +18,7 @@ const TeamFromRow = ({ teamMetadata, actionType }: TeamFromRowProps) => {
   const getTooltipContent = () => {
     switch (actionType) {
       case ColonyActionType.SetUserRoles:
+      case ColonyActionType.SetUserRolesMultisig:
       case ColonyActionType.EmitDomainReputationPenalty:
       case ColonyActionType.EmitDomainReputationReward:
         return formatText({
@@ -32,6 +33,7 @@ const TeamFromRow = ({ teamMetadata, actionType }: TeamFromRowProps) => {
   const getRowTitle = () => {
     switch (actionType) {
       case ColonyActionType.SetUserRoles:
+      case ColonyActionType.SetUserRolesMultisig:
       case ColonyActionType.EmitDomainReputationPenalty:
       case ColonyActionType.EmitDomainReputationReward:
         return formatText({ id: 'actionSidebar.team' });

--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -36,8 +36,9 @@ const actionsMessageDescriptors = {
       ${ColonyActionType.EmitDomainReputationPenaltyMotion} {Remove {reputationChangeNumeral} reputation {reputationChange, plural, one {point} other {points}} from {recipient} by {initiator}}
       ${ColonyActionType.EmitDomainReputationReward} {Add {reputationChangeNumeral} reputation {reputationChange, plural, one {point} other {points}} to {recipient} by {initiator}}
       ${ColonyActionType.EmitDomainReputationRewardMotion} {Add {reputationChangeNumeral} reputation {reputationChange, plural, one {point} other {points}} to {recipient} by {initiator}}
-      ${ColonyActionType.SetUserRoles} {{direction} permissions for {recipient} in {fromDomain} by {initiator}}
-      ${ColonyActionType.SetUserRolesMotion} {{direction} permissions for {recipient} in {fromDomain} by {initiator}}
+      ${ColonyActionType.SetUserRoles} {{direction} {multiSigAuthority}permissions for {recipient} in {fromDomain} by {initiator}}
+      ${ColonyActionType.SetUserRolesMotion} {{direction} {multiSigAuthority}permissions for {recipient} in {fromDomain} by {initiator}}
+      ${ColonyActionType.SetUserRolesMultisig} {{direction} {multiSigAuthority}permissions for {recipient} in {fromDomain} by {initiator}}
       ${ColonyActionType.AddVerifiedMembers} {Add {members} verified {members, plural, one {member} other {members}} by {initiator}}
       ${ColonyActionType.AddVerifiedMembersMotion} {Add {members} verified {members, plural, one {member} other {members}} by {initiator}}
       ${ColonyActionType.AddVerifiedMembersMultisig} {Add {members} verified {members, plural, one {member} other {members}} by {initiator}}
@@ -87,6 +88,7 @@ const actionsMessageDescriptors = {
       ${ColonyActionType.EditDomainMultisig} {Edit Team}
       ${ColonyActionType.SetUserRoles} {Manage permissions}
       ${ColonyActionType.SetUserRolesMotion} {Manage permissions}
+      ${ColonyActionType.SetUserRolesMultisig} {Manage permissions}
       ${ColonyActionType.Recovery} {Recovery}
       ${ColonyActionType.EmitDomainReputationPenalty} {Manage reputation}
       ${ColonyActionType.EmitDomainReputationPenaltyMotion} {Manage reputation}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -430,6 +430,7 @@
     "transaction.MultisigPermissionsClient.execute.title": "Execute MultiSig motion",
     "transaction.MultisigPermissionsClient.executeWithoutFailure.title": "Execute MultiSig motion",
     "transaction.MultisigPermissionsClient.createMotion.title": "Create motion",
+    "transaction.group.setInitialMultiSigRoles.title": "Set initial multi-sig roles",
     "metatransaction.debug.description": "DEBUG: context: {context} methodName: {methodName}",
     "metatransaction.group.deposit.title": "Activate tokens",
     "metatransaction.group.deposit.description": "Activate tokens",

--- a/src/redux/sagas/motions/managePermissionsMotion.ts
+++ b/src/redux/sagas/motions/managePermissionsMotion.ts
@@ -185,7 +185,7 @@ function* managePermissionsMotion({
 
         return {
           context: ClientType.MultisigPermissionsClient,
-          methodName: 'createMotion',
+          methodName: TRANSACTION_METHODS.CreateMotion,
           identifier: colonyAddress,
           params,
           group: {
@@ -256,7 +256,7 @@ function* managePermissionsMotion({
 
       return {
         context: ClientType.VotingReputationClient,
-        methodName: 'createMotion',
+        methodName: TRANSACTION_METHODS.CreateMotion,
         identifier: colonyAddress,
         params: [
           createdInDomainId,

--- a/src/redux/sagas/motions/managePermissionsMotion.ts
+++ b/src/redux/sagas/motions/managePermissionsMotion.ts
@@ -1,16 +1,18 @@
 import {
   ClientType,
   Id,
-  getPermissionProofs,
   getChildIndex,
-  ColonyRole,
+  type ColonyRole,
 } from '@colony/colony-js';
 import { hexlify, hexZeroPad } from 'ethers/lib/utils';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
+import { PERMISSIONS_NEEDED_FOR_ACTION } from '~constants/actions.ts';
 import { ADDRESS_ZERO } from '~constants/index.ts';
+import { type ColonyRoleFragment } from '~gql';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 import { Authority } from '~types/authority.ts';
+import { type Domain } from '~types/graphql.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { putError, takeFrom } from '~utils/saga/effects.ts';
 
@@ -25,7 +27,169 @@ import {
   initiateTransaction,
   uploadAnnotation,
   createActionMetadataInDB,
+  getPermissionProofsLocal,
 } from '../utils/index.ts';
+
+function* getCreateMotionParams({
+  roles,
+  authority,
+  isMultiSig,
+  colonyAddress,
+  motionDomainId,
+  colonyRoles,
+  colonyDomains,
+  userAddress,
+  domainId,
+  batchKey,
+  metaId,
+}: {
+  roles: Record<ColonyRole, boolean>;
+  authority: Authority;
+  isMultiSig: boolean;
+  colonyAddress: string;
+  motionDomainId: number;
+  colonyRoles: ColonyRoleFragment[];
+  colonyDomains: Domain[];
+  userAddress: string;
+  domainId: number;
+  batchKey: TRANSACTION_METHODS;
+  metaId: string;
+}) {
+  const colonyManager = yield getColonyManager();
+
+  const colonyClient = yield colonyManager.getClient(
+    ClientType.ColonyClient,
+    colonyAddress,
+  );
+
+  const roleArray = Object.values(roles).reverse();
+  roleArray.splice(2, 0, false);
+
+  let roleBitmask = '';
+
+  roleArray.forEach((role) => {
+    roleBitmask += role ? '1' : '0';
+  });
+
+  const hexString = hexlify(parseInt(roleBitmask, 2));
+  const zeroPadHexString = hexZeroPad(hexString, 32);
+
+  let altTarget: string;
+
+  switch (authority) {
+    case Authority.ViaMultiSig: {
+      const multiSigClient = yield colonyManager.getClient(
+        ClientType.MultisigPermissionsClient,
+        colonyAddress,
+      );
+      altTarget = multiSigClient.address;
+      break;
+    }
+    case Authority.Own:
+    default: {
+      altTarget = isMultiSig ? colonyAddress : ADDRESS_ZERO;
+      break;
+    }
+  }
+
+  let initiatorAddress: string;
+
+  if (isMultiSig) {
+    initiatorAddress = yield colonyClient.signer.getAddress();
+  } else {
+    const votingReputationClient = yield colonyManager.getClient(
+      ClientType.VotingReputationClient,
+      colonyAddress,
+    );
+
+    initiatorAddress = votingReputationClient.address;
+  }
+
+  const requiredRoles =
+    motionDomainId === Id.RootDomain
+      ? PERMISSIONS_NEEDED_FOR_ACTION.ManagePermissionsInRootDomain
+      : PERMISSIONS_NEEDED_FOR_ACTION.ManagePermissionsInSubDomain;
+
+  const [permissionDomainId, childSkillIndex] = yield call(
+    getPermissionProofsLocal,
+    {
+      networkClient: colonyClient.networkClient,
+      colonyRoles,
+      colonyDomains,
+      requiredDomainId: motionDomainId,
+      requiredColonyRole: requiredRoles,
+      permissionAddress: initiatorAddress,
+      isMultiSig,
+    },
+  );
+
+  const encodedAction = colonyClient.interface.encodeFunctionData(
+    'setUserRoles',
+    [
+      permissionDomainId,
+      childSkillIndex,
+      userAddress,
+      domainId,
+      zeroPadHexString,
+    ],
+  );
+
+  if (isMultiSig) {
+    return {
+      context: ClientType.MultisigPermissionsClient,
+      methodName: 'createMotion',
+      identifier: colonyAddress,
+      params: [Id.RootDomain, childSkillIndex, [altTarget], [encodedAction]],
+      group: {
+        key: batchKey,
+        id: metaId,
+        index: 0,
+      },
+      ready: false,
+    };
+  }
+
+  const motionChildSkillIndex = yield call(
+    getChildIndex,
+    colonyClient.networkClient,
+    colonyClient,
+    motionDomainId,
+    domainId,
+  );
+
+  const { skillId } = yield call(
+    [colonyClient, colonyClient.getDomain],
+    motionDomainId,
+  );
+
+  const { key, value, branchMask, siblings } = yield call(
+    colonyClient.getReputation,
+    skillId,
+    ADDRESS_ZERO,
+  );
+
+  return {
+    context: ClientType.VotingReputationClient,
+    methodName: 'createMotion',
+    identifier: colonyAddress,
+    params: [
+      motionDomainId,
+      motionChildSkillIndex,
+      altTarget,
+      encodedAction,
+      key,
+      value,
+      branchMask,
+      siblings,
+    ],
+    group: {
+      key: batchKey,
+      id: metaId,
+      index: 0,
+    },
+    ready: false,
+  };
+}
 
 function* managePermissionsMotion({
   payload: {
@@ -36,56 +200,18 @@ function* managePermissionsMotion({
     authority,
     colonyName,
     annotationMessage,
-    motionDomainId,
     customActionTitle,
+    motionDomainId,
+    colonyRoles,
+    colonyDomains,
+    // Is using the multi-sig decision method
+    isMultiSig = false,
   },
   meta: { id: metaId, navigate, setTxHash },
   meta,
 }: Action<ActionTypes.MOTION_USER_ROLES_SET>) {
   let txChannel;
   try {
-    const colonyManager = yield getColonyManager();
-    const colonyClient = yield colonyManager.getClient(
-      ClientType.ColonyClient,
-      colonyAddress,
-    );
-    const votingReputationClient = yield colonyManager.getClient(
-      ClientType.VotingReputationClient,
-      colonyAddress,
-    );
-    const multiSigClient = yield colonyManager.getClient(
-      ClientType.MultisigPermissionsClient,
-      colonyAddress,
-    );
-
-    const [permissionDomainId, childSkillIndex] = yield call(
-      getPermissionProofs,
-      colonyClient.networkClient,
-      colonyClient,
-      domainId,
-      domainId === Id.RootDomain ? ColonyRole.Root : ColonyRole.Architecture,
-      votingReputationClient.address,
-    );
-
-    const motionChildSkillIndex = yield call(
-      getChildIndex,
-      colonyClient.networkClient,
-      colonyClient,
-      motionDomainId,
-      domainId,
-    );
-
-    const { skillId } = yield call(
-      [colonyClient, colonyClient.getDomain],
-      motionDomainId,
-    );
-
-    const { key, value, branchMask, siblings } = yield call(
-      colonyClient.getReputation,
-      skillId,
-      ADDRESS_ZERO,
-    );
-
     txChannel = yield call(getTxChannel, metaId);
 
     // setup batch ids and channels
@@ -97,56 +223,21 @@ function* managePermissionsMotion({
         'annotateSetUserRolesMotion',
       ]);
 
-    const roleArray = Object.values(roles).reverse();
-    roleArray.splice(2, 0, false);
-
-    let roleBitmask = '';
-
-    roleArray.forEach((role) => {
-      roleBitmask += role ? '1' : '0';
+    const transactionParams = yield getCreateMotionParams({
+      roles,
+      authority,
+      isMultiSig,
+      colonyAddress,
+      motionDomainId,
+      colonyRoles,
+      colonyDomains,
+      userAddress,
+      domainId,
+      batchKey,
+      metaId,
     });
 
-    const hexString = hexlify(parseInt(roleBitmask, 2));
-    const zeroPadHexString = hexZeroPad(hexString, 32);
-
-    const encodedAction = colonyClient.interface.encodeFunctionData(
-      'setUserRoles',
-      [
-        permissionDomainId,
-        childSkillIndex,
-        userAddress,
-        domainId,
-        zeroPadHexString,
-      ],
-    );
-
-    const altTargetMap = {
-      [Authority.Own]: ADDRESS_ZERO,
-      [Authority.ViaMultiSig]: multiSigClient.address,
-    };
-
-    // create transactions
-    yield fork(createTransaction, createMotion.id, {
-      context: ClientType.VotingReputationClient,
-      methodName: 'createMotion',
-      identifier: colonyAddress,
-      params: [
-        motionDomainId,
-        motionChildSkillIndex,
-        altTargetMap[authority],
-        encodedAction,
-        key,
-        value,
-        branchMask,
-        siblings,
-      ],
-      group: {
-        key: batchKey,
-        id: metaId,
-        index: 0,
-      },
-      ready: false,
-    });
+    yield fork(createTransaction, createMotion.id, transactionParams);
 
     if (annotationMessage) {
       yield fork(createTransaction, annotateSetUserRolesMotion.id, {

--- a/src/redux/sagas/motions/managePermissionsMotion.ts
+++ b/src/redux/sagas/motions/managePermissionsMotion.ts
@@ -234,7 +234,6 @@ function* managePermissionsMotion({
         ],
       );
 
-      // eslint-disable-next-line no-inner-declarations
       const motionChildSkillIndex = yield call(getChildIndexLocal, {
         networkClient: colonyClient.networkClient,
         parentDomainNativeId: createdInDomain.nativeId,
@@ -284,7 +283,7 @@ function* managePermissionsMotion({
     if (annotationMessage) {
       yield fork(createTransaction, annotateSetUserRolesMotion.id, {
         context: ClientType.ColonyClient,
-        methodName: 'annotateTransaction',
+        methodName: TRANSACTION_METHODS.AnnotateTransaction,
         identifier: colonyAddress,
         params: [],
         group: {

--- a/src/redux/types/actions/motion.ts
+++ b/src/redux/types/actions/motion.ts
@@ -282,8 +282,11 @@ export type MotionActionTypes =
         userAddress: Address;
         roles: Record<ColonyRole, boolean>;
         authority: Authority;
-        motionDomainId: string;
+        motionDomainId: number;
         annotationMessage?: string;
+        colonyRoles: ColonyRoleFragment[];
+        colonyDomains: Domain[];
+        isMultiSig?: boolean;
       },
       MetaWithSetter<object>
     >

--- a/src/utils/multiSig.ts
+++ b/src/utils/multiSig.ts
@@ -1,4 +1,4 @@
-import { type ColonyRole } from '@colony/colony-js';
+import { Id, type ColonyRole } from '@colony/colony-js';
 
 import { PERMISSIONS_NEEDED_FOR_ACTION } from '~constants/actions.ts';
 import { ColonyActionType, type ColonyActionFragment } from '~gql';
@@ -9,9 +9,13 @@ import { MotionState } from './colonyMotions.ts';
 import { extractColonyRoles } from './colonyRoles.ts';
 import { extractColonyDomains } from './domains.ts';
 
-export const getRolesNeededForMultiSigAction = (
-  actionType: ColonyActionType,
-): ColonyRole[] | undefined => {
+export const getRolesNeededForMultiSigAction = ({
+  actionType,
+  createdIn,
+}: {
+  actionType: ColonyActionType;
+  createdIn: number;
+}): ColonyRole[] | undefined => {
   switch (actionType) {
     case ColonyActionType.ColonyEditMultisig:
       return PERMISSIONS_NEEDED_FOR_ACTION.EditColonyDetails;
@@ -28,6 +32,14 @@ export const getRolesNeededForMultiSigAction = (
       return PERMISSIONS_NEEDED_FOR_ACTION.ManageVerifiedMembers;
     case ColonyActionType.MoveFundsMultisig:
       return PERMISSIONS_NEEDED_FOR_ACTION.TransferFunds;
+    case ColonyActionType.SetUserRolesMultisig:
+      if (!createdIn) {
+        return undefined;
+      }
+      if (createdIn === Id.RootDomain) {
+        return PERMISSIONS_NEEDED_FOR_ACTION.ManagePermissionsInRootDomain;
+      }
+      return PERMISSIONS_NEEDED_FOR_ACTION.ManagePermissionsInSubDomain;
     default:
       return undefined;
   }


### PR DESCRIPTION
Related block-ingestor PR: https://github.com/JoinColony/block-ingestor/pull/247

## Description

As a user moderating a colony, I want to be able to create and finalize a multi-sig manage roles motion.

It should be possible to create a manage permissions multi-sig motion in the general team. Users with the `root` role (owner) should be able to create, vote and finalize.

It should be possible to create a manage permissions multi-sig motion in any sub team. Users with the `architecture` role (admin) should be able to create, vote and finalize.

(At a later point, in a sub team it should be possible to vote if you have either the `root` or `architecture` role in `general`, but this will be addressed in a separate PR.)

(Note: The completed action screen will not show the correct permissions if you are updating the multi-sig permissions of someone who already has multi-sig permissions. The same issue occurs on master when assigning permissions via a reputation motion so I've opened a new issue for this.)

## Testing

* Step 1: Install the multi-sig extension. Set the fixed threshold to 2 in the extension settings tab.
* Step 2: Assign admin permissions to Amy using `Take actions via Multi-Sig` as the authority, and `Permissions` as the decision method.

<img width="681" alt="Screenshot 2024-07-05 at 15 16 44" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/7c8c410f-a26e-417c-a90e-2154e3c0a5b9">

* Step 3: Assign admin permissions to Fry in the `Andromeda` team using `Take actions via Multi-Sig` as the authority, `Multi-Sig` as the decision method, and `Andromeda` as the `CreatedIn` domain.

<img width="681" alt="Screenshot 2024-07-05 at 15 18 29" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/592111bc-8572-477c-bbba-851a6e102a12">

<img width="1065" alt="Screenshot 2024-07-05 at 15 19 48" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/68fd8d6b-f64a-4c34-b78d-1e5e2678a9a8">

* Step 4: Open an incognito window and connect Amy's wallet. Copy the URL to open the same multi-sig transaction in the incognito window. Then approve the multi-sig motion as Amy.

<img width="1059" alt="Screenshot 2024-07-05 at 15 21 42" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/c80bf27f-edb2-42cc-8d6a-086b2ad5a13b">

* Step 5: Finalize the multi-sig motion. Refresh and confirm Fry has been assigned the appropriate permissions.

<img width="1288" alt="Screenshot 2024-07-05 at 15 22 39" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/17bb6654-0a7e-4d2e-ac69-8198a66cbf20">

* Further testing: Step 6: Switch to Fry's wallet and create a manage permissions action using your new found permission powers. Select `Multi-Sig` as the decision method and `General` as the team. Note both validation notifications. As Fry, we don't have multi-sig permissions in `General` so we see the permissions notification, but also Leela is the only user with `Root` permissions in `General` so there are also not enough users with permissions for the action. When managing permissions in the `root` domain, the `root` permission role is required.

<img width="1290" alt="Screenshot 2024-07-05 at 15 37 32" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/8f93431a-e480-4713-a7d6-204d10ef3dd2">

* Step 7: Switch the team to `Serenity`. When managing permissions in a sub-domain, only the `architecture` role is required. Amy is an admin in `General` so she has the `architecture` role meaning there are sufficient members for the multi-sig motion to be created.

* Step 8: Switch the team to `Andromeda`. Fry actually has permissions here so we can create the multi-sig motion. Leela and Amy both have permissions in General so we should expect to see them as eligible signees here. Select a member, and a permissions type. Set the authority to `Take actions on their own` so we can test this works okay too.

<img width="1293" alt="Screenshot 2024-07-05 at 15 46 24" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/ece4009c-291d-4f61-8598-9ef5ee8e4eff">

<img width="1290" alt="Screenshot 2024-07-05 at 15 46 37" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/dd34aa8b-5347-466e-9459-9afbaa29b9e7">

* Step 9: Switch back to Leela or Amy to approve and finalize.

<img width="1716" alt="Screenshot 2024-07-05 at 15 47 54" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/cce62d67-97ca-41b2-ae58-cfd750f69b62">

Really further testing:
* Check you can assign a user permissions in a sub-domain with `createdIn` set to general. (You will need to assign owner permissions to Amy in `General` to have enough users to vote this through).
* Install the reputation voting extension and check motions are unaffected by any changes here. (Test in general, sub-domain, sub-domain created in general - can also test assigning own permissions or multi-sig permissions).
* Can also test multi-sig motions with both the multi-sig extension and reputation extension installed.
* Can also test reputation motions with the multi-sig extension uninstalled.

## Diffs

**New stuff** ✨

* Manage permissions motion now supports multi-sig decision method
* Manage permissions motion now supports assigning multi-sig permissions via multi-sig decision method

## TODO

- [ ] It should be possible to create / vote as a user with either the `root` role or `architecture` role in a sub-domain. Currently it requires `architecture` and users with only `root` will be unable to create or vote. I will address in this a future PR.

Contributes #2192
