### PR TITLE
feat: added list for permissions fundings

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/PaymentBuilderWidget.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/PaymentBuilderWidget.tsx
@@ -28,6 +28,7 @@ import FinalizeByPaymentCreatorInfo from '../FinalizeByPaymentCreatorInfo/Finali
 import FundingModal from '../FundingModal/FundingModal.tsx';
 import MotionBox from '../MotionBox/MotionBox.tsx';
 import PaymentStepDetailsBlock from '../PaymentStepDetailsBlock/PaymentStepDetailsBlock.tsx';
+import PermissionsBox from '../PermissionsBox/PermissionsBox.tsx';
 import ReleasePaymentModal from '../ReleasePaymentModal/ReleasePaymentModal.tsx';
 import RequestBox from '../RequestBox/RequestBox.tsx';
 import StepDetailsBlock from '../StepDetailsBlock/StepDetailsBlock.tsx';
@@ -52,6 +53,9 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
     isReleaseModalOpen: isReleasePaymentModalOpen,
     toggleOffReleaseModal: hideReleasePaymentModal,
     toggleOnReleaseModal: showReleasePaymentModal,
+    selectedTransaction,
+    setSelectedTransaction,
+    selectedPermissionAction,
   } = usePaymentBuilderContext();
 
   const { expenditureId } = action;
@@ -148,9 +152,6 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
     );
   }, [motions]);
 
-  const { selectedTransaction, setSelectedTransaction } =
-    usePaymentBuilderContext();
-
   const {
     action: motionAction,
     motionState,
@@ -232,6 +233,11 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
   useEffect(() => {
     setSelectedTransaction(fundingMotions?.[0]?.transactionHash);
   }, [fundingMotions, fundingMotions.length, setSelectedTransaction]);
+
+  const mappedFundingActionsItems = (fundingActionsItems || []).map((item) => ({
+    createdAt: item?.createdAt || '',
+    initiatorAddress: item?.initiatorAddress || '',
+  }));
 
   const items: StepperItem<ExpenditureStep>[] = [
     {
@@ -399,11 +405,25 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
                 />
               </div>
             ) : undefined}
-            {fundingActionsItems?.[0] && (
-              <ActionWithPermissionsInfo
-                userAdddress={fundingActionsItems[0].initiatorAddress}
-                createdAt={fundingActionsItems[0]?.createdAt}
-              />
+            {fundingActionsItems && fundingActionsItems.length > 0 && (
+              <>
+                {fundingActionsItems.length === 1 ? (
+                  <ActionWithPermissionsInfo
+                    userAdddress={fundingActionsItems[0]?.initiatorAddress}
+                    createdAt={fundingActionsItems[0]?.createdAt}
+                  />
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    <PermissionsBox items={mappedFundingActionsItems} />
+                    {selectedPermissionAction && (
+                      <ActionWithPermissionsInfo
+                        userAdddress={selectedPermissionAction.initiatorAddress}
+                        createdAt={selectedPermissionAction.createdAt}
+                      />
+                    )}
+                  </div>
+                )}
+              </>
             )}
           </>
         ),

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PermissionsBox/PermissionsBox.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PermissionsBox/PermissionsBox.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import React, { type FC } from 'react';
 import { FormattedDate } from 'react-intl';
 
@@ -10,7 +11,8 @@ import MenuContainer from '~v5/shared/MenuContainer/MenuContainer.tsx';
 import { type PermissionsBoxProps } from './types.ts';
 
 const PermissionsBox: FC<PermissionsBoxProps> = ({ items }) => {
-  const { setSelectedPermissionAction } = usePaymentBuilderContext();
+  const { selectedPermissionAction, setSelectedPermissionAction } =
+    usePaymentBuilderContext();
 
   return (
     <MenuContainer
@@ -27,12 +29,24 @@ const PermissionsBox: FC<PermissionsBoxProps> = ({ items }) => {
           <li className="mb-2 w-full last:mb-0" key={createdAt}>
             <button
               type="button"
-              className="group flex w-full items-center justify-between text-gray-600 outline-none transition-all hover:text-blue-400"
+              className={clsx(
+                'group flex w-full items-center justify-between outline-none transition-all hover:text-blue-400',
+                {
+                  'text-blue-400':
+                    selectedPermissionAction?.createdAt === createdAt,
+                  'text-gray-600':
+                    selectedPermissionAction?.createdAt !== createdAt,
+                },
+              )}
               onClick={() =>
                 setSelectedPermissionAction({ createdAt, initiatorAddress })
               }
             >
-              <span className="text-sm group-hover:underline">
+              <span
+                className={clsx('text-sm group-hover:underline', {
+                  underline: selectedPermissionAction?.createdAt === createdAt,
+                })}
+              >
                 <FormattedDate
                   value={new Date(createdAt)}
                   day="numeric"

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PermissionsBox/PermissionsBox.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PermissionsBox/PermissionsBox.tsx
@@ -1,0 +1,52 @@
+import React, { type FC } from 'react';
+import { FormattedDate } from 'react-intl';
+
+import ActionBadge from '~common/ColonyActionsTable/partials/ActionBadge/ActionBadge.tsx';
+import { usePaymentBuilderContext } from '~context/PaymentBuilderContext/PaymentBuilderContext.ts';
+import { MotionState } from '~utils/colonyMotions.ts';
+import { formatText } from '~utils/intl.ts';
+import MenuContainer from '~v5/shared/MenuContainer/MenuContainer.tsx';
+
+import { type PermissionsBoxProps } from './types.ts';
+
+const PermissionsBox: FC<PermissionsBoxProps> = ({ items }) => {
+  const { setSelectedPermissionAction } = usePaymentBuilderContext();
+
+  return (
+    <MenuContainer
+      className="w-full overflow-hidden p-[1.125rem]"
+      withPadding={false}
+    >
+      <h5 className="mb-2 text-1">
+        {formatText({
+          id: 'expenditure.fundingRequest.title',
+        })}
+      </h5>
+      <ul className="max-h-[6.25rem] overflow-y-auto overflow-x-hidden">
+        {items.map(({ createdAt, initiatorAddress }) => (
+          <li className="mb-2 w-full last:mb-0" key={createdAt}>
+            <button
+              type="button"
+              className="group flex w-full items-center justify-between text-gray-600 outline-none transition-all hover:text-blue-400"
+              onClick={() =>
+                setSelectedPermissionAction({ createdAt, initiatorAddress })
+              }
+            >
+              <span className="text-sm group-hover:underline">
+                <FormattedDate
+                  value={new Date(createdAt)}
+                  day="numeric"
+                  month="short"
+                  year="numeric"
+                />
+              </span>
+              <ActionBadge motionState={MotionState.Passed} />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </MenuContainer>
+  );
+};
+
+export default PermissionsBox;

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PermissionsBox/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PermissionsBox/types.ts
@@ -1,0 +1,8 @@
+export interface PermissionsBoxItem {
+  initiatorAddress: string;
+  createdAt: string;
+}
+
+export interface PermissionsBoxProps {
+  items: PermissionsBoxItem[];
+}

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/RequestBox/partials/RequestBoxItem.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/RequestBox/partials/RequestBoxItem.tsx
@@ -31,7 +31,7 @@ const RequestBoxItem: FC<RequestBoxItemProps> = ({
     <button
       type="button"
       className={clsx(
-        'relative flex w-full items-center justify-between text-gray-600 outline-none transition-colors',
+        'group flex w-full items-center justify-between text-gray-600 outline-none transition-all',
         {
           'hover:text-blue-400': isMotionFailed || !isSingleItem,
         },
@@ -49,7 +49,11 @@ const RequestBoxItem: FC<RequestBoxItemProps> = ({
         }
       }}
     >
-      <span className="text-sm">
+      <span
+        className={clsx('text-sm', {
+          'group-hover:underline': isMotionFailed || !isSingleItem,
+        })}
+      >
         <FormattedDate
           value={new Date(date)}
           day="numeric"

--- a/src/context/PaymentBuilderContext/PaymentBuilderContext.ts
+++ b/src/context/PaymentBuilderContext/PaymentBuilderContext.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext } from 'react';
 
 import noop from '~utils/noop.ts';
+import { type PermissionsBoxItem } from '~v5/common/CompletedAction/partials/PaymentBuilder/partials/PermissionsBox/types.ts';
 
 export const PaymentBuilderContext = createContext<{
   toggleOnFundingModal: () => void;
@@ -9,6 +10,8 @@ export const PaymentBuilderContext = createContext<{
   toggleOnReleaseModal: () => void;
   toggleOffReleaseModal: () => void;
   isReleaseModalOpen: boolean;
+  selectedPermissionAction: PermissionsBoxItem | undefined;
+  setSelectedPermissionAction: (data: PermissionsBoxItem) => void;
   selectedTransaction: string;
   setSelectedTransaction: (transaction: string) => void;
 }>({
@@ -18,6 +21,8 @@ export const PaymentBuilderContext = createContext<{
   toggleOnReleaseModal: noop,
   toggleOffReleaseModal: noop,
   isReleaseModalOpen: false,
+  selectedPermissionAction: undefined,
+  setSelectedPermissionAction: noop,
   selectedTransaction: '',
   setSelectedTransaction: noop,
 });

--- a/src/context/PaymentBuilderContext/PaymentBuilderContextProvider.tsx
+++ b/src/context/PaymentBuilderContext/PaymentBuilderContextProvider.tsx
@@ -6,6 +6,7 @@ import React, {
 } from 'react';
 
 import useToggle from '~hooks/useToggle/index.ts';
+import { type PermissionsBoxItem } from '~v5/common/CompletedAction/partials/PaymentBuilder/partials/PermissionsBox/types.ts';
 
 import { PaymentBuilderContext } from './PaymentBuilderContext.ts';
 
@@ -19,6 +20,9 @@ const PaymentBuilderContextProvider: FC<PropsWithChildren> = ({ children }) => {
     { toggleOn: toggleOnReleaseModal, toggleOff: toggleOffReleaseModal },
   ] = useToggle();
   const [selectedTransaction, setSelectedTransaction] = useState<string>('');
+  const [selectedPermissionAction, setSelectedPermissionAction] = useState<
+    PermissionsBoxItem | undefined
+  >(undefined);
 
   const value = useMemo(
     () => ({
@@ -28,6 +32,8 @@ const PaymentBuilderContextProvider: FC<PropsWithChildren> = ({ children }) => {
       toggleOnReleaseModal,
       toggleOffReleaseModal,
       isReleaseModalOpen,
+      selectedPermissionAction,
+      setSelectedPermissionAction,
       selectedTransaction,
       setSelectedTransaction,
     }),
@@ -38,6 +44,8 @@ const PaymentBuilderContextProvider: FC<PropsWithChildren> = ({ children }) => {
       toggleOnReleaseModal,
       toggleOffReleaseModal,
       isReleaseModalOpen,
+      selectedPermissionAction,
+      setSelectedPermissionAction,
       selectedTransaction,
       setSelectedTransaction,
     ],


### PR DESCRIPTION
## Description

- Added list for funding using permission method
<img width="319" alt="image" src="https://github.com/JoinColony/colonyCDapp/assets/76940796/bf569a17-9dcc-40fe-a359-13d174572c7b">

## Testing

* Create a Payment builder action.
* At the Funding step, fund the payment twice. You should be able to do it by clicking the button twice.
* Continue to the next step.
* Click back in the funding step.

Resolves [https://github.com/JoinColony/colonyCDapp/issues/2399](https://github.com/JoinColony/colonyCDapp/issues/2399)
