### PR TITLE
fix: changed userpopover font-size

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/PermissionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/PermissionSidebar.tsx
@@ -90,17 +90,19 @@ const PermissionSidebar: FC<PermissionSidebarProps> = ({ transactionId }) => {
                 })}
               </h4>
               {initiatorAddress && (
-                <div className="mt-2 flex items-center justify-between gap-2">
+                <div className="mt-2 flex items-center gap-2">
                   <span className="text-sm text-gray-600">
                     {formatText({
                       id: 'action.executed.permissions.member',
                     })}
                   </span>
-                  <UserPopover
-                    size={20}
-                    textClassName="text-sm"
-                    walletAddress={initiatorAddress || ''}
-                  />
+                  <div className="ml-auto">
+                    <UserPopover
+                      size={20}
+                      textClassName="text-sm"
+                      walletAddress={initiatorAddress || ''}
+                    />
+                  </div>
                 </div>
               )}
               {initiatorAddress && (

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/PermissionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/PermissionSidebar.tsx
@@ -98,6 +98,7 @@ const PermissionSidebar: FC<PermissionSidebarProps> = ({ transactionId }) => {
                   </span>
                   <UserPopover
                     size={20}
+                    textClassName="text-sm"
                     walletAddress={initiatorAddress || ''}
                   />
                 </div>

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizeWithPermissionsInfo/FinalizeWithPermissionsInfo.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizeWithPermissionsInfo/FinalizeWithPermissionsInfo.tsx
@@ -92,17 +92,19 @@ const FinalizeWithPermissionsInfo: FC<FinalizeWithPermissionsInfoProps> = ({
               </h4>
               {userAdddress && (
                 <>
-                  <div className="mt-2 flex items-center justify-between gap-2">
+                  <div className="mt-2 flex items-center gap-2">
                     <span className="text-sm text-gray-600">
                       {formatText({
                         id: 'action.executed.permissions.member',
                       })}
                     </span>
-                    <UserPopover
-                      size={18}
-                      textClassName="text-sm"
-                      walletAddress={userAdddress || ''}
-                    />
+                    <div className="ml-auto">
+                      <UserPopover
+                        size={18}
+                        textClassName="text-sm"
+                        walletAddress={userAdddress || ''}
+                      />
+                    </div>
                   </div>
                   <div className="mt-2 flex items-center justify-between gap-2">
                     <span className="text-sm text-gray-600">

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizeWithPermissionsInfo/FinalizeWithPermissionsInfo.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizeWithPermissionsInfo/FinalizeWithPermissionsInfo.tsx
@@ -98,7 +98,11 @@ const FinalizeWithPermissionsInfo: FC<FinalizeWithPermissionsInfoProps> = ({
                         id: 'action.executed.permissions.member',
                       })}
                     </span>
-                    <UserPopover size={18} walletAddress={userAdddress || ''} />
+                    <UserPopover
+                      size={18}
+                      textClassName="text-sm"
+                      walletAddress={userAdddress || ''}
+                    />
                   </div>
                   <div className="mt-2 flex items-center justify-between gap-2">
                     <span className="text-sm text-gray-600">


### PR DESCRIPTION
## Description

- Changed font-size for usernames in permission cards
- Paddings of motion cards seems to be fixed in some other PR
<img width="370" alt="image" src="https://github.com/JoinColony/colonyCDapp/assets/76940796/3a644306-5025-45d3-b467-e647e27e8348">

## Testing

* Create any action using permissions

Resolves [https://github.com/JoinColony/colonyCDapp/issues/2337](https://github.com/JoinColony/colonyCDapp/issues/2337)
