### PR TITLE
Feat: Add extra checks to fetchTokenFromChain to better validate address

### DIFF
--- a/amplify/backend/function/fetchTokenFromChain/src/graphql.js
+++ b/amplify/backend/function/fetchTokenFromChain/src/graphql.js
@@ -47,4 +47,22 @@ module.exports = {
       }
     }
   `,
+  getColonyByAddress: /* GraphQL */ `
+    query GetColonyByAddress($address: ID!) {
+      getColonyByAddress(id: $address) {
+        items {
+          id
+        }
+      }
+    }
+  `,
+  getUserByAddress: /* GraphQL */ `
+    query GetUserByAddress($address: ID!) {
+      getUserByAddress(id: $address) {
+        items {
+          id
+        }
+      }
+    }
+  `,
 };


### PR DESCRIPTION
## Description

This PR adds some validation to the `fetchTokenFromChain` lambda to better check is the provided address is a "valid" token. (It is not really possible to check if it is a "valid" token, but it implements the following: )

* The function already returns the token if it exists in our database
* If it does not exist as a token in our database, it will now check if it exists as either a colony address or a user address and will throw an error if it is already in use for one of these as it therefore means it cannot be a token address.
* If it still does not exist in our database, it will call the required ERC20 functions - if none of these throw an error, it is likely an ERC20 token contract

This is probably still not foolproof, but it does at the very least prevent users from putting in colony addresses instead of token addresses and wondering why it is not working.

## Testing

* Run the `create-data` script
* Run the `node scripts/create-colony-url.js`
* Follow the URL and follow the colony creation flow, select to use an existing token
* Open the amplify console in docker if you want to check the error messages
* Test out some different addresses. Copy the colony address and paste it in. Copy a user address and paste it in. Copy a valid token address (CREDS / ƓƓƓ) and confirm that is allowed. Paste in any other properly formatted address: `0x0000000000000000000000000000000000000001`

![Screenshot 2024-07-09 at 16 35 49](https://github.com/JoinColony/colonyCDapp/assets/34915414/5996a44c-916b-4141-91ee-4872fa327144)


## Diffs

**New stuff** ✨

* Check address is not already in use by a colony or user
* Check none of the required ERC20 functions throw an error

Resolves #2671
