### PR TITLE
Fix: CreatedIn Field should be read only for Move Funds motions

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/TransferFundsForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/TransferFundsForm.tsx
@@ -25,7 +25,7 @@ const TransferFundsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
   const selectedTeam = watch('from');
 
   const hasNoDecisionMethods = useHasNoDecisionMethods();
-  const createdInFilterFn = useFilterCreatedInField('from');
+  const createdInFilterFn = useFilterCreatedInField('from', true);
 
   return (
     <>
@@ -71,7 +71,7 @@ const TransferFundsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       />
 
       <DecisionMethodField />
-      <CreatedIn filterOptionsFn={createdInFilterFn} />
+      <CreatedIn readonly filterOptionsFn={createdInFilterFn} />
       <Description />
     </>
   );


### PR DESCRIPTION
## Description

- Set the createdIn field to read only, and fix it as root, when making a motion of type Move Funds.
- Right now, only General (the root domain) should be allowed to be used when making this type of motion, since no other domain will work. The created in domain must be a parent domain of both the To and the From domains.

## Testing

- Install the reputation weighted extension (then refresh the page).
- Create a new action, and select Transfer Funds as the action type, and Reputation as the decision method.
- Try to change the created in field. You should not be able to, and it should be `General`.

<img width="688" alt="Screenshot 2024-07-09 at 17 16 03" src="https://github.com/JoinColony/colonyCDapp/assets/38098203/c0ab4afc-4db0-4265-8651-07399deb177e">


## Diffs

**Changes** 🏗

* Set the createdIn field to read only, and fix it as root, when making a motion of type Move Funds.

Resolves #2683
