### PR TITLE
Feat/2658 remove multi sig permissions banner

### DIFF
--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/PermissionsNeededBanner.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/PermissionsNeededBanner.tsx
@@ -37,13 +37,13 @@ interface Props {
 }
 
 const PermissionsNeededBanner = ({ extensionData }: Props) => {
+  const shouldDisplay =
+    extensionData.extensionId !== Extension.MultisigPermissions;
   const { colony } = useColonyContext();
   const { user } = useAppContext();
   const { checkExtensionEnabled } = useCheckExtensionEnabled(
     extensionData.extensionId ?? '',
   );
-
-  const [shouldDisplay, setShouldDisplay] = useState(false);
   const [isPermissionEnabled, setIsPermissionEnabled] = useState(false);
   const userHasRoles = addressHasRoles({
     requiredRolesDomains: [Id.RootDomain],
@@ -81,9 +81,8 @@ const PermissionsNeededBanner = ({ extensionData }: Props) => {
         // Enable Extension.MultisigPermissions by default
         enableAndCheckStatus();
       }
-    } else {
-      setShouldDisplay(true);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [extensionData.extensionId, colony.colonyAddress]);
 
   const getBanner = () => {

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/utils.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/utils.tsx
@@ -105,7 +105,9 @@ export const waitForDbAfterExtensionAction = ({
         }
 
         case ExtensionMethods.ENABLE: {
-          condition = !!extension?.isInitialized;
+          // Extension.MultisigPermissions doesn't need initialisation by default
+          condition =
+            !!extension?.isInitialized || !!extension?.params?.multiSig;
           break;
         }
 

--- a/src/redux/sagas/extensions/extensionEnable.ts
+++ b/src/redux/sagas/extensions/extensionEnable.ts
@@ -48,7 +48,7 @@ function* extensionEnable({
   yield removeOldExtensionClients(colonyAddress, extensionId);
 
   const needsInitialisation = !isInitialized && initializationParams;
-  const needsSettingRoles = missingColonyPermissions.length;
+  const needsSettingRoles = !!missingColonyPermissions.length;
 
   const { initialise, setUserRoles }: Record<string, ChannelDefinition> =
     yield createTransactionChannels(meta.id, ['initialise', 'setUserRoles']);


### PR DESCRIPTION
Enable multi-sig extension without showing the permissions banner

## Description

- Install multisig and immediately give it permissions so we don't need the Enable permissions banner
- As a quick fix, I added the logic to trigger the extension enabling in the PermissionsNeededBanner component

## Testing

After installing multisig extension check if permission banner still shows up and extension is enabled without page refresh.

* Step 1. Go to Colony > Admin > Extensions > Multi-sig Permissions
* Step 2. Install extension
![Screenshot 2024-07-10 at 10 52 39](https://github.com/JoinColony/colonyCDapp/assets/32430018/22baf9a4-d4e2-400a-aa22-324bb298e2d9)
* Step 3. This banner should **NOT show up**
![Screenshot 2024-07-10 at 10 52 49](https://github.com/JoinColony/colonyCDapp/assets/32430018/7f1d4661-d25e-4ea7-920e-2b1ef71df5b2)
* Step 4. Check extension is enabled by creating a new action
* Step 5. Check Multi-Sig is among decision methods

Contributes to [#2658](https://github.com/JoinColony/colonyCDapp/issues/2658)
