### PR TITLE
Feat: Upgrade Colony version via Multi-Sig

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=bdd13f149661e64b1191db5a417a86b6642b985a
+ENV BLOCK_INGESTOR_HASH=08a63d670f711ffd23bc2d8b7a931fecf9b896fe
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/scripts/create-data.js
+++ b/scripts/create-data.js
@@ -516,7 +516,10 @@ const createColony = async (
 
   const metadata = {};
   if (colonyDescription) {
-    metadata.description = colonyDescription.slice(0, CHAR_LIMITS.COLONY.MAX_COLONY_DESCRIPTION);
+    metadata.description = colonyDescription.slice(
+      0,
+      CHAR_LIMITS.COLONY.MAX_COLONY_DESCRIPTION,
+    );
   }
   if (colonyAvatar) {
     metadata.avatar = colonyAvatar;
@@ -1484,9 +1487,13 @@ const checkArguments = () => {
     `If you wish to change these values, please pass --coloniesCount <number> and --timeout <number> respectively to this script.`,
   );
   console.log();
-  console.log(
-    `Colonies will be deployed using the current Colony version. To deploy with the previous version pass --usePreviousColonyVersion`,
-  );
+
+  if (!usePreviousColonyVersionArg) {
+    console.log(
+      `Colonies will be deployed using the current Colony version. To deploy with the previous version pass --usePreviousColonyVersion`,
+    );
+  }
+
   console.log(
     `(For this to work, you will need to have already deployed the previous Colony version resolver to the network.)`,
   );

--- a/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/TransferFundsForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/TransferFundsForm.tsx
@@ -2,6 +2,7 @@ import { ArrowDownRight, UsersThree } from '@phosphor-icons/react';
 import React, { type FC } from 'react';
 import { useFormContext } from 'react-hook-form';
 
+import { DecisionMethod } from '~types/actions.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
 import useFilterCreatedInField from '~v5/common/ActionSidebar/hooks/useFilterCreatedInField.ts';
@@ -23,9 +24,13 @@ const TransferFundsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
 
   const { watch } = useFormContext();
   const selectedTeam = watch('from');
+  const decisionMethod = watch('decisionMethod');
 
   const hasNoDecisionMethods = useHasNoDecisionMethods();
-  const createdInFilterFn = useFilterCreatedInField('from', true);
+  const createdInFilterFn = useFilterCreatedInField(
+    'from',
+    decisionMethod === DecisionMethod.MultiSig,
+  );
 
   return (
     <>
@@ -71,7 +76,10 @@ const TransferFundsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       />
 
       <DecisionMethodField />
-      <CreatedIn readonly filterOptionsFn={createdInFilterFn} />
+      <CreatedIn
+        readonly={decisionMethod === DecisionMethod.MultiSig}
+        filterOptionsFn={createdInFilterFn}
+      />
       <Description />
     </>
   );

--- a/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/TransferFundsForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/TransferFundsForm.tsx
@@ -2,7 +2,6 @@ import { ArrowDownRight, UsersThree } from '@phosphor-icons/react';
 import React, { type FC } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { DecisionMethod } from '~types/actions.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
 import useFilterCreatedInField from '~v5/common/ActionSidebar/hooks/useFilterCreatedInField.ts';
@@ -24,13 +23,9 @@ const TransferFundsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
 
   const { watch } = useFormContext();
   const selectedTeam = watch('from');
-  const decisionMethod = watch('decisionMethod');
 
   const hasNoDecisionMethods = useHasNoDecisionMethods();
-  const createdInFilterFn = useFilterCreatedInField(
-    'from',
-    decisionMethod === DecisionMethod.MultiSig,
-  );
+  const createdInFilterFn = useFilterCreatedInField('from', true);
 
   return (
     <>
@@ -76,10 +71,7 @@ const TransferFundsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       />
 
       <DecisionMethodField />
-      <CreatedIn
-        readonly={decisionMethod === DecisionMethod.MultiSig}
-        filterOptionsFn={createdInFilterFn}
-      />
+      <CreatedIn readonly filterOptionsFn={createdInFilterFn} />
       <Description />
     </>
   );

--- a/src/components/v5/common/CompletedAction/CompletedAction.tsx
+++ b/src/components/v5/common/CompletedAction/CompletedAction.tsx
@@ -65,6 +65,7 @@ const CompletedAction = ({ action }: CompletedActionProps) => {
         return <UnlockToken action={action} />;
       case ColonyActionType.VersionUpgrade:
       case ColonyActionType.VersionUpgradeMotion:
+      case ColonyActionType.VersionUpgradeMultisig:
         return <UpgradeColonyVersion action={action} />;
       case ColonyActionType.CreateDecisionMotion:
         return <CreateDecision action={action} />;

--- a/src/components/v5/common/CompletedAction/partials/UpgradeColonyVersion/UpgradeColonyVersion.tsx
+++ b/src/components/v5/common/CompletedAction/partials/UpgradeColonyVersion/UpgradeColonyVersion.tsx
@@ -40,6 +40,10 @@ const UpgradeColonyVersion = ({ action }: UpgradeColonyVersionProps) => {
   const { customTitle = formatText(MSG.defaultTitle) } = action?.metadata || {};
   const { initiatorUser, newColonyVersion } = action;
 
+  const motionDomainMetadata =
+    action.motionData?.motionDomain.metadata ??
+    action.multiSigData?.multiSigDomain.metadata;
+
   return (
     <>
       <ActionTitle>{customTitle}</ActionTitle>
@@ -86,10 +90,8 @@ const UpgradeColonyVersion = ({ action }: UpgradeColonyVersionProps) => {
           isMultisig={action.isMultiSig || false}
         />
 
-        {action.motionData?.motionDomain.metadata && (
-          <CreatedInRow
-            motionDomainMetadata={action.motionData.motionDomain.metadata}
-          />
+        {motionDomainMetadata && (
+          <CreatedInRow motionDomainMetadata={motionDomainMetadata} />
         )}
       </ActionDataGrid>
       {action.annotation?.message && (

--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -88,6 +88,7 @@ const actionsMessageDescriptors = {
       ${ColonyActionType.CreateDomainMultisig} {Create new team}
       ${ColonyActionType.VersionUpgrade} {Version Upgrade}
       ${ColonyActionType.VersionUpgradeMotion} {Version Upgrade}
+      ${ColonyActionType.VersionUpgradeMultisig} {Version Upgrade}
       ${ColonyActionType.ColonyEdit} {Edit Colony details}
       ${ColonyActionType.ColonyEditMotion} {Edit Colony details}
       ${ColonyActionType.ColonyEditMultisig} {Edit Colony details}

--- a/src/utils/multiSig.ts
+++ b/src/utils/multiSig.ts
@@ -63,6 +63,9 @@ export const getRolesNeededForMultiSigAction = ({
     case ColonyActionType.PaymentMultisig:
       permissions = PERMISSIONS_NEEDED_FOR_ACTION.SimplePayment;
       break;
+    case ColonyActionType.VersionUpgradeMultisig:
+      permissions = PERMISSIONS_NEEDED_FOR_ACTION.UpgradeColonyVersion;
+      break;
     default:
       permissions = undefined;
       break;


### PR DESCRIPTION
## Description

This PR enables users to upgrade their Colony's version via a Multi-Sig motion.

![Colony Version MS](https://github.com/user-attachments/assets/c3330891-2918-43ca-90a0-d4e7c488c63f)

## Testing

As of the time this PR is created, the most recent Colony version is 16. In order to test a Colony version upgrade, we will need to deploy a newer Colony version since the Multi-Sig extension is only available from Colony version 16 upwards.

> [!IMPORTANT]
> Please test this with these block-ingestor updates: [block-ingestor#254  - Feat: Enable Colony version upgrade via a multi-sig motion](https://github.com/JoinColony/block-ingestor/pull/254)
> 1. Updates were made for `colony-js` so it's important you run `npm ci`
> 2. Run `npm run dev`
> 3. Wait for the auth proxy and block-ingestor services to be up and running
> 4. Open the `hardhat` console:
> ```bash
> npm run hardhat
> ```
> 5. Confirm that you are now in the `hardhat` console
> ![image](https://github.com/user-attachments/assets/9a108f0c-694f-4db4-a2ca-b4117286cd69)
> 6. Run the following commands to deploy Colony version 17:
> > _Deploying a Colony version will take a while. Feel free to brew a cup of coffee in the meantime... ☕_ 
> ```solidity
> deployNext = require("./scripts/deployOldUpgradeableVersion.js").deployNextColonyVersion
> cn = await artifacts.require("IColonyNetwork").at("0x777760996135F0791E2e1a74aFAa060711197777")
> await deployNext(cn)
> ```
> 7. For an extra peace of mind, you can check if you have successfully deployed Colony version 17:
> > _This should return a non-zero address_
> ```solidity
> await cn.getColonyVersionResolver(17)
> ```
> 8. Use a previous Colony version to set up your Colonies. In this PR, the previous Colony version is 16:
> ```console
> node scripts/create-data.js --usePreviousColonyVersion
> ```
> 9. Run the frontend
> ```console
> npm run frontend
> ```
> 10. Install & enable the Multi-SIg extension
> 11. Reload the page

> [!TIP]
> ## Troubleshooting
> ### OneTxPayment version error when finalising the motion
> If you see block ingestor throwing this error:
> ```console
> Error: Extension OneTxPayment in version 8 is not compatible with Colony version 16
> ```
> It might be that block ingestor is still running a stale version of colony-js. Delete your `node_modules` directory and reinstall all deps again:
> ```console
> rm -rf node_modules
> npm i
>```
>
> ### Errors when running the create-data script:
> ![Screenshot 2024-07-17 at 18 32 02](https://github.com/user-attachments/assets/9a236028-f2d6-44fd-9c12-017c5ba951f6)
> If you're having a bunch of these errors when running the create-data script and it crashes, stop all docker containers then open your Docker Dashboard and delete all of these in order
> 
> 1. Containers
> 2. Images
> 3. Volumes
> 4. Builds
>
> Quit and relaunch Docker then spin up your dev environment again:
> ```console
> npm run dev
> ```
> If you're still getting those errors, this will sound ridiculous but please restart your machine. It certainly worked for me at some point but I really have no clue about what's causing it 😅
>
> Please let me know if there's a better solution for this 🙏
>
> ### Multi-Sig extension installation hang
> On my machine, sometimes the installation just works and sometimes it hangs when you install it for the first time after spinning up your dev environment. If you're experiencing this, just reload the page and install it again.
>
> ### Invalid threshold on the Completed Action Component's Multi-Sig motion panel
> - Check your Colony's members list. If it's 0, chances are something in your dev environment broke 😞 Having no members means that we cannot verify if you have the required permissions to interact with the Multi-Sig panel. You'll have to restart everything again unfortunately.
> - If your members list is still in tact, give it 10 seconds then reload the page. The data should then come up.
>
> ### You get a blank page when visiting localhost:9091
> Re-bundle vite:
> ```console
> npm run frontend -- --force
> ```

> [!WARNING]
> I find that after a Colony has been updated to version 17, all other motions will stop working. Judging from the console errors, it seems that the colony-js lib needs to be fixed.

### Testing Steps

1. Bring up the Action Form and set it to "Upgrade Colony version"
2. Verify that
  - Current version is 16
  - New version is 17
3. Set the Decision method field to Multi-Sig
4. Fill in all other required fields
5. Submit the Form
6. On the CompletedAction component, verify that the Action Type is "Version Upgrade"
7. Finalise the motion
8. Verify that the message "Action was approved and executed." appears on the Completed Action component
9. Verify that the banner which prompts you to upgrade your Colony version isn't rendered anymore
10. Close the Action Form
11. Bring up the Action Form and set it to "Upgrade Colony version"
12. Verify that:
  - You see the message: "Your Colony version is up to date"
  - Current version is 17
  - New version is 17

13: Visit the GraphQL playground: http://localhost:20002
14. Run this GraphQL query:
```gql
query MyQuery {
  listColonies {
    items {
      version
      name
    }
  }
}
```
15. Verify that the Colony you upgraded has its version set to 17. If you updated Colony "planex", you should see:
```gql
{
  "data": {
    "listColonies": {
      "items": [
        {
          "version": 17,
          "name": "planex"
        },
        {
          "version": 16,
          "name": "wayne"
        }
      ]
    }
  }
}
```

## Diffs

**Changes** 🏗

The rootMotion saga thankfully already handles the multi-sig flow for the Colony Upgrade action so I just needed to make the necessary UI-related updates.

Resolves #2186 