### PR TITLE
Feat: Manage Reputation via Multi-Sig

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=75683b00a9ffca90c95636e19da58a3de1a96169
+ENV BLOCK_INGESTOR_HASH=d3f1c9c2c93680e416460fef90addb9180cb4ecf
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/utils.ts
@@ -5,7 +5,10 @@ import { type TestContext } from 'yup';
 
 import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { type ManageReputationMotionPayload } from '~redux/sagas/motions/manageReputationMotion.ts';
+import { DecisionMethod } from '~types/actions.ts';
 import { type Colony } from '~types/graphql.ts';
+import { extractColonyRoles } from '~utils/colonyRoles.ts';
+import { extractColonyDomains } from '~utils/domains.ts';
 import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
 
 import { ModificationOption } from './consts.ts';
@@ -21,6 +24,7 @@ export const getManageReputationPayload = (
     member,
     createdIn,
     modification,
+    decisionMethod,
   }: ManageReputationFormValues,
 ): ManageReputationMotionPayload => {
   const isSmiteAction = modification === ModificationOption.RemoveReputation;
@@ -28,6 +32,7 @@ export const getManageReputationPayload = (
     .mul(new Decimal(10).pow(nativeTokenDecimals))
     // Smite amount needs to be negative, otherwise leave it as it is
     .mul(isSmiteAction ? -1 : 1);
+  const isMultiSig = decisionMethod === DecisionMethod.MultiSig;
 
   return {
     colonyAddress: colony.colonyAddress,
@@ -39,6 +44,9 @@ export const getManageReputationPayload = (
     annotationMessage: description,
     customActionTitle: '',
     motionDomainId: createdIn,
+    isMultiSig,
+    colonyRoles: extractColonyRoles(colony.roles),
+    colonyDomains: extractColonyDomains(colony.domains),
   };
 };
 

--- a/src/components/v5/common/CompletedAction/CompletedAction.tsx
+++ b/src/components/v5/common/CompletedAction/CompletedAction.tsx
@@ -126,6 +126,8 @@ const CompletedAction = ({ action }: CompletedActionProps) => {
       case ColonyActionType.ColonyEditMotion:
       case ColonyActionType.EditExpenditureMotion:
       case ColonyActionType.FundExpenditureMotion:
+      case ColonyActionType.EmitDomainReputationPenaltyMotion:
+      case ColonyActionType.EmitDomainReputationRewardMotion:
       case ExtendedColonyActionType.UpdateColonyObjectiveMotion:
         // @NOTE: Enabling those 2 above temporarily
         return <Motions transactionId={action.transactionHash} />;

--- a/src/components/v5/common/CompletedAction/CompletedAction.tsx
+++ b/src/components/v5/common/CompletedAction/CompletedAction.tsx
@@ -81,8 +81,10 @@ const CompletedAction = ({ action }: CompletedActionProps) => {
         return <RemoveVerifiedMembers action={action} />;
       case ColonyActionType.EmitDomainReputationReward:
       case ColonyActionType.EmitDomainReputationRewardMotion:
+      case ColonyActionType.EmitDomainReputationRewardMultisig:
       case ColonyActionType.EmitDomainReputationPenalty:
       case ColonyActionType.EmitDomainReputationPenaltyMotion:
+      case ColonyActionType.EmitDomainReputationPenaltyMultisig:
         return <ManageReputation action={action} />;
       case ColonyActionType.ColonyEdit:
       case ColonyActionType.ColonyEditMotion:

--- a/src/components/v5/common/CompletedAction/partials/ManageReputation/ManageReputation.tsx
+++ b/src/components/v5/common/CompletedAction/partials/ManageReputation/ManageReputation.tsx
@@ -69,9 +69,11 @@ const ManageReputation: FC<ManageReputationProps> = ({ action }) => {
     networkMotionState === NetworkMotionState.Finalized ||
     networkMotionState === NetworkMotionState.Failed;
 
-  const isSmite =
-    action.type === ColonyActionType.EmitDomainReputationPenalty ||
-    action.type === ColonyActionType.EmitDomainReputationPenaltyMotion;
+  const isSmite = [
+    ColonyActionType.EmitDomainReputationPenalty,
+    ColonyActionType.EmitDomainReputationPenaltyMotion,
+    ColonyActionType.EmitDomainReputationPenaltyMultisig,
+  ].includes(action.type);
 
   const positiveAmountValue = BigNumber.from(amount || '0')
     .abs()

--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -34,8 +34,10 @@ const actionsMessageDescriptors = {
       ${ColonyActionType.Recovery} {Enter recovery mode by {initiator}}
       ${ColonyActionType.EmitDomainReputationPenalty} {Remove {reputationChangeNumeral} reputation {reputationChange, plural, one {point} other {points}} from {recipient} by {initiator}}
       ${ColonyActionType.EmitDomainReputationPenaltyMotion} {Remove {reputationChangeNumeral} reputation {reputationChange, plural, one {point} other {points}} from {recipient} by {initiator}}
+      ${ColonyActionType.EmitDomainReputationPenaltyMultisig} {Remove {reputationChangeNumeral} reputation {reputationChange, plural, one {point} other {points}} from {recipient} by {initiator}}
       ${ColonyActionType.EmitDomainReputationReward} {Add {reputationChangeNumeral} reputation {reputationChange, plural, one {point} other {points}} to {recipient} by {initiator}}
       ${ColonyActionType.EmitDomainReputationRewardMotion} {Add {reputationChangeNumeral} reputation {reputationChange, plural, one {point} other {points}} to {recipient} by {initiator}}
+      ${ColonyActionType.EmitDomainReputationRewardMultisig} {Add {reputationChangeNumeral} reputation {reputationChange, plural, one {point} other {points}} to {recipient} by {initiator}}
       ${ColonyActionType.SetUserRoles} {{direction} {multiSigAuthority}permissions for {recipient} in {fromDomain} by {initiator}}
       ${ColonyActionType.SetUserRolesMotion} {{direction} {multiSigAuthority}permissions for {recipient} in {fromDomain} by {initiator}}
       ${ColonyActionType.SetUserRolesMultisig} {{direction} {multiSigAuthority}permissions for {recipient} in {fromDomain} by {initiator}}
@@ -92,8 +94,10 @@ const actionsMessageDescriptors = {
       ${ColonyActionType.Recovery} {Recovery}
       ${ColonyActionType.EmitDomainReputationPenalty} {Manage reputation}
       ${ColonyActionType.EmitDomainReputationPenaltyMotion} {Manage reputation}
+      ${ColonyActionType.EmitDomainReputationPenaltyMultisig} {Manage reputation}
       ${ColonyActionType.EmitDomainReputationReward} {Manage reputation}
       ${ColonyActionType.EmitDomainReputationRewardMotion} {Manage reputation}
+      ${ColonyActionType.EmitDomainReputationRewardMultisig} {Manage reputation}
       ${ColonyActionType.CreateDecisionMotion} {Decision}
       ${ColonyActionType.AddVerifiedMembers} {Manage verified members}
       ${ColonyActionType.AddVerifiedMembersMotion} {Manage verified members}

--- a/src/redux/sagas/actions/manageReputation.ts
+++ b/src/redux/sagas/actions/manageReputation.ts
@@ -23,6 +23,9 @@ import {
   createActionMetadataInDB,
 } from '../utils/index.ts';
 
+export type ManageReputationPermissionsPayload =
+  Action<ActionTypes.ACTION_MANAGE_REPUTATION>['payload'];
+
 function* manageReputationAction({
   payload: {
     colonyAddress,

--- a/src/redux/sagas/motions/manageReputationMotion.ts
+++ b/src/redux/sagas/motions/manageReputationMotion.ts
@@ -8,6 +8,7 @@ import {
 import { AddressZero } from '@ethersproject/constants';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
+import { PERMISSIONS_NEEDED_FOR_ACTION } from '~constants/actions.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
 import { ActionTypes } from '../../actionTypes.ts';
@@ -26,6 +27,7 @@ import {
   uploadAnnotation,
   initiateTransaction,
   createActionMetadataInDB,
+  getPermissionProofsLocal,
 } from '../utils/index.ts';
 
 export type ManageReputationMotionPayload =
@@ -42,6 +44,9 @@ function* manageReputationMotion({
     motionDomainId,
     isSmitingReputation,
     customActionTitle,
+    isMultiSig,
+    colonyDomains,
+    colonyRoles,
   },
   meta: { id: metaId, navigate, setTxHash },
   meta,
@@ -67,45 +72,6 @@ function* manageReputationMotion({
       );
     }
 
-    const context = yield getColonyManager();
-    const colonyClient = yield context.getClient(
-      ClientType.ColonyClient,
-      colonyAddress,
-    );
-
-    const votingReputationClient = yield context.getClient(
-      ClientType.VotingReputationClient,
-      colonyAddress,
-    );
-
-    const [permissionDomainId, childSkillIndex] = yield call(
-      getPermissionProofs,
-      colonyClient.networkClient,
-      colonyClient,
-      domainId,
-      ColonyRole.Architecture,
-      votingReputationClient.address,
-    );
-
-    const motionChildSkillIndex = yield call(
-      getChildIndex,
-      colonyClient.networkClient,
-      colonyClient,
-      motionDomainId,
-      isSmitingReputation ? domainId : Id.RootDomain,
-    );
-
-    const { skillId } = yield call(
-      [colonyClient, colonyClient.getDomain],
-      motionDomainId,
-    );
-
-    const { key, value, branchMask, siblings } = yield call(
-      colonyClient.getReputation,
-      skillId,
-      AddressZero,
-    );
-
     txChannel = yield call(getTxChannel, metaId);
 
     // setup batch ids and channels
@@ -117,42 +83,162 @@ function* manageReputationMotion({
         'annotateManageReputationMotion',
       ]);
 
-    let encodedAction;
+    // eslint-disable-next-line no-inner-declarations
+    function* getCreateMotionParams() {
+      const requiredRoles = isSmitingReputation
+        ? PERMISSIONS_NEEDED_FOR_ACTION.ManageReputationRemove
+        : PERMISSIONS_NEEDED_FOR_ACTION.ManageReputationAward;
 
-    if (isSmitingReputation) {
-      encodedAction = colonyClient.interface.encodeFunctionData(
-        'emitDomainReputationPenalty',
-        [permissionDomainId, childSkillIndex, domainId, userAddress, amount],
+      const context = yield getColonyManager();
+      const colonyClient = yield context.getClient(
+        ClientType.ColonyClient,
+        colonyAddress,
       );
-    } else {
-      encodedAction = colonyClient.interface.encodeFunctionData(
-        'emitDomainReputationReward',
-        [domainId, userAddress, amount],
+
+      if (isMultiSig) {
+        const multiSigPermissionsClient = yield context.getClient(
+          ClientType.MultisigPermissionsClient,
+          colonyAddress,
+        );
+
+        let encodedAction;
+
+        if (isSmitingReputation) {
+          const permissionsUserAddress = yield colonyClient.signer.getAddress();
+
+          const [permissionDomainId, childSkillIndex] =
+            yield getPermissionProofsLocal({
+              networkClient: colonyClient.networkClient,
+              colonyRoles,
+              colonyDomains,
+              requiredDomainId: domainId,
+              requiredColonyRole: requiredRoles,
+              permissionAddress: permissionsUserAddress,
+              isMultiSig: true,
+            });
+
+          encodedAction = colonyClient.interface.encodeFunctionData(
+            'emitDomainReputationPenalty',
+            [
+              permissionDomainId,
+              childSkillIndex,
+              domainId,
+              userAddress,
+              amount,
+            ],
+          );
+        } else {
+          encodedAction = colonyClient.interface.encodeFunctionData(
+            'emitDomainReputationReward',
+            [domainId, userAddress, amount],
+          );
+        }
+
+        const [motionPermissionDomainId, motionChildSkillIndex] = yield call(
+          getPermissionProofsLocal,
+          {
+            networkClient: colonyClient.networkClient,
+            colonyRoles,
+            colonyDomains,
+            requiredDomainId: motionDomainId,
+            requiredColonyRole: requiredRoles,
+            permissionAddress: multiSigPermissionsClient.address,
+            isMultiSig: false,
+          },
+        );
+
+        return {
+          context: ClientType.MultisigPermissionsClient,
+          methodName: 'createMotion',
+          identifier: colonyAddress,
+          params: [
+            motionPermissionDomainId,
+            motionChildSkillIndex,
+            [colonyAddress],
+            [encodedAction],
+          ],
+          group: {
+            key: batchKey,
+            id: metaId,
+            index: 0,
+          },
+          ready: false,
+        };
+      }
+
+      const votingReputationClient = yield context.getClient(
+        ClientType.VotingReputationClient,
+        colonyAddress,
       );
+
+      const [permissionDomainId, childSkillIndex] = yield call(
+        getPermissionProofs,
+        colonyClient.networkClient,
+        colonyClient,
+        domainId,
+        ColonyRole.Architecture,
+        votingReputationClient.address,
+      );
+
+      const motionChildSkillIndex = yield call(
+        getChildIndex,
+        colonyClient.networkClient,
+        colonyClient,
+        motionDomainId,
+        isSmitingReputation ? domainId : Id.RootDomain,
+      );
+
+      const { skillId } = yield call(
+        [colonyClient, colonyClient.getDomain],
+        motionDomainId,
+      );
+
+      const { key, value, branchMask, siblings } = yield call(
+        colonyClient.getReputation,
+        skillId,
+        AddressZero,
+      );
+
+      let encodedAction;
+
+      if (isSmitingReputation) {
+        encodedAction = colonyClient.interface.encodeFunctionData(
+          'emitDomainReputationPenalty',
+          [permissionDomainId, childSkillIndex, domainId, userAddress, amount],
+        );
+      } else {
+        encodedAction = colonyClient.interface.encodeFunctionData(
+          'emitDomainReputationReward',
+          [domainId, userAddress, amount],
+        );
+      }
+
+      return {
+        context: ClientType.VotingReputationClient,
+        methodName: 'createMotion',
+        identifier: colonyAddress,
+        params: [
+          motionDomainId,
+          motionChildSkillIndex,
+          AddressZero,
+          encodedAction,
+          key,
+          value,
+          branchMask,
+          siblings,
+        ],
+        group: {
+          key: batchKey,
+          id: metaId,
+          index: 0,
+        },
+        ready: false,
+      };
     }
 
+    const transactionParams = yield getCreateMotionParams();
     // create transactions
-    yield fork(createTransaction, createMotion.id, {
-      context: ClientType.VotingReputationClient,
-      methodName: 'createMotion',
-      identifier: colonyAddress,
-      params: [
-        motionDomainId,
-        motionChildSkillIndex,
-        AddressZero,
-        encodedAction,
-        key,
-        value,
-        branchMask,
-        siblings,
-      ],
-      group: {
-        key: batchKey,
-        id: metaId,
-        index: 0,
-      },
-      ready: false,
-    });
+    yield fork(createTransaction, createMotion.id, transactionParams);
 
     if (annotationMessage) {
       yield fork(createTransaction, annotateManageReputationMotion.id, {

--- a/src/redux/types/actions/motion.ts
+++ b/src/redux/types/actions/motion.ts
@@ -318,6 +318,9 @@ export type MotionActionTypes =
         motionDomainId: number;
         annotationMessage?: string;
         isSmitingReputation?: boolean;
+        isMultiSig?: boolean;
+        colonyDomains: Domain[];
+        colonyRoles: ColonyRoleFragment[];
       },
       MetaWithSetter<object>
     >

--- a/src/utils/multiSig.ts
+++ b/src/utils/multiSig.ts
@@ -23,6 +23,10 @@ export const getRolesNeededForMultiSigAction = ({
       return PERMISSIONS_NEEDED_FOR_ACTION.CreateNewTeam;
     case ColonyActionType.EditDomainMultisig:
       return PERMISSIONS_NEEDED_FOR_ACTION.EditExistingTeam;
+    case ColonyActionType.EmitDomainReputationRewardMultisig:
+      return PERMISSIONS_NEEDED_FOR_ACTION.ManageReputationAward;
+    case ColonyActionType.EmitDomainReputationPenaltyMultisig:
+      return PERMISSIONS_NEEDED_FOR_ACTION.ManageReputationRemove;
     case ColonyActionType.MintTokensMultisig:
       return PERMISSIONS_NEEDED_FOR_ACTION.MintTokens;
     case ColonyActionType.UnlockTokenMultisig:


### PR DESCRIPTION
## Description

- Allow users to manage reputation using a multi-sig action.

Block Ingestor changes [here](https://github.com/JoinColony/block-ingestor/pull/253)

## Testing

**First**: Restart your dev env so that you have the correct block ingestor version running. Also visit http://0.0.0.0:3001/reputation/monitor/toggle (make sure you do this only once [or three times, or five...]! - this is explained [here](https://www.notion.so/colony/Reputation-in-development-c05b7a1f79fc4465a220c2806792e4a7)) so that reputation updates happen in dev.

* Step 1. As Leela, install Multi Sig Extension, and set the threshold to 2 (then refresh the page).
* Step 2. Create an action to give Amy multi-sig permissions (then refresh the page).
<img width="1920" alt="Screenshot 2024-07-11 at 17 28 11" src="https://github.com/JoinColony/colonyCDapp/assets/38098203/bf44122b-18ab-4bf4-aa99-c8d61a2876b5">

* Step 3. Navigate to the Contributors tab, and make a note of Fry's reputation. Here you can see it is 3.12%.
<img width="1920" alt="Screenshot 2024-07-11 at 17 31 22" src="https://github.com/JoinColony/colonyCDapp/assets/38098203/18c73931-527e-49ec-b4e6-faeb5fd8bab5">

* Step 4. As Leela, create an action to award Fry some reputation using multi-sig as the decision method.
<img width="1920" alt="Screenshot 2024-07-11 at 17 32 15" src="https://github.com/JoinColony/colonyCDapp/assets/38098203/c4bbc696-b42e-4c83-ada8-ddb9e711c480">

* Step 5. As Amy (I suggest an incognito window), navigate to the above action, and using the sidebar approve and finalise the motion.
<img width="1920" alt="Screenshot 2024-07-11 at 17 32 52" src="https://github.com/JoinColony/colonyCDapp/assets/38098203/33ba0bf1-e548-43b6-9f21-9dc7bbe112c8">

* Step 6. Go back to the Contributors tab from step 3, and refresh the page (you may need to wait a few seconds or refresh a couple of times because of the way the hook / lambda is currently set up to fetch reputation updates). You should see that Fry's reputation has changed reflecting your action.
<img width="1920" alt="Screenshot 2024-07-11 at 17 34 13" src="https://github.com/JoinColony/colonyCDapp/assets/38098203/793a60de-668a-4dfc-87f5-1bdf889e0f49">

* Step 7. Repeat steps 4, 5 and 6, however this time try to _remove_ reputation from Fry, instead of awarding it.
<img width="1920" alt="Screenshot 2024-07-11 at 17 35 47" src="https://github.com/JoinColony/colonyCDapp/assets/38098203/9c813562-fc2e-4480-822a-e28e2f3568c7">
<img width="1920" alt="Screenshot 2024-07-11 at 17 36 06" src="https://github.com/JoinColony/colonyCDapp/assets/38098203/066d9fcb-5e6e-4584-9ef8-34e6603398c9">
<img width="1920" alt="Screenshot 2024-07-11 at 17 37 27" src="https://github.com/JoinColony/colonyCDapp/assets/38098203/57010098-5888-47d1-bf23-1363657f8879">

* Optional Step 8. Repeat steps 3, 4, 5 and 6, but this time do everything in a sub domain. This means checking the current reputation percentage in the Contributors tab after first changing the current team at the top of the page to a sub domain, then creating the remove reputation action in that sub domain instead of General. Things should still work the same way!

## Diffs

**Changes** 🏗

* Edited the Manage Reputation Motion saga to handle multi sig.

Resolves #2190
