### PR TITLE
fix: flashing pending button

### DIFF
--- a/src/context/UserTransactionContext/UserTransactionContextProvider.tsx
+++ b/src/context/UserTransactionContext/UserTransactionContextProvider.tsx
@@ -178,6 +178,7 @@ const useGroupState = ({
       }, 3000);
     } else if (
       hasLatestGroupPendingTx &&
+      !someFailed &&
       groupState !== TransactionGroupStates.SomePending
     ) {
       if (!previousPending) {


### PR DESCRIPTION
## Description

Part of the fix for flashing "Pending" button when rejecting first transaction. 

## Testing

* Step 1. Ensure you are connected locally via a Metamask wallet. (Let me know if you are unsure how to do this)
* Step 2. Perform a transaction with multiple grouped transactions, e.g. staking with no activated tokens.
* Step 3. Reject the first transaction.
* Step 4. Check if the Pending button is stuck in a flashing state.

## Diffs

**New stuff** ✨

* 

**Changes** 🏗

* Checking if any transaction group failed, so that the pending state won't be applied

**Deletions** ⚰️

* 

## TODO

- [ ] Check if transactions that are after the failed one should go into the pending state. Right now, if the first one fails, the others can be in completed or pending states.
![image](https://github.com/user-attachments/assets/65bf9920-66e1-4524-8414-1c31e7bcd086)

Contributes https://github.com/JoinColony/colonyCDapp/issues/2397
