### PR TITLE
fix: broken loading in Transactions in UserHub + fixed text overflow in pills

### DIFF
--- a/src/components/common/Extensions/UserHub/UserHub.tsx
+++ b/src/components/common/Extensions/UserHub/UserHub.tsx
@@ -111,7 +111,7 @@ const UserHub: FC<UserHubProps> = ({
           </>
         )}
       </div>
-      <div className={clsx('relative h-full w-full')}>
+      <div className="relative h-full w-full min-w-0">
         {selectedTab === UserHubTabs.Balance && (
           <ReputationTab onTabChange={handleTabChange} />
         )}

--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransaction.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransaction.tsx
@@ -124,7 +124,7 @@ const GroupedTransaction: FC<GroupedTransactionProps> = ({
               onClick={handleNavigateToAction}
               disabled={!canLinkToAction || hideSummary}
               className={clsx(
-                'flex w-full flex-col items-start gap-1  sm:px-6',
+                'flex w-full min-w-0 flex-col items-start gap-1  sm:px-6',
                 {
                   'cursor-default': !canLinkToAction,
                 },
@@ -138,7 +138,7 @@ const GroupedTransaction: FC<GroupedTransactionProps> = ({
                       {value}
                     </h4>
                     {createdAt && (
-                      <span className="mt-0.5 block text-xs text-gray-400">
+                      <span className="mt-0.5 block whitespace-nowrap text-xs text-gray-400">
                         {createdAt}
                       </span>
                     )}
@@ -156,7 +156,7 @@ const GroupedTransaction: FC<GroupedTransactionProps> = ({
                     />
                   </p>
                 </div>
-                <div className="flex gap-2 pr-8">
+                <div className="flex min-w-0 gap-2 pr-8">
                   {!isMobile && <GroupedTransactionStatus status={status} />}
                 </div>
               </div>

--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransactionStatus.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransactionStatus.tsx
@@ -17,25 +17,29 @@ const GroupedTransactionStatus: FC<TransactionStatusProps> = ({ status }) => {
 
   return (
     <div
-      className={clsx('flex flex-col items-end', {
+      className={clsx('flex min-w-0 flex-col items-end', {
         'text-success-400': succeeded,
         'text-negative-400': failed,
       })}
     >
-      {pending && (
-        <SpinnerGap
-          className="ml-2.5 h-[0.8125rem] w-[0.8125rem] animate-spin text-blue-400"
-          size={14}
-        />
-      )}
       <PillsBase
-        className={clsx({
-          'bg-success-100 text-success-400': succeeded,
-          'bg-negative-100 text-negative-400': failed,
-          'bg-gray-100 text-gray-500': !succeeded && !failed,
-        })}
+        className={clsx(
+          {
+            'bg-success-100 text-success-400': succeeded,
+            'bg-negative-100 text-negative-400': failed,
+            'bg-gray-100 text-gray-500': !succeeded && !failed,
+          },
+          'min-w-0 max-w-full',
+        )}
+        textClassName="flex min-w-0 items-center"
       >
-        {status.toLowerCase()}
+        <span className="min-w-0 truncate">{status.toLowerCase()}</span>
+        {pending && (
+          <SpinnerGap
+            className="flex-grow-1 ml-1 inline-block h-[0.8125rem] w-[0.8125rem] flex-shrink-0 animate-spin text-blue-400"
+            size={14}
+          />
+        )}
       </PillsBase>
     </div>
   );


### PR DESCRIPTION
## Description
- [x] Fixed loading icon for pending pills in transaction list in User hub. 

## Testing
* Step 1. Perform a transaction using Metamask i.e., not a Dev wallet.
* Step 2. Don't sign the transaction.
* Step 3. Click on the Pending button to load up the transactions tab in the Userhub.
* Step 4. The loader icon is perfectly positioned inside pending pill

<img width="689" alt="Screenshot 2024-07-17 at 15 52 05" src="https://github.com/user-attachments/assets/80bed4cf-a874-4ac4-841d-684cb00ce1bd">


## Diffs

**New stuff** ✨

* For large texts status will be wrapped with 3 dots and will not exceed parent div

<img width="460" alt="Screenshot 2024-07-17 at 15 54 35" src="https://github.com/user-attachments/assets/a8f299f2-caf4-4090-900f-fc50ffe99d6f">


Resolves #2520 
