### PR TITLE
[Multi-sig] feat: display banner if user's approval/rejection won't count towards the total

### DIFF
--- a/src/components/shared/ExternalLink/ExternalLink.tsx
+++ b/src/components/shared/ExternalLink/ExternalLink.tsx
@@ -16,8 +16,8 @@ const ExternalLink: FC<ExternalLinkProps> = ({
   return (
     <a
       className={clsx(
-        className,
         'text-gray-900 transition-colors duration-normal hover:text-blue-400',
+        className,
       )}
       href={href}
       target="_blank"

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/MultiSigSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/MultiSigSidebar.tsx
@@ -41,10 +41,7 @@ const MultiSigSidebar: FC<MultiSigSidebarProps> = ({ transactionId }) => {
 
   return (
     <div>
-      <MultiSigWidget
-        action={action}
-        initiatorAddress={action.initiatorAddress}
-      />
+      <MultiSigWidget action={action} />
     </div>
   );
 };

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/hooks/useRelevantUserRoles.ts
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/hooks/useRelevantUserRoles.ts
@@ -1,0 +1,56 @@
+import { Id, type ColonyRole } from '@colony/colony-js';
+
+import { useAppContext } from '~context/AppContext/AppContext.ts';
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { getUserRolesForDomain } from '~transformers';
+import { extractColonyRoles } from '~utils/colonyRoles.ts';
+
+interface UseRelevantUserRolesParams {
+  requiredRoles: ColonyRole[];
+  domainId: number;
+}
+
+interface UseRelevantUserRolesResult {
+  relevantUserRoles: ColonyRole[];
+}
+
+export const useRelevantUserRoles = ({
+  requiredRoles,
+  domainId,
+}: UseRelevantUserRolesParams): UseRelevantUserRolesResult => {
+  const { user } = useAppContext();
+  const { colony } = useColonyContext();
+
+  if (!user?.walletAddress) {
+    return { relevantUserRoles: [] };
+  }
+
+  const colonyRoles = extractColonyRoles(colony.roles);
+
+  const userRolesInDomain = getUserRolesForDomain({
+    colonyRoles,
+    userAddress: user.walletAddress,
+    domainId,
+    excludeInherited: true,
+    isMultiSig: true,
+  });
+  const userRolesInRoot = getUserRolesForDomain({
+    colonyRoles,
+    userAddress: user.walletAddress,
+    domainId: Id.RootDomain,
+    excludeInherited: true,
+    isMultiSig: true,
+  });
+
+  const allUserRoles = Array.from(
+    new Set([...userRolesInDomain, ...userRolesInRoot]),
+  );
+
+  const relevantUserRoles = allUserRoles.filter((role) =>
+    requiredRoles.includes(role),
+  );
+
+  return {
+    relevantUserRoles,
+  };
+};

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ThresholdPassedBanner/ThresholdPassedBanner.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ThresholdPassedBanner/ThresholdPassedBanner.tsx
@@ -1,0 +1,170 @@
+import { type ColonyRole } from '@colony/colony-js';
+import React, { type FC } from 'react';
+import { defineMessages } from 'react-intl';
+
+import { MULTI_SIG_HELP_URL } from '~constants/externalUrls.ts';
+import ExternalLink from '~shared/ExternalLink/ExternalLink.tsx';
+import { type MultiSigUserSignature } from '~types/graphql.ts';
+import { type Threshold } from '~types/multisig.ts';
+import { getMultipleRolesText } from '~utils/colonyRoles.ts';
+import { formatText } from '~utils/intl.ts';
+
+import { useRelevantUserRoles } from '../../../../hooks/useRelevantUserRoles.ts';
+
+const displayName =
+  'v5.common.ActionSidebar.partials.MultiSig.partials.MultiSigWidget.partials.ThresholdPassedBanner';
+
+interface ThresholdPassedBannerProps {
+  approvalsPerRole: Record<number, MultiSigUserSignature[]>;
+  rejectionsPerRole: Record<number, MultiSigUserSignature[]>;
+  thresholdPerRole: Threshold;
+  requiredRoles: ColonyRole[];
+  multiSigDomainId: number;
+}
+
+const MSG = defineMessages({
+  cantApproveText: {
+    id: `${displayName}.cantApproveText`,
+    defaultMessage:
+      'The {passedRoles} {numberOfPassedRoles, plural, one {permission has} other {permissions have}} passed the required threshold. Only the {remainingRoles} {numberOfRemainingRoles, plural, one {permission is} other {permissions are}} required to approve. Your approval won’t count towards the total. ',
+  },
+  cantRejectText: {
+    id: `${displayName}.cantRejectText`,
+    defaultMessage:
+      'The {passedRoles} {numberOfPassedRoles, plural, one {permission has} other {permissions have}} passed the required threshold. Only the {remainingRoles} {numberOfRemainingRoles, plural, one {permission is} other {permissions are}} required to reject. Your rejection won’t count towards the total. ',
+  },
+  learnMoreLink: {
+    id: `${displayName}.learnMoreLink`,
+    defaultMessage: 'Learn more',
+  },
+});
+
+// This component assumes you won't render it if the user has already signed the multisig
+const ThresholdPassedBanner: FC<ThresholdPassedBannerProps> = ({
+  rejectionsPerRole,
+  approvalsPerRole,
+  thresholdPerRole,
+  requiredRoles,
+  multiSigDomainId,
+}) => {
+  const { relevantUserRoles } = useRelevantUserRoles({
+    requiredRoles,
+    domainId: multiSigDomainId,
+  });
+  const rolesPassedApproval: number[] = [];
+  const rolesRemainingApproval: number[] = [];
+
+  const rolesPassedRejection: number[] = [];
+  const rolesRemainingRejection: number[] = [];
+
+  Object.keys(approvalsPerRole).forEach((role) => {
+    const approvals = approvalsPerRole[role]?.length || 0;
+
+    if (!thresholdPerRole || !thresholdPerRole[role]) {
+      return;
+    }
+
+    const roleThreshold = thresholdPerRole[role];
+
+    if (approvals >= roleThreshold) {
+      rolesPassedApproval.push(Number(role));
+    } else {
+      rolesRemainingApproval.push(Number(role));
+    }
+  });
+
+  Object.keys(rejectionsPerRole).forEach((role) => {
+    const approvals = rejectionsPerRole[role]?.length || 0;
+
+    if (!thresholdPerRole || !thresholdPerRole[role]) {
+      return;
+    }
+
+    const roleThreshold = thresholdPerRole[role];
+
+    if (approvals >= roleThreshold) {
+      rolesPassedRejection.push(Number(role));
+    } else {
+      rolesRemainingRejection.push(Number(role));
+    }
+  });
+
+  const userRolesPassedApproval = relevantUserRoles.filter((role) =>
+    rolesPassedApproval.includes(role),
+  );
+  const userRolesNotPassedApproval = relevantUserRoles.filter(
+    (role) => !userRolesPassedApproval.includes(role),
+  );
+
+  const userRolesPassedRejection = relevantUserRoles.filter((role) =>
+    rolesPassedRejection.includes(role),
+  );
+  const userRolesNotPassedRejection = relevantUserRoles.filter(
+    (role) => !userRolesPassedRejection.includes(role),
+  );
+
+  // @TODO tweak what to do if both are true
+
+  // if there are more roles that have passed the approval threshold and user has no roles to approve with left
+  if (
+    userRolesPassedApproval.length > 0 &&
+    userRolesNotPassedApproval.length === 0
+  ) {
+    const remainingApprovalRoles = requiredRoles.filter(
+      (role) => !rolesPassedApproval.includes(role),
+    );
+
+    return (
+      <div className="flex flex-col gap-1 bg-negative-100 px-4 py-3 text-negative-400">
+        <p className="text-sm">
+          {formatText(MSG.cantApproveText, {
+            passedRoles: getMultipleRolesText(userRolesPassedApproval),
+            numberOfPassedRoles: userRolesPassedApproval.length,
+            remainingRoles: getMultipleRolesText(remainingApprovalRoles),
+            numberOfRemainingRoles: remainingApprovalRoles.length,
+          })}
+        </p>
+        <ExternalLink
+          className="text-xs font-medium text-negative-400 underline"
+          href={MULTI_SIG_HELP_URL}
+        >
+          {formatText(MSG.learnMoreLink)}
+        </ExternalLink>
+      </div>
+    );
+  }
+
+  // if there are more roles that have passed the rejection threshold and user has no roles to reject with left
+  if (
+    userRolesPassedRejection.length > 0 &&
+    userRolesNotPassedRejection.length === 0
+  ) {
+    const remainingRejectionRoles = requiredRoles.filter(
+      (role) => !rolesPassedRejection.includes(role),
+    );
+
+    return (
+      <div className="flex flex-col gap-1 bg-negative-100 px-4 py-3 text-negative-400">
+        <p className="text-sm">
+          {formatText(MSG.cantRejectText, {
+            passedRoles: getMultipleRolesText(userRolesPassedRejection),
+            numberOfPassedRoles: userRolesPassedRejection.length,
+            remainingRoles: getMultipleRolesText(remainingRejectionRoles),
+            numberOfRemainingRoles: remainingRejectionRoles.length,
+          })}
+        </p>
+        <ExternalLink
+          className="text-xs font-medium text-negative-400 underline"
+          href={MULTI_SIG_HELP_URL}
+        >
+          {formatText(MSG.learnMoreLink)}
+        </ExternalLink>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+ThresholdPassedBanner.displayName = displayName;
+export default ThresholdPassedBanner;

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/utils.ts
@@ -84,3 +84,31 @@ export const getAllUserSignatures = (
 
   return allUserSignatures;
 };
+
+export const getSignaturesPerRole = (
+  signatures: MultiSigUserSignature[],
+): {
+  approvalsPerRole: Record<number, MultiSigUserSignature[]>;
+  rejectionsPerRole: Record<number, MultiSigUserSignature[]>;
+} => {
+  const approvalsPerRole = {};
+  const rejectionsPerRole = {};
+
+  signatures.forEach((signature) => {
+    const { role, vote } = signature;
+
+    if (vote === MultiSigVote.Approve) {
+      if (!approvalsPerRole[role]) {
+        approvalsPerRole[role] = [];
+      }
+      approvalsPerRole[role].push(signature);
+    } else if (vote === MultiSigVote.Reject) {
+      if (!rejectionsPerRole[role]) {
+        rejectionsPerRole[role] = [];
+      }
+      rejectionsPerRole[role].push(signature);
+    }
+  });
+
+  return { approvalsPerRole, rejectionsPerRole };
+};

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/Signees/partials/RoleApprovalTooltip/RoleApprovalTooltip.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/Signees/partials/RoleApprovalTooltip/RoleApprovalTooltip.tsx
@@ -5,6 +5,7 @@ import { defineMessages } from 'react-intl';
 
 import { MultiSigVote } from '~gql';
 import Tooltip from '~shared/Extensions/Tooltip/Tooltip.tsx';
+import { getMultipleRolesText } from '~utils/colonyRoles.ts';
 import { formatText } from '~utils/intl.ts';
 
 const displayName =
@@ -34,10 +35,6 @@ const MSG = defineMessages({
   },
 });
 
-const getRolesText = (roles: ColonyRole[]) => {
-  return roles.map((roleId) => formatText({ id: `role.${roleId}` })).join(', ');
-};
-
 const RoleApprovalTooltip: FC<RoleApprovalTooltipProps> = ({
   vote,
   rolesSignedWith,
@@ -56,7 +53,7 @@ const RoleApprovalTooltip: FC<RoleApprovalTooltipProps> = ({
                 numberOfRolesPending: numberOfUserRoles,
               })}
             </span>
-            <span>{getRolesText(userRoles)}</span>
+            <span>{getMultipleRolesText(userRoles)}</span>
           </>
         }
       >
@@ -84,7 +81,7 @@ const RoleApprovalTooltip: FC<RoleApprovalTooltipProps> = ({
               },
             )}
           </span>
-          <span>{getRolesText(rolesSignedWith)}</span>
+          <span>{getMultipleRolesText(rolesSignedWith)}</span>
         </>
       }
     >

--- a/src/components/v5/shared/MenuWithSections/MenuWithSections.tsx
+++ b/src/components/v5/shared/MenuWithSections/MenuWithSections.tsx
@@ -18,8 +18,8 @@ const MenuWithSections: React.FC<MenuWithSectionsProps> = ({
         <div
           key={key}
           className={clsx(
-            className,
             'border-b border-gray-200 p-[1.125rem] last:border-b-0',
+            className,
           )}
         >
           {content}

--- a/src/constants/externalUrls.ts
+++ b/src/constants/externalUrls.ts
@@ -62,6 +62,8 @@ export const PAYMENTS = `https://docs.colony.io/use/making-payments/payments`;
 export const STREAMING_PAYMENTS = `https://docs.colony.io/use/making-payments/streaming-payments`;
 export const PERMISSIONS = `https://docs.colony.io/learn/advanced-concepts/permissions`;
 export const MULTI_SIG_EXTENSION = `https://blog.colony.io/new-feature-fully-control-a-multi-sig-safe-with-a-dao/`;
+export const MULTI_SIG_HELP_URL =
+  'https://help.colony.io/en/articles/9619272-multi-sig-permissions#h_3d3820ca17';
 
 /*
  * Navigation

--- a/src/hooks/multiSig/useDomainThreshold.ts
+++ b/src/hooks/multiSig/useDomainThreshold.ts
@@ -2,6 +2,7 @@ import { type ColonyRole, Extension } from '@colony/colony-js';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useExtensionData from '~hooks/useExtensionData.ts';
+import { type Threshold } from '~types/multisig.ts';
 import { isInstalledExtensionData } from '~utils/extensions.ts';
 
 import { useEligibleSignees } from './useEligibleSignees.ts';
@@ -10,8 +11,6 @@ interface UseDomainThresholdParams {
   domainId: number;
   requiredRoles?: ColonyRole[][];
 }
-
-type Threshold = { [role: number]: number } | null;
 
 interface UseDomainThresholdResult {
   thresholdPerRole: Threshold;

--- a/src/types/multisig.ts
+++ b/src/types/multisig.ts
@@ -1,0 +1,1 @@
+export type Threshold = { [role: number]: number } | null;

--- a/src/utils/colonyRoles.ts
+++ b/src/utils/colonyRoles.ts
@@ -1,9 +1,19 @@
-import { type ColonyRole, type Colony } from '~types/graphql.ts';
+import { type ColonyRole } from '@colony/colony-js';
+
+import {
+  type ColonyRole as ColonyRoleFragment,
+  type Colony,
+} from '~types/graphql.ts';
 
 import { notMaybe } from './arrays/index.ts';
+import { formatText } from './intl.ts';
 
 export const extractColonyRoles = (
   colonyRoles: Colony['roles'],
-): ColonyRole[] => {
+): ColonyRoleFragment[] => {
   return colonyRoles?.items.filter(notMaybe) ?? [];
+};
+
+export const getMultipleRolesText = (roles: ColonyRole[]): string => {
+  return roles.map((roleId) => formatText({ id: `role.${roleId}` })).join(', ');
 };


### PR DESCRIPTION
## Description

Display a banner displaying info that a user's vote won't count towards the total if they only have roles which have already passed the threshold.

## Testing
The only way to test this now is using the simple payment action.
There's gonna be a lot of setup, but it's not so hard to test once you have the initial setup done :)
You will need 3 browsers, `leela`, `amy` and `fry` logged into each of them

1. Install the multisig extension
2. Set the threshold to Fixed with the number of approvals of 2
3. Assign a random user that's not `fry` or `amy` Payer multi-sig permissions
![image](https://github.com/user-attachments/assets/6fde3eac-5f8c-48bc-a56d-694f1795ee71)
4. Assign `amy` custom multi-sig permissions - Arbitration and funding
![image](https://github.com/user-attachments/assets/cfc9f4e8-bd29-47d4-bf14-6caa8985513c)
5. Assign `fry` just the funding multi-sig permission 
![image](https://github.com/user-attachments/assets/20dbf643-84ad-4818-99ba-8c2d9b3a5a16)
6. Refresh the page and create a `Simple payment` action as `leela`, note that all 4 users should display as potential signees (ignore the hardcoded pending 3 roles for signing)
![image](https://github.com/user-attachments/assets/a8c56d6a-5ac6-40d4-9607-db32ef344946)
7. Approve the action as `amy`
![image](https://github.com/user-attachments/assets/b134efda-7a36-438f-923e-10dc066b2fcd)
8. Open the action as `fry` and note that this banner should show up
![image](https://github.com/user-attachments/assets/0681d169-d4b8-41d9-b274-8afc59570ea6)


Then repeat everything just reject the action instead of approving it, the banner should show up with different text

![image](https://github.com/user-attachments/assets/b675ba3f-9471-4b02-9fe6-8bdc384669cd)

## Diffs

**New stuff** ✨

* `useRelevantUserRoles` hook which returns roles which the user can vote on a multisig with
* `ThresholdPassedBanner` which gets all the user's roles and displays a banner if necessary. Before you drop a comment to unify the component for approvals and rejections passed, we won't be doing it :D The reason is simple, we don't really know what will happen to the rejection banner, the styles may change, it may go away, so it's not worth it to unify it with a few if statements


Resolves  #2174 
