### PR TITLE
fix: permissions card alignment

### DIFF
--- a/src/components/v5/common/Filter/ExtensionCard/SimpleExtensionCard.tsx
+++ b/src/components/v5/common/Filter/ExtensionCard/SimpleExtensionCard.tsx
@@ -23,12 +23,12 @@ const SimpleExtensionCard: FC<SimpleExtensionCardProps> = ({
           <span className="inline-block w-full truncate text-1">
             {extensionName}
           </span>
+        </div>
+        <div className="flex flex-shrink-0 items-center justify-end gap-2">
           <ExtensionStatusBadge
             mode="extension"
             text={formatText({ id: 'permissionsPage.extension' })}
           />
-        </div>
-        <div className="flex-shrink-0">
           <MeatBallMenu withVerticalIcon {...meatBallMenuProps} />
         </div>
       </div>

--- a/src/components/v5/common/MemberCardList/MemberCardList.tsx
+++ b/src/components/v5/common/MemberCardList/MemberCardList.tsx
@@ -18,13 +18,10 @@ const MemberCardList: FC<MemberCardListProps> = ({
     (childrenLength === 0 && placeholderCardProps) ? (
     <ul
       className={clsx('grid', {
-        'grid-cols-1 md:grid-cols-2 lg:grid-cols-4': !isSimple,
-        'grid-cols-[repeat(auto-fit,minmax(18.75rem,1fr))]':
-          isSimple && childrenLength > 3,
-        'grid-cols-[repeat(auto-fit,minmax(18.75rem,1fr))] md:grid-cols-4':
-          isSimple && childrenLength <= 3,
-        'gap-x-6 gap-y-6 sm:gap-y-4': !isSimple,
-        'gap-6': isSimple,
+        'grid-cols-1 gap-x-6 gap-y-6 sm:gap-y-4 md:grid-cols-2 lg:grid-cols-4':
+          !isSimple,
+        'grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4':
+          isSimple,
       })}
     >
       {/* @todo: update the animation */}


### PR DESCRIPTION
## Description

Updated the alignment of permission cards and the `Extension` badge

## Testing

* Step 1. Ensure you have some extensions installed with permissions.
* Step 2. Ensure you have users with different grouped permissions.
* Step 3. Ensure you have a screen size in the first breakpoint, between 1425px and 996px.
* Step 4. Navigate to the 'Permissions' page and review the member cards.

## Diffs

**New stuff** ✨

* 

**Changes** 🏗

* Removed repeat with minmax functions from `MemberCardList` component when `isSimple` prop is true. Now there are some static cols for each breakpoint

**Deletions** ⚰️

* 

## TODO

- 

Resolves https://github.com/JoinColony/colonyCDapp/issues/2722
