### PR TITLE
fix: redirect back to invite colony screen after creating user

### DIFF
--- a/src/components/common/Onboarding/wizardSteps/StepCreateUser/StepCreateUser.tsx
+++ b/src/components/common/Onboarding/wizardSteps/StepCreateUser/StepCreateUser.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
+import { Navigate } from 'react-router-dom';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { ActionTypes } from '~redux/index.ts';
+import { LANDING_PAGE_ROUTE } from '~routes/routeConstants.ts';
 import { ActionForm } from '~shared/Fields/index.ts';
 import { type WizardStepProps } from '~shared/Wizard/index.ts';
 import { withMeta } from '~utils/actions.ts';
@@ -36,8 +38,15 @@ const StepCreateUser = ({
     initialValues: { username, emailAddress },
   },
 }: Props) => {
-  const { updateUser } = useAppContext();
+  const { user, updateUser } = useAppContext();
 
+  if (user) {
+    return <Navigate to={LANDING_PAGE_ROUTE} />;
+  }
+
+  const transformWithMeta = withMeta({
+    updateUser,
+  });
   return (
     <ActionForm<CreateUserFormValues>
       className="flex max-w-lg flex-col items-end"
@@ -48,9 +57,7 @@ const StepCreateUser = ({
       }}
       mode="onChange"
       actionType={ActionTypes.USERNAME_CREATE}
-      transform={withMeta({
-        updateUser,
-      })}
+      transform={transformWithMeta}
       onSuccess={nextStep}
     >
       {({ formState: { isSubmitting } }) => (

--- a/src/components/frame/v5/pages/OnboardingPage/OnboardingPage.tsx
+++ b/src/components/frame/v5/pages/OnboardingPage/OnboardingPage.tsx
@@ -1,14 +1,13 @@
 import { HandWaving, HandsClapping } from '@phosphor-icons/react';
 import React, { type PropsWithChildren } from 'react';
 import { defineMessages } from 'react-intl';
-import { useParams, Navigate } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import Onboarding, { Flow } from '~common/Onboarding/index.ts';
 import HeaderRow from '~common/Onboarding/wizardSteps/HeaderRow.tsx';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { MainLayout } from '~frame/Extensions/layouts/index.ts';
 import { useGetPrivateBetaCodeInviteValidityQuery } from '~gql';
-import { LANDING_PAGE_ROUTE } from '~routes/index.ts';
 import { formatText } from '~utils/intl.ts';
 import PageLoader from '~v5/common/PageLoader/index.ts';
 import CardConnectWallet from '~v5/shared/CardConnectWallet/index.ts';
@@ -62,7 +61,7 @@ const SplashLayout = ({ children }: PropsWithChildren) => (
 );
 
 const OnboardingPage = ({ flow }: Props) => {
-  const { connectWallet, user, userLoading, wallet, walletConnecting } =
+  const { connectWallet, userLoading, wallet, walletConnecting } =
     useAppContext();
   const { inviteCode } = useParams<{ inviteCode: string }>();
   const { data, loading } = useGetPrivateBetaCodeInviteValidityQuery({
@@ -77,10 +76,6 @@ const OnboardingPage = ({ flow }: Props) => {
         <PageLoader loadingText={formatText(MSG.loadingMessage)} />
       </SplashLayout>
     );
-  }
-
-  if (flow === Flow.User && user) {
-    return <Navigate to={LANDING_PAGE_ROUTE} />;
   }
 
   if (!wallet || (flow === Flow.Colony && !valid)) {

--- a/src/redux/sagas/users/index.ts
+++ b/src/redux/sagas/users/index.ts
@@ -140,6 +140,10 @@ function* usernameCreate({
       refetchQueries,
     });
 
+    if (updateUser) {
+      yield call(updateUser, walletAddress, true);
+    }
+
     yield put<AllActions>({
       type: ActionTypes.USERNAME_CREATE_SUCCESS,
       payload: {
@@ -148,11 +152,6 @@ function* usernameCreate({
       },
       meta,
     });
-
-    if (updateUser) {
-      updateUser(walletAddress, true);
-    }
-
     if (navigate) {
       navigate(colonyName ? `/${colonyName}` : LANDING_PAGE_ROUTE);
     }


### PR DESCRIPTION
## Description
Due to check in OnboardingPage if it is user-flow and user exists, we were redirected to "/" , because the user were added on First step. So we never came to second (redirect) step because of it.

## Testing

Step 1. Create invite link: 
```
 query MyQuery {
     listColonies {
       items {
         id
         colonyMemberInviteCode
         name
       }
     }
   }
```
And put `colonyMemberInviteCode` in the URL:
`http://localhost:9091/invite/planex/{colonyMemberInviteCode}`

Step 2. Connect empty wallet (4-16 dev wallets are good for testing)
Step 3. Go to your generated link: http://localhost:9091/invite/planex/{colonyMemberInviteCode}  
You will be redirected to `/create-profile` page 
Step 4. Fill form and submit
Step 5. You should be redirected to http://localhost:9091/invite/planex/{colonyMemberInviteCode}  

![Jul-19-2024 15-15-23](https://github.com/user-attachments/assets/ec59a4af-4a53-4da9-81d7-c3b69c7983bd)

Another case to test:
Step 1. Connect empty wallet (4-16 dev wallets are good for testing)
Step 2. Generate `create-colony` link: `node scripts/create-colony-url.js`
Step 3. Go to http://localhost:9091/create-colony/aa10c360-2fc0-404e-9b5c-67fee6c9778d
Step 4. You should see `create profile` form
Step 5. Submit `create profile` form
Step 6. You should NOT be redirected, you should see `create colony form`
Step 7.  Go to http://localhost:9091/create-colony/aa10c360-2fc0-404e-9b5c-67fee6c9778d again
Step 8. You should NOT see `create profile` form and should see `create colony` form 

![Jul-19-2024 15-18-48](https://github.com/user-attachments/assets/642016d0-64ca-4467-b46c-451970bca9a6)

Resolves #2655 
