### PR TITLE
[Multi-sig] feat: get eligible signees from the database instead of context

### DIFF
--- a/src/components/v5/common/ActionSidebar/hooks/useGetColonyAction.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useGetColonyAction.ts
@@ -11,7 +11,7 @@ import {
 } from '~gql';
 import useEnabledExtensions from '~hooks/useEnabledExtensions.ts';
 import { MotionState, getMotionState } from '~utils/colonyMotions.ts';
-import { getMultiSigState } from '~utils/multiSig.ts';
+import { getMultiSigState } from '~utils/multiSig/index.ts';
 import { getSafePollingInterval } from '~utils/queries.ts';
 import { isTransactionFormat } from '~utils/web3/index.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -133,7 +133,9 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
             <ActionSidebarDescription />
           </div>
         )}
-        <SidebarBanner />
+        <SidebarBanner
+          hasEnoughMembersWithPermissions={hasEnoughMembersWithPermissions}
+        />
         {!readonly && <NoPermissionsError />}
         <ActionTypeSelect
           className={clsx(

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -73,16 +73,18 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
 
   const hasPermissions = useHasActionPermissions();
   const hasNoDecisionMethods = useHasNoDecisionMethods();
-  const hasEnoughMembersWithPermissions = useHasEnoughMembersWithPermissions({
-    decisionMethod: formValues[DECISION_METHOD_FIELD_NAME],
-    selectedAction: formValues[ACTION_TYPE_FIELD_NAME],
-    createdIn: formValues[CREATED_IN_FIELD_NAME],
-  });
+  const { hasEnoughMembersWithPermissions, isLoading } =
+    useHasEnoughMembersWithPermissions({
+      decisionMethod: formValues[DECISION_METHOD_FIELD_NAME],
+      selectedAction: formValues[ACTION_TYPE_FIELD_NAME],
+      createdIn: formValues[CREATED_IN_FIELD_NAME],
+    });
 
   const isSubmitDisabled =
     !selectedAction ||
     hasPermissions === false ||
     !hasEnoughMembersWithPermissions ||
+    isLoading ||
     hasNoDecisionMethods;
 
   const [isModalVisible, { toggleOn: showModal, toggleOff: hideModal }] =

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/hooks.ts
@@ -40,20 +40,25 @@ export const useHasEnoughMembersWithPermissions = ({
   const { watch } = useFormContext();
   const formValues = watch();
 
-  // @NOTE this needs to be memoed because formValues are constantly changing and it rerenders too much otherwise
   const requiredRoles = useMemo(
     () => getPermissionsNeededForAction(selectedAction, formValues) || [],
-    [formValues, selectedAction],
+    [selectedAction, formValues],
   );
+
+  /*
+   * This may seem like a hack, but for display purposes, we always fetch all possible roles
+   * The only action where this can break is managing permissions in a subdomain via permissions, not via multisig, so we are good
+   */
+  const multiSigRoles = requiredRoles.flat();
 
   const { thresholdPerRole } = useDomainThreshold({
     domainId: createdIn,
-    requiredRoles,
+    requiredRoles: multiSigRoles,
   });
 
   const { countPerRole } = useEligibleSignees({
     domainId: createdIn,
-    requiredRoles,
+    requiredRoles: multiSigRoles,
   });
 
   if (

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/hooks.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { type Action } from '~constants/actions.ts';
@@ -26,6 +27,7 @@ export const useGetFormActionErrors = () => {
   };
 };
 
+// @TODO somehow rework this so we don't always fetch it, but only call the business logic if decision method is multisig
 export const useHasEnoughMembersWithPermissions = ({
   decisionMethod,
   selectedAction,
@@ -38,9 +40,10 @@ export const useHasEnoughMembersWithPermissions = ({
   const { watch } = useFormContext();
   const formValues = watch();
 
-  const requiredRoles = getPermissionsNeededForAction(
-    selectedAction,
-    formValues,
+  // @NOTE this needs to be memoed because formValues are constantly changing and it rerenders too much otherwise
+  const requiredRoles = useMemo(
+    () => getPermissionsNeededForAction(selectedAction, formValues) || [],
+    [formValues, selectedAction],
   );
 
   const { thresholdPerRole } = useDomainThreshold({

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/SidebarBanner.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/SidebarBanner.tsx
@@ -16,11 +16,9 @@ import NotificationBanner from '~v5/shared/NotificationBanner/index.ts';
 
 import {
   ACTION_TYPE_FIELD_NAME,
-  CREATED_IN_FIELD_NAME,
   DECISION_METHOD_FIELD_NAME,
 } from '../../../consts.ts';
 import { useIsFieldDisabled } from '../../hooks.ts';
-import { useHasEnoughMembersWithPermissions } from '../hooks.ts';
 
 const displayName =
   'v5.common.ActionSidebar.ActionSidebarContent.SidebarBanner';
@@ -33,12 +31,17 @@ const MSG = defineMessages({
   },
 });
 
-export const SidebarBanner: FC = () => {
+interface SidebarBannerProps {
+  hasEnoughMembersWithPermissions: boolean;
+}
+
+export const SidebarBanner: FC<SidebarBannerProps> = ({
+  hasEnoughMembersWithPermissions,
+}) => {
   const { watch } = useFormContext();
-  const [selectedAction, decisionMethod, createdIn] = watch([
+  const [selectedAction, decisionMethod] = watch([
     ACTION_TYPE_FIELD_NAME,
     DECISION_METHOD_FIELD_NAME,
-    CREATED_IN_FIELD_NAME,
   ]);
 
   const { installedExtensionsData } = useExtensionsData();
@@ -66,12 +69,6 @@ export const SidebarBanner: FC = () => {
 
   const showVersionUpToDateNotification =
     selectedAction === Action.UpgradeColonyVersion && !canUpgrade;
-
-  const hasEnoughMembersWithPermissions = useHasEnoughMembersWithPermissions({
-    decisionMethod,
-    selectedAction,
-    createdIn,
-  });
 
   return (
     <>

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/MultiSigSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/MultiSigSidebar.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import useExtensionData from '~hooks/useExtensionData.ts';
 import SpinnerLoader from '~shared/Preloaders/SpinnerLoader.tsx';
 import { isInstalledExtensionData } from '~utils/extensions.ts';
-import { isMultiSig } from '~utils/multiSig.ts';
+import { isMultiSig } from '~utils/multiSig/index.ts';
 import UninstalledMessage from '~v5/common/UninstalledMessage/index.ts';
 
 import useGetColonyAction from '../../hooks/useGetColonyAction.ts';

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/MultiSigWidget.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/MultiSigWidget.tsx
@@ -40,10 +40,11 @@ const MSG = defineMessages({
 
 const MultiSigWidget: FC<MultiSigWidgetProps> = ({ action }) => {
   const { type: actionType, multiSigData } = action;
-  const requiredRoles = getRolesNeededForMultiSigAction({
-    actionType,
-    createdIn: Number(multiSigData.nativeMultiSigDomainId),
-  });
+  const requiredRoles =
+    getRolesNeededForMultiSigAction({
+      actionType,
+      createdIn: Number(multiSigData.nativeMultiSigDomainId),
+    }) || [];
 
   const { isLoading, thresholdPerRole } = useDomainThreshold({
     domainId: Number(multiSigData.nativeMultiSigDomainId),

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/MultiSigWidget.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/MultiSigWidget.tsx
@@ -7,7 +7,7 @@ import { useDomainThreshold } from '~hooks/multiSig/useDomainThreshold.ts';
 import { type MultiSigAction } from '~types/motions.ts';
 import { notMaybe } from '~utils/arrays/index.ts';
 import { formatText } from '~utils/intl.ts';
-import { getRolesNeededForMultiSigAction } from '~utils/multiSig.ts';
+import { getRolesNeededForMultiSigAction } from '~utils/multiSig/index.ts';
 import NotificationBanner from '~v5/shared/NotificationBanner/NotificationBanner.tsx';
 import Stepper from '~v5/shared/Stepper/Stepper.tsx';
 

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
@@ -11,7 +11,8 @@ import {
 } from '~gql';
 import { useEligibleSignees } from '~hooks/multiSig/useEligibleSignees.ts';
 import Tooltip from '~shared/Extensions/Tooltip/Tooltip.tsx';
-import { type Threshold } from '~types/multisig.ts';
+import SpinnerLoader from '~shared/Preloaders/SpinnerLoader.tsx';
+import { type Threshold } from '~types/multiSig.ts';
 import { notMaybe } from '~utils/arrays/index.ts';
 import { formatText } from '~utils/intl.ts';
 import { getRolesNeededForMultiSigAction } from '~utils/multiSig/index.ts';
@@ -128,14 +129,8 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
       actionType,
       createdIn: Number(multiSigData.nativeMultiSigDomainId),
     }) || [];
-  /*
-   * @NOTE we can remove this once we flatten fetching of eligible signees to not use a 2d array
-   * The only action which has a 2d array of required roles is managing roles in a subdomain via permissions, not multisig
-   * so we can safely assume that we can use just the first array of roles
-   */
-  const requiredMultiSigRoles = requiredRoles[0] || [];
 
-  const doesActionRequireMultipleRoles = requiredMultiSigRoles.length > 1;
+  const doesActionRequireMultipleRoles = requiredRoles.length > 1;
   const isMotionOlderThanWeek = hasWeekPassed(createdAt);
 
   const signatures = (multiSigData?.signatures?.items ?? []).filter(notMaybe);
@@ -164,7 +159,7 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
     });
 
   if (areEligibleSigneesLoading) {
-    return <div>Loading</div>;
+    return <SpinnerLoader appearance={{ size: 'medium' }} />;
   }
 
   const notSignedUsers = getNotSignedUsers({
@@ -172,10 +167,7 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
     signatures,
   });
 
-  const allUserSignatures = getAllUserSignatures(
-    signatures,
-    requiredMultiSigRoles,
-  );
+  const allUserSignatures = getAllUserSignatures(signatures, requiredRoles);
 
   const signaturesToDisplay = [
     ...Object.values(allUserSignatures),
@@ -359,7 +351,7 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
               approvalsPerRole={approvalsPerRole}
               thresholdPerRole={thresholdPerRole}
               multiSigDomainId={Number(multiSigData.nativeMultiSigDomainId)}
-              requiredRoles={requiredMultiSigRoles}
+              requiredRoles={requiredRoles}
             />
           ) : null,
         },

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
@@ -14,7 +14,7 @@ import Tooltip from '~shared/Extensions/Tooltip/Tooltip.tsx';
 import { type Threshold } from '~types/multisig.ts';
 import { notMaybe } from '~utils/arrays/index.ts';
 import { formatText } from '~utils/intl.ts';
-import { getRolesNeededForMultiSigAction } from '~utils/multiSig.ts';
+import { getRolesNeededForMultiSigAction } from '~utils/multiSig/index.ts';
 import MenuWithStatusText from '~v5/shared/MenuWithStatusText/MenuWithStatusText.tsx';
 import ProgressBar from '~v5/shared/ProgressBar/ProgressBar.tsx';
 import { StatusTypes } from '~v5/shared/StatusText/consts.ts';

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ThresholdPassedBanner/ThresholdPassedBanner.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ThresholdPassedBanner/ThresholdPassedBanner.tsx
@@ -5,7 +5,7 @@ import { defineMessages } from 'react-intl';
 import { MULTI_SIG_HELP_URL } from '~constants/externalUrls.ts';
 import ExternalLink from '~shared/ExternalLink/ExternalLink.tsx';
 import { type MultiSigUserSignature } from '~types/graphql.ts';
-import { type Threshold } from '~types/multisig.ts';
+import { type Threshold } from '~types/multiSig.ts';
 import { getMultipleRolesText } from '~utils/colonyRoles.ts';
 import { formatText } from '~utils/intl.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/utils.ts
@@ -2,7 +2,8 @@ import { type ColonyRole } from '@colony/colony-js';
 import { isBefore, parseISO, subWeeks } from 'date-fns';
 
 import { MultiSigVote } from '~gql';
-import { type User, type MultiSigUserSignature } from '~types/graphql.ts';
+import { type MultiSigUserSignature } from '~types/graphql.ts';
+import { type EligibleSignee } from '~types/multiSig.ts';
 
 import { type MultiSigSignee } from './types.ts';
 
@@ -17,29 +18,27 @@ export const hasWeekPassed = (createdAt: string) => {
 };
 
 export const getNotSignedUsers = ({
-  requiredRoles,
   signatures,
   eligibleSignees,
 }: {
   signatures: MultiSigUserSignature[];
-  eligibleSignees: User[];
-  requiredRoles: ColonyRole[];
+  eligibleSignees: EligibleSignee[];
 }): MultiSigSignee[] => {
   const notSignedUsers: MultiSigSignee[] = eligibleSignees
     .filter((eligibleSignee) => {
       return !signatures.find(
-        (signature) => signature.userAddress === eligibleSignee?.walletAddress,
+        (signature) => signature.userAddress === eligibleSignee.userAddress,
       );
     })
     .map((eligibleSignee) => {
       return {
-        userAddress: eligibleSignee?.walletAddress,
+        userAddress: eligibleSignee.userAddress,
         user: {
-          profile: eligibleSignee?.profile,
+          profile: eligibleSignee.user.profile,
         },
         vote: MultiSigVote.None,
         rolesSignedWith: [],
-        userRoles: requiredRoles || [], // @TODO get this from the hook for signees
+        userRoles: eligibleSignee.userRoles,
       };
     });
 

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/RemoveVoteButton/RemoveVoteButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/RemoveVoteButton/RemoveVoteButton.tsx
@@ -11,7 +11,7 @@ import { mapPayload } from '~utils/actions.ts';
 import { extractColonyRoles } from '~utils/colonyRoles.ts';
 import { extractColonyDomains } from '~utils/domains.ts';
 import { formatText } from '~utils/intl.ts';
-import { getRolesNeededForMultiSigAction } from '~utils/multiSig.ts';
+import { getRolesNeededForMultiSigAction } from '~utils/multiSig/index.ts';
 import Button from '~v5/shared/Button/Button.tsx';
 import TxButton from '~v5/shared/Button/TxButton.tsx';
 

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/VoteButton/VoteButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/VoteButton/VoteButton.tsx
@@ -11,7 +11,7 @@ import { mapPayload } from '~utils/actions.ts';
 import { extractColonyRoles } from '~utils/colonyRoles.ts';
 import { extractColonyDomains } from '~utils/domains.ts';
 import { formatText } from '~utils/intl.ts';
-import { getRolesNeededForMultiSigAction } from '~utils/multiSig.ts';
+import { getRolesNeededForMultiSigAction } from '~utils/multiSig/index.ts';
 import Button from '~v5/shared/Button/Button.tsx';
 import TxButton from '~v5/shared/Button/TxButton.tsx';
 import { type ButtonProps } from '~v5/shared/Button/types.ts';

--- a/src/constants/permissions.ts
+++ b/src/constants/permissions.ts
@@ -155,16 +155,14 @@ export const findFirstUserRoleWithColonyRoles = ({
   colonyRoles,
   isMultiSig,
 }: {
-  colonyRoles?: ColonyRole[][];
+  colonyRoles: ColonyRole[];
   isMultiSig?: boolean;
 }) => {
   if (!colonyRoles || colonyRoles.length === 0) {
     return UserRole.Owner;
   }
   const matchingUserRole = USER_ROLES.find((userRole) =>
-    colonyRoles.some((roles) =>
-      roles.every((role) => userRole.permissions.includes(role)),
-    ),
+    colonyRoles.every((role) => userRole.permissions.includes(role)),
   );
 
   if (!matchingUserRole) {

--- a/src/graphql/fragments/roles.graphql
+++ b/src/graphql/fragments/roles.graphql
@@ -1,0 +1,12 @@
+fragment ColonyUserRole on ColonyRole {
+  id
+  targetUser {
+    ...User
+  }
+  targetAddress
+  role_1
+  role_2
+  role_3
+  role_5
+  role_6
+}

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -9597,6 +9597,14 @@ export type GetRolesForDomainQueryVariables = Exact<{
 
 export type GetRolesForDomainQuery = { __typename?: 'Query', getRoleByDomainAndColony?: { __typename?: 'ModelColonyRoleConnection', items: Array<{ __typename?: 'ColonyRole', id: string, targetAddress: string, targetUser?: { __typename?: 'User', id: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null } | null } | null } | null> } | null };
 
+export type GetMultiSigRolesForDomainQueryVariables = Exact<{
+  domainId: Scalars['ID'];
+  filter: ModelColonyRoleFilterInput;
+}>;
+
+
+export type GetMultiSigRolesForDomainQuery = { __typename?: 'Query', getRoleByDomainAndColony?: { __typename?: 'ModelColonyRoleConnection', items: Array<{ __typename?: 'ColonyRole', id: string, targetAddress: string, role_1?: boolean | null, role_2?: boolean | null, role_3?: boolean | null, role_5?: boolean | null, role_6?: boolean | null, targetUser?: { __typename?: 'User', walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, displayNameChanged?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null, preferredCurrency?: SupportedCurrencies | null, meta?: { __typename?: 'ProfileMetadata', metatransactionsEnabled?: boolean | null, decentralizedModeEnabled?: boolean | null, customRpc?: string | null } | null } | null, privateBetaInviteCode?: { __typename?: 'PrivateBetaInviteCode', id: string, shareableInvites?: number | null } | null } | null } | null> } | null };
+
 export type GetUserStakesQueryVariables = Exact<{
   userAddress: Scalars['ID'];
   colonyAddress: Scalars['ID'];
@@ -12888,6 +12896,53 @@ export function useGetRolesForDomainLazyQuery(baseOptions?: Apollo.LazyQueryHook
 export type GetRolesForDomainQueryHookResult = ReturnType<typeof useGetRolesForDomainQuery>;
 export type GetRolesForDomainLazyQueryHookResult = ReturnType<typeof useGetRolesForDomainLazyQuery>;
 export type GetRolesForDomainQueryResult = Apollo.QueryResult<GetRolesForDomainQuery, GetRolesForDomainQueryVariables>;
+export const GetMultiSigRolesForDomainDocument = gql`
+    query GetMultiSigRolesForDomain($domainId: ID!, $filter: ModelColonyRoleFilterInput!) {
+  getRoleByDomainAndColony(domainId: $domainId, filter: $filter, limit: 9999) {
+    items {
+      id
+      targetUser {
+        ...User
+      }
+      targetAddress
+      role_1
+      role_2
+      role_3
+      role_5
+      role_6
+    }
+  }
+}
+    ${UserFragmentDoc}`;
+
+/**
+ * __useGetMultiSigRolesForDomainQuery__
+ *
+ * To run a query within a React component, call `useGetMultiSigRolesForDomainQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetMultiSigRolesForDomainQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetMultiSigRolesForDomainQuery({
+ *   variables: {
+ *      domainId: // value for 'domainId'
+ *      filter: // value for 'filter'
+ *   },
+ * });
+ */
+export function useGetMultiSigRolesForDomainQuery(baseOptions: Apollo.QueryHookOptions<GetMultiSigRolesForDomainQuery, GetMultiSigRolesForDomainQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetMultiSigRolesForDomainQuery, GetMultiSigRolesForDomainQueryVariables>(GetMultiSigRolesForDomainDocument, options);
+      }
+export function useGetMultiSigRolesForDomainLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetMultiSigRolesForDomainQuery, GetMultiSigRolesForDomainQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetMultiSigRolesForDomainQuery, GetMultiSigRolesForDomainQueryVariables>(GetMultiSigRolesForDomainDocument, options);
+        }
+export type GetMultiSigRolesForDomainQueryHookResult = ReturnType<typeof useGetMultiSigRolesForDomainQuery>;
+export type GetMultiSigRolesForDomainLazyQueryHookResult = ReturnType<typeof useGetMultiSigRolesForDomainLazyQuery>;
+export type GetMultiSigRolesForDomainQueryResult = Apollo.QueryResult<GetMultiSigRolesForDomainQuery, GetMultiSigRolesForDomainQueryVariables>;
 export const GetUserStakesDocument = gql`
     query GetUserStakes($userAddress: ID!, $colonyAddress: ID!) {
   getUserStakes(

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -9143,6 +9143,8 @@ export type ExtensionFragment = { __typename?: 'ColonyExtension', hash: string, 
 
 export type ExtensionDisplayFragmentFragment = { __typename?: 'ColonyExtension', hash: string, address: string };
 
+export type ColonyUserRoleFragment = { __typename?: 'ColonyRole', id: string, targetAddress: string, role_1?: boolean | null, role_2?: boolean | null, role_3?: boolean | null, role_5?: boolean | null, role_6?: boolean | null, targetUser?: { __typename?: 'User', walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, displayNameChanged?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null, preferredCurrency?: SupportedCurrencies | null, meta?: { __typename?: 'ProfileMetadata', metatransactionsEnabled?: boolean | null, decentralizedModeEnabled?: boolean | null, customRpc?: string | null } | null } | null, privateBetaInviteCode?: { __typename?: 'PrivateBetaInviteCode', id: string, shareableInvites?: number | null } | null } | null };
+
 export type NftDataFragment = { __typename?: 'NFTData', address: string, description?: string | null, id: string, imageUri?: string | null, logoUri: string, name?: string | null, tokenName: string, tokenSymbol: string, uri: string };
 
 export type FunctionParamFragment = { __typename?: 'FunctionParam', name: string, type: string, value: string };
@@ -9587,15 +9589,6 @@ export type GetColonyHistoricRoleRolesQueryVariables = Exact<{
 
 
 export type GetColonyHistoricRoleRolesQuery = { __typename?: 'Query', getColonyHistoricRole?: { __typename?: 'ColonyHistoricRole', role_0?: boolean | null, role_1?: boolean | null, role_2?: boolean | null, role_3?: boolean | null, role_5?: boolean | null, role_6?: boolean | null } | null };
-
-export type GetRolesForDomainQueryVariables = Exact<{
-  domainId: Scalars['ID'];
-  colonyAddress: Scalars['ID'];
-  filter: ModelColonyRoleFilterInput;
-}>;
-
-
-export type GetRolesForDomainQuery = { __typename?: 'Query', getRoleByDomainAndColony?: { __typename?: 'ModelColonyRoleConnection', items: Array<{ __typename?: 'ColonyRole', id: string, targetAddress: string, targetUser?: { __typename?: 'User', id: string, profile?: { __typename?: 'Profile', avatar?: string | null, displayName?: string | null } | null } | null } | null> } | null };
 
 export type GetMultiSigRolesForDomainQueryVariables = Exact<{
   domainId: Scalars['ID'];
@@ -10141,6 +10134,20 @@ ${ExpenditureStageFragmentDoc}
 ${ColonyMotionFragmentDoc}
 ${ExpenditureBalanceFragmentDoc}
 ${ExpenditureActionFragmentDoc}`;
+export const ColonyUserRoleFragmentDoc = gql`
+    fragment ColonyUserRole on ColonyRole {
+  id
+  targetUser {
+    ...User
+  }
+  targetAddress
+  role_1
+  role_2
+  role_3
+  role_5
+  role_6
+}
+    ${UserFragmentDoc}`;
 export const UserDisplayFragmentDoc = gql`
     fragment UserDisplay on User {
   walletAddress: id
@@ -12845,75 +12852,15 @@ export function useGetColonyHistoricRoleRolesLazyQuery(baseOptions?: Apollo.Lazy
 export type GetColonyHistoricRoleRolesQueryHookResult = ReturnType<typeof useGetColonyHistoricRoleRolesQuery>;
 export type GetColonyHistoricRoleRolesLazyQueryHookResult = ReturnType<typeof useGetColonyHistoricRoleRolesLazyQuery>;
 export type GetColonyHistoricRoleRolesQueryResult = Apollo.QueryResult<GetColonyHistoricRoleRolesQuery, GetColonyHistoricRoleRolesQueryVariables>;
-export const GetRolesForDomainDocument = gql`
-    query GetRolesForDomain($domainId: ID!, $colonyAddress: ID!, $filter: ModelColonyRoleFilterInput!) {
-  getRoleByDomainAndColony(
-    domainId: $domainId
-    colonyAddress: {eq: $colonyAddress}
-    filter: $filter
-  ) {
-    items {
-      id
-      targetUser {
-        id
-        profile {
-          avatar
-          displayName
-        }
-      }
-      targetAddress
-    }
-  }
-}
-    `;
-
-/**
- * __useGetRolesForDomainQuery__
- *
- * To run a query within a React component, call `useGetRolesForDomainQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetRolesForDomainQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetRolesForDomainQuery({
- *   variables: {
- *      domainId: // value for 'domainId'
- *      colonyAddress: // value for 'colonyAddress'
- *      filter: // value for 'filter'
- *   },
- * });
- */
-export function useGetRolesForDomainQuery(baseOptions: Apollo.QueryHookOptions<GetRolesForDomainQuery, GetRolesForDomainQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetRolesForDomainQuery, GetRolesForDomainQueryVariables>(GetRolesForDomainDocument, options);
-      }
-export function useGetRolesForDomainLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetRolesForDomainQuery, GetRolesForDomainQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetRolesForDomainQuery, GetRolesForDomainQueryVariables>(GetRolesForDomainDocument, options);
-        }
-export type GetRolesForDomainQueryHookResult = ReturnType<typeof useGetRolesForDomainQuery>;
-export type GetRolesForDomainLazyQueryHookResult = ReturnType<typeof useGetRolesForDomainLazyQuery>;
-export type GetRolesForDomainQueryResult = Apollo.QueryResult<GetRolesForDomainQuery, GetRolesForDomainQueryVariables>;
 export const GetMultiSigRolesForDomainDocument = gql`
     query GetMultiSigRolesForDomain($domainId: ID!, $filter: ModelColonyRoleFilterInput!) {
   getRoleByDomainAndColony(domainId: $domainId, filter: $filter, limit: 9999) {
     items {
-      id
-      targetUser {
-        ...User
-      }
-      targetAddress
-      role_1
-      role_2
-      role_3
-      role_5
-      role_6
+      ...ColonyUserRole
     }
   }
 }
-    ${UserFragmentDoc}`;
+    ${ColonyUserRoleFragmentDoc}`;
 
 /**
  * __useGetMultiSigRolesForDomainQuery__

--- a/src/graphql/queries/roles.graphql
+++ b/src/graphql/queries/roles.graphql
@@ -32,3 +32,23 @@ query GetRolesForDomain(
     }
   }
 }
+
+query GetMultiSigRolesForDomain(
+  $domainId: ID!
+  $filter: ModelColonyRoleFilterInput!
+) {
+  getRoleByDomainAndColony(domainId: $domainId, filter: $filter, limit: 9999) {
+    items {
+      id
+      targetUser {
+        ...User
+      }
+      targetAddress
+      role_1
+      role_2
+      role_3
+      role_5
+      role_6
+    }
+  }
+}

--- a/src/graphql/queries/roles.graphql
+++ b/src/graphql/queries/roles.graphql
@@ -9,46 +9,13 @@ query GetColonyHistoricRoleRoles($id: ID!) {
   }
 }
 
-query GetRolesForDomain(
-  $domainId: ID!
-  $colonyAddress: ID!
-  $filter: ModelColonyRoleFilterInput!
-) {
-  getRoleByDomainAndColony(
-    domainId: $domainId
-    colonyAddress: { eq: $colonyAddress }
-    filter: $filter
-  ) {
-    items {
-      id
-      targetUser {
-        id
-        profile {
-          avatar
-          displayName
-        }
-      }
-      targetAddress
-    }
-  }
-}
-
 query GetMultiSigRolesForDomain(
   $domainId: ID!
   $filter: ModelColonyRoleFilterInput!
 ) {
   getRoleByDomainAndColony(domainId: $domainId, filter: $filter, limit: 9999) {
     items {
-      id
-      targetUser {
-        ...User
-      }
-      targetAddress
-      role_1
-      role_2
-      role_3
-      role_5
-      role_6
+      ...ColonyUserRole
     }
   }
 }

--- a/src/hooks/multiSig/useDomainThreshold.ts
+++ b/src/hooks/multiSig/useDomainThreshold.ts
@@ -9,7 +9,7 @@ import { useEligibleSignees } from './useEligibleSignees.ts';
 
 interface UseDomainThresholdParams {
   domainId: number;
-  requiredRoles?: ColonyRole[][];
+  requiredRoles: ColonyRole[][];
 }
 
 interface UseDomainThresholdResult {
@@ -29,13 +29,14 @@ export const useDomainThreshold = ({
     Extension.MultisigPermissions,
   );
 
-  const { countPerRole } = useEligibleSignees({
-    domainId,
-    requiredRoles,
-  });
+  const { countPerRole, isLoading: loadingEligibleSignees } =
+    useEligibleSignees({
+      domainId,
+      requiredRoles,
+    });
 
   const getDomainThreshold = (): Threshold => {
-    if (loadingExtension || !requiredRoles) {
+    if (loadingExtension || loadingEligibleSignees || !requiredRoles) {
       return null;
     }
 

--- a/src/hooks/multiSig/useDomainThreshold.ts
+++ b/src/hooks/multiSig/useDomainThreshold.ts
@@ -2,14 +2,14 @@ import { type ColonyRole, Extension } from '@colony/colony-js';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useExtensionData from '~hooks/useExtensionData.ts';
-import { type Threshold } from '~types/multisig.ts';
+import { type Threshold } from '~types/multiSig.ts';
 import { isInstalledExtensionData } from '~utils/extensions.ts';
 
 import { useEligibleSignees } from './useEligibleSignees.ts';
 
 interface UseDomainThresholdParams {
   domainId: number;
-  requiredRoles: ColonyRole[][];
+  requiredRoles: ColonyRole[];
 }
 
 interface UseDomainThresholdResult {
@@ -69,11 +69,9 @@ export const useDomainThreshold = ({
       const thresholdMap: { [role: number]: number } = {};
 
       // Iterate over each array of roles in requiredRoles
-      requiredRoles.forEach((roles) => {
+      requiredRoles.forEach((role) => {
         // Assign the thresholdConfig to each role in the current roles array
-        roles.forEach((role) => {
-          thresholdMap[role] = thresholdConfig;
-        });
+        thresholdMap[role] = thresholdConfig;
       });
 
       return thresholdMap;

--- a/src/hooks/multiSig/useEligibleSignees.ts
+++ b/src/hooks/multiSig/useEligibleSignees.ts
@@ -42,10 +42,10 @@ export const useEligibleSignees = ({
           domainId,
         });
         setSigneesResult(response);
-        setIsLoading(false);
       } catch (error) {
         console.warn('Error while fetching eligible signees', error);
         setIsError(true);
+      } finally {
         setIsLoading(false);
       }
     }

--- a/src/hooks/multiSig/useEligibleSignees.ts
+++ b/src/hooks/multiSig/useEligibleSignees.ts
@@ -1,104 +1,53 @@
-import { Id, type ColonyRole } from '@colony/colony-js';
+import { type ColonyRole } from '@colony/colony-js';
+import { useEffect, useState } from 'react';
 
-import { useMemberContext } from '~context/MemberContext/MemberContext.ts';
-import { type ColonyContributor } from '~types/graphql.ts';
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import {
+  getEligibleSignees as getEligibleSigneesApi,
+  type GetEligibleSigneesResult,
+} from '~utils/multiSig/getEligibleSignees.ts';
 
 interface UseEligibleSigneesParams {
   domainId: number;
-  requiredRoles?: ColonyRole[][];
+  requiredRoles: ColonyRole[][];
+}
+
+interface UseEligibleSigneesResult extends GetEligibleSigneesResult {
+  isLoading: boolean;
 }
 
 export const useEligibleSignees = ({
   domainId,
   requiredRoles,
-}: UseEligibleSigneesParams) => {
-  const { totalMembers } = useMemberContext();
-
-  if (Number.isNaN(domainId)) {
-    throw new Error('domainId must be a number');
-  }
-
-  const domainIds =
-    domainId === Id.RootDomain ? [Id.RootDomain] : [Id.RootDomain, domainId];
-
-  const getEligibleSignees = (members: ColonyContributor[]) => {
-    if (!requiredRoles || requiredRoles.length === 0) {
-      return {
-        eligibleSignees: {},
-        uniqueEligibleSignees: [],
-      };
-    }
-
-    const matches: {
-      [role: number]: { [userAddress: string]: ColonyContributor['user'] };
-    } = {};
-
-    const uniqueEligibleSignees = new Set<ColonyContributor['user']>();
-
-    members.forEach((member) => {
-      if (!member.roles) {
-        return;
-      }
-
-      member.roles.items.forEach((item) => {
-        if (!item || !item.isMultiSig) {
-          return;
-        }
-
-        const [, nativeDomainId] = item.domainId.split('_');
-        const hasRoleInDomain = domainIds.includes(Number(nativeDomainId));
-
-        if (!hasRoleInDomain) {
-          return;
-        }
-
-        const assignedRoles = Object.keys(item)
-          .filter((key) => key.startsWith('role_') && item[key] === true)
-          .map((key) => Number(key.split('_')[1]));
-
-        // Check if assignedRoles includes any roles in any requiredRoles array
-        if (
-          requiredRoles.some((roles) =>
-            roles.some((role) => assignedRoles.includes(role)),
-          )
-        ) {
-          if (member.user) {
-            const key = member.user.walletAddress;
-            uniqueEligibleSignees.add(member.user);
-
-            requiredRoles.forEach((roles) => {
-              roles.forEach((role) => {
-                if (assignedRoles.includes(role)) {
-                  if (!matches[role]) {
-                    matches[role] = {};
-                  }
-                  matches[role][key] = member.user;
-                }
-              });
-            });
-          }
-        }
-      });
-    });
-
-    return {
-      eligibleSignees: matches,
-      uniqueEligibleSignees: [...uniqueEligibleSignees],
-    };
-  };
-
-  const { eligibleSignees, uniqueEligibleSignees } =
-    getEligibleSignees(totalMembers);
-
-  const countPerRole: { [role: number]: number } = {};
-  Object.keys(eligibleSignees).forEach((role) => {
-    const numberOfUsers = Object.keys(eligibleSignees[role]).length;
-    countPerRole[role] = numberOfUsers;
+}: UseEligibleSigneesParams): UseEligibleSigneesResult => {
+  const {
+    colony: { colonyAddress },
+  } = useColonyContext();
+  const [isLoading, setIsLoading] = useState(false);
+  const [signeesResult, setSigneesResult] = useState<GetEligibleSigneesResult>({
+    countPerRole: {},
+    uniqueEligibleSignees: {},
+    signeesPerRole: {},
   });
 
+  useEffect(() => {
+    async function fetchEligibleSignees() {
+      setIsLoading(true);
+      const response = await getEligibleSigneesApi({
+        requiredRoles,
+        colonyAddress,
+        domainId,
+      });
+      setSigneesResult(response);
+      setIsLoading(false);
+    }
+
+    fetchEligibleSignees();
+    // Don't think of removing JSON.stringify, because 2d arrays are really really bad hook deps
+  }, [colonyAddress, domainId, JSON.stringify(requiredRoles)]);
+
   return {
-    eligibleSignees,
-    uniqueEligibleSignees,
-    countPerRole,
+    isLoading,
+    ...signeesResult,
   };
 };

--- a/src/hooks/useActivityFeed/helpers.ts
+++ b/src/hooks/useActivityFeed/helpers.ts
@@ -8,7 +8,7 @@ import { type ColonyAction } from '~types/graphql.ts';
 import { notMaybe } from '~utils/arrays/index.ts';
 import { getExtendedActionType } from '~utils/colonyActions.ts';
 import { getMotionState, MotionState } from '~utils/colonyMotions.ts';
-import { getMultiSigState } from '~utils/multiSig.ts';
+import { getMultiSigState } from '~utils/multiSig/index.ts';
 
 import {
   ActivityDecisionMethod,

--- a/src/redux/sagas/utils/proofs.ts
+++ b/src/redux/sagas/utils/proofs.ts
@@ -211,7 +211,7 @@ interface GetAnyPermissionProofsLocalParams {
   colonyRoles: ColonyRoleFragment[];
   colonyDomains: Domain[];
   requiredDomainId: number;
-  requiredColonyRoles: RoleGroupSet;
+  requiredColonyRoles: RoleGroup;
   permissionAddress: string;
   isMultiSig: boolean;
 }
@@ -228,29 +228,26 @@ export const getAnyPermissionProofsLocal = async ({
 }: GetAnyPermissionProofsLocalParams): Promise<
   [BigNumber, BigNumber, string]
 > => {
-  // Iterate over each RoleGroup in the RoleGroupSet
-  for (const roleGroup of requiredColonyRoles) {
-    for (const singleRole of roleGroup) {
-      try {
-        // Attempt to get proofs for the current RoleGroup
-        // eslint-disable-next-line no-await-in-loop
-        const proof = await getSinglePermissionProofsLocal({
-          networkClient,
-          colonyRoles,
-          colonyDomains,
-          requiredDomainId,
-          requiredColonyRole: singleRole,
-          permissionAddress,
-          isMultiSig,
-        });
+  for (const singleRole of requiredColonyRoles) {
+    try {
+      // Attempt to get proofs for the current RoleGroup
+      // eslint-disable-next-line no-await-in-loop
+      const proof = await getSinglePermissionProofsLocal({
+        networkClient,
+        colonyRoles,
+        colonyDomains,
+        requiredDomainId,
+        requiredColonyRole: singleRole,
+        permissionAddress,
+        isMultiSig,
+      });
 
-        // If we get here, it means the current singleRole satisfies the conditions,
-        // so we can return its proof.
-        return proof;
-      } catch (error) {
-        // Catch any errors and continue to the next singleRole in the RoleGroup or the next RoleGroup in the RoleGroupSet
-        // No need to do anything here, just continue to the next iteration
-      }
+      // If we get here, it means the current singleRole satisfies the conditions,
+      // so we can return its proof.
+      return proof;
+    } catch (error) {
+      // Catch any errors and continue to the next singleRole in the RoleGroup or the next RoleGroup in the RoleGroupSet
+      // No need to do anything here, just continue to the next iteration
     }
   }
 

--- a/src/redux/types/actions/multiSig.ts
+++ b/src/redux/types/actions/multiSig.ts
@@ -42,7 +42,7 @@ export type MultiSigActionTypes =
         colonyRoles: ColonyRoleFragment[];
         vote: MultiSigVote;
         domainId: number;
-        roles: ColonyRole[][];
+        roles: ColonyRole[];
         multiSigId: string;
       },
       MetaWithSetter<object>

--- a/src/types/multiSig.ts
+++ b/src/types/multiSig.ts
@@ -1,0 +1,9 @@
+import { type ColonyRole } from '@colony/colony-js';
+
+import { type User } from '~types/graphql.ts';
+
+export interface EligibleSignee {
+  userAddress: string;
+  user: Partial<User>;
+  userRoles: ColonyRole[];
+}

--- a/src/types/multiSig.ts
+++ b/src/types/multiSig.ts
@@ -7,3 +7,4 @@ export interface EligibleSignee {
   user: Partial<User>;
   userRoles: ColonyRole[];
 }
+export type Threshold = { [role: number]: number } | null;

--- a/src/types/multisig.ts
+++ b/src/types/multisig.ts
@@ -1,1 +1,0 @@
-export type Threshold = { [role: number]: number } | null;

--- a/src/utils/multiSig/getEligibleSignees.ts
+++ b/src/utils/multiSig/getEligibleSignees.ts
@@ -1,14 +1,15 @@
-/* eslint-disable camelcase */
 import { ColonyRole, Id } from '@colony/colony-js';
 
 import { apolloClient } from '~apollo';
 import {
+  type ColonyUserRoleFragment,
   GetMultiSigRolesForDomainDocument,
   type GetMultiSigRolesForDomainQuery,
   type GetMultiSigRolesForDomainQueryVariables,
   type ModelColonyRoleFilterInput,
 } from '~gql';
 import { type EligibleSignee } from '~types/multiSig.ts';
+import { notMaybe } from '~utils/arrays/index.ts';
 
 const COLONY_ROLE_TO_FILTER_KEY = {
   [ColonyRole.Root]: 'role_1',
@@ -21,7 +22,7 @@ const COLONY_ROLE_TO_FILTER_KEY = {
 interface GetEligibleSigneesParams {
   colonyAddress: string;
   domainId: number;
-  requiredRoles: ColonyRole[][];
+  requiredRoles: ColonyRole[];
 }
 
 interface SigneeEntry {
@@ -50,87 +51,81 @@ export async function getEligibleSignees({
   const signeesPerRole: SigneesPerRole = {};
   const uniqueEligibleSignees: SigneeEntry = {};
 
-  // Loop through each array of required roles and fetch permission holders for each domain
-  // It may seem scary, but this array will be longer than 1 just for managing permissions in a subdomain :)
+  const roleFilter = requiredRoles
+    .filter((role) => !!COLONY_ROLE_TO_FILTER_KEY[role])
+    .map((role) => ({ [COLONY_ROLE_TO_FILTER_KEY[role]]: { eq: true } }));
+
+  const queryFilter: ModelColonyRoleFilterInput = {
+    isMultiSig: { eq: true },
+    or: roleFilter,
+  };
+  // amplify doesn't provide it in the UI, but the syntax of or: [{att: {eq: SOMETHING}}, {att2: {eq: SOMETHING@}}] works!
+  // but sadly having 2 or statements is impossible so we need to loop through domains
+
   await Promise.all(
-    requiredRoles.map(async (roleSet) => {
-      // amplify doesn't provide it in the UI, but the syntax of or: [{att: {eq: SOMETHING}}, {att2: {eq: SOMETHING@}}] works!
-      const roleFilter = roleSet
-        .filter((role) => !!COLONY_ROLE_TO_FILTER_KEY[role])
-        .map((role) => ({ [COLONY_ROLE_TO_FILTER_KEY[role]]: { eq: true } }));
+    domainIds.map(async (permissionDomainId) => {
+      const response = await apolloClient.query<
+        GetMultiSigRolesForDomainQuery,
+        GetMultiSigRolesForDomainQueryVariables
+      >({
+        query: GetMultiSigRolesForDomainDocument,
+        variables: {
+          domainId: `${colonyAddress}_${permissionDomainId}`,
+          filter: queryFilter,
+        },
+      });
 
-      const queryFilter: ModelColonyRoleFilterInput = {
-        isMultiSig: { eq: true },
-        or: roleFilter,
-      };
+      const usersWithRoles: ColonyUserRoleFragment[] = (
+        response.data.getRoleByDomainAndColony?.items || []
+      ).filter(notMaybe);
 
-      const matchingUsers = await Promise.all(
-        domainIds.map(async (permissionDomainId) => {
-          const response = await apolloClient.query<
-            GetMultiSigRolesForDomainQuery,
-            GetMultiSigRolesForDomainQueryVariables
-          >({
-            query: GetMultiSigRolesForDomainDocument,
-            variables: {
-              domainId: `${colonyAddress}_${permissionDomainId}`,
-              filter: queryFilter,
-            },
-            fetchPolicy: 'cache-first',
-          });
+      usersWithRoles.forEach((userRoleEntry) => {
+        if (!notMaybe(userRoleEntry.targetUser)) {
+          return;
+        }
 
-          const usersWithRoles = (
-            response.data.getRoleByDomainAndColony?.items ?? []
-          ).filter((item) => {
-            return item !== undefined && item !== null && !!item.targetUser;
-          });
+        const userAddress = userRoleEntry.targetAddress;
 
-          return usersWithRoles;
-        }),
-      );
+        // first we determine all the roles user is holding
+        const userRoles = requiredRoles.filter(
+          (role) => !!userRoleEntry[COLONY_ROLE_TO_FILTER_KEY[role]],
+        );
 
-      // @TODO for some reason flatMap Typescript still assumes it's a 2d array
-      matchingUsers.forEach((matchingUserSet) => {
-        matchingUserSet.forEach((matchingUser) => {
-          if (!matchingUser || !matchingUser.targetUser) {
+        // This means a user has the same permissions in both the parent and the child domain
+        // The main edge case here is: a user has Administration in root and Funding in the child domain, the action is simple payment
+        // in that case we can just concat the array since they will sign for both roles
+        const existingUserEntry = uniqueEligibleSignees[userAddress];
+
+        if (existingUserEntry) {
+          uniqueEligibleSignees[userAddress] = {
+            ...existingUserEntry,
+            userRoles: [
+              ...new Set([...existingUserEntry.userRoles, ...userRoles]),
+            ],
+          };
+        } else {
+          uniqueEligibleSignees[userAddress] = {
+            userAddress,
+            user: userRoleEntry.targetUser,
+            userRoles,
+          };
+        }
+
+        userRoles.forEach((role) => {
+          if (!signeesPerRole[role]) {
+            signeesPerRole[role] = {};
+          }
+
+          // Because it's a nested loop, the upper if statement doesn't infer the type in here
+          if (!notMaybe(userRoleEntry.targetUser)) {
             return;
           }
 
-          const userAddress = matchingUser.targetAddress;
-
-          // first we determine all the roles user is holding
-          const userRoles = roleSet.filter(
-            (role) =>
-              matchingUser !== null &&
-              !!matchingUser[COLONY_ROLE_TO_FILTER_KEY[role]],
-          );
-
-          // extremely unlikely, as this entire loop is going to be ran more than once just for one action type
-          const existingUserEntry = uniqueEligibleSignees[userAddress];
-          // but if the user exists, we just add the role into the array of held roles
-          if (existingUserEntry) {
-            uniqueEligibleSignees[userAddress] = {
-              ...existingUserEntry,
-              userRoles: [...existingUserEntry.userRoles, ...userRoles],
-            };
-          } else {
-            uniqueEligibleSignees[userAddress] = {
-              userAddress,
-              user: matchingUser.targetUser,
-              userRoles,
-            };
-          }
-
-          userRoles.forEach((role) => {
-            if (!signeesPerRole[role]) {
-              signeesPerRole[role] = {};
-            }
-
-            signeesPerRole[role][userAddress] = {
-              userAddress,
-              user: matchingUser.targetUser,
-              userRoles,
-            };
-          });
+          signeesPerRole[role][userAddress] = {
+            userAddress,
+            user: userRoleEntry.targetUser,
+            userRoles,
+          };
         });
       });
     }),

--- a/src/utils/multiSig/getEligibleSignees.ts
+++ b/src/utils/multiSig/getEligibleSignees.ts
@@ -1,0 +1,149 @@
+/* eslint-disable camelcase */
+import { ColonyRole, Id } from '@colony/colony-js';
+
+import { apolloClient } from '~apollo';
+import {
+  GetMultiSigRolesForDomainDocument,
+  type GetMultiSigRolesForDomainQuery,
+  type GetMultiSigRolesForDomainQueryVariables,
+  type ModelColonyRoleFilterInput,
+} from '~gql';
+import { type EligibleSignee } from '~types/multiSig.ts';
+
+const COLONY_ROLE_TO_FILTER_KEY = {
+  [ColonyRole.Root]: 'role_1',
+  [ColonyRole.Arbitration]: 'role_2',
+  [ColonyRole.Architecture]: 'role_3',
+  [ColonyRole.Funding]: 'role_5',
+  [ColonyRole.Administration]: 'role_6',
+};
+
+interface GetEligibleSigneesParams {
+  colonyAddress: string;
+  domainId: number;
+  requiredRoles: ColonyRole[][];
+}
+
+interface SigneeEntry {
+  [userAddress: string]: EligibleSignee;
+}
+
+interface SigneesPerRole {
+  [role: number]: SigneeEntry;
+}
+
+export interface GetEligibleSigneesResult {
+  signeesPerRole: SigneesPerRole;
+  countPerRole: {
+    [role: number]: number;
+  };
+  uniqueEligibleSignees: SigneeEntry;
+}
+
+export async function getEligibleSignees({
+  colonyAddress,
+  domainId,
+  requiredRoles,
+}: GetEligibleSigneesParams): Promise<GetEligibleSigneesResult> {
+  const domainIds =
+    domainId === Id.RootDomain ? [Id.RootDomain] : [Id.RootDomain, domainId];
+  const signeesPerRole: SigneesPerRole = {};
+  const uniqueEligibleSignees: SigneeEntry = {};
+
+  // Loop through each array of required roles and fetch permission holders for each domain
+  // It may seem scary, but this array will be longer than 1 just for managing permissions in a subdomain :)
+  await Promise.all(
+    requiredRoles.map(async (roleSet) => {
+      // amplify doesn't provide it in the UI, but the syntax of or: [{att: {eq: SOMETHING}}, {att2: {eq: SOMETHING@}}] works!
+      const roleFilter = roleSet
+        .filter((role) => !!COLONY_ROLE_TO_FILTER_KEY[role])
+        .map((role) => ({ [COLONY_ROLE_TO_FILTER_KEY[role]]: { eq: true } }));
+
+      const queryFilter: ModelColonyRoleFilterInput = {
+        isMultiSig: { eq: true },
+        or: roleFilter,
+      };
+
+      const matchingUsers = await Promise.all(
+        domainIds.map(async (permissionDomainId) => {
+          const response = await apolloClient.query<
+            GetMultiSigRolesForDomainQuery,
+            GetMultiSigRolesForDomainQueryVariables
+          >({
+            query: GetMultiSigRolesForDomainDocument,
+            variables: {
+              domainId: `${colonyAddress}_${permissionDomainId}`,
+              filter: queryFilter,
+            },
+            fetchPolicy: 'cache-first',
+          });
+
+          const usersWithRoles = (
+            response.data.getRoleByDomainAndColony?.items ?? []
+          ).filter((item) => {
+            return item !== undefined && item !== null && !!item.targetUser;
+          });
+
+          return usersWithRoles;
+        }),
+      );
+
+      // @TODO for some reason flatMap Typescript still assumes it's a 2d array
+      matchingUsers.forEach((matchingUserSet) => {
+        matchingUserSet.forEach((matchingUser) => {
+          if (!matchingUser || !matchingUser.targetUser) {
+            return;
+          }
+
+          const userAddress = matchingUser.targetAddress;
+
+          // first we determine all the roles user is holding
+          const userRoles = roleSet.filter(
+            (role) =>
+              matchingUser !== null &&
+              !!matchingUser[COLONY_ROLE_TO_FILTER_KEY[role]],
+          );
+
+          // extremely unlikely, as this entire loop is going to be ran more than once just for one action type
+          const existingUserEntry = uniqueEligibleSignees[userAddress];
+          // but if the user exists, we just add the role into the array of held roles
+          if (existingUserEntry) {
+            uniqueEligibleSignees[userAddress] = {
+              ...existingUserEntry,
+              userRoles: [...existingUserEntry.userRoles, ...userRoles],
+            };
+          } else {
+            uniqueEligibleSignees[userAddress] = {
+              userAddress,
+              user: matchingUser.targetUser,
+              userRoles,
+            };
+          }
+
+          userRoles.forEach((role) => {
+            if (!signeesPerRole[role]) {
+              signeesPerRole[role] = {};
+            }
+
+            signeesPerRole[role][userAddress] = {
+              userAddress,
+              user: matchingUser.targetUser,
+              userRoles,
+            };
+          });
+        });
+      });
+    }),
+  );
+
+  const countPerRole: { [role: number]: number } = Object.entries(
+    signeesPerRole,
+  ).reduce((countPerRoleAcc, [role, signees]) => {
+    return {
+      ...countPerRoleAcc,
+      [role]: Object.keys(signees).length,
+    };
+  }, {});
+
+  return { signeesPerRole, uniqueEligibleSignees, countPerRole };
+}

--- a/src/utils/multiSig/getEligibleSignees.ts
+++ b/src/utils/multiSig/getEligibleSignees.ts
@@ -7,11 +7,24 @@ import {
   type GetMultiSigRolesForDomainQuery,
   type GetMultiSigRolesForDomainQueryVariables,
   type ModelColonyRoleFilterInput,
+  type ColonyActionRoles,
 } from '~gql';
 import { type EligibleSignee } from '~types/multiSig.ts';
 import { notMaybe } from '~utils/arrays/index.ts';
 
-const COLONY_ROLE_TO_FILTER_KEY = {
+type MultiSigColonyRoles =
+  | ColonyRole.Recovery
+  | ColonyRole.Root
+  | ColonyRole.Arbitration
+  | ColonyRole.Architecture
+  | ColonyRole.Funding
+  | ColonyRole.Administration;
+
+const COLONY_ROLE_TO_FILTER_KEY: Record<
+  MultiSigColonyRoles,
+  keyof ColonyActionRoles
+> = {
+  [ColonyRole.Recovery]: 'role_0',
   [ColonyRole.Root]: 'role_1',
   [ColonyRole.Arbitration]: 'role_2',
   [ColonyRole.Architecture]: 'role_3',

--- a/src/utils/multiSig/index.ts
+++ b/src/utils/multiSig/index.ts
@@ -15,7 +15,7 @@ export const getRolesNeededForMultiSigAction = ({
 }: {
   actionType: ColonyActionType;
   createdIn: number;
-}): ColonyRole[][] | undefined => {
+}): ColonyRole[] | undefined => {
   let permissions: ColonyRole[][] | undefined;
 
   switch (actionType) {
@@ -82,7 +82,7 @@ export const getRolesNeededForMultiSigAction = ({
     return undefined;
   }
 
-  return permissions;
+  return permissions[0];
 };
 
 export const getMultiSigState = (

--- a/src/utils/multiSig/index.ts
+++ b/src/utils/multiSig/index.ts
@@ -5,9 +5,9 @@ import { ColonyActionType, type ColonyActionFragment } from '~gql';
 import { type Colony, type ColonyAction } from '~types/graphql.ts';
 import { type MultiSigAction } from '~types/motions.ts';
 
-import { MotionState } from './colonyMotions.ts';
-import { extractColonyRoles } from './colonyRoles.ts';
-import { extractColonyDomains } from './domains.ts';
+import { MotionState } from '../colonyMotions.ts';
+import { extractColonyRoles } from '../colonyRoles.ts';
+import { extractColonyDomains } from '../domains.ts';
 
 export const getRolesNeededForMultiSigAction = ({
   actionType,


### PR DESCRIPTION
## Description

This was a doozie :) I wanted to simplify our fetching of eligible signees to not use a 2d array anymore and it actually worked!

## Testing

Only 2 test cases to try out, no need to reset anything in between

### Can't create an action without enough permission holders
1. Install the MultiSig extension and give it a fixed threshold of 2
2. Refresh the page and try to create any action with Multi-Sig as the decision method
![image](https://github.com/user-attachments/assets/0947a091-e0a9-454a-8f61-0b5d772b4b71)
Manage reputation is also of special interest to us 
![image](https://github.com/user-attachments/assets/0e2c25ec-803e-4128-857d-3d04a53dc480)
3. You shouldn't be able to create any multi sig motion, because `leela` is the only permission holder

On to the next test case we go!

### Multi sig widget works
1. Assign `amy` `arbitration` and `administration` Multisig roles
![image](https://github.com/user-attachments/assets/c82d0515-93ce-4eb6-a43f-576fa9525c44)
2. Assign `fry` `funding` and `architecture` Multisig roles
![image](https://github.com/user-attachments/assets/d2197949-8f85-44cf-9560-577c99014bc5)
3. Refresh the page and create a simple payment motion
![image](https://github.com/user-attachments/assets/befe4051-494e-41f1-a5f9-33bfec97543d)
4. Verify that when hovering over `amy`'s `Awaiting 2` (the square for the 2 :') ) you get which roles she can approve with
![image](https://github.com/user-attachments/assets/726e77ba-36c5-4435-b0a3-5171268497bc)
5. Do the same for `fry`
![image](https://github.com/user-attachments/assets/c3a748c8-6a7e-4c21-9e30-b87ad4b598dd)
6. If you're feeling like it (it's more of a sanity check), open up 2 more browsers, log in as `amy` and `fry` and approve this motion as each of them
7. Verify that the motion can be finalized, if you click on `Approval` in the stepper, 
![image](https://github.com/user-attachments/assets/ac9212b7-9d1a-449e-a16e-46839e992b4d)
the tooltips should show up correctly :)

### Some more test cases
* Motions requiring root permission holders (e.g. mint tokens), shouldn't be able to get created
![image](https://github.com/user-attachments/assets/98c7fd54-90a8-4788-855e-0382273bf976)

* You can create motions that require `Architecture` permission holders e.g. creating a new team
![image](https://github.com/user-attachments/assets/903b7558-c1ed-47c5-a7a9-2dceff578629)

* You can't create an award reputation multisig motion
![image](https://github.com/user-attachments/assets/6a3d6dbe-a958-4e78-9c8e-fae7b8de55a5)

* You can however create a reputation smite multisig motion
![image](https://github.com/user-attachments/assets/3610d1cd-957c-4176-8704-736722b1ccc1)

## Diffs

**New stuff** ✨

* `getEligibleSignees` async helper to fetch users from the API

**Changes** 🏗

* `useEligibleSignees` is now just a dumb hook wrapper around `getEligibleSignees`
* flattened `requiredRoles` to always be a 1d array when working with MultiSig
* `getAnyPermissionProofs` now uses a 1d array since MultiSig voting was it's only use case
* `voteOnMultiSig` saga now receives a 1d array or roles to vote with

Resolves #2633 
