### PR TITLE
Feat/2658 invalidate permissions query

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/FinalizeStep/FinalizeStep.tsx
@@ -158,7 +158,6 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
 
   const { approvalsPerRole, rejectionsPerRole } =
     getSignaturesPerRole(signatures);
-  const finalizedAt = multiSigData.executedAt || multiSigData.rejectedAt;
 
   const numberOfApprovals = getNumberOfApprovals(
     approvalsPerRole,
@@ -176,6 +175,16 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
     rejectionsPerRole,
     thresholdPerRole,
   );
+
+  let finalizedAt;
+
+  if (isMultiSigRejected) {
+    finalizedAt = multiSigData.rejectedAt;
+  }
+
+  if (isMultiSigExecuted) {
+    finalizedAt = multiSigData.executedAt;
+  }
 
   let stepTitle = MSG.heading;
 
@@ -282,12 +291,14 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
                       })}
                     </span>
                   </div>
-                  <div className="flex items-center justify-between gap-2 text-sm">
-                    <span className="text-gray-600">
-                      {formatText(MSG.finalized)}
-                    </span>
-                    <span>{finalizedAt && formatDate(finalizedAt)}</span>
-                  </div>
+                  {finalizedAt && (
+                    <div className="flex items-center justify-between gap-2 text-sm">
+                      <span className="text-gray-600">
+                        {formatText(MSG.finalized)}
+                      </span>
+                      <span>{formatDate(finalizedAt)}</span>
+                    </div>
+                  )}
                 </>
               )}
             </div>

--- a/src/components/v5/common/ActionSidebar/utils.ts
+++ b/src/components/v5/common/ActionSidebar/utils.ts
@@ -1,6 +1,9 @@
 import { type Action } from '~constants/actions.ts';
 import { type ColonyAction, ColonyActionType } from '~types/graphql.ts';
-import { updateContributorVerifiedStatus } from '~utils/members.ts';
+import {
+  clearContributorsAndRolesCache,
+  updateContributorVerifiedStatus,
+} from '~utils/members.ts';
 
 export const translateAction = (action?: Action) => {
   const actionName = action
@@ -39,6 +42,11 @@ export const handleMotionCompleted = (action: ColonyAction) => {
           false,
         );
       }
+      break;
+    }
+    case ColonyActionType.SetUserRolesMotion:
+    case ColonyActionType.SetUserRolesMultisig: {
+      clearContributorsAndRolesCache();
       break;
     }
     default: {

--- a/src/redux/sagas/actions/managePermissions.ts
+++ b/src/redux/sagas/actions/managePermissions.ts
@@ -5,6 +5,7 @@ import { PERMISSIONS_NEEDED_FOR_ACTION } from '~constants/actions.ts';
 import { type ColonyManager } from '~context/index.ts';
 import { Authority } from '~types/authority.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
+import { clearContributorsAndRolesCache } from '~utils/members.ts';
 import { intArrayToBytes32 } from '~utils/web3/index.ts';
 
 import {
@@ -203,6 +204,8 @@ function* managePermissionsAction({
         state: { isRedirect: true },
       });
     }
+
+    yield clearContributorsAndRolesCache();
   } catch (error) {
     yield putError(ActionTypes.ACTION_USER_ROLES_SET_ERROR, error, meta);
   } finally {

--- a/src/redux/sagas/extensions/extensionEnable.ts
+++ b/src/redux/sagas/extensions/extensionEnable.ts
@@ -8,6 +8,7 @@ import { fork, put, takeEvery } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context/index.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
+import { clearContributorsAndRolesCache } from '~utils/members.ts';
 import { intArrayToBytes32 } from '~utils/web3/index.ts';
 
 import { ActionTypes } from '../../actionTypes.ts';
@@ -129,6 +130,8 @@ function* extensionEnable({
       payload: {},
       meta,
     });
+
+    yield clearContributorsAndRolesCache();
   } catch (error) {
     console.error(error);
     return yield putError(ActionTypes.EXTENSION_ENABLE_ERROR, error, meta);

--- a/src/redux/sagas/motions/managePermissionsMotion.ts
+++ b/src/redux/sagas/motions/managePermissionsMotion.ts
@@ -8,7 +8,6 @@ import { ADDRESS_ZERO } from '~constants/index.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 import { Authority } from '~types/authority.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
-import { clearContributorsAndRolesCache } from '~utils/members.ts';
 import { putError, takeFrom } from '~utils/saga/effects.ts';
 
 import {
@@ -335,8 +334,6 @@ function* managePermissionsMotion({
         state: { isRedirect: true },
       });
     }
-
-    yield clearContributorsAndRolesCache();
   } catch (caughtError) {
     yield putError(ActionTypes.MOTION_USER_ROLES_SET_ERROR, caughtError, meta);
   } finally {

--- a/src/redux/sagas/motions/managePermissionsMotion.ts
+++ b/src/redux/sagas/motions/managePermissionsMotion.ts
@@ -8,6 +8,7 @@ import { ADDRESS_ZERO } from '~constants/index.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 import { Authority } from '~types/authority.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
+import { clearContributorsAndRolesCache } from '~utils/members.ts';
 import { putError, takeFrom } from '~utils/saga/effects.ts';
 
 import {
@@ -334,6 +335,8 @@ function* managePermissionsMotion({
         state: { isRedirect: true },
       });
     }
+
+    yield clearContributorsAndRolesCache();
   } catch (caughtError) {
     yield putError(ActionTypes.MOTION_USER_ROLES_SET_ERROR, caughtError, meta);
   } finally {

--- a/src/redux/sagas/multiSig/setThresholds.ts
+++ b/src/redux/sagas/multiSig/setThresholds.ts
@@ -3,6 +3,7 @@ import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
 import { ActionTypes } from '~redux/actionTypes.ts';
 import { type Action, type AllActions } from '~redux/types/index.ts';
+import { clearContributorsAndRolesCache } from '~utils/members.ts';
 
 import {
   createTransaction,
@@ -60,6 +61,8 @@ function* setThresholds({
       type: ActionTypes.MULTISIG_SET_THRESHOLDS_SUCCESS,
       meta,
     });
+
+    yield clearContributorsAndRolesCache();
   } catch (error) {
     return yield putError(
       ActionTypes.MULTISIG_SET_THRESHOLDS_ERROR,

--- a/src/utils/members.ts
+++ b/src/utils/members.ts
@@ -145,3 +145,8 @@ export const updateMemberProfile = (
     colonyAddress,
   );
 };
+
+export const clearContributorsAndRolesCache = () => {
+  apolloClient.cache.evict({ fieldName: 'searchColonyContributors' });
+  apolloClient.cache.evict({ fieldName: 'getRoleByDomainAndColony' });
+};


### PR DESCRIPTION
## Description

- After users are given multi-sig permissions (including when the extension is installed and as a result of a manage permissions action / motion finalization), invalidate the permission holder query so we can immediately create multi-sig actions with them as potential signers

## Testing

Check members get multi-sig permissions after Multi-Sig extension is installed or after a Manage Permissions action without a page refresh.

* Step 1. Install Multi-Sig extension in Colony > Admin > Extension
![Screenshot 2024-07-23 at 18 01 24](https://github.com/user-attachments/assets/2e7a2323-a4d2-4a0b-87b4-dfcd67ddc8eb)

* Step 2. Without refreshing the page, check the Extension details section and click on `leela`
![Screenshot 2024-07-23 at 18 07 09](https://github.com/user-attachments/assets/719aba01-5a8b-419b-ad67-c14bfd2e7829)

* Step 3. Check `leela` already has Multi-Sig permissions
![Screenshot 2024-07-23 at 18 07 15](https://github.com/user-attachments/assets/fd281ced-1068-4919-a4a5-54348e76f2a1)

* Step 4. Go to Colony > Members > Permissions
![Screenshot 2024-07-23 at 18 09 26](https://github.com/user-attachments/assets/5cad0225-07fe-49a0-bef6-1f3ac198c7a4)

* Step 5. Switch to the **Multi-sig Authority** tab and check `leela` is present in the list
![Screenshot 2024-07-23 at 18 01 54](https://github.com/user-attachments/assets/fb60d6e5-fd7c-40d5-8364-5d6a132332e3)

* Step 6. Assign `amy` some custom permissions using **Permissions** as decision method and **Takes actions via Multi-Sig** as authority
![Screenshot 2024-07-23 at 18 02 30](https://github.com/user-attachments/assets/2afbca43-15a1-49ef-b675-254ccf915b9e)

* Step 7. Check `amy` appears in the **Multi-sig Authority** page without the need for refresh
![Screenshot 2024-07-23 at 18 02 37](https://github.com/user-attachments/assets/8e47f9ad-2d97-4432-82a9-de42209c2b2e)

### Further testing scenario - 1
* Try setting the Multi-sig extension threshold to 3 
![Screenshot 2024-07-24 at 16 38 45](https://github.com/user-attachments/assets/6240aa1c-26e3-4550-a90e-953c0bea9473)
* Give 3 users Owner permissions
* Try creating a Mint tokens action
![Screenshot 2024-07-24 at 16 18 51](https://github.com/user-attachments/assets/5cc5f85c-c631-4f2b-a94f-f06297daf3ed)
* Change Multi-sig extension threshold to 4
* Try creating a Mint tokens action - an error message should appear
![Screenshot 2024-07-24 at 16 19 26](https://github.com/user-attachments/assets/f796a101-07be-4859-ab83-720e376e3068)

### Further testing scenario - 2
You can continue creating multiple Manage permissions actions and check the Members/Contributors/Permissions page update accordingly without the need for a page refresh

Contributes to #2658
