### PR TITLE
Change undefined to empty string in AmountField component

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
@@ -64,7 +64,7 @@ const AmountField: FC<AmountFieldProps> = ({
     dropdownRef,
     adjustInputWidth,
   } = useAmountField(tokenAddressController.value, maxWidth);
-  const [value, setValue] = useState<string | undefined>(
+  const [value, setValue] = useState<string>(
     field.value ? formatNumeral(field.value, formattingOptions) : '',
   );
 

--- a/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
@@ -65,7 +65,7 @@ const AmountField: FC<AmountFieldProps> = ({
     adjustInputWidth,
   } = useAmountField(tokenAddressController.value, maxWidth);
   const [value, setValue] = useState<string | undefined>(
-    field.value ? formatNumeral(field.value, formattingOptions) : undefined,
+    field.value ? formatNumeral(field.value, formattingOptions) : '',
   );
 
   const handleFieldChange = (e: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Description

This is a very simple PR to hopefully solve a nuisance that has consistently been occurring for me for quite some time. I'm not really sure if it is the right way to solve it, but it seems to make sense.

Basically, I am just assigning a value to a visible component instead of having the initial value as undefined. Validation still works, and the field seems to work as expected still.

## Testing

| Step | Expected |
| :--- | :-- |
| Create an action with an Amount field (e.g. Simple payment) and enter a value. | You should not get an error in console. |

## Changes
- Changed initial undefined value to empty string in `AmountField` component.

## Issue

- The first time entering a value in the Amount field of an action results in a console error "A component is changing an uncontrolled input to be controlled."
- Error can be repeated after refreshing the app.

![image](https://github.com/user-attachments/assets/5286ad17-a071-4921-8fed-a1c177dd9b63)



Resolves N/A