### PR TITLE
Fix pending order of `stakeMotion` transactions

### DIFF
--- a/src/redux/sagas/motions/stakeMotion.ts
+++ b/src/redux/sagas/motions/stakeMotion.ts
@@ -170,6 +170,20 @@ function* stakeMotion({
       yield takeFrom(annotateStaking.channel, ActionTypes.TRANSACTION_CREATED);
     }
 
+    if (activateTokens) {
+      yield put(transactionPending(approve.id));
+
+      yield initiateTransaction({ id: approve.id });
+
+      yield waitForTxResult(approve.channel);
+
+      yield put(transactionPending(deposit.id));
+
+      yield initiateTransaction({ id: deposit.id });
+
+      yield waitForTxResult(deposit.channel);
+    }
+
     yield put(transactionPending(approveStake.id));
 
     const { domainId, rootHash } = yield call(
@@ -184,16 +198,6 @@ function* stakeMotion({
         amount,
       ]),
     );
-
-    if (activateTokens) {
-      yield initiateTransaction({ id: approve.id });
-
-      yield waitForTxResult(approve.channel);
-
-      yield initiateTransaction({ id: deposit.id });
-
-      yield waitForTxResult(deposit.channel);
-    }
 
     yield initiateTransaction({ id: approveStake.id });
 


### PR DESCRIPTION
## Description

In very specific cases there can be a problem with two transactions appearing to be pending when staking a motion (see @arrenv's [issue](https://github.com/JoinColony/colonyCDapp/issues/2739) for a full walkthrough).

This is a problem with the order certain transaction functions are called. In this case a transactions further down is set to pending while two others are not completed yet. This PR fixes that. For a fix that resolves this for good see my [Transactions API refactor](https://github.com/JoinColony/colonyCDapp/pull/2528) in which this can't happen.

## Testing

Follow the steps in @arrenv's [issue](https://github.com/JoinColony/colonyCDapp/issues/2739). At least you should not be seeing two loading spinners.

## Diffs

**Changes** 🏗

* Fix `stakeMotion` action pending transaction order
* Add some more `transactionPending`s for good measure

Resolves #2739 (at least partly)
