### PR TITLE
[Multi-sig] feat: allow failing multi-sig if a week has passed and realign all dates with the blockchain

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -2715,6 +2715,10 @@ type ColonyMultiSig @model {
   The timestamp when the motion was rejected
   """
   rejectedAt: AWSDateTime
+  """
+  The timestamp when the motion was created at
+  """
+  createdAt: AWSDateTime!
 }
 """
 Represents a Motion within a Colony

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=98a3d79b26070cbb2e6d96c426fb4182ffdc634f
+ENV BLOCK_INGESTOR_HASH=71015c9ac0473d6395945f977857fd619c239a5a
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/FinalizeButton/FinalizeButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/FinalizeButton/FinalizeButton.tsx
@@ -18,6 +18,7 @@ interface FinalizeButtonProps {
   multiSigId: string;
   isPending: boolean;
   setIsPending: (isPending: boolean) => void;
+  isMotionOlderThanAWeek: boolean;
 }
 
 const MSG = defineMessages({
@@ -31,11 +32,13 @@ const FinalizeButton: FC<FinalizeButtonProps> = ({
   multiSigId,
   isPending,
   setIsPending,
+  isMotionOlderThanAWeek,
 }) => {
   const { colony } = useColonyContext();
   const transform = mapPayload(() => ({
     colonyAddress: colony.colonyAddress,
     multiSigId,
+    canActionFail: isMotionOlderThanAWeek,
   }));
 
   return (

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
@@ -10,6 +10,7 @@ import {
   MultiSigVote,
 } from '~gql';
 import { useEligibleSignees } from '~hooks/multiSig/useEligibleSignees.ts';
+import useCurrentBlockTime from '~hooks/useCurrentBlockTime.ts';
 import Tooltip from '~shared/Extensions/Tooltip/Tooltip.tsx';
 import SpinnerLoader from '~shared/Preloaders/SpinnerLoader.tsx';
 import { type Threshold } from '~types/multiSig.ts';
@@ -134,8 +135,10 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
     }) || [];
 
   const doesActionRequireMultipleRoles = requiredRoles.length > 1;
-  const isMotionOlderThanWeek = hasWeekPassed(createdAt);
-
+  const { currentBlockTime } = useCurrentBlockTime();
+  const isMotionOlderThanWeek = currentBlockTime
+    ? hasWeekPassed(createdAt, currentBlockTime * 1000)
+    : false;
   const signatures = (multiSigData?.signatures?.items ?? []).filter(notMaybe);
 
   const userSignature = signatures.find(

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/FinalizeStep/FinalizeStep.tsx
@@ -83,6 +83,18 @@ const MSG = defineMessages({
     id: `${displayName}.finalizeCancelButton`,
     defaultMessage: 'Finalize cancel',
   },
+  finalizedNotExecuted: {
+    id: `${displayName}.finalizedNotExecuted`,
+    defaultMessage: 'Not executed',
+  },
+  notExecutedReasonLabel: {
+    id: `${displayName}.notExecutedReasonLabel`,
+    defaultMessage: 'Reason',
+  },
+  notExecutedReasonValue: {
+    id: `${displayName}.notExecutedReasonValue`,
+    defaultMessage: 'Execution failed beyond timeout',
+  },
 });
 
 const formatDate = (value: string | undefined) => {
@@ -135,8 +147,14 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
   thresholdPerRole,
 }) => {
   const [isFinalizePending, setIsFinalizePending] = useState(false);
+
   const isMultiSigExecuted = multiSigData.isExecuted;
+  const hasMultiSigActionCompleted = multiSigData.hasActionCompleted;
   const isMultiSigRejected = multiSigData.isRejected;
+  // used if failing execution after a week
+  const isMultiSigFailingExecution =
+    isMultiSigExecuted && !hasMultiSigActionCompleted;
+
   const isMotionOlderThanWeek = hasWeekPassed(createdAt);
   const rejectedByOwner = multiSigData.rejectedBy === initiatorAddress;
 
@@ -236,12 +254,27 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
                       })}
                     </span>
                   </div>
-                  {finalizedAt && (
+                  {isMultiSigFailingExecution ? (
+                    <>
+                      <div className="mb-2 flex items-center justify-between gap-2 text-sm">
+                        <span className="text-gray-600">
+                          {formatText(MSG.finalized)}
+                        </span>
+                        <span>{formatText(MSG.finalizedNotExecuted)}</span>
+                      </div>
+                      <div className="flex items-center justify-between gap-2 text-sm">
+                        <span className="text-gray-600">
+                          {formatText(MSG.notExecutedReasonLabel)}
+                        </span>
+                        <span>{formatText(MSG.notExecutedReasonValue)}</span>
+                      </div>
+                    </>
+                  ) : (
                     <div className="flex items-center justify-between gap-2 text-sm">
                       <span className="text-gray-600">
                         {formatText(MSG.finalized)}
                       </span>
-                      <span>{formatDate(finalizedAt)}</span>
+                      <span>{finalizedAt && formatDate(finalizedAt)}</span>
                     </div>
                   )}
                 </>

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/FinalizeStep/FinalizeStep.tsx
@@ -45,6 +45,10 @@ const MSG = defineMessages({
     id: `${displayName}.headingSuccess`,
     defaultMessage: 'Action was approved and executed.',
   },
+  headingFailed: {
+    id: `${displayName}.headingFailed`,
+    defaultMessage: "Action was approved but couldn't be executed.",
+  },
   headingRejected: {
     id: `${displayName}.headingRejected`,
     defaultMessage: 'Action was rejected and cannot be executed.',
@@ -193,7 +197,9 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
 
   let stepTitle = MSG.heading;
 
-  if (isMultiSigExecuted) {
+  if (isMultiSigFailingExecution) {
+    stepTitle = MSG.headingFailed;
+  } else if (isMultiSigExecuted) {
     stepTitle = MSG.headingSuccess;
   } else if (isMultiSigRejected && rejectedByOwner) {
     stepTitle = MSG.headingRejectedByOwner;

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/FinalizeStep/FinalizeStep.tsx
@@ -214,6 +214,7 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
                   <div className="flex flex-col gap-2">
                     {isMultiSigExecutable && (
                       <FinalizeButton
+                        isMotionOlderThanAWeek={isMotionOlderThanWeek}
                         isPending={isFinalizePending}
                         setIsPending={setIsFinalizePending}
                         multiSigId={multiSigData.nativeMultiSigId}

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/FinalizeStep/FinalizeStep.tsx
@@ -3,6 +3,7 @@ import React, { useState, type FC, useEffect } from 'react';
 import { FormattedDate, defineMessages } from 'react-intl';
 
 import { type ColonyMultiSigFragment } from '~gql';
+import useCurrentBlockTime from '~hooks/useCurrentBlockTime.ts';
 import { type ColonyAction } from '~types/graphql.ts';
 import { type Threshold } from '~types/multiSig.ts';
 import { notMaybe } from '~utils/arrays/index.ts';
@@ -148,6 +149,11 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
 }) => {
   const [isFinalizePending, setIsFinalizePending] = useState(false);
 
+  const { currentBlockTime } = useCurrentBlockTime();
+  const isMotionOlderThanWeek = currentBlockTime
+    ? hasWeekPassed(createdAt, currentBlockTime * 1000)
+    : false;
+
   const isMultiSigExecuted = multiSigData.isExecuted;
   const hasMultiSigActionCompleted = multiSigData.hasActionCompleted;
   const isMultiSigRejected = multiSigData.isRejected;
@@ -155,7 +161,6 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
   const isMultiSigFailingExecution =
     isMultiSigExecuted && !hasMultiSigActionCompleted;
 
-  const isMotionOlderThanWeek = hasWeekPassed(createdAt);
   const rejectedByOwner = multiSigData.rejectedBy === initiatorAddress;
 
   const signatures = (multiSigData?.signatures?.items ?? []).filter(notMaybe);

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/utils.ts
@@ -7,10 +7,10 @@ import { type Threshold, type EligibleSignee } from '~types/multiSig.ts';
 
 import { type MultiSigSignee } from './types.ts';
 
-export const hasWeekPassed = (createdAt: string) => {
+export const hasWeekPassed = (createdAt: string, currentBlockTime: number) => {
   const createdAtDate = parseISO(createdAt);
 
-  const currentDate = new Date();
+  const currentDate = new Date(currentBlockTime);
 
   const oneWeekAgo = subWeeks(currentDate, 1);
 

--- a/src/graphql/fragments/actions.graphql
+++ b/src/graphql/fragments/actions.graphql
@@ -288,6 +288,7 @@ fragment ColonyMultiSig on ColonyMultiSig {
   isExecuted
   hasActionCompleted
   isRejected
+  hasActionCompleted
   isDecision
   executedAt
   signatures {

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -1094,6 +1094,7 @@ export type ColonyMultiSig = {
   action?: Maybe<ColonyAction>;
   /** Colony address the multiSig belongs to */
   colonyAddress: Scalars['ID'];
+  /** The timestamp when the motion was created at */
   createdAt: Scalars['AWSDateTime'];
   /** The timestamp when the motion was finalized */
   executedAt?: Maybe<Scalars['AWSDateTime']>;
@@ -1556,6 +1557,7 @@ export type CreateColonyMotionInput = {
 
 export type CreateColonyMultiSigInput = {
   colonyAddress: Scalars['ID'];
+  createdAt?: InputMaybe<Scalars['AWSDateTime']>;
   executedAt?: InputMaybe<Scalars['AWSDateTime']>;
   executedBy?: InputMaybe<Scalars['ID']>;
   hasActionCompleted: Scalars['Boolean'];
@@ -3062,6 +3064,7 @@ export type ModelColonyMotionFilterInput = {
 export type ModelColonyMultiSigConditionInput = {
   and?: InputMaybe<Array<InputMaybe<ModelColonyMultiSigConditionInput>>>;
   colonyAddress?: InputMaybe<ModelIdInput>;
+  createdAt?: InputMaybe<ModelStringInput>;
   executedAt?: InputMaybe<ModelStringInput>;
   executedBy?: InputMaybe<ModelIdInput>;
   hasActionCompleted?: InputMaybe<ModelBooleanInput>;
@@ -3088,6 +3091,7 @@ export type ModelColonyMultiSigConnection = {
 export type ModelColonyMultiSigFilterInput = {
   and?: InputMaybe<Array<InputMaybe<ModelColonyMultiSigFilterInput>>>;
   colonyAddress?: InputMaybe<ModelIdInput>;
+  createdAt?: InputMaybe<ModelStringInput>;
   executedAt?: InputMaybe<ModelStringInput>;
   executedBy?: InputMaybe<ModelIdInput>;
   hasActionCompleted?: InputMaybe<ModelBooleanInput>;
@@ -4101,6 +4105,7 @@ export type ModelSubscriptionColonyMotionFilterInput = {
 export type ModelSubscriptionColonyMultiSigFilterInput = {
   and?: InputMaybe<Array<InputMaybe<ModelSubscriptionColonyMultiSigFilterInput>>>;
   colonyAddress?: InputMaybe<ModelSubscriptionIdInput>;
+  createdAt?: InputMaybe<ModelSubscriptionStringInput>;
   executedAt?: InputMaybe<ModelSubscriptionStringInput>;
   executedBy?: InputMaybe<ModelSubscriptionIdInput>;
   hasActionCompleted?: InputMaybe<ModelSubscriptionBooleanInput>;
@@ -8912,6 +8917,7 @@ export type UpdateColonyMotionInput = {
 
 export type UpdateColonyMultiSigInput = {
   colonyAddress?: InputMaybe<Scalars['ID']>;
+  createdAt?: InputMaybe<Scalars['AWSDateTime']>;
   executedAt?: InputMaybe<Scalars['AWSDateTime']>;
   executedBy?: InputMaybe<Scalars['ID']>;
   hasActionCompleted?: InputMaybe<Scalars['Boolean']>;

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -11007,6 +11007,7 @@ export const ColonyMultiSigFragmentDoc = gql`
   isExecuted
   hasActionCompleted
   isRejected
+  hasActionCompleted
   isDecision
   executedAt
   signatures {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -239,6 +239,7 @@
     "transaction.group.escalateMotion.description": "Escalate Motion",
     "transaction.group.finalizeMotion.title": "Finalize motion",
     "transaction.group.finalizeMotion.description": "Finalize motion",
+    "transaction.group.finalizeMultiSig.title": "Finalize motion",
     "transaction.group.deposit.title": "Activate tokens",
     "transaction.group.deposit.description": "Activate tokens",
     "transaction.group.editExpenditure.title": "Edit Expenditure",

--- a/src/redux/sagas/multiSig/finalizeMultiSig.ts
+++ b/src/redux/sagas/multiSig/finalizeMultiSig.ts
@@ -12,7 +12,7 @@ import {
 import { initiateTransaction, putError, takeFrom } from '../utils/effects.ts';
 
 function* finalizeMultiSigAction({
-  payload: { colonyAddress, multiSigId },
+  payload: { colonyAddress, multiSigId, canActionFail },
   meta,
 }: Action<ActionTypes.MULTISIG_FINALIZE>) {
   const txChannel = yield call(getTxChannel, meta.id);
@@ -25,7 +25,7 @@ function* finalizeMultiSigAction({
 
     yield fork(createTransaction, meta.id, {
       context: ClientType.MultisigPermissionsClient,
-      methodName: 'executeWithoutFailure',
+      methodName: canActionFail ? 'execute' : 'executeWithoutFailure',
       identifier: colonyAddress,
       params: [multiSigId],
       group: {

--- a/src/redux/types/actions/multiSig.ts
+++ b/src/redux/types/actions/multiSig.ts
@@ -57,6 +57,7 @@ export type MultiSigActionTypes =
       {
         colonyAddress: Address;
         multiSigId: string;
+        canActionFail: boolean;
       },
       MetaWithSetter<object>
     >


### PR DESCRIPTION
## Description

Instead of calling `executeWithoutFailure` we need to call `execute` if a week has passed since the motion was created.
Additionally, I've realigned multisig's createdAt date with the blockchain date.
[Block ingestor PR](https://github.com/JoinColony/block-ingestor/pull/257)
[Figma link](https://www.figma.com/design/SaO0Zj6e7yGqLzjEsxqVhy/Permissions?node-id=22256-71198&t=2x9d7EMZkK6MCGCF-4)
![image](https://github.com/user-attachments/assets/8be9ef0a-98a8-41dc-ab2c-332db6354dc3)


## Testing

You can do all of this as just `leela` (but for testing the rejection timestamp, you need to assign `amy` the `Owner` multi-sig role, and reject the motion as both `leela` and `amy`)

1. Install the multisig extension, you can leave the threshold as is. Assign `leela` Multi-sig owner permissions
2. Go to the balances page, choose `Andromeda` and note the amount of CREDS it has
![image](https://github.com/user-attachments/assets/75dab481-c839-478d-bab8-7f426f78effa)
3. Create a transfer funds multisig motion, moving all but 20 CREDS from `Andromeda` to `General`
![image](https://github.com/user-attachments/assets/c69bf1e2-607b-4a1f-85c7-6c19f19b524e)
4. As `leela` move ~50 CREDS from Andromeda to General using permissions
![image](https://github.com/user-attachments/assets/4f96cd28-6946-4470-999f-d9cebf526261)
5. Open the previous motion from the activity table and finalize it. It should error out since the action can't complete due to a lack of funds
![image](https://github.com/user-attachments/assets/82ad7714-dd72-496c-98fc-574bd2c10ba3)
6. Now for the tricky part! Forward time for about a week by running `npm run forward-time 170`. Note that when going back to the `Approval` step, it should display the 7 days have passed disclaimer
![image](https://github.com/user-attachments/assets/ea6c21a4-a308-4452-b1d6-5d814a57a310)

7. Open up the multisig motion again from the activity table and click `Finalize`. The action should fail and this screen should show up
![image](https://github.com/user-attachments/assets/cd8139f8-9a34-40a0-af6e-8df52e89ce28)

Additionally check that when a motion is successfully passed, the blockchain timestamp appears
![image](https://github.com/user-attachments/assets/8036062e-b6ec-4abd-b6fa-2e9ccbcc3c2e)

Same for rejection
![image](https://github.com/user-attachments/assets/d40991a4-11c6-45c2-8c50-a8a0ceb7030a)



## Diffs

**New stuff** ✨

* Display new rows if motion was executed but the actions hasn't passed

**Changes** 🏗

* If motion is older than a week, we call `execute` instead of `executeWithoutFailure`

Contributes to #2658 
