### PR TITLE
Fix: Reject multi-sig as owner button and message

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/MultiSigWidget.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/MultiSigWidget.tsx
@@ -14,11 +14,7 @@ import Stepper from '~v5/shared/Stepper/Stepper.tsx';
 import ApprovalStep from './partials/ApprovalStep/ApprovalStep.tsx';
 import FinalizeStep from './partials/FinalizeStep/FinalizeStep.tsx';
 import { MultiSigState } from './types.ts';
-import {
-  getIsMultiSigCancelable,
-  getIsMultiSigExecutable,
-  getSignaturesPerRole,
-} from './utils.ts';
+import { getIsMultiSigExecutable, getSignaturesPerRole } from './utils.ts';
 
 const displayName =
   'v5.common.ActionSidebar.partials.MultiSig.partials.MultiSigWidget';
@@ -57,15 +53,10 @@ const MultiSigWidget: FC<MultiSigWidgetProps> = ({ action }) => {
 
   const signatures = (multiSigData?.signatures?.items ?? []).filter(notMaybe);
 
-  const { approvalsPerRole, rejectionsPerRole } =
-    getSignaturesPerRole(signatures);
+  const { approvalsPerRole } = getSignaturesPerRole(signatures);
 
   const isMultiSigExecutable = getIsMultiSigExecutable(
     approvalsPerRole,
-    thresholdPerRole,
-  );
-  const isMultiSigCancelable = getIsMultiSigCancelable(
-    rejectionsPerRole,
     thresholdPerRole,
   );
 
@@ -98,7 +89,7 @@ const MultiSigWidget: FC<MultiSigWidgetProps> = ({ action }) => {
           <FinalizeStep
             thresholdPerRole={thresholdPerRole}
             multiSigData={multiSigData}
-            // initiatorAddress={initiatorAddress}
+            initiatorAddress={action.initiatorAddress}
             action={action}
             createdAt={multiSigData.createdAt}
           />
@@ -115,20 +106,10 @@ const MultiSigWidget: FC<MultiSigWidgetProps> = ({ action }) => {
   );
 
   useEffect(() => {
-    if (
-      isMultiSigExecutable ||
-      isMultiSigCancelable ||
-      isMultiSigExecuted ||
-      isMultiSigRejected
-    ) {
+    if (isMultiSigExecutable || isMultiSigExecuted || isMultiSigRejected) {
       setActiveStepKey(MultiSigState.Finalize);
     }
-  }, [
-    isMultiSigExecutable,
-    isMultiSigRejected,
-    isMultiSigExecuted,
-    isMultiSigCancelable,
-  ]);
+  }, [isMultiSigExecutable, isMultiSigRejected, isMultiSigExecuted]);
 
   if (thresholdPerRole === null && !isLoading) {
     console.warn('Invalid threshold');

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/MultiSigWidget.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/MultiSigWidget.tsx
@@ -108,6 +108,8 @@ const MultiSigWidget: FC<MultiSigWidgetProps> = ({ action }) => {
   useEffect(() => {
     if (isMultiSigExecutable || isMultiSigExecuted || isMultiSigRejected) {
       setActiveStepKey(MultiSigState.Finalize);
+    } else {
+      setActiveStepKey(MultiSigState.Approval);
     }
   }, [isMultiSigExecutable, isMultiSigRejected, isMultiSigExecuted]);
 

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
@@ -287,7 +287,7 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
                 </div>
               )}
             </div>
-            {isOwner && signaturesToDisplay.length > 5 && (
+            {isOwner && !isMotionOlderThanWeek && !userSignature && (
               <div className="mt-2">
                 <StatusText
                   status={StatusTypes.Info}
@@ -300,7 +300,7 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
                 </StatusText>
               </div>
             )}
-            {isMotionOlderThanWeek && (
+            {isMotionOlderThanWeek && !userSignature && (
               <div className="mt-2">
                 <StatusText
                   status={StatusTypes.Info}
@@ -395,8 +395,7 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
                           disabled: expectedStep === VoteExpectedStep.cancel,
                         }}
                       />
-                      {(isOwner && signaturesToDisplay.length > 5) ||
-                      isMotionOlderThanWeek ? (
+                      {isOwner || isMotionOlderThanWeek ? (
                         <CancelButton
                           multiSigId={multiSigData.nativeMultiSigId}
                           isPending={

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
@@ -28,7 +28,6 @@ import VoteButton from '../../../VoteButton/VoteButton.tsx';
 import { VoteExpectedStep } from '../../types.ts';
 import {
   getAllUserSignatures,
-  getIsMultiSigCancelable,
   getIsMultiSigExecutable,
   getNotSignedUsers,
   getNumberOfApprovals,
@@ -222,12 +221,8 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
     approvalsPerRole,
     thresholdPerRole,
   );
-  const isMultiSigCancelable = getIsMultiSigCancelable(
-    rejectionsPerRole,
-    thresholdPerRole,
-  );
 
-  const isMultiSigFinalizable = isMultiSigExecutable || isMultiSigCancelable;
+  const isMultiSigFinalizable = isMultiSigExecutable;
   const isMultiSigExecuted = multiSigData.isExecuted;
   const isMultiSigRejected = multiSigData.isRejected;
   const isMultiSigInFinalizeState =

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
@@ -222,11 +222,10 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
     thresholdPerRole,
   );
 
-  const isMultiSigFinalizable = isMultiSigExecutable;
   const isMultiSigExecuted = multiSigData.isExecuted;
   const isMultiSigRejected = multiSigData.isRejected;
   const isMultiSigInFinalizeState =
-    isMultiSigFinalizable || isMultiSigExecuted || isMultiSigRejected;
+    isMultiSigExecutable || isMultiSigExecuted || isMultiSigRejected;
 
   const shouldCheckUserRoles = !userSignature && !isMultiSigInFinalizeState;
 
@@ -348,7 +347,7 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
                 signees={signaturesToDisplay}
                 shouldShowRoleNumber={doesActionRequireMultipleRoles}
               />
-              {!isMultiSigInFinalizeState && canUserSign && (
+              {!isMultiSigExecuted && !isMultiSigRejected && canUserSign && (
                 <>
                   {userSignature ? (
                     <>

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/utils.ts
@@ -163,21 +163,3 @@ export const getIsMultiSigExecutable = (
 
   return isMultiSigExecutable;
 };
-
-export const getIsMultiSigCancelable = (
-  rejectionsPerRole: Record<number, MultiSigUserSignature[]>,
-  thresholdPerRole: Threshold,
-): boolean => {
-  const isMultiSigCancelable =
-    Object.keys(rejectionsPerRole).length > 0 &&
-    Object.keys(rejectionsPerRole).every((role) => {
-      const rejections = rejectionsPerRole[role]?.length || 0;
-      if (!thresholdPerRole) {
-        return false;
-      }
-      const roleThreshold = thresholdPerRole[role] || 0;
-      return rejections >= roleThreshold;
-    });
-
-  return isMultiSigCancelable;
-};


### PR DESCRIPTION
## Description

As the user who created the multi-sig motion, I should be able to cancel it when clicking "reject".

This PR fixes some conditional statements to correctly show the "reject as owner" notification and ensure the "reject" button calls the "cancel" saga when you are the user who created the multi-sig motion.

This PR also removes the "finalize cancellation" step now that the contract automatically rejects when the rejection threshold is met.

New addition: This PR also makes it so that once the approvals threshold has been met, it is possible to return to the "approval" step and remove your "approval" vote.

## Testing

* Step 1 - Install the multi-sig motion, set the fixed threshold to 2 and assign Owner permissions to Amy.
* Step 2 - Create any multi-sig motion
* Step 3 - Remove your automatic approval vote. You should now see the "reject as owner" notification.

<img width="409" alt="Screenshot 2024-07-24 at 11 48 28" src="https://github.com/user-attachments/assets/ee5abf4d-bb98-43c4-b9fd-825e27253efb">

* Step 4 - Click the "reject" button and the multi-sig motion should be cancelled and display the appropriate message.

<img width="370" alt="Screenshot 2024-07-24 at 13 12 30" src="https://github.com/user-attachments/assets/8fbc608c-7be4-41fb-9870-1ced952f256b">

Further testing - check the flow as a non-owner to ensure you do not see the notification and cannot cancel the motion on your own.

<img width="408" alt="Screenshot 2024-07-24 at 11 48 34" src="https://github.com/user-attachments/assets/2cb14a68-be53-47c4-a6d0-8e564cdedc5e">

Give another user Owner multi-sig permissions and add a second rejection. The rejection threshold will have been met and the multi-sig motion should be cancelled. Check the message is as expected.

<img width="408" alt="Screenshot 2024-07-24 at 13 13 59" src="https://github.com/user-attachments/assets/c6554478-f941-449e-ac27-1a0c11e74155">

New addition:

* Step 1 - Create a new multi-sig motion
* Step 2 - Switch to another user and add an approval vote to meet the threshold.
* Step 3 - Return to the "approval" step, you should be able to remove your vote and be unable to return to the "finalize" step until the threshold has been met again.

https://github.com/user-attachments/assets/b8f4e991-9dfe-4320-a7b5-57824ad31ebd


## Diffs

**Changes** 🏗

* Correctly show the "reject as owner" notification and ensure the "reject" button calls the "cancel" saga when you are the user who created the multi-sig motion.

**Deletions**

* "Finalize cancellation" step is now removed and relevant tidy up.

Contributes to #2658 (Points 14 + 18)
