### PR TITLE
Fix: Auto-populate the Role and Permissions fields in the Manage Permissions form

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=15de50502ed714367b9d1b0aca78ab773f92497a
+ENV BLOCK_INGESTOR_HASH=561ff5537a4b027ebf13e9fc9d822512fc2d3d28
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/ManagePermissionsForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/ManagePermissionsForm.tsx
@@ -147,36 +147,6 @@ const ManagePermissionsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
         <TeamsSelect name="team" disabled={hasNoDecisionMethods} />
       </FormRow>
       <FormRow
-        icon={Shield}
-        fieldName="role"
-        tooltips={{
-          label: {
-            tooltipContent: formatText({
-              id: 'actionSidebar.tooltip.managePermissions.permissions',
-            }),
-          },
-        }}
-        title={formatText({ id: 'actionSidebar.permissions' })}
-        isDisabled={hasNoDecisionMethods}
-      >
-        <FormCardSelect
-          name="role"
-          cardClassName="max-w-[calc(100vw-2.5rem)] md:max-w-sm md:px-4 md:[&_.section-title]:px-2"
-          renderSelectedValue={(_, placeholder) =>
-            getRoleLabel(role) || placeholder
-          }
-          options={ALLOWED_PERMISSION_OPTIONS}
-          title={formatText({ id: 'actionSidebar.permissions' })}
-          placeholder={formatText({
-            id: 'actionSidebar.managePermissions.roleSelect.placeholder',
-          })}
-          itemClassName="group flex text-md md:transition-colors md:[&_.role-title]:hover:font-medium md:hover:bg-gray-50 rounded-lg p-2 w-full cursor-pointer"
-          footer={permissionSelectFooter}
-          disabled={hasNoDecisionMethods}
-          valueOverride={role}
-        />
-      </FormRow>
-      <FormRow
         icon={Signature}
         fieldName="authority"
         tooltips={{
@@ -213,6 +183,36 @@ const ManagePermissionsForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
           placeholder={formatText({
             id: 'actionSidebar.managePermissions.authoritySelect.placeholder',
           })}
+        />
+      </FormRow>
+      <FormRow
+        icon={Shield}
+        fieldName="role"
+        tooltips={{
+          label: {
+            tooltipContent: formatText({
+              id: 'actionSidebar.tooltip.managePermissions.permissions',
+            }),
+          },
+        }}
+        title={formatText({ id: 'actionSidebar.permissions' })}
+        isDisabled={hasNoDecisionMethods}
+      >
+        <FormCardSelect
+          name="role"
+          cardClassName="max-w-[calc(100vw-2.5rem)] md:max-w-sm md:px-4 md:[&_.section-title]:px-2"
+          renderSelectedValue={(_, placeholder) =>
+            getRoleLabel(role) || placeholder
+          }
+          options={ALLOWED_PERMISSION_OPTIONS}
+          title={formatText({ id: 'actionSidebar.permissions' })}
+          placeholder={formatText({
+            id: 'actionSidebar.managePermissions.roleSelect.placeholder',
+          })}
+          itemClassName="group flex text-md md:transition-colors md:[&_.role-title]:hover:font-medium md:hover:bg-gray-50 rounded-lg p-2 w-full cursor-pointer"
+          footer={permissionSelectFooter}
+          disabled={hasNoDecisionMethods}
+          valueOverride={role}
         />
       </FormRow>
       <DecisionMethodField />

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/hooks.ts
@@ -61,9 +61,9 @@ export const useManagePermissions = (
      * This effect handles the population of permissions-related form values when the
      * Manage Permissions form is given default values via the "Redo action" flow
      */
-    const { member, role, team } = defaultValues ?? {};
+    const { member, role, team, authority } = defaultValues ?? {};
 
-    if (member && role && team) {
+    if (member && role && team && authority) {
       configureFormRoles({
         colony,
         isSubmitted: false,
@@ -71,6 +71,7 @@ export const useManagePermissions = (
         role,
         setValue,
         team,
+        authority,
       });
     }
   }, [colony, defaultValues, setValue]);
@@ -96,8 +97,6 @@ export const useManagePermissions = (
           return;
         }
 
-        const isMultiSig = authority === Authority.ViaMultiSig;
-
         configureFormRoles({
           colony,
           isSubmitted,
@@ -105,7 +104,7 @@ export const useManagePermissions = (
           role,
           setValue,
           team,
-          isMultiSig,
+          authority,
         });
       },
     );

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/hooks.ts
@@ -4,16 +4,14 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { type DeepPartial } from 'utility-types';
 
-import { getRole, UserRole } from '~constants/permissions.ts';
+import { UserRole } from '~constants/permissions.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { ActionTypes } from '~redux/index.ts';
-import { getUserRolesForDomain } from '~transformers';
 import { DecisionMethod } from '~types/actions.ts';
 import { Authority } from '~types/authority.ts';
 import { mapPayload, pipe } from '~utils/actions.ts';
 import { notMaybe } from '~utils/arrays/index.ts';
-import { extractColonyRoles } from '~utils/colonyRoles.ts';
 
 import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
 import { type ActionFormBaseProps } from '../../../types.ts';
@@ -100,25 +98,6 @@ export const useManagePermissions = (
 
         const isMultiSig = authority === Authority.ViaMultiSig;
 
-        const userPermissions = getUserRolesForDomain({
-          colonyRoles: extractColonyRoles(colony.roles),
-          userAddress: member,
-          domainId: Number(team),
-          excludeInherited: true,
-          isMultiSig,
-        });
-
-        const userRole = getRole(userPermissions);
-
-        setValue(
-          'role',
-          userRole.permissions.length ? userRole.role : undefined,
-        );
-
-        if (userRole.role !== UserRole.Custom) {
-          return;
-        }
-
         configureFormRoles({
           colony,
           isSubmitted,
@@ -126,6 +105,7 @@ export const useManagePermissions = (
           role,
           setValue,
           team,
+          isMultiSig,
         });
       },
     );

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/utils.ts
@@ -152,6 +152,7 @@ export const configureFormRoles = ({
   member,
   role,
   team,
+  isMultiSig = false,
 }: {
   colony: ColonyFragment;
   setValue: UseFormSetValue<ManagePermissionsFormValues>;
@@ -161,12 +162,14 @@ export const configureFormRoles = ({
   role: ManagePermissionsFormValues['role'];
   shouldPersistRole?: boolean;
   setShouldPersistRole?: React.Dispatch<React.SetStateAction<boolean>>;
+  isMultiSig?: boolean;
 }) => {
   const userRolesForDomain = getUserRolesForDomain({
     colonyRoles: extractColonyRoles(colony.roles),
     userAddress: member,
     domainId: team,
     intersectingRoles: true,
+    isMultiSig,
   });
 
   const userRoleMeta = getRole(userRolesForDomain);

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/utils.ts
@@ -10,6 +10,7 @@ import {
 import { type ColonyFragment } from '~gql';
 import { getUserRolesForDomain } from '~transformers';
 import { DecisionMethod } from '~types/actions.ts';
+import { Authority } from '~types/authority.ts';
 import { type Colony } from '~types/graphql.ts';
 import { extractColonyRoles } from '~utils/colonyRoles.ts';
 import { extractColonyDomains } from '~utils/domains.ts';
@@ -152,7 +153,7 @@ export const configureFormRoles = ({
   member,
   role,
   team,
-  isMultiSig = false,
+  authority,
 }: {
   colony: ColonyFragment;
   setValue: UseFormSetValue<ManagePermissionsFormValues>;
@@ -162,14 +163,14 @@ export const configureFormRoles = ({
   role: ManagePermissionsFormValues['role'];
   shouldPersistRole?: boolean;
   setShouldPersistRole?: React.Dispatch<React.SetStateAction<boolean>>;
-  isMultiSig?: boolean;
+  authority: ManagePermissionsFormValues['authority'];
 }) => {
   const userRolesForDomain = getUserRolesForDomain({
     colonyRoles: extractColonyRoles(colony.roles),
     userAddress: member,
     domainId: team,
     intersectingRoles: true,
-    isMultiSig,
+    isMultiSig: authority === Authority.ViaMultiSig,
   });
 
   const userRoleMeta = getRole(userRolesForDomain);

--- a/src/components/v5/common/CompletedAction/partials/SetUserRoles/SetUserRoles.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SetUserRoles/SetUserRoles.tsx
@@ -94,6 +94,10 @@ const SetUserRoles = ({ action }: Props) => {
     rolesAreMultiSig,
   } = action;
 
+  const roleAuthority = rolesAreMultiSig
+    ? Authority.ViaMultiSig
+    : Authority.Own;
+
   const { data: historicRoles } = useGetColonyHistoricRoleRolesQuery({
     variables: {
       id: getHistoricRolesDatabaseId({
@@ -101,6 +105,7 @@ const SetUserRoles = ({ action }: Props) => {
         colonyAddress,
         nativeId: fromDomain?.nativeId,
         recipientAddress,
+        isMultiSig: roleAuthority === Authority.ViaMultiSig,
       }),
     },
     fetchPolicy: 'cache-and-network',
@@ -110,11 +115,12 @@ const SetUserRoles = ({ action }: Props) => {
     historicRoles?.getColonyHistoricRole,
   );
 
-  const { name: roleName, role } = getRole(userColonyRoles);
   const rolesTitle = formatRolesTitle(roles);
-  const roleAuthority = rolesAreMultiSig
-    ? Authority.ViaMultiSig
-    : Authority.Own;
+
+  const { name: roleName, role } = getRole(
+    userColonyRoles,
+    roleAuthority === Authority.ViaMultiSig,
+  );
 
   const metadata =
     action.motionData?.motionDomain.metadata ??

--- a/src/components/v5/common/CompletedAction/partials/SetUserRoles/SetUserRoles.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SetUserRoles/SetUserRoles.tsx
@@ -98,53 +98,21 @@ const SetUserRoles = ({ action }: Props) => {
     ? Authority.ViaMultiSig
     : Authority.Own;
 
-  /**
-   * Hack explained:
-   * If you give a user multi-sig permissions for the 1st time, this "_multisig" chunk gets added to the ID
-   * But the next time you give this user another multisig permission, this chunk is not added
-   * By chunk, I mean: 0x0000_2_0x0000_8293_roles VERSUS 0x0000_2_0x0000_8293_multisig_roles
-   * I cannot come up with a cleaner way to identify whether or not a user already has multisig prior
-   * And to get the user's real historic role, I needed to test with both the "_multisig" chunk and without
-   * I also don't know what other scenario will add the _multisig chunk to the ID
-   */
-
-  // Historic role without the "_multisig" ID chunk
-  const { data: historicRolesA } = useGetColonyHistoricRoleRolesQuery({
+  const { data: historicRoles } = useGetColonyHistoricRoleRolesQuery({
     variables: {
       id: getHistoricRolesDatabaseId({
         blockNumber,
         colonyAddress,
         nativeId: fromDomain?.nativeId,
         recipientAddress,
+        isMultiSig: rolesAreMultiSig,
       }),
     },
     fetchPolicy: 'cache-and-network',
   });
 
-  // Historic role with the "_multisig" ID chunk, only if the authority is Authority.ViaMultiSig
-  const { data: historicRolesB } = useGetColonyHistoricRoleRolesQuery({
-    variables: {
-      id: getHistoricRolesDatabaseId({
-        blockNumber,
-        colonyAddress,
-        nativeId: fromDomain?.nativeId,
-        recipientAddress,
-        isMultiSig: roleAuthority === Authority.ViaMultiSig,
-      }),
-    },
-    fetchPolicy: 'cache-and-network',
-  });
-
-  const userColonyRolesA = transformActionRolesToColonyRoles(
-    historicRolesA?.getColonyHistoricRole,
-  );
-
-  const userColonyRolesB = transformActionRolesToColonyRoles(
-    historicRolesB?.getColonyHistoricRole,
-  );
-
-  const userColonyRoles = Array.from(
-    new Set([...userColonyRolesA, ...userColonyRolesB]),
+  const userColonyRoles = transformActionRolesToColonyRoles(
+    historicRoles?.getColonyHistoricRole,
   );
 
   const rolesTitle = formatRolesTitle(roles);

--- a/src/utils/databaseId.ts
+++ b/src/utils/databaseId.ts
@@ -24,11 +24,13 @@ export const getHistoricRolesDatabaseId = ({
   nativeId,
   recipientAddress,
   blockNumber,
+  isMultiSig,
 }: {
   colonyAddress: string;
   nativeId: number | undefined;
   recipientAddress: string | null | undefined;
   blockNumber: number;
+  isMultiSig: boolean;
 }) => {
-  return `${colonyAddress}_${nativeId}_${recipientAddress}_${blockNumber}_roles`;
+  return `${colonyAddress}_${nativeId}_${recipientAddress}_${blockNumber}${isMultiSig ? '_multisig' : ''}_roles`;
 };

--- a/src/utils/databaseId.ts
+++ b/src/utils/databaseId.ts
@@ -1,3 +1,5 @@
+import { type ColonyActionFragment } from '~gql';
+
 export const getDomainDatabaseId = (
   colonyAddress: string,
   nativeDomainId: number,
@@ -30,7 +32,7 @@ export const getHistoricRolesDatabaseId = ({
   nativeId: number | undefined;
   recipientAddress: string | null | undefined;
   blockNumber: number;
-  isMultiSig?: boolean;
+  isMultiSig?: ColonyActionFragment['rolesAreMultiSig'];
 }) => {
   return `${colonyAddress}_${nativeId}_${recipientAddress}_${blockNumber}${isMultiSig ? '_multisig' : ''}_roles`;
 };

--- a/src/utils/databaseId.ts
+++ b/src/utils/databaseId.ts
@@ -30,7 +30,7 @@ export const getHistoricRolesDatabaseId = ({
   nativeId: number | undefined;
   recipientAddress: string | null | undefined;
   blockNumber: number;
-  isMultiSig: boolean;
+  isMultiSig?: boolean;
 }) => {
   return `${colonyAddress}_${nativeId}_${recipientAddress}_${blockNumber}${isMultiSig ? '_multisig' : ''}_roles`;
 };


### PR DESCRIPTION
## Description

This is just a tiny fix that brings back the auto-populate behaviour for the Roles and Permissions fields in the Manage Permissions form which got slightly affected in the recent rebase.

## Testing

> [!NOTE]
>
> I am not very familiar with this new flow where we also take into account the Multi-Sig Authority for a user to properly identify the role. These steps are ported over from #2565. Please let me know if my test steps needs updating.

> [!IMPORTANT]
> - Please test this with [block-ingestor#259: Fix: conditionally add multisig chunk to historic role id](https://github.com/JoinColony/block-ingestor/pull/259)
> - I don't want you to accidentally revoke your Owner permissions for your Colony so give Amy the Owner role in the General (Parent domain) team
> - Remove all permissions from Fry in team Andromeda

### Non-submitted Form Flow
| Steps | Expected Result |
| ---- | ---- |
| 1. Set Member field to amy | |
| 2. Set Team field to General | |
| 3. Set a value for the Authority field | - The permissions field is automatically set to Owner<br />- No error message is shown for permissions |
| 4. Set Permissions to Custom | - The Permission toggles are automatically set<br />- No error message is shown for permissions |
| 5. Set Member to Fry | |
| 6. Set Team to Andromeda | - No error message is shown for permissions |

###  Submitted Form Flow

| Steps | Expected Result |
| ---- | ---- |
| 1. Set Member to Fry | |
| 2. Set team to Andromeda | |
| 3. Set a value for the Authority field | |
| 4. Set Permissions to Custom | |
| 5. Submit the form | Error message: "You have to enable at least one permission" |
| 6. Set Permissions to Custom | - The Permission toggles are automatically set<br />- No error message is shown for permissions |
| 7. Switch on at least 1 Permission | The Permissions error message disappears |
| 8. Turn off all Permission toggles AND **do not** submit the form | Error message: "You have to enable at least one permission" |
| 9. Set Member to amy | |
| 10. Set Team to General | - The permission toggles are automatically set<br />- Error message: "This user already has these permissions" |
| 11. Switch off 1 Permission toggle | The Permissions error message disappears |
| 12. Turn on all Permission toggles AND **do not** submit the form | Error message: "This user already has these permissions" |
| 13. Set Permissions to Admin | The Permissions error message disappears |
| 14. Set Permissions to Owner | Error message: "This user already has these permissions" |

### Redo Action Flow (Authority to take actions on their own)

> [!IMPORTANT]
> 1. Set up the form:
>   - Team: Andromeda
>   - Member: Fry
>   - Authority: Take actions on their own
>   - Permissions: Payer
> 2. On the Completed Action form, click the meatball icon and click "Redo action"
> 3. Confirm you can see the Manage Permissions form with auto-populated fields

| Steps | Expected Result |
| ---- | ---- |
| 1. Submit the form | Error message: "This user already has these permissions" |
| 2. Set Permissions to Mod AND **do not** submit the form | The Permissions error goes away |
| 3. Submit the form | The form is successfully submitted |
| 4. Bring up the Manage Permissions form | |
| 5. Set Team to Andromeda | |
| 6. Set Member to Fry | |
| 7. Set a value for the Authority field | The Permissions field is automatically set to Mod |

### Redo Action Flow (Authority to take actions via Multi-Sig)

> [!IMPORTANT]
> 1. The previous section "Redo Action Flow (Authority to take actions on their own)" is a dependency so please do that first
> 2. Set up the form:
>   - Team: Andromeda
>   - Member: Fry
>   - Authority: Take actions via Multi-Sig
>   - Permissions: Admin
> 3. On the Completed Action form, verify that the Permissions field is set to Admin
> 4. On the Completed Action form, click the meatball icon and click "Redo action"
> 5. Confirm you can see the Manage Permissions form with auto-populated fields

| Steps | Expected Result |
| ---- | ---- |
| 1. Submit the form | Error message: "This user already has these permissions" |
| 2. Set Permissions to Payer AND **do not** submit the form | The Permissions error goes away |
| 3. Set Authority to take actions on their own | - Permissions is automatically set to Mod<br />- Error message: "This user already has these permissions"  |
| 4. Set Authority to Take actions via Multi-Sig | - Permissions is automatically set to Admin<br />- Error message: "This user already has these permissions" |
| 5. Set Permissions to Payer | Error messages goes away |
| 6. Submit the form | - The form is successfully submitted<br />- The Permissions field is set to Payer |
| 7. Bring up the Manage Permissions form | |
| 8. Set Team to Andromeda | |
| 9. Set Member to Fry | |
| 7. Set Authority to Take actions via Multi-Sig | The Permissions field is automatically set to Payer |

Contributes to #2565 