### PR TITLE
Fix: User info popover should not show multi-sig icon if no multi-sig roles

### DIFF
--- a/src/components/v5/shared/UserInfoPopover/partials/UserInfo.tsx
+++ b/src/components/v5/shared/UserInfoPopover/partials/UserInfo.tsx
@@ -210,17 +210,30 @@ const UserInfo: FC<UserInfoProps> = ({
                   reputationPercentage,
                   reputationRaw,
                 }) => {
-                  const getFilteredPermissions = (
-                    unfilteredPermissions: AvailablePermission[],
-                  ) => {
+                  const getFilteredPermissions = ({
+                    unfilteredPermissions,
+                    isMultiSig = false,
+                  }: {
+                    unfilteredPermissions: AvailablePermission[];
+                    isMultiSig?: boolean;
+                  }) => {
                     if (unfilteredPermissions?.length) {
                       return unfilteredPermissions;
                     }
                     const rootDomain = domains.find(
                       ({ nativeId }) => nativeId === Id.RootDomain,
                     );
+                    if (!isMultiSig) {
+                      return rootDomain
+                        ? rootDomain.permissions.filter(
+                            (permission) =>
+                              permission !== ColonyRole.Root &&
+                              permission !== ColonyRole.Recovery,
+                          )
+                        : [];
+                    }
                     return rootDomain
-                      ? rootDomain.permissions.filter(
+                      ? rootDomain.multiSigPermissions.filter(
                           (permission) =>
                             permission !== ColonyRole.Root &&
                             permission !== ColonyRole.Recovery,
@@ -228,9 +241,14 @@ const UserInfo: FC<UserInfoProps> = ({
                       : [];
                   };
 
-                  const finalPermissions = getFilteredPermissions(permissions);
-                  const finalMultiSigPermissions =
-                    getFilteredPermissions(multiSigPermissions);
+                  const finalPermissions = getFilteredPermissions({
+                    unfilteredPermissions: permissions,
+                  });
+
+                  const finalMultiSigPermissions = getFilteredPermissions({
+                    unfilteredPermissions: multiSigPermissions,
+                    isMultiSig: true,
+                  });
 
                   const permissionRole = finalPermissions?.length
                     ? getRole(finalPermissions)

--- a/src/hooks/multiSig/useEligibleSignees.ts
+++ b/src/hooks/multiSig/useEligibleSignees.ts
@@ -32,12 +32,16 @@ export const useEligibleSignees = ({
     signeesPerRole: {},
   });
 
+  // Since it's an array fetched from a function, we "memo" this by stringify it to prevent it always triggering the useEffect
+  const requiredRolesString = JSON.stringify(requiredRoles);
+
   useEffect(() => {
     async function fetchEligibleSignees() {
+      const parsedRequiredRoles = JSON.parse(requiredRolesString);
       try {
         setIsLoading(true);
         const response = await getEligibleSigneesApi({
-          requiredRoles,
+          requiredRoles: parsedRequiredRoles,
           colonyAddress,
           domainId,
         });
@@ -51,8 +55,7 @@ export const useEligibleSignees = ({
     }
 
     fetchEligibleSignees();
-    // Since it's an array fetched from a function, it will always trigger this, so we "memo" it by stringifying it :)
-  }, [colonyAddress, domainId, JSON.stringify(requiredRoles)]);
+  }, [colonyAddress, domainId, requiredRolesString]);
 
   return {
     isLoading,


### PR DESCRIPTION
## Description

Fixes point 20 on the QoL issue.

This PR fixes an issue where a user with no multi-sig permissions would still have the icon appear on their user info popover if they had core permissions.

It also fixes an issue with the requiredRoles useEffect dependancies.

## Testing

Step 1 - Install the multi-sig extension
Step 2 - Remove all multi-sig permissions from Leela
Step 3 - Refresh and check the user info popover, only Leela's core permissions should show:

<img width="497" alt="Screenshot 2024-07-26 at 14 43 25" src="https://github.com/user-attachments/assets/54f49e4b-9793-4465-9af5-7f01f120a77d">

Step 4 - Assign Leela multi-sig permissions in a sub-domain. Refresh and check the user info popover, they should have the icon appear next to that domain:

<img width="353" alt="Screenshot 2024-07-26 at 14 44 33" src="https://github.com/user-attachments/assets/8ed0fb6b-1c9a-4d80-84e1-6d01aedd882e">

Step 5 - Assign Leela multi-sig permissions in general. Refresh and check the user info popover, they should have the icon next to every domain as they will have inherited permissions from the root domain:
 
<img width="432" alt="Screenshot 2024-07-26 at 14 45 41" src="https://github.com/user-attachments/assets/da69d1ba-ba73-460b-8f8d-b668c2a47b0c">

> [!NOTE]  
> There is an issue which is out of scope for this PR. If a user is assigned payer permissions in a Andromeda and then assigned admin permissions in General, this means they will have inherited admin permissions in Andromeda, however the icon tooltip next to Andromeda will only show "Payer" permissions. I am opening a new issue for this as it potentially quite complex.


## Diffs

**Changes** 🏗

* The multi-sig icon no longer shows if the user does not have multi-sig permissions

Contributes to #2658
