### PR TITLE
Fix: update KYC verification copy

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/KycCard.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/KycCard.tsx
@@ -20,7 +20,7 @@ const MSG = defineMessages({
   message: {
     id: `${displayName}.message`,
     defaultMessage:
-      'Regulatory compliance requires users to fiat off-ramp must complete KYC/AML checks. It only takes a couple of minutes.',
+      'Regulatory compliance requires users to fiat off-ramp must complete KYC/AML checks. It only takes a couple of minutes (up to 1 business day if a manual check is required).',
   },
   completeVerification: {
     id: `${displayName}.completeVerification`,

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/Verification/consts.ts
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/Verification/consts.ts
@@ -160,7 +160,7 @@ export const MSG = defineMessages({
   bodyDescription: {
     id: `${displayName}.bodyDescription`,
     defaultMessage:
-      'Regulatory compliance requires users to fiat off-ramp must complete KYC/AML checks. It only takes a couple of minutes.',
+      'Regulatory compliance requires users to fiat off-ramp must complete KYC/AML checks. It only takes a couple of minutes (up to 1 business day if a manual check is required).',
   },
   bodyCtaTitle: {
     id: `${displayName}.bodyCtaTitle`,


### PR DESCRIPTION
## Description

| User Hub | Settings page |
| ---- | ---- |
| ![Screenshot 2024-07-26 at 15 29 24](https://github.com/user-attachments/assets/eb59845a-1c72-4bb7-941a-eb8f05764968) | ![Screenshot 2024-07-26 at 15 26 49](https://github.com/user-attachments/assets/b3eca899-a383-4463-bac9-9eedc6bad29b) |

## Secrets setup
> [!IMPORTANT]
> If you haven't done the secrets file set up yet, expand this section:

<details>
<summary><h4>Click to view the secrets setup 👈 🤫 </h4></summary>

### Setting up your local environment

Create a `.env.local.secrets` file in the parent directory and populate it with the correct environment variables:
```console
echo -e "BSCSCAN_API_KEY=\nETHERSCAN_API_KEY=\nGOOGLE_TAG_MANAGER_ID=\nPINATA_API_KEY=\nPINATA_API_SECRET=\nCOINGECKO_API_KEY=\nCOINGECKO_API_URL=\nPOSTHOG_KEY=\nPOSTHOG_HOST=\nUSDC_LOCAL_ADDRESS=" > .env.local.secrets
```
Once the `.env.local.secrets` file is created, open it and you should see the following content. You will need to provide values for `POSTHOG_KEY` and `POSTHOG_HOST` so please ask a fellow dev about this.
```js
BSCSCAN_API_KEY=
ETHERSCAN_API_KEY=
GOOGLE_TAG_MANAGER_ID=
PINATA_API_KEY=
PINATA_API_SECRET=
COINGECKO_API_KEY=
COINGECKO_API_URL=
POSTHOG_KEY=
POSTHOG_HOST=
USDC_LOCAL_ADDRESS=
```
Once you've provided values for `POSTHOG_KEY` and `POSTHOG_HOST`, inject them:
```console
npm run prepare
```

</details>

## Testing

> [!IMPORTANT]
> Open the `amplify/backend/function/bridgeXYZMutation/src/index.js` file and make sure you enter the right sandbox api key. Otherwise, you won't be able to do the KYC flow:
> ```js
> // Use the sandbox API key instead of 'xxx'
> let apiKey = 'xxx';
> ```
> Enable the Crypto to Fiat tab via our Feature Flag. I'm sure there's a better way to do this but open the `src/context/FeatureFlagsContext/FeatureFlagsContextProvider.tsx` file and do the following replacement:
> ```js
> // From
> [FeatureFlag.CRYPTO_TO_FIAT]: cryptoToFiatFeature,
> [FeatureFlag.CRYPTO_TO_FIAT_WITHDRAWALS]: cryptoToFiatWithdrawalsFeature,
> // To
> [FeatureFlag.CRYPTO_TO_FIAT]: { isEnabled: true }
> [FeatureFlag.CRYPTO_TO_FIAT_WITHDRAWALS]: { isEnabled: true },
> ```
> Make sure to log in using a user account that has not yet completed the KYC checks and visit the following URL: http://localhost:9091/account/crypto-to-fiat. It should take you directly to the Crypto to Fiat tab.

Make sure that the KYC verification copy now says:
```
Regulatory compliance requires users to fiat off-ramp must complete KYC/AML checks. It only takes a couple of minutes (up to 1 business day if a manual check is required).
```

Resolves #2744 