### PR TITLE
Fix: Prevent payment actions with locked tokens

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
@@ -112,6 +112,7 @@ const AmountField: FC<AmountFieldProps> = ({
       <span
         className={clsx('text-md', {
           'text-gray-300': isDisabled,
+          'text-negative-400': tokenAddressError,
         })}
       >
         {multiLineTextEllipsis(activeToken.symbol, 5)}

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/hooks.ts
@@ -41,7 +41,7 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
         .map((colonyToken) => colonyToken.token) || [],
     [colony.tokens?.items],
   );
-  const tokenStatesMap = useTokenLockStates();
+  const tokenLockStatesMap = useTokenLockStates();
 
   return useMemo(
     () =>
@@ -108,7 +108,7 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
                         !shouldPreventPaymentsWithTokenInColony(
                           value || '',
                           colony,
-                          tokenStatesMap,
+                          tokenLockStatesMap,
                         ),
                     ),
                   delay: string()
@@ -174,7 +174,7 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
         )
         .defined()
         .concat(ACTION_BASE_VALIDATION_SCHEMA),
-    [colony, colonyTokens, networkInverseFee, tokenStatesMap],
+    [colony, colonyTokens, networkInverseFee, tokenLockStatesMap],
   );
 };
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/hooks.ts
@@ -6,12 +6,14 @@ import { array, type InferType, number, object, string } from 'yup';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
+import useTokenLockStates from '~hooks/useTokenLockStates.ts';
 import { ActionTypes } from '~redux/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { mapPayload, pipe } from '~utils/actions.ts';
 import getLastIndexFromPath from '~utils/getLastIndexFromPath.ts';
 import { formatText } from '~utils/intl.ts';
 import { toFinite } from '~utils/lodash.ts';
+import { shouldPreventPaymentsWithTokenInColony } from '~utils/tokens.ts';
 import { amountGreaterThanZeroValidation } from '~utils/validation/amountGreaterThanZeroValidation.ts';
 import { hasEnoughFundsValidation } from '~utils/validation/hasEnoughFundsValidation.ts';
 import {
@@ -28,6 +30,7 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
   const { colony } = useColonyContext();
   const { watch } = useFormContext();
   const fromDomainId: number | undefined = watch('from');
+  const tokenStatesMap = useTokenLockStates();
 
   const validationSchema = useMemo(
     () =>
@@ -64,7 +67,19 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
                   networkInverseFee,
                 }),
             ),
-          tokenAddress: string().address().required(),
+          tokenAddress: string()
+            .address()
+            .required()
+            .test(
+              'token-unlocked',
+              formatText({ id: 'errors.amount.tokenIsLocked' }) || '',
+              (value) =>
+                !shouldPreventPaymentsWithTokenInColony(
+                  value || '',
+                  colony,
+                  tokenStatesMap,
+                ),
+            ),
           createdIn: number().defined(),
           recipientAddress: string().address().required(),
           from: number().required(),
@@ -96,7 +111,7 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
         })
         .defined()
         .concat(ACTION_BASE_VALIDATION_SCHEMA),
-    [colony, fromDomainId, networkInverseFee],
+    [colony, fromDomainId, networkInverseFee, tokenStatesMap],
   );
 
   return validationSchema;

--- a/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/hooks.ts
@@ -30,7 +30,7 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
   const { colony } = useColonyContext();
   const { watch } = useFormContext();
   const fromDomainId: number | undefined = watch('from');
-  const tokenStatesMap = useTokenLockStates();
+  const tokenLockStatesMap = useTokenLockStates();
 
   const validationSchema = useMemo(
     () =>
@@ -77,7 +77,7 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
                 !shouldPreventPaymentsWithTokenInColony(
                   value || '',
                   colony,
-                  tokenStatesMap,
+                  tokenLockStatesMap,
                 ),
             ),
           createdIn: number().defined(),
@@ -111,7 +111,7 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
         })
         .defined()
         .concat(ACTION_BASE_VALIDATION_SCHEMA),
-    [colony, fromDomainId, networkInverseFee, tokenStatesMap],
+    [colony, fromDomainId, networkInverseFee, tokenLockStatesMap],
   );
 
   return validationSchema;

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/hooks.ts
@@ -25,7 +25,7 @@ export const useValidationSchema = () => {
   const { colony } = useColonyContext();
   const { watch } = useFormContext();
   const selectedTeam = watch('team');
-  const tokenStatesMap = useTokenLockStates();
+  const tokenLockStatesMap = useTokenLockStates();
 
   const validationSchema = useMemo(
     () =>
@@ -62,7 +62,7 @@ export const useValidationSchema = () => {
                 !shouldPreventPaymentsWithTokenInColony(
                   value || '',
                   colony,
-                  tokenStatesMap,
+                  tokenLockStatesMap,
                 ),
             ),
         }).required(),
@@ -96,7 +96,7 @@ export const useValidationSchema = () => {
       })
         .defined()
         .concat(ACTION_BASE_VALIDATION_SCHEMA),
-    [colony, selectedTeam, tokenStatesMap],
+    [colony, selectedTeam, tokenLockStatesMap],
   );
 
   return validationSchema;

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/hooks.ts
@@ -4,11 +4,13 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import { array, type InferType, number, object, string } from 'yup';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import useTokenLockStates from '~hooks/useTokenLockStates.ts';
 import { ActionTypes } from '~redux/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { mapPayload } from '~utils/actions.ts';
 import { notNull } from '~utils/arrays/index.ts';
 import { formatText } from '~utils/intl.ts';
+import { shouldPreventPaymentsWithTokenInColony } from '~utils/tokens.ts';
 import { amountGreaterThanZeroValidation } from '~utils/validation/amountGreaterThanZeroValidation.ts';
 import { hasEnoughFundsValidation } from '~utils/validation/hasEnoughFundsValidation.ts';
 import {
@@ -23,6 +25,7 @@ export const useValidationSchema = () => {
   const { colony } = useColonyContext();
   const { watch } = useFormContext();
   const selectedTeam = watch('team');
+  const tokenStatesMap = useTokenLockStates();
 
   const validationSchema = useMemo(
     () =>
@@ -49,7 +52,19 @@ export const useValidationSchema = () => {
                   colony,
                 }),
             ),
-          tokenAddress: string().address().required(),
+          tokenAddress: string()
+            .address()
+            .required()
+            .test(
+              'token-unlocked',
+              formatText({ id: 'errors.amount.tokenIsLocked' }) || '',
+              (value) =>
+                !shouldPreventPaymentsWithTokenInColony(
+                  value || '',
+                  colony,
+                  tokenStatesMap,
+                ),
+            ),
         }).required(),
         createdIn: number().defined(),
         team: number().required(),
@@ -81,7 +96,7 @@ export const useValidationSchema = () => {
       })
         .defined()
         .concat(ACTION_BASE_VALIDATION_SCHEMA),
-    [colony, selectedTeam],
+    [colony, selectedTeam, tokenStatesMap],
   );
 
   return validationSchema;

--- a/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/hooks.ts
@@ -27,7 +27,7 @@ export const useValidationSchema = () => {
   const { colony } = useColonyContext();
   const { watch } = useFormContext();
   const selectedTeam = watch('from');
-  const tokenStatesMap = useTokenLockStates();
+  const tokenLockStatesMap = useTokenLockStates();
 
   const validationSchema = useMemo(
     () =>
@@ -64,7 +64,7 @@ export const useValidationSchema = () => {
                 !shouldPreventPaymentsWithTokenInColony(
                   value || '',
                   colony,
-                  tokenStatesMap,
+                  tokenLockStatesMap,
                 ),
             ),
           createdIn: number().defined(),
@@ -81,7 +81,7 @@ export const useValidationSchema = () => {
         })
         .defined()
         .concat(ACTION_BASE_VALIDATION_SCHEMA),
-    [colony, selectedTeam, tokenStatesMap],
+    [colony, selectedTeam, tokenLockStatesMap],
   );
 
   return validationSchema;

--- a/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/hooks.ts
@@ -5,10 +5,12 @@ import { type DeepPartial } from 'utility-types';
 import { type InferType, number, object, string } from 'yup';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import useTokenLockStates from '~hooks/useTokenLockStates.ts';
 import { ActionTypes } from '~redux/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { mapPayload, pipe } from '~utils/actions.ts';
 import { formatText } from '~utils/intl.ts';
+import { shouldPreventPaymentsWithTokenInColony } from '~utils/tokens.ts';
 import { amountGreaterThanZeroValidation } from '~utils/validation/amountGreaterThanZeroValidation.ts';
 import { hasEnoughFundsValidation } from '~utils/validation/hasEnoughFundsValidation.ts';
 import {
@@ -25,6 +27,7 @@ export const useValidationSchema = () => {
   const { colony } = useColonyContext();
   const { watch } = useFormContext();
   const selectedTeam = watch('from');
+  const tokenStatesMap = useTokenLockStates();
 
   const validationSchema = useMemo(
     () =>
@@ -51,7 +54,19 @@ export const useValidationSchema = () => {
                   colony,
                 }),
             ),
-          tokenAddress: string().address().required(),
+          tokenAddress: string()
+            .address()
+            .required()
+            .test(
+              'token-unlocked',
+              formatText({ id: 'errors.amount.tokenIsLocked' }) || '',
+              (value) =>
+                !shouldPreventPaymentsWithTokenInColony(
+                  value || '',
+                  colony,
+                  tokenStatesMap,
+                ),
+            ),
           createdIn: number().defined(),
           from: number().required(),
           to: number()
@@ -66,7 +81,7 @@ export const useValidationSchema = () => {
         })
         .defined()
         .concat(ACTION_BASE_VALIDATION_SCHEMA),
-    [colony, selectedTeam],
+    [colony, selectedTeam, tokenStatesMap],
   );
 
   return validationSchema;

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -9335,6 +9335,13 @@ export type GetColonyMemberInviteQueryVariables = Exact<{
 
 export type GetColonyMemberInviteQuery = { __typename?: 'Query', getColonyMemberInvite?: { __typename?: 'ColonyMemberInvite', invitesRemaining: number, colony: { __typename?: 'Colony', name: string, colonyAddress: string, metadata?: { __typename?: 'ColonyMetadata', avatar?: string | null, displayName: string, thumbnail?: string | null, externalLinks?: Array<{ __typename?: 'ExternalLink', link: string, name: ExternalLinks }> | null } | null } } | null };
 
+export type GetColonyTokensWithLockedStatesQueryVariables = Exact<{
+  name: Scalars['String'];
+}>;
+
+
+export type GetColonyTokensWithLockedStatesQuery = { __typename?: 'Query', getColonyByName?: { __typename?: 'ModelColonyConnection', items: Array<{ __typename?: 'Colony', tokens?: { __typename?: 'ModelColonyTokensConnection', items: Array<{ __typename?: 'ColonyTokens', token: { __typename?: 'Token', name: string, id: string, colonies?: { __typename?: 'ModelColonyTokensConnection', items: Array<{ __typename?: 'ColonyTokens', colony: { __typename?: 'Colony', nativeTokenId: string, name: string, status?: { __typename?: 'ColonyStatus', nativeToken?: { __typename?: 'NativeTokenStatus', unlocked?: boolean | null } | null } | null } } | null> } | null } } | null> } | null } | null> } | null };
+
 export type OnUpdateColonySubscriptionVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -12266,6 +12273,63 @@ export function useGetColonyMemberInviteLazyQuery(baseOptions?: Apollo.LazyQuery
 export type GetColonyMemberInviteQueryHookResult = ReturnType<typeof useGetColonyMemberInviteQuery>;
 export type GetColonyMemberInviteLazyQueryHookResult = ReturnType<typeof useGetColonyMemberInviteLazyQuery>;
 export type GetColonyMemberInviteQueryResult = Apollo.QueryResult<GetColonyMemberInviteQuery, GetColonyMemberInviteQueryVariables>;
+export const GetColonyTokensWithLockedStatesDocument = gql`
+    query GetColonyTokensWithLockedStates($name: String!) {
+  getColonyByName(name: $name) {
+    items {
+      tokens {
+        items {
+          token {
+            colonies {
+              items {
+                colony {
+                  status {
+                    nativeToken {
+                      unlocked
+                    }
+                  }
+                  nativeTokenId
+                  name
+                }
+              }
+            }
+            name
+            id
+          }
+        }
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetColonyTokensWithLockedStatesQuery__
+ *
+ * To run a query within a React component, call `useGetColonyTokensWithLockedStatesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetColonyTokensWithLockedStatesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetColonyTokensWithLockedStatesQuery({
+ *   variables: {
+ *      name: // value for 'name'
+ *   },
+ * });
+ */
+export function useGetColonyTokensWithLockedStatesQuery(baseOptions: Apollo.QueryHookOptions<GetColonyTokensWithLockedStatesQuery, GetColonyTokensWithLockedStatesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetColonyTokensWithLockedStatesQuery, GetColonyTokensWithLockedStatesQueryVariables>(GetColonyTokensWithLockedStatesDocument, options);
+      }
+export function useGetColonyTokensWithLockedStatesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetColonyTokensWithLockedStatesQuery, GetColonyTokensWithLockedStatesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetColonyTokensWithLockedStatesQuery, GetColonyTokensWithLockedStatesQueryVariables>(GetColonyTokensWithLockedStatesDocument, options);
+        }
+export type GetColonyTokensWithLockedStatesQueryHookResult = ReturnType<typeof useGetColonyTokensWithLockedStatesQuery>;
+export type GetColonyTokensWithLockedStatesLazyQueryHookResult = ReturnType<typeof useGetColonyTokensWithLockedStatesLazyQuery>;
+export type GetColonyTokensWithLockedStatesQueryResult = Apollo.QueryResult<GetColonyTokensWithLockedStatesQuery, GetColonyTokensWithLockedStatesQueryVariables>;
 export const OnUpdateColonyDocument = gql`
     subscription OnUpdateColony {
   onUpdateColony {

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -9335,12 +9335,12 @@ export type GetColonyMemberInviteQueryVariables = Exact<{
 
 export type GetColonyMemberInviteQuery = { __typename?: 'Query', getColonyMemberInvite?: { __typename?: 'ColonyMemberInvite', invitesRemaining: number, colony: { __typename?: 'Colony', name: string, colonyAddress: string, metadata?: { __typename?: 'ColonyMetadata', avatar?: string | null, displayName: string, thumbnail?: string | null, externalLinks?: Array<{ __typename?: 'ExternalLink', link: string, name: ExternalLinks }> | null } | null } } | null };
 
-export type GetColonyTokensWithLockedStatesQueryVariables = Exact<{
-  name: Scalars['String'];
+export type GetColonyTokenLockedStateQueryVariables = Exact<{
+  nativeTokenId: Scalars['ID'];
 }>;
 
 
-export type GetColonyTokensWithLockedStatesQuery = { __typename?: 'Query', getColonyByName?: { __typename?: 'ModelColonyConnection', items: Array<{ __typename?: 'Colony', tokens?: { __typename?: 'ModelColonyTokensConnection', items: Array<{ __typename?: 'ColonyTokens', token: { __typename?: 'Token', name: string, id: string, colonies?: { __typename?: 'ModelColonyTokensConnection', items: Array<{ __typename?: 'ColonyTokens', colony: { __typename?: 'Colony', nativeTokenId: string, name: string, status?: { __typename?: 'ColonyStatus', nativeToken?: { __typename?: 'NativeTokenStatus', unlocked?: boolean | null } | null } | null } } | null> } | null } } | null> } | null } | null> } | null };
+export type GetColonyTokenLockedStateQuery = { __typename?: 'Query', getColoniesByNativeTokenId?: { __typename?: 'ModelColonyConnection', items: Array<{ __typename?: 'Colony', status?: { __typename?: 'ColonyStatus', nativeToken?: { __typename?: 'NativeTokenStatus', unlocked?: boolean | null } | null } | null } | null> } | null };
 
 export type OnUpdateColonySubscriptionVariables = Exact<{ [key: string]: never; }>;
 
@@ -12273,29 +12273,13 @@ export function useGetColonyMemberInviteLazyQuery(baseOptions?: Apollo.LazyQuery
 export type GetColonyMemberInviteQueryHookResult = ReturnType<typeof useGetColonyMemberInviteQuery>;
 export type GetColonyMemberInviteLazyQueryHookResult = ReturnType<typeof useGetColonyMemberInviteLazyQuery>;
 export type GetColonyMemberInviteQueryResult = Apollo.QueryResult<GetColonyMemberInviteQuery, GetColonyMemberInviteQueryVariables>;
-export const GetColonyTokensWithLockedStatesDocument = gql`
-    query GetColonyTokensWithLockedStates($name: String!) {
-  getColonyByName(name: $name) {
+export const GetColonyTokenLockedStateDocument = gql`
+    query GetColonyTokenLockedState($nativeTokenId: ID!) {
+  getColoniesByNativeTokenId(nativeTokenId: $nativeTokenId, limit: 1) {
     items {
-      tokens {
-        items {
-          token {
-            colonies {
-              items {
-                colony {
-                  status {
-                    nativeToken {
-                      unlocked
-                    }
-                  }
-                  nativeTokenId
-                  name
-                }
-              }
-            }
-            name
-            id
-          }
+      status {
+        nativeToken {
+          unlocked
         }
       }
     }
@@ -12304,32 +12288,32 @@ export const GetColonyTokensWithLockedStatesDocument = gql`
     `;
 
 /**
- * __useGetColonyTokensWithLockedStatesQuery__
+ * __useGetColonyTokenLockedStateQuery__
  *
- * To run a query within a React component, call `useGetColonyTokensWithLockedStatesQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetColonyTokensWithLockedStatesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useGetColonyTokenLockedStateQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetColonyTokenLockedStateQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetColonyTokensWithLockedStatesQuery({
+ * const { data, loading, error } = useGetColonyTokenLockedStateQuery({
  *   variables: {
- *      name: // value for 'name'
+ *      nativeTokenId: // value for 'nativeTokenId'
  *   },
  * });
  */
-export function useGetColonyTokensWithLockedStatesQuery(baseOptions: Apollo.QueryHookOptions<GetColonyTokensWithLockedStatesQuery, GetColonyTokensWithLockedStatesQueryVariables>) {
+export function useGetColonyTokenLockedStateQuery(baseOptions: Apollo.QueryHookOptions<GetColonyTokenLockedStateQuery, GetColonyTokenLockedStateQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetColonyTokensWithLockedStatesQuery, GetColonyTokensWithLockedStatesQueryVariables>(GetColonyTokensWithLockedStatesDocument, options);
+        return Apollo.useQuery<GetColonyTokenLockedStateQuery, GetColonyTokenLockedStateQueryVariables>(GetColonyTokenLockedStateDocument, options);
       }
-export function useGetColonyTokensWithLockedStatesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetColonyTokensWithLockedStatesQuery, GetColonyTokensWithLockedStatesQueryVariables>) {
+export function useGetColonyTokenLockedStateLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetColonyTokenLockedStateQuery, GetColonyTokenLockedStateQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetColonyTokensWithLockedStatesQuery, GetColonyTokensWithLockedStatesQueryVariables>(GetColonyTokensWithLockedStatesDocument, options);
+          return Apollo.useLazyQuery<GetColonyTokenLockedStateQuery, GetColonyTokenLockedStateQueryVariables>(GetColonyTokenLockedStateDocument, options);
         }
-export type GetColonyTokensWithLockedStatesQueryHookResult = ReturnType<typeof useGetColonyTokensWithLockedStatesQuery>;
-export type GetColonyTokensWithLockedStatesLazyQueryHookResult = ReturnType<typeof useGetColonyTokensWithLockedStatesLazyQuery>;
-export type GetColonyTokensWithLockedStatesQueryResult = Apollo.QueryResult<GetColonyTokensWithLockedStatesQuery, GetColonyTokensWithLockedStatesQueryVariables>;
+export type GetColonyTokenLockedStateQueryHookResult = ReturnType<typeof useGetColonyTokenLockedStateQuery>;
+export type GetColonyTokenLockedStateLazyQueryHookResult = ReturnType<typeof useGetColonyTokenLockedStateLazyQuery>;
+export type GetColonyTokenLockedStateQueryResult = Apollo.QueryResult<GetColonyTokenLockedStateQuery, GetColonyTokenLockedStateQueryVariables>;
 export const OnUpdateColonyDocument = gql`
     subscription OnUpdateColony {
   onUpdateColony {

--- a/src/graphql/queries/colony.graphql
+++ b/src/graphql/queries/colony.graphql
@@ -86,28 +86,12 @@ query GetColonyMemberInvite($id: ID!) {
   }
 }
 
-query GetColonyTokensWithLockedStates($name: String!) {
-  getColonyByName(name: $name) {
+query GetColonyTokenLockedState($nativeTokenId: ID!) {
+  getColoniesByNativeTokenId(nativeTokenId: $nativeTokenId, limit: 1) {
     items {
-      tokens {
-        items {
-          token {
-            colonies {
-              items {
-                colony {
-                  status {
-                    nativeToken {
-                      unlocked
-                    }
-                  }
-                  nativeTokenId
-                  name
-                }
-              }
-            }
-            name
-            id
-          }
+      status {
+        nativeToken {
+          unlocked
         }
       }
     }

--- a/src/graphql/queries/colony.graphql
+++ b/src/graphql/queries/colony.graphql
@@ -86,6 +86,34 @@ query GetColonyMemberInvite($id: ID!) {
   }
 }
 
+query GetColonyTokensWithLockedStates($name: String!) {
+  getColonyByName(name: $name) {
+    items {
+      tokens {
+        items {
+          token {
+            colonies {
+              items {
+                colony {
+                  status {
+                    nativeToken {
+                      unlocked
+                    }
+                  }
+                  nativeTokenId
+                  name
+                }
+              }
+            }
+            name
+            id
+          }
+        }
+      }
+    }
+  }
+}
+
 subscription OnUpdateColony {
   onUpdateColony {
     lastUpdatedContributorsWithReputation

--- a/src/hooks/useTokenLockStates.ts
+++ b/src/hooks/useTokenLockStates.ts
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { type Token, useGetColonyTokensWithLockedStatesQuery } from '~gql';
+
+const useTokenLockStates = (): Record<string, boolean> => {
+  const {
+    colony: { name },
+  } = useColonyContext();
+  const { data } = useGetColonyTokensWithLockedStatesQuery({
+    variables: { name },
+  });
+
+  const tokenStatusMap = useMemo(() => {
+    if (!data) return {};
+
+    const tokens = data?.getColonyByName?.items?.[0]?.tokens?.items.flatMap(
+      (token) => token?.token,
+    );
+
+    return (tokens || []).reduce(
+      (map: Record<string, boolean>, token: Token) => {
+        if (!token) {
+          return map;
+        }
+
+        const colony = token.colonies?.items.find(
+          (colonyTokens) => colonyTokens?.colony.nativeTokenId === token.id,
+        );
+
+        if (!colony) {
+          return map;
+        }
+
+        return {
+          ...map,
+          [token.id]: !!colony.colony.status?.nativeToken?.unlocked,
+        };
+      },
+      {},
+    );
+  }, [data]);
+
+  return tokenStatusMap;
+};
+
+export default useTokenLockStates;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1367,6 +1367,7 @@
     "errors.colonyObjective.max.progress": "Objective progress must be less than or equal to 100",
     "errors.title.required": "Title is required",
     "errors.decisionMethod.required": "Please select a decision method",
+    "errors.amount.tokenIsLocked": "This token is locked and is not able to be used for payments. Check with the token creator for details.",
     "errors.amount.notEnoughTokens": "Not enough tokens",
     "errors.amount.notEnoughTokensIn": "Not enough tokens in {paymentIndex, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} payment.",
     "errors.amount.greaterThanZero": "Amount must be greater than zero",

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -8,6 +8,7 @@ import {
   ADDRESS_ZERO,
   SUPPORTED_SAFE_NETWORKS,
 } from '~constants/index.ts';
+import { type ColonyFragment } from '~gql';
 import {
   type Colony,
   type ColonyBalances,
@@ -128,4 +129,19 @@ export const getNativeTokenByChainId = (chainId: string): Token => {
     tokenAddress: ADDRESS_ZERO,
     ...selectedNetwork.nativeToken,
   };
+};
+
+export const shouldPreventPaymentsWithTokenInColony = (
+  tokenAddress: string,
+  colony: ColonyFragment,
+  tokenStatesMap: Record<string, boolean>,
+): boolean => {
+  const isTokenLocked = tokenStatesMap[tokenAddress] === false;
+  const isTokenNativeToThisColony =
+    tokenAddress === colony.nativeToken.tokenAddress;
+  const isTokenCreatedByThisColony = colony.status?.nativeToken?.mintable;
+
+  return (
+    isTokenLocked && (!isTokenNativeToThisColony || !isTokenCreatedByThisColony)
+  );
 };

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -134,9 +134,9 @@ export const getNativeTokenByChainId = (chainId: string): Token => {
 export const shouldPreventPaymentsWithTokenInColony = (
   tokenAddress: string,
   colony: ColonyFragment,
-  tokenStatesMap: Record<string, boolean>,
+  tokenLockStatesMap: Record<string, boolean>,
 ): boolean => {
-  const isTokenLocked = tokenStatesMap[tokenAddress] === false;
+  const isTokenLocked = tokenLockStatesMap[tokenAddress] === false;
   const isTokenNativeToThisColony =
     tokenAddress === colony.nativeToken.tokenAddress;
   const isTokenCreatedByThisColony = colony.status?.nativeToken?.mintable;


### PR DESCRIPTION
## Description

It is important that users cannot make a payment with a locked token from anywhere that is not the colony which created it.

For example:
- User creates new colony `Davecol` with a new token `DaveCoin`. This coin is locked by default, until a user with the correct permissions makes an 'unlock token' action.
- Whilst the coin is locked, you should still be able to make payments with this coin wherever you want, as long as you are making that payment from within the colony `Davecol`.
- Lets say the user makes another colony `NewDavecol`, and this colony uses the already existing `DaveCoin` as it's token.
- It is completely fine to transfer funds from `Davecol` to `NewDaveCol`, even when the token is locked.
- It should _not_ be possible however, to transfer funds or make any type of payment using `DaveCoin` from within `NewDaveCol`, that is until a user in `DaveCol` unlocks the token.

All of this is currently working fine on the contracts side, and as it stands, if you try to make one of these payments, the UI will let you, but the transaction will fail. We want to stop users from even trying to make these types of payments, since it's not something they will be able to do. We also want to be helpful to the user and inform them why they can't do it.

This PR solves this by introducing a new graphql query and hook which can combine to give access to token locked states, so that the action forms can include this behaviour in their validation. Unfortunately, we don't store locked states on tokens directly in the db, and making that change (which was something I considered and explored) would be quite a large change requiring changes to schemas, ui, block-ingestor, and a migration. This approach keeps the current data structure intact and still manages to solve the problem in an at least slightly elegant way, in my opinion.

## Testing

* After running the create data script, you should be in a state where (as Leela) you're in Planex and Wayne colonies. Planex uses CREDS (locked) and Wayne uses GGG (locked). There should also be incoming funds from Wayne to Planex.
* Inside Planex, go to the incoming funds page, and claim the GGG funds which were sent from Wayne to Planex during the create data script process.
<img width="1473" alt="Screenshot 2024-07-26 at 16 21 50" src="https://github.com/user-attachments/assets/d3884120-cdf1-47a7-935d-10e79d2d8556">

* Still inside Planex, open the create new action form, and try to make a simple payment. Fill out the form as usual, but be sure to select GGG as the token you are paying with.
* You should not be able to submit the form, and should see an error informing you that the token is locked so you cannot make a payment.
<img width="686" alt="Screenshot 2024-07-26 at 16 23 04" src="https://github.com/user-attachments/assets/d4f18a9c-2602-411d-987a-4380a1734853">

* Go to Wayne and try again to create a simple payment using GGG. It should work totally fine, since even though it is a locked token, GGG was created by Wayne.
<img width="1069" alt="Screenshot 2024-07-26 at 16 24 14" src="https://github.com/user-attachments/assets/09ddee60-8074-4fb0-a617-5d430e7f99fc">

**(See further testing steps at this stage if you want to be thorough, or if you want to just do a quick test move onto the next step)**
* Still inside Wayne, create an unlock token action, and complete it.
<img width="1068" alt="Screenshot 2024-07-26 at 16 31 49" src="https://github.com/user-attachments/assets/e1fe98c2-6201-4806-ba84-b68473780854">

* Refresh the page, and go back to Planex. Try again to create a simple payment using GGG as before, only this time it should go through fine!
<img width="1065" alt="Screenshot 2024-07-26 at 16 33 48" src="https://github.com/user-attachments/assets/6ee21a6f-4ed6-48d2-9c8d-0e6014f63be6">
<img width="1912" alt="Screenshot 2024-07-26 at 16 32 55" src="https://github.com/user-attachments/assets/68b46392-80ff-42e9-9a2f-57c81fb6640f">


**Further testing**

If you'd like to test more in-depth (thank you!) then before unlocking the token there's a couple of other things you can try:
* Try making a transfer funds action in Planex using GGG (instead of simple payment). It should fail in the same way.
<img width="682" alt="Screenshot 2024-07-26 at 16 25 06" src="https://github.com/user-attachments/assets/54411848-60d6-4650-a9e8-61e32c210d85">

* Try making an advanced payment action in Planex using GGG (instead of simple payment). It should fail in the same way.
<img width="688" alt="Screenshot 2024-07-26 at 16 25 43" src="https://github.com/user-attachments/assets/c67806ab-e430-4bee-8310-9730c93041c0">

* Try making a new colony (run `node scripts/create-colony-url.js` to get a create url) and select existing token during the creation steps. Put in the address for the Gotham Guilder (GGG) - you can find this address on the dashboard of Wayne. Once the colony is created, transfer some funds to it from Wayne, then try all the payment types mentioned above inside that colony, using GGG. They should all fail, since this colony did not create the token, and it's still locked.
<img width="1409" alt="Screenshot 2024-07-26 at 16 26 20" src="https://github.com/user-attachments/assets/fc897fad-5980-4c91-b5e8-e5d9d7a7edca">
<img width="1912" alt="Screenshot 2024-07-26 at 16 27 25" src="https://github.com/user-attachments/assets/e6826acd-486f-46de-b551-ff674ea124f2">
<img width="684" alt="Screenshot 2024-07-26 at 16 30 01" src="https://github.com/user-attachments/assets/094df189-87f0-48cd-9b25-a9467bd54a06">
<img width="1906" alt="Screenshot 2024-07-26 at 16 30 26" src="https://github.com/user-attachments/assets/6e2e242c-d7f3-4cf1-8d19-6d3930156018">
<img width="686" alt="Screenshot 2024-07-26 at 16 31 02" src="https://github.com/user-attachments/assets/deb6ae55-dd38-46a7-a4c7-ce1faf6d9a10">


## Diffs

**New stuff** ✨

* New graphql query `GetColonyTokensWithLockedStates`
* New hook `useTokenLockStates`

**Changes** 🏗

* Update the validation of all forms which create payment actions

Resolves #2299
