### PR TITLE
feat: handle reputation method to release payments

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/MotionBox/MotionBox.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/MotionBox/MotionBox.tsx
@@ -2,6 +2,7 @@ import { MotionState as NetworkMotionState } from '@colony/colony-js';
 import React, { type FC, useEffect, useState, useMemo } from 'react';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
+import SpinnerLoader from '~shared/Preloaders/SpinnerLoader.tsx';
 import { type MotionAction } from '~types/motions.ts';
 import { MotionState } from '~utils/colonyMotions.ts';
 import useGetColonyAction from '~v5/common/ActionSidebar/hooks/useGetColonyAction.ts';
@@ -127,7 +128,9 @@ const MotionBox: FC<MotionBoxProps> = ({ transactionId }) => {
         <React.Fragment key={key}>{isVisible && content}</React.Fragment>
       ))}
     </MotionProvider>
-  ) : null;
+  ) : (
+    <SpinnerLoader />
+  );
 };
 
 export default MotionBox;

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/PaymentBuilderWidget.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/PaymentBuilderWidget.tsx
@@ -160,15 +160,20 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
     );
   }, [motions]);
 
-  const { selectedTransaction, setSelectedTransaction } =
-    usePaymentBuilderContext();
+  const {
+    selectedTransaction,
+    setSelectedTransaction,
+    selectedMilestoneMotion,
+  } = usePaymentBuilderContext();
 
   const {
     action: motionAction,
     motionState,
     refetchMotionState,
   } = useGetColonyAction(
-    selectedTransaction || fundingMotions?.[0]?.transactionHash,
+    selectedTransaction ||
+      fundingMotions?.[0]?.transactionHash ||
+      selectedMilestoneMotion?.transactionHash,
   );
 
   const selectedMotion = fundingMotions.find(
@@ -285,6 +290,20 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
           key: ExpenditureStep.Payment,
           heading: {
             label: formatText({ id: 'expenditure.paymentStage.label' }),
+            decor:
+              !motionAction?.motionData?.motionStateHistory.hasPassed &&
+              !motionAction?.motionData?.motionStateHistory.hasFailed &&
+              !motionAction?.motionData?.motionStateHistory
+                .hasFailedNotFinalizable &&
+              motionStakes ? (
+                <MotionCountDownTimer
+                  key={`${motionAction?.transactionHash}-${motionState}-${motionId}}`}
+                  motionState={motionState}
+                  motionId={motionId}
+                  motionStakes={motionStakes}
+                  refetchMotionState={refetchMotionState}
+                />
+              ) : null,
           },
           content: (
             <StagedPaymentStep

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/StagedPaymentStep.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/StagedPaymentStep.tsx
@@ -1,10 +1,10 @@
 import { SpinnerGap } from '@phosphor-icons/react';
 import { isEqual } from 'lodash';
-import React, { type FC } from 'react';
+import React, { useEffect, type FC } from 'react';
 import { defineMessages } from 'react-intl';
 
 import { usePaymentBuilderContext } from '~context/PaymentBuilderContext/PaymentBuilderContext.ts';
-import { type Expenditure } from '~types/graphql.ts';
+import { ColonyActionType, type Expenditure } from '~types/graphql.ts';
 import { formatText } from '~utils/intl.ts';
 import Button from '~v5/shared/Button/Button.tsx';
 import TxButton from '~v5/shared/Button/TxButton.tsx';
@@ -17,6 +17,7 @@ import StepDetailsBlock from '../StepDetailsBlock/StepDetailsBlock.tsx';
 import MilestoneReleaseModal from './partials/MilestoneReleaseModal/MilestoneReleaseModal.tsx';
 import { type MilestoneItem } from './partials/MilestoneReleaseModal/types.ts';
 import ReleasedBox from './partials/ReleasedBox/ReleasedBox.tsx';
+import { type ReleaseBoxItem } from './partials/ReleasedBoxItem/ReleasedBoxItem.tsx';
 
 const displayName =
   'v5.common.CompletedAction.partials.PaymentBuilder.partials.StagedPaymentStep';
@@ -57,6 +58,7 @@ const StagedPaymentStep: FC<StagedPaymentStepProps> = ({
     toggleOffMilestoneModal: hideModal,
     selectedMilestones,
     setSelectedMilestones,
+    setSelectedMilestoneMotion,
   } = usePaymentBuilderContext();
 
   const firstMilestone = items
@@ -69,19 +71,107 @@ const StagedPaymentStep: FC<StagedPaymentStepProps> = ({
   };
 
   const notReleasedMilestones = items.filter((item) => !item.isClaimed);
-  const releasedMilestones = items.filter((item) => item.isClaimed);
   const hasAllMilestonesReleased = isEqual(
     notReleasedMilestones,
     selectedMilestones,
   );
+  const releaseMilestoneMotions = expenditure.motions?.items.filter(
+    (motion) =>
+      motion?.action?.type === ColonyActionType.ReleaseStagedPaymentsMotion,
+  );
+  const motionMilestones: ReleaseBoxItem[] = (
+    releaseMilestoneMotions || []
+  ).map((motion, index) => {
+    const matchingItems = items.filter((milestone) =>
+      motion?.expenditureSlotIds?.includes(milestone.slotId),
+    );
+
+    const slotIds = matchingItems.map((item) => item.slotId);
+
+    const firstItem = matchingItems[0];
+
+    return {
+      amount: firstItem.amount || '0',
+      isClaimed: firstItem.isClaimed || false,
+      milestone: firstItem.milestone || '',
+      slotId: slotIds,
+      tokenAddress: firstItem.tokenAddress || '',
+      transactionHash: motion?.transactionHash,
+      uniqueId: `${slotIds.join('-')}-${index + 1}`,
+      createdAt: motion?.createdAt || '',
+    };
+  });
+  const releasedMilestones = items
+    .filter((item) => item.isClaimed)
+    .map((item) => {
+      const createdAt = releaseActions.find((action) =>
+        action.slotIds.includes(item.slotId),
+      )?.createdAt;
+
+      return {
+        ...item,
+        uniqueId: `${item.slotId}-0`,
+        createdAt: createdAt || '',
+      };
+    })
+    .filter((item) => {
+      const motion = releaseMilestoneMotions?.find((m) =>
+        m?.expenditureSlotIds?.includes(item.slotId),
+      );
+
+      return !motion?.motionStateHistory.hasPassed;
+    });
+  const releaseItems = [...motionMilestones, ...releasedMilestones].sort(
+    (a, b) => {
+      if (new Date(a.createdAt) > new Date(b.createdAt)) return -1;
+      if (new Date(a.createdAt) < new Date(b.createdAt)) return 1;
+      return 0;
+    },
+  );
+  const hasEveryMotionEnded =
+    releaseMilestoneMotions &&
+    releaseMilestoneMotions.length > 0 &&
+    releaseMilestoneMotions.every(
+      (motion) =>
+        !motion?.motionStateHistory.hasPassed ||
+        !motion?.motionStateHistory.hasFailed ||
+        !motion?.motionStateHistory.hasFailedNotFinalizable,
+    );
+  const activeMotionsIds = (releaseMilestoneMotions || [])
+    .filter(
+      (motion) =>
+        !motion?.motionStateHistory.hasPassed ||
+        !motion?.motionStateHistory.hasFailed ||
+        !motion?.motionStateHistory.hasFailedNotFinalizable,
+    )
+    .flatMap((motion) => motion?.expenditureSlotIds || 0);
 
   const totals = getSummedTokens(items);
   const paid = getSummedTokens(items, true);
   const allPaid = items.every(({ isClaimed }) => isClaimed);
+  const hasAllStakesClaimed = releaseMilestoneMotions?.every((releaseMotion) =>
+    releaseMotion?.stakerRewards.every(
+      (stakerReward) => stakerReward.isClaimed,
+    ),
+  );
+
+  const motionMilestonesRef = React.useRef(motionMilestones);
+
+  useEffect(() => {
+    if (motionMilestonesRef.current.length !== motionMilestones.length) {
+      if (!motionMilestones) {
+        return;
+      }
+      setSelectedMilestoneMotion(
+        motionMilestones?.[motionMilestones.length - 1],
+      );
+      motionMilestonesRef.current = motionMilestones;
+    }
+  }, [motionMilestones, setSelectedMilestoneMotion]);
 
   return (
     <>
-      {allPaid ? (
+      {allPaid && hasAllStakesClaimed ? (
         <PaymentOverview
           className="rounded-lg border border-gray-200 bg-base-white p-[1.125rem]"
           total={totals}
@@ -89,39 +179,40 @@ const StagedPaymentStep: FC<StagedPaymentStepProps> = ({
         />
       ) : (
         <>
-          {releasedMilestones.length > 0 && (
-            <ReleasedBox
-              items={releasedMilestones}
-              releaseActions={releaseActions}
+          {(releasedMilestones.length > 0 ||
+            (releaseMilestoneMotions || []).length > 0) && (
+            <ReleasedBox items={releaseItems} releaseActions={releaseActions} />
+          )}
+          {hasEveryMotionEnded && (
+            <StepDetailsBlock
+              text={formatText(MSG.releaseNextMilestone)}
+              content={
+                expectedStepKey === ExpenditureStep.Payment ? (
+                  <TxButton
+                    className="max-h-[2.5rem] w-full !text-md"
+                    rounded="s"
+                    text={{ id: 'button.pending' }}
+                    icon={
+                      <span className="ml-1.5 flex shrink-0">
+                        <SpinnerGap className="animate-spin" size={14} />
+                      </span>
+                    }
+                  />
+                ) : (
+                  <Button
+                    className="w-full"
+                    onClick={releaseNextMilestone}
+                    text={formatText(MSG.releaseNextButton)}
+                  />
+                )
+              }
             />
           )}
-          <StepDetailsBlock
-            text={formatText(MSG.releaseNextMilestone)}
-            content={
-              expectedStepKey === ExpenditureStep.Payment ? (
-                <TxButton
-                  className="max-h-[2.5rem] w-full !text-md"
-                  rounded="s"
-                  text={{ id: 'button.pending' }}
-                  icon={
-                    <span className="ml-1.5 flex shrink-0">
-                      <SpinnerGap className="animate-spin" size={14} />
-                    </span>
-                  }
-                />
-              ) : (
-                <Button
-                  className="w-full"
-                  onClick={releaseNextMilestone}
-                  text={formatText(MSG.releaseNextButton)}
-                />
-              )
-            }
-          />
         </>
       )}
       <MilestoneReleaseModal
         items={selectedMilestones}
+        motionIds={activeMotionsIds}
         expenditure={expenditure}
         isOpen={isMilestoneModalOpen}
         hasAllMilestonesReleased={hasAllMilestonesReleased}

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/MilestoneReleaseModal.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/MilestoneReleaseModal.tsx
@@ -56,12 +56,18 @@ const MSG = defineMessages({
     id: `${displayName}.releaseAllPayments`,
     defaultMessage: 'Make payments',
   },
+  duplicatedMotion: {
+    id: `${displayName}.duplicatedMotion`,
+    defaultMessage:
+      'A request already exists for this milestone. You can use an alternative decision method, if you have the option to.',
+  },
 });
 
 const MilestoneModalContent: FC<MilestoneModalContentProps> = ({
   onClose,
   items,
   hasAllMilestonesReleased,
+  motionIds,
 }) => {
   const {
     watch,
@@ -75,6 +81,10 @@ const MilestoneModalContent: FC<MilestoneModalContentProps> = ({
 
   const noDecisionMethodAvailable = fundingDecisionMethodOptions.every(
     ({ isDisabled }) => isDisabled,
+  );
+
+  const hasMotionActive = items.some(({ slotId }) =>
+    motionIds.find((motionId) => motionId === slotId),
   );
 
   return (
@@ -100,6 +110,14 @@ const MilestoneModalContent: FC<MilestoneModalContentProps> = ({
           options={fundingDecisionMethodOptions}
           name="decisionMethod"
         />
+        {method &&
+          method.value &&
+          method.value === DecisionMethod.Reputation &&
+          hasMotionActive && (
+            <div className="mt-4 rounded-[.25rem] border border-negative-300 bg-negative-100 p-[1.125rem] text-sm font-medium text-negative-400">
+              {formatText(MSG.duplicatedMotion)}
+            </div>
+          )}
         {method && method.value && (
           <div className="mt-4 rounded border border-gray-300 bg-base-bg p-[1.125rem]">
             <p className="text-sm text-gray-600">
@@ -155,6 +173,7 @@ const MilestoneReleaseModal: FC<MilestoneReleaseModalProps> = ({
   onClose,
   hasAllMilestonesReleased,
   expenditure,
+  motionIds,
 }) => {
   const { colony } = useColonyContext();
   const { user } = useAppContext();
@@ -219,6 +238,7 @@ const MilestoneReleaseModal: FC<MilestoneReleaseModalProps> = ({
       >
         <MilestoneModalContent
           items={items}
+          motionIds={motionIds}
           onClose={onClose}
           hasAllMilestonesReleased={hasAllMilestonesReleased}
         />

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/types.ts
@@ -12,9 +12,10 @@ export interface MilestoneReleaseModalProps extends ModalProps {
   items: MilestoneItem[];
   hasAllMilestonesReleased: boolean;
   expenditure: Expenditure;
+  motionIds: number[];
 }
 
 export type MilestoneModalContentProps = Pick<
   MilestoneReleaseModalProps,
-  'onClose' | 'items' | 'hasAllMilestonesReleased'
+  'onClose' | 'items' | 'hasAllMilestonesReleased' | 'motionIds'
 >;

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/ReleasedBoxItem/ReleasedBoxItem.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/ReleasedBoxItem/ReleasedBoxItem.tsx
@@ -1,0 +1,87 @@
+import clsx from 'clsx';
+import React, { type FC } from 'react';
+import { defineMessages } from 'react-intl';
+
+import ActionBadge from '~common/ColonyActionsTable/partials/ActionBadge/ActionBadge.tsx';
+import { usePaymentBuilderContext } from '~context/PaymentBuilderContext/PaymentBuilderContext.ts';
+import SpinnerLoader from '~shared/Preloaders/SpinnerLoader.tsx';
+import { formatText } from '~utils/intl.ts';
+import useGetColonyAction from '~v5/common/ActionSidebar/hooks/useGetColonyAction.ts';
+import PillsBase from '~v5/common/Pills/PillsBase.tsx';
+
+import { type MilestoneItem } from '../MilestoneReleaseModal/types.ts';
+
+const displayName =
+  'v5.common.CompletedAction.partials.PaymentBuilder.partials.StagedReleaseStep.partials.ReleasedBoxItem';
+
+export interface ReleaseBoxItem extends Omit<MilestoneItem, 'slotId'> {
+  transactionHash?: string;
+  uniqueId: string;
+  createdAt: string;
+  slotId: number | number[];
+}
+
+interface ReleasedBoxItemProps {
+  item: ReleaseBoxItem;
+  isReleasingMultipleMilestones?: boolean;
+}
+
+const MSG = defineMessages({
+  releaseAll: {
+    id: `${displayName}.releaseAll`,
+    defaultMessage: 'All remaining milestones',
+  },
+});
+
+const ReleasedBoxItem: FC<ReleasedBoxItemProps> = ({
+  item,
+  isReleasingMultipleMilestones,
+}) => {
+  const { setSelectedMilestoneMotion, selectedMilestoneMotion } =
+    usePaymentBuilderContext();
+  const { motionState, loadingAction } = useGetColonyAction(
+    item?.transactionHash,
+  );
+
+  return (
+    <button
+      className="group flex w-full items-center justify-between gap-2"
+      type="button"
+      onClick={() => setSelectedMilestoneMotion(item)}
+    >
+      <span
+        className={clsx(
+          'truncate text-sm underline transition-colors group-hover:text-blue-400',
+          {
+            'text-blue-400':
+              selectedMilestoneMotion?.uniqueId === item.uniqueId,
+          },
+        )}
+      >
+        {isReleasingMultipleMilestones
+          ? formatText(MSG.releaseAll)
+          : item.milestone}
+      </span>
+      {!item.transactionHash ? (
+        <PillsBase
+          className="bg-success-100 text-success-400"
+          isCapitalized={false}
+        >
+          {formatText({ id: 'action.passed' })}
+        </PillsBase>
+      ) : (
+        <>
+          {loadingAction ? (
+            <SpinnerLoader />
+          ) : (
+            <ActionBadge motionState={motionState} />
+          )}
+        </>
+      )}
+    </button>
+  );
+};
+
+ReleasedBoxItem.displayName = displayName;
+
+export default ReleasedBoxItem;

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentTable/StagedPaymentTable.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentTable/StagedPaymentTable.tsx
@@ -37,18 +37,18 @@ const useStagedPaymentTableColumns = (
   isPaymentStep?: boolean,
   isLoading?: boolean,
 ) => {
-  const hasMoreThanOneToken = data.length > 1;
   const dataRef = useWrapWithRef(data);
+  const hasMoreThanOneToken = dataRef.current.length > 1;
   const isMobile = useMobile();
   const { toggleOnMilestoneModal: showModal, setSelectedMilestones } =
     usePaymentBuilderContext();
+  const hasMoreThanOneMilestone =
+    dataRef.current.filter((item) => !item.isClaimed).length > 1;
 
   const columns: ColumnDef<StagedPaymentRecipientsFieldModel, string>[] =
     useMemo(() => {
       const columnHelper =
         createColumnHelper<StagedPaymentRecipientsFieldModel>();
-      const hasMoreThanOneMilestone =
-        dataRef.current.filter((item) => !item.isClaimed).length > 1;
 
       return [
         columnHelper.accessor('milestone', {
@@ -156,6 +156,7 @@ const useStagedPaymentTableColumns = (
       ];
     }, [
       hasMoreThanOneToken,
+      hasMoreThanOneMilestone,
       isPaymentStep,
       isMobile,
       dataRef,

--- a/src/context/PaymentBuilderContext/PaymentBuilderContext.ts
+++ b/src/context/PaymentBuilderContext/PaymentBuilderContext.ts
@@ -2,6 +2,7 @@ import { createContext, useContext } from 'react';
 
 import noop from '~utils/noop.ts';
 import { type MilestoneItem } from '~v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/types.ts';
+import { type ReleaseBoxItem } from '~v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/ReleasedBoxItem/ReleasedBoxItem.tsx';
 
 export const PaymentBuilderContext = createContext<{
   toggleOnFundingModal: () => void;
@@ -15,6 +16,8 @@ export const PaymentBuilderContext = createContext<{
   isReleaseModalOpen: boolean;
   selectedTransaction: string;
   setSelectedTransaction: (transaction: string) => void;
+  selectedMilestoneMotion: ReleaseBoxItem | null;
+  setSelectedMilestoneMotion: (transaction: ReleaseBoxItem) => void;
   selectedMilestones: MilestoneItem[];
   setSelectedMilestones: (transaction: MilestoneItem[]) => void;
 }>({
@@ -29,6 +32,8 @@ export const PaymentBuilderContext = createContext<{
   isReleaseModalOpen: false,
   selectedTransaction: '',
   setSelectedTransaction: noop,
+  selectedMilestoneMotion: null,
+  setSelectedMilestoneMotion: noop,
   selectedMilestones: [],
   setSelectedMilestones: noop,
 });

--- a/src/context/PaymentBuilderContext/PaymentBuilderContextProvider.tsx
+++ b/src/context/PaymentBuilderContext/PaymentBuilderContextProvider.tsx
@@ -7,6 +7,7 @@ import React, {
 
 import useToggle from '~hooks/useToggle/index.ts';
 import { type MilestoneItem } from '~v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/types.ts';
+import { type ReleaseBoxItem } from '~v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/ReleasedBoxItem/ReleasedBoxItem.tsx';
 
 import { PaymentBuilderContext } from './PaymentBuilderContext.ts';
 
@@ -27,6 +28,8 @@ const PaymentBuilderContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const [selectedMilestones, setSelectedMilestones] = useState<MilestoneItem[]>(
     [],
   );
+  const [selectedMilestoneMotion, setSelectedMilestoneMotion] =
+    useState<ReleaseBoxItem | null>(null);
 
   const value = useMemo(
     () => ({
@@ -43,6 +46,8 @@ const PaymentBuilderContextProvider: FC<PropsWithChildren> = ({ children }) => {
       setSelectedTransaction,
       selectedMilestones,
       setSelectedMilestones,
+      selectedMilestoneMotion,
+      setSelectedMilestoneMotion,
     }),
     [
       toggleOnFundingModal,
@@ -58,6 +63,8 @@ const PaymentBuilderContextProvider: FC<PropsWithChildren> = ({ children }) => {
       setSelectedTransaction,
       selectedMilestones,
       setSelectedMilestones,
+      selectedMilestoneMotion,
+      setSelectedMilestoneMotion,
     ],
   );
 


### PR DESCRIPTION
## Description

- Added flow for staged payment for permission and reputation method
- Issue - https://github.com/JoinColony/colonyCDapp/issues/2669

## Testing

* Install Staged payment extension and give this extension owner permission
* Create staged payment action and go to payment step (every step before payment should work the same as in payment builder action)
* Release payments using permission (reputation method will be handled in next PR)
