### PR TITLE
Feat: Refetch extension data when updating thresholds

### DIFF
--- a/src/components/frame/Extensions/pages/partials/SaveSettingsButton.tsx
+++ b/src/components/frame/Extensions/pages/partials/SaveSettingsButton.tsx
@@ -7,12 +7,16 @@ import ActionButton from '~v5/shared/Button/ActionButton.tsx';
 const displayName = 'pages.ExtensionDetailsPage.SaveSettingsButton';
 
 const SaveSettingsButton = () => {
-  const { isVisible, actionType, handleGetValues } = useContext(
-    ExtensionSaveSettingsContext,
-  );
+  const { isVisible, actionType, handleGetValues, handleOnSuccess } =
+    useContext(ExtensionSaveSettingsContext);
 
   return isVisible && !!actionType ? (
-    <ActionButton useTxLoader actionType={actionType} values={handleGetValues}>
+    <ActionButton
+      useTxLoader
+      actionType={actionType}
+      values={handleGetValues}
+      onSuccess={handleOnSuccess}
+    >
       {formatText({ id: 'button.saveSettings' })}
     </ActionButton>
   ) : null;

--- a/src/context/ExtensionSaveSettingsContext/ExtensionSaveSettingsContext.ts
+++ b/src/context/ExtensionSaveSettingsContext/ExtensionSaveSettingsContext.ts
@@ -13,6 +13,7 @@ interface ExtensionSaveSettingsContextValues {
   handleGetValues: () => any;
   handleSetVisible: (value: boolean) => void;
   handleSetActionType: (value: ActionTypes) => void;
+  handleOnSuccess: () => void;
   resetAll: () => void;
   callbackRef: RefObject<RefWithGetValues | null>;
 }
@@ -24,6 +25,7 @@ export const ExtensionSaveSettingsContext =
     handleGetValues: noop,
     handleSetVisible: noop,
     handleSetActionType: noop,
+    handleOnSuccess: noop,
     resetAll: noop,
     callbackRef: { current: null },
   });

--- a/src/context/ExtensionSaveSettingsContext/ExtensionSaveSettingsContextProvider.tsx
+++ b/src/context/ExtensionSaveSettingsContext/ExtensionSaveSettingsContextProvider.tsx
@@ -5,7 +5,9 @@ import React, {
   useMemo,
   useRef,
 } from 'react';
+import { useParams } from 'react-router-dom';
 
+import useExtensionData from '~hooks/useExtensionData.ts';
 import { type ActionTypes } from '~redux/actionTypes.ts';
 
 import {
@@ -16,6 +18,9 @@ import {
 export const ExtensionSaveSettingsContextProvider: FC<PropsWithChildren> = ({
   children,
 }) => {
+  const { extensionId } = useParams();
+  const { refetchExtensionData } = useExtensionData(extensionId ?? '');
+
   const [isVisible, setIsVisible] = useState(false);
   const [actionType, setActionType] = useState<ActionTypes | null>(null);
   const callbackRef = useRef<RefWithGetValues | null>(null);
@@ -34,6 +39,10 @@ export const ExtensionSaveSettingsContextProvider: FC<PropsWithChildren> = ({
     setActionType(null);
   };
 
+  const handleOnSuccess = () => {
+    refetchExtensionData();
+  };
+
   const value = useMemo(
     () => ({
       callbackRef,
@@ -42,6 +51,7 @@ export const ExtensionSaveSettingsContextProvider: FC<PropsWithChildren> = ({
       handleGetValues,
       handleSetVisible,
       handleSetActionType,
+      handleOnSuccess,
       resetAll,
     }),
     [isVisible, actionType],


### PR DESCRIPTION
## Description

When we attempt to create a multi-sig action, we check the threshold settings from the extension data.

This PR adds an onSuccess function to the 'Save settings' button to refetch the extension data after a successful save. This means when we next check the thresholds we don't have stale data.

## Testing

Do not refresh the page at any step of testing

Step 1 - Install the extension (this should give Leela multi-sig permissions)
Step 2 - Open the action sidebar select create a mint tokens multi-sig action - there should be no error notices as the threshold is set to “majority” and you are the only user with multi-sig permissions
Step 3 - Close the sidebar, and change to a fixed threshold of 2. Click save. Now we are expecting an error notice as we do not have enough users with permissions to meet the threshold.

<img width="815" alt="Screenshot 2024-07-29 at 11 38 08" src="https://github.com/user-attachments/assets/4b1c4e7a-3997-48a4-8c30-c87c5cbe58cf">

Step 4 - Open the action sidebar again and select create a mint tokens action with the multi-sig decision method. We should have the error notice.

<img width="678" alt="Screenshot 2024-07-29 at 11 39 55" src="https://github.com/user-attachments/assets/60100886-d066-4fb7-8ac9-e60d841f1325">

If you want to further validate this is working, set the fixed threshold to 1 and the notice should be gone.

## Diffs

**New stuff** ✨

* New stuff goes here

**Changes** 🏗

* Changes go here

**Deletions** ⚰️

* Deletions go here

## TODO

- [ ] Add TODOs

Contributes to #2658
