### PR TITLE
[Multi-sig] feat: disable submit motion until we know if there are enough members, fetching optimisation

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -1,7 +1,7 @@
 import { useApolloClient } from '@apollo/client';
 import { WarningCircle } from '@phosphor-icons/react';
 import clsx from 'clsx';
-import React, { useEffect, type FC } from 'react';
+import React, { useEffect, type FC, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 
@@ -35,10 +35,8 @@ import ActionSidebarDescription from '../ActionSidebarDescription/ActionSidebarD
 import Motions from '../Motions/index.ts';
 import RemoveDraftModal from '../RemoveDraftModal/RemoveDraftModal.tsx';
 
-import {
-  useGetFormActionErrors,
-  useHasEnoughMembersWithPermissions,
-} from './hooks.ts';
+import { useGetFormActionErrors } from './hooks.ts';
+import { MultiSigMembersError } from './partials/MultiSigMembersError/MultiSigMembersError.tsx';
 import NoPermissionsError from './partials/NoPermissionsError.tsx';
 import NoReputationError from './partials/NoReputationError.tsx';
 import PermissionSidebar from './partials/PermissionSidebar.tsx';
@@ -61,6 +59,19 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
   const { readonly } = useAdditionalFormOptionsContext();
   const { flatFormErrors } = useGetFormActionErrors();
 
+  const [areMemberPermissionsLoading, setAreMemberPermissionsLoading] =
+    useState(false);
+  // Until we choose Multi-Sig as the decision method we can safely assume this is true
+  const [canCreateAction, setCanCreateAction] = useState(true);
+
+  const updateMembersLoadingState = (isLoading: boolean) => {
+    setAreMemberPermissionsLoading(isLoading);
+  };
+
+  const updateCanCreateAction = (canCreate: boolean) => {
+    setCanCreateAction(canCreate);
+  };
+
   const {
     formState: {
       errors: { this: customError },
@@ -71,20 +82,22 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
 
   const formValues = getValues();
 
+  const decisionMethod = formValues[DECISION_METHOD_FIELD_NAME];
+
+  // if we switch decision method to something not multisig, we "stop" loading and assume we can create the action
+  useEffect(() => {
+    setAreMemberPermissionsLoading(false);
+    setCanCreateAction(true);
+  }, [decisionMethod]);
+
   const hasPermissions = useHasActionPermissions();
   const hasNoDecisionMethods = useHasNoDecisionMethods();
-  const { hasEnoughMembersWithPermissions, isLoading } =
-    useHasEnoughMembersWithPermissions({
-      decisionMethod: formValues[DECISION_METHOD_FIELD_NAME],
-      selectedAction: formValues[ACTION_TYPE_FIELD_NAME],
-      createdIn: formValues[CREATED_IN_FIELD_NAME],
-    });
 
   const isSubmitDisabled =
     !selectedAction ||
     hasPermissions === false ||
-    !hasEnoughMembersWithPermissions ||
-    isLoading ||
+    areMemberPermissionsLoading ||
+    !canCreateAction ||
     hasNoDecisionMethods;
 
   const [isModalVisible, { toggleOn: showModal, toggleOff: hideModal }] =
@@ -133,9 +146,13 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
             <ActionSidebarDescription />
           </div>
         )}
-        <SidebarBanner
-          hasEnoughMembersWithPermissions={hasEnoughMembersWithPermissions}
-        />
+        <SidebarBanner />
+        {decisionMethod === DecisionMethod.MultiSig && (
+          <MultiSigMembersError
+            updateCanCreateAction={updateCanCreateAction}
+            updateMembersLoadingState={updateMembersLoadingState}
+          />
+        )}
         {!readonly && <NoPermissionsError />}
         <ActionTypeSelect
           className={clsx(

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/hooks.ts
@@ -1,14 +1,8 @@
-import { useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { type Action } from '~constants/actions.ts';
-import { useDomainThreshold } from '~hooks/multiSig/useDomainThreshold.ts';
-import { useEligibleSignees } from '~hooks/multiSig/useEligibleSignees.ts';
 import useFlatFormErrors from '~hooks/useFlatFormErrors.ts';
-import { DecisionMethod } from '~types/actions.ts';
 import { uniqBy } from '~utils/lodash.ts';
 
-import { getPermissionsNeededForAction } from '../../hooks/permissions/helpers.ts';
 import { REPUTATION_VALIDATION_FIELD_NAME } from '../../hooks/useReputationValidation.ts';
 
 export const useGetFormActionErrors = () => {
@@ -24,67 +18,5 @@ export const useGetFormActionErrors = () => {
 
   return {
     flatFormErrors,
-  };
-};
-
-interface UseHasEnoughMembersWithPermissionsResult {
-  hasEnoughMembersWithPermissions: boolean;
-  isLoading: boolean;
-}
-
-// @TODO somehow rework this so we don't always fetch it, but only call the business logic if decision method is multisig
-export const useHasEnoughMembersWithPermissions = ({
-  decisionMethod,
-  selectedAction,
-  createdIn,
-}: {
-  decisionMethod: DecisionMethod;
-  selectedAction: Action;
-  createdIn: number;
-}): UseHasEnoughMembersWithPermissionsResult => {
-  const { watch } = useFormContext();
-  const formValues = watch();
-
-  const requiredRoles = useMemo(
-    () => getPermissionsNeededForAction(selectedAction, formValues) || [],
-    [selectedAction, formValues],
-  );
-
-  /*
-   * This may seem like a hack, but for display purposes, we always fetch all possible roles
-   * The only action where this can break is managing permissions in a subdomain via permissions, not via multisig, so we are good
-   */
-  const multiSigRoles = requiredRoles.flat();
-
-  const { thresholdPerRole, isLoading: isDomainThresholdLoading } =
-    useDomainThreshold({
-      domainId: createdIn,
-      requiredRoles: multiSigRoles,
-    });
-
-  const { countPerRole, isLoading: areEligibleSigneesLoading } =
-    useEligibleSignees({
-      domainId: createdIn,
-      requiredRoles: multiSigRoles,
-    });
-
-  if (
-    decisionMethod !== DecisionMethod.MultiSig ||
-    !thresholdPerRole ||
-    !requiredRoles
-  ) {
-    return {
-      hasEnoughMembersWithPermissions: true,
-      isLoading: false,
-    };
-  }
-
-  const hasEnoughMembersWithPermissions = requiredRoles.some((roles) =>
-    roles.every((role) => countPerRole[role] >= thresholdPerRole[role]),
-  );
-
-  return {
-    hasEnoughMembersWithPermissions,
-    isLoading: isDomainThresholdLoading || areEligibleSigneesLoading,
   };
 };

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/MultiSigMembersError/MultiSigMembersError.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/MultiSigMembersError/MultiSigMembersError.tsx
@@ -1,0 +1,59 @@
+import { WarningCircle } from '@phosphor-icons/react';
+import { useEffect, type FC } from 'react';
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  ACTION_TYPE_FIELD_NAME,
+  CREATED_IN_FIELD_NAME,
+} from '~v5/common/ActionSidebar/consts.ts';
+import NotificationBanner from '~v5/shared/NotificationBanner/NotificationBanner.tsx';
+
+import { useHasEnoughMembersWithPermissions } from './useHasEnoughMembersWithPermissions.ts';
+
+const displayName =
+  'v5.common.ActionSidebar.ActionSidebarContent.MultiSigMembersError';
+
+// Needs these two props to notice the parent about the loading state and sync the can create value
+// It's conditionally rendered, so it won't slow down the app until we choose Multi-Sig as the decision method
+interface MultiSigMembersErrorProps {
+  updateMembersLoadingState: (isLoading: boolean) => void;
+  updateCanCreateAction: (canCreate: boolean) => void;
+}
+
+export const MultiSigMembersError: FC<MultiSigMembersErrorProps> = ({
+  updateMembersLoadingState,
+  updateCanCreateAction,
+}) => {
+  const { watch } = useFormContext();
+  const [selectedAction, createdIn] = watch([
+    ACTION_TYPE_FIELD_NAME,
+    CREATED_IN_FIELD_NAME,
+  ]);
+
+  const { isLoading, hasEnoughMembersWithPermissions } =
+    useHasEnoughMembersWithPermissions({ createdIn, selectedAction });
+
+  useEffect(() => {
+    updateMembersLoadingState(isLoading);
+  }, [isLoading, updateMembersLoadingState]);
+
+  useEffect(() => {
+    updateCanCreateAction(hasEnoughMembersWithPermissions);
+  }, [hasEnoughMembersWithPermissions, updateCanCreateAction]);
+
+  if (!hasEnoughMembersWithPermissions) {
+    return (
+      <div className="mt-6">
+        <NotificationBanner icon={WarningCircle} status="error">
+          <FormattedMessage id="actionSidebar.notEnoughMembersWithPermissions" />
+        </NotificationBanner>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+MultiSigMembersError.displayName = displayName;

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/MultiSigMembersError/useHasEnoughMembersWithPermissions.ts
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/MultiSigMembersError/useHasEnoughMembersWithPermissions.ts
@@ -1,0 +1,65 @@
+import { useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { type Action } from '~constants/actions.ts';
+import { useDomainThreshold } from '~hooks/multiSig/useDomainThreshold.ts';
+import { useEligibleSignees } from '~hooks/multiSig/useEligibleSignees.ts';
+
+import { getPermissionsNeededForAction } from '../../../../hooks/permissions/helpers.ts';
+
+interface UseHasEnoughMembersWithPermissionsResult {
+  hasEnoughMembersWithPermissions: boolean;
+  isLoading: boolean;
+}
+
+export const useHasEnoughMembersWithPermissions = ({
+  selectedAction,
+  createdIn,
+}: {
+  selectedAction: Action;
+  createdIn: number;
+}): UseHasEnoughMembersWithPermissionsResult => {
+  const { watch } = useFormContext();
+  const formValues = watch();
+
+  const requiredRoles = useMemo(
+    () => getPermissionsNeededForAction(selectedAction, formValues) || [],
+    [selectedAction, formValues],
+  );
+
+  /*
+   * This may seem like a hack, but for display purposes, we always fetch all possible roles
+   * The only action where this can break is managing permissions in a subdomain via permissions, not via multisig, so we are good
+   */
+  const multiSigRoles = requiredRoles.flat();
+
+  const { thresholdPerRole, isLoading: isDomainThresholdLoading } =
+    useDomainThreshold({
+      domainId: createdIn,
+      requiredRoles: multiSigRoles,
+    });
+
+  const { countPerRole, isLoading: areEligibleSigneesLoading } =
+    useEligibleSignees({
+      domainId: createdIn,
+      requiredRoles: multiSigRoles,
+    });
+
+  const isLoading = isDomainThresholdLoading || areEligibleSigneesLoading;
+
+  if (!thresholdPerRole || !requiredRoles) {
+    return {
+      hasEnoughMembersWithPermissions: true,
+      isLoading,
+    };
+  }
+
+  const hasEnoughMembersWithPermissions = requiredRoles.some((roles) =>
+    roles.every((role) => countPerRole[role] >= thresholdPerRole[role]),
+  );
+
+  return {
+    hasEnoughMembersWithPermissions,
+    isLoading,
+  };
+};

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/SidebarBanner.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/SidebarBanner.tsx
@@ -31,13 +31,7 @@ const MSG = defineMessages({
   },
 });
 
-interface SidebarBannerProps {
-  hasEnoughMembersWithPermissions: boolean;
-}
-
-export const SidebarBanner: FC<SidebarBannerProps> = ({
-  hasEnoughMembersWithPermissions,
-}) => {
+export const SidebarBanner: FC = () => {
   const { watch } = useFormContext();
   const [selectedAction, decisionMethod] = watch([
     ACTION_TYPE_FIELD_NAME,
@@ -93,13 +87,6 @@ export const SidebarBanner: FC<SidebarBannerProps> = ({
         <div className="mt-6">
           <NotificationBanner icon={CheckCircle} status="success">
             <FormattedMessage id="actionSidebar.upToDate" />
-          </NotificationBanner>
-        </div>
-      )}
-      {!hasEnoughMembersWithPermissions && (
-        <div className="mt-6">
-          <NotificationBanner icon={WarningCircle} status="error">
-            <FormattedMessage id="actionSidebar.notEnoughMembersWithPermissions" />
           </NotificationBanner>
         </div>
       )}


### PR DESCRIPTION
## Description
When we were loading member data, we didn't disable submit, so users with a slow connection could technically submit the form before we even know if they can

https://github.com/user-attachments/assets/6cab29b7-5430-4bca-a43a-d130d72c61dc

## Testing

1. Install the Multi-Sig extension as `leela`
2. Give `amy` `Admin` Multi-Sig permissions in `General`
3. Refresh the page, open the dev tools on the `Network` tab (or use that GQL extension, whichever really), throttle the conenction to 3G
4. Try to create a mint tokens action, change all fields except changing the decision method to `Multi-Sig`, verify that nothing gets fetched
![image](https://github.com/user-attachments/assets/239fa24f-b68a-492e-b2d3-5545e9839292)
5. Choose `Multi-Sig` as the decision method, 2 things will happen in quick succession, verify both that:
a) The form submit is disabled at first with only 2 network requests going out
![image](https://github.com/user-attachments/assets/3d660d79-b442-402a-9321-cdc135d42b36)
b) After loading is done, verify that the banner appears up top, submit stays disabled
![image](https://github.com/user-attachments/assets/c7a49a01-f66f-45d1-b3fe-89756f341c55)
6. Choose a different action type like `Create new team`, use `Multi-sig` as the decision method, after some loading, the button should change from being disabled to enabled
![image](https://github.com/user-attachments/assets/fbc02ffa-5cf1-482d-9b22-5abbde3f9b26)

## Diffs

**New stuff** ✨

* `MultiSigMembersError` banner component which handles fetching if there are enough members

**Changes** 🏗

* `ActionSidebarContent` now keeps 2 state boolean values called `areMemberPermissionsLoading` and `canCreateAction` to use when deciding if form submit should be disabled

Contributes to #2658 
