### PR TITLE
Chore: Add Eslint absolute import rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -144,7 +144,7 @@ module.exports = {
     '@limegrass/import-alias/import-alias': [
       'error',
       {
-        relativeImportOverrides: [{ depth: 1 }],
+        relativeImportOverrides: [{ path: '.', depth: 1 }],
       },
     ],
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     'jsdoc',
     'react-hooks',
     'react-refresh',
+    '@limegrass/import-alias',
   ],
   overrides: [
     {
@@ -138,6 +139,12 @@ module.exports = {
           },
         ],
         warnOnUnassignedImports: true,
+      },
+    ],
+    '@limegrass/import-alias/import-alias': [
+      'error',
+      {
+        relativeImportOverrides: [{ depth: 1 }],
       },
     ],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,6 +118,7 @@
         "@import-meta-env/unplugin": "^0.5.1",
         "@jackfranklin/test-data-bot": "^1.4.0",
         "@jest/globals": "^29.0.2",
+        "@limegrass/eslint-plugin-import-alias": "^1.4.1",
         "@storybook/addon-essentials": "^8.0.0",
         "@storybook/addon-interactions": "^8.0.0",
         "@storybook/addon-links": "^8.0.0",
@@ -7038,6 +7039,58 @@
       "version": "2.0.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@limegrass/eslint-plugin-import-alias": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@limegrass/eslint-plugin-import-alias/-/eslint-plugin-import-alias-1.4.1.tgz",
+      "integrity": "sha512-3aWSwwih7CRfZu6XnoduuHn3PeeuhkYag+cDSNJG37xH2/zOp84DOhyJaBXNxU/NyNbB3XjF4o7P37EN1yep/g==",
+      "dev": true,
+      "dependencies": {
+        "fs-extra": "^10.0.1",
+        "micromatch": "^4.0.0",
+        "slash": "^3.0.0",
+        "tsconfig-paths": "^4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+      }
+    },
+    "node_modules/@limegrass/eslint-plugin-import-alias/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@limegrass/eslint-plugin-import-alias/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@limegrass/eslint-plugin-import-alias/node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@mdx-js/react": {
       "version": "3.0.1",
@@ -22664,7 +22717,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@import-meta-env/unplugin": "^0.5.1",
     "@jackfranklin/test-data-bot": "^1.4.0",
     "@jest/globals": "^29.0.2",
+    "@limegrass/eslint-plugin-import-alias": "^1.4.1",
     "@storybook/addon-essentials": "^8.0.0",
     "@storybook/addon-interactions": "^8.0.0",
     "@storybook/addon-links": "^8.0.0",

--- a/src/components/common/Extensions/UserHub/partials/ReputationTab/partials/PendingReputation/PendingReputation.tsx
+++ b/src/components/common/Extensions/UserHub/partials/ReputationTab/partials/PendingReputation/PendingReputation.tsx
@@ -1,13 +1,12 @@
 import React, { type FC, useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 
+import reputationTabClasses from '~common/Extensions/UserHub/partials/ReputationTab/ReputationTab.styles.ts';
+import { type PendingReputationProps } from '~common/Extensions/UserHub/partials/ReputationTab/types.ts';
 import { useGetReputationMiningCycleMetadataQuery } from '~gql';
 import useUserReputation from '~hooks/useUserReputation.ts';
 import TimeRelative from '~shared/TimeRelative/index.ts';
 import TitleLabel from '~v5/shared/TitleLabel/index.ts';
-
-import reputationTabClasses from '../../ReputationTab.styles.ts';
-import { type PendingReputationProps } from '../../types.ts';
 
 import {
   getNextMiningCycleDate,

--- a/src/components/common/Extensions/UserHub/partials/ReputationTab/types.ts
+++ b/src/components/common/Extensions/UserHub/partials/ReputationTab/types.ts
@@ -1,7 +1,6 @@
+import { type UserHubTab } from '~common/Extensions/UserHub/types.ts';
 import { type Token } from '~types/graphql.ts';
 import { type ColonyWallet } from '~types/wallet.ts';
-
-import { type UserHubTab } from '../../types.ts';
 
 export interface ReputationTabProps {
   onTabChange: (newTab: UserHubTab) => void;

--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/TransactionsItem/TransactionsItem.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/TransactionsItem/TransactionsItem.tsx
@@ -4,11 +4,11 @@ import { AnimatePresence, motion } from 'framer-motion';
 import React, { type FC } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
+import { type TransactionsItemProps } from '~common/Extensions/UserHub/partials/TransactionsTab/types.ts';
 import { accordionAnimation } from '~constants/accordionAnimation.ts';
 import { TransactionStatus } from '~gql';
 import NotificationBanner from '~v5/shared/NotificationBanner/index.ts';
 
-import { type TransactionsItemProps } from '../../types.ts';
 import TransactionsHeader from '../TransactionsHeader.tsx';
 
 import transactionsItemClasses from './TransactionsItem.styles.ts';

--- a/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Currency/Currency.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Currency/Currency.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
+import { currencyIcons } from '~common/Extensions/UserNavigation/partials/UserMenu/consts.ts';
+import CoinGeckoAttribution from '~common/Extensions/UserNavigation/partials/UserSubmenu/CoinGeckoAttribution.tsx';
 import { useCurrencyContext } from '~context/CurrencyContext/CurrencyContext.ts';
 import { SupportedCurrencies } from '~gql';
 import ClnyTokenIcon from '~icons/ClnyTokenIcon.tsx';
 
-import { currencyIcons } from '../../../UserMenu/consts.ts';
-import CoinGeckoAttribution from '../../CoinGeckoAttribution.tsx';
 import MenuList from '../MenuList/index.ts';
 import MenuListItem from '../MenuListItem/index.ts';
 import { actionItemClass, actionItemLabelClass } from '../submenu.styles.ts';

--- a/src/components/frame/Extensions/layouts/partials/ColonySwitcherContent/ColonySwitcherContent.tsx
+++ b/src/components/frame/Extensions/layouts/partials/ColonySwitcherContent/ColonySwitcherContent.tsx
@@ -3,12 +3,12 @@ import clsx from 'clsx';
 import React, { type FC } from 'react';
 import { defineMessages } from 'react-intl';
 
+import { getChainIcon } from '~frame/Extensions/layouts/utils.ts';
 import { SpinnerLoader } from '~shared/Preloaders/index.ts';
 import { formatText } from '~utils/intl.ts';
 import EmptyContent from '~v5/common/EmptyContent/index.ts';
 import SearchInput from '~v5/shared/SearchSelect/partials/SearchInput/index.ts';
 
-import { getChainIcon } from '../../utils.ts';
 import ColonySwitcherItem from '../ColonySwitcherItem/index.ts';
 
 import { useColonySwitcherContent } from './hooks.ts';

--- a/src/components/frame/Extensions/layouts/partials/DashboardContent/DashboardContent.tsx
+++ b/src/components/frame/Extensions/layouts/partials/DashboardContent/DashboardContent.tsx
@@ -1,11 +1,13 @@
 import React, { type FC } from 'react';
 
 import { useMemberContext } from '~context/MemberContext/MemberContext.ts';
+import {
+  dashboardMainMenu,
+  dashboardMenu,
+} from '~frame/Extensions/layouts/consts.ts';
 import { SpinnerLoader } from '~shared/Preloaders/index.ts';
 import { formatText } from '~utils/intl.ts';
 import NavigationSidebarLinksList from '~v5/frame/NavigationSidebar/partials/NavigationSidebarLinksList/index.ts';
-
-import { dashboardMainMenu, dashboardMenu } from '../../consts.ts';
 
 const DashboardContent: FC = () => {
   const { totalContributorCount, totalMemberCount, loading } =

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetails/hooks.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetails/hooks.tsx
@@ -3,12 +3,11 @@ import React, { useState } from 'react';
 import { toast } from 'react-toastify';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { waitForDbAfterExtensionAction } from '~frame/Extensions/pages/ExtensionDetailsPage/utils.tsx';
 import useAsyncFunction from '~hooks/useAsyncFunction.ts';
 import useExtensionData, { ExtensionMethods } from '~hooks/useExtensionData.ts';
 import { ActionTypes } from '~redux/index.ts';
 import Toast from '~shared/Extensions/Toast/index.ts';
-
-import { waitForDbAfterExtensionAction } from '../../utils.tsx';
 
 export const useDeprecate = ({ extensionId }: { extensionId: Extension }) => {
   const {

--- a/src/components/frame/v5/pages/AgreementsPage/partials/ActiveFiltersList/hooks.ts
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/ActiveFiltersList/hooks.ts
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 
+import { useFiltersContext } from '~frame/v5/pages/AgreementsPage/FiltersContext/index.ts';
+import { FiltersValues } from '~frame/v5/pages/AgreementsPage/FiltersContext/types.ts';
 import { formatText } from '~utils/intl.ts';
 
-import { useFiltersContext } from '../../FiltersContext/index.ts';
-import { FiltersValues } from '../../FiltersContext/types.ts';
 import { DATE_FILTERS } from '../AgreementsPageFilters/partials/DateFilters/consts.ts';
 import { STATUS_FILTERS } from '../AgreementsPageFilters/partials/StatusFilters/consts.ts';
 import { getCustomDateLabel } from '../AgreementsPageFilters/utils.ts';

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/AgreementsPageFilters.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/AgreementsPageFilters.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import React, { useState, type FC } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
 
+import { useFiltersContext } from '~frame/v5/pages/AgreementsPage/FiltersContext/FiltersContext.ts';
 import { useMobile } from '~hooks/index.ts';
 import { formatText } from '~utils/intl.ts';
 import SearchInput from '~v5/common/Filter/partials/SearchInput/index.ts';
@@ -11,7 +12,6 @@ import FilterButton from '~v5/shared/Filter/FilterButton.tsx';
 import Modal from '~v5/shared/Modal/index.ts';
 import PopoverBase from '~v5/shared/PopoverBase/index.ts';
 
-import { useFiltersContext } from '../../FiltersContext/FiltersContext.ts';
 import ActiveFiltersList from '../ActiveFiltersList/ActiveFiltersList.tsx';
 import AgreementsPageFiltersItem from '../AgreementsPageFiltersItem/index.ts';
 

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/partials/ActiveFiltersList/hooks.ts
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/partials/ActiveFiltersList/hooks.ts
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 
+import { useFiltersContext } from '~frame/v5/pages/BalancePage/partials/BalanceTable/Filters/FiltersContext/index.ts';
+import { FiltersValues } from '~frame/v5/pages/BalancePage/partials/BalanceTable/Filters/FiltersContext/types.ts';
 import { formatText } from '~utils/intl.ts';
 
-import { useFiltersContext } from '../../FiltersContext/index.ts';
-import { FiltersValues } from '../../FiltersContext/types.ts';
 import { ATTRIBUTE_FILTERS } from '../filters/AttributeFilters/consts.ts';
 import { useGetTokenTypeFilters } from '../filters/TokenFilters/hooks.ts';
 

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/partials/filters/AttributeFilters/AttributeFilters.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/partials/filters/AttributeFilters/AttributeFilters.tsx
@@ -1,9 +1,8 @@
 import React, { type FC } from 'react';
 
+import { useFiltersContext } from '~frame/v5/pages/BalancePage/partials/BalanceTable/Filters/FiltersContext/FiltersContext.ts';
 import { formatText } from '~utils/intl.ts';
 import Checkbox from '~v5/common/Checkbox/index.ts';
-
-import { useFiltersContext } from '../../../FiltersContext/FiltersContext.ts';
 
 import { ATTRIBUTE_FILTERS } from './consts.ts';
 

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/partials/filters/TokenFilters/TokenFilters.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/partials/filters/TokenFilters/TokenFilters.tsx
@@ -1,11 +1,10 @@
 import React, { type FC } from 'react';
 
+import { useFiltersContext } from '~frame/v5/pages/BalancePage/partials/BalanceTable/Filters/FiltersContext/FiltersContext.ts';
 import { formatText } from '~utils/intl.ts';
 import { multiLineTextEllipsis } from '~utils/strings.ts';
 import Checkbox from '~v5/common/Checkbox/index.ts';
 import { TokenAvatar } from '~v5/shared/TokenAvatar/TokenAvatar.tsx';
-
-import { useFiltersContext } from '../../../FiltersContext/FiltersContext.ts';
 
 import { useGetTokenTypeFilters } from './hooks.ts';
 

--- a/src/components/frame/v5/pages/MembersPage/partials/MembersTabContent/hooks.tsx
+++ b/src/components/frame/v5/pages/MembersPage/partials/MembersTabContent/hooks.tsx
@@ -7,6 +7,10 @@ import { DEFAULT_NETWORK_INFO } from '~constants/index.ts';
 import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 // @BETA: Disabled for now
 // import { useMemberModalContext } from '~context/MemberModalContext';
+import {
+  type MemberCardItem,
+  type MemberItem,
+} from '~frame/v5/pages/MembersPage/types.ts';
 import { useMobile } from '~hooks';
 import useCopyToClipboard from '~hooks/useCopyToClipboard.ts';
 import Tooltip from '~shared/Extensions/Tooltip/index.ts';
@@ -14,8 +18,6 @@ import { getBlockExplorerLink } from '~utils/external/index.ts';
 import { formatText } from '~utils/intl.ts';
 import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import Link from '~v5/shared/Link/index.ts';
-
-import { type MemberCardItem, type MemberItem } from '../../types.ts';
 
 export const useMembersTabContentItems = (
   items: MemberItem[],

--- a/src/components/frame/v5/pages/MembersPage/partials/MembersTabContent/types.ts
+++ b/src/components/frame/v5/pages/MembersPage/partials/MembersTabContent/types.ts
@@ -1,7 +1,6 @@
+import { type MemberItem } from '~frame/v5/pages/MembersPage/types.ts';
 import { type EmptyContentProps } from '~v5/common/EmptyContent/types.ts';
 import { type TextButtonProps } from '~v5/shared/Button/types.ts';
-
-import { type MemberItem } from '../../types.ts';
 
 export interface MembersTabContentProps {
   items: MemberItem[];

--- a/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/FilterItem.tsx
+++ b/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/FilterItem.tsx
@@ -2,14 +2,13 @@ import { CaretDown } from '@phosphor-icons/react';
 import React, { type FC } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
 
+import { type TeamsPageFiltersField } from '~frame/v5/pages/TeamsPage/types.ts';
 import { type ModelSortDirection } from '~gql';
 import { useMobile } from '~hooks';
 import useToggle from '~hooks/useToggle/index.ts';
 import Checkbox from '~v5/common/Checkbox/index.ts';
 import AccordionItem from '~v5/shared/Accordion/partials/AccordionItem/index.ts';
 import PopoverBase from '~v5/shared/PopoverBase/PopoverBase.tsx';
-
-import { type TeamsPageFiltersField } from '../../types.ts';
 
 import { type TeamsPageFilterRootProps } from './types.ts';
 

--- a/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/types.ts
+++ b/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/types.ts
@@ -1,11 +1,10 @@
 import { type Icon } from '@phosphor-icons/react';
 
-import { type ModelSortDirection } from '~gql';
-
 import {
   type TeamsPageFiltersField,
   type TeamsPageFilters,
-} from '../../types.ts';
+} from '~frame/v5/pages/TeamsPage/types.ts';
+import { type ModelSortDirection } from '~gql';
 
 export interface RootItem {
   name: TeamsPageFiltersField;

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/AutomaticDeposits/AutomaticDeposits.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/AutomaticDeposits/AutomaticDeposits.tsx
@@ -3,12 +3,12 @@ import { toast } from 'react-toastify';
 
 import { LEARN_MORE_CRYPTO_TO_FIAT } from '~constants';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
+import { useCryptoToFiatContext } from '~frame/v5/pages/UserCryptoToFiatPage/context/CryptoToFiatContext.ts';
 import { KycStatus, useUpdateUserProfileMutation } from '~gql';
 import Toast from '~shared/Extensions/Toast/Toast.tsx';
 import { formatText } from '~utils/intl.ts';
 import Switch from '~v5/common/Fields/Switch/Switch.tsx';
 
-import { useCryptoToFiatContext } from '../../context/CryptoToFiatContext.ts';
 import RowItem from '../RowItem/index.ts';
 
 import { BODY_MSG, getBadgeProps, HEADING_MSG } from './consts.ts';

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/AutomaticDeposits/consts.ts
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/AutomaticDeposits/consts.ts
@@ -1,12 +1,11 @@
 import { WarningCircle } from '@phosphor-icons/react';
 import { defineMessages } from 'react-intl';
 
+import { type KycStatusData } from '~frame/v5/pages/UserCryptoToFiatPage/types.ts';
 import { KycStatus } from '~gql';
 import { type BridgeBankAccount } from '~types/graphql.ts';
 import { formatText } from '~utils/intl.ts';
 import { type CryptoToFiatBadgeProps } from '~v5/common/Pills/CryptoToFiatBadge.tsx/types.ts';
-
-import { type KycStatusData } from '../../types.ts';
 
 export const displayName =
   'v5.pages.UserCryptoToFiatPage.partials.AutomaticDeposits';

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetails/BankDetails.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetails/BankDetails.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 
+import { useCryptoToFiatContext } from '~frame/v5/pages/UserCryptoToFiatPage/context/CryptoToFiatContext.ts';
 import { formatText } from '~utils/intl.ts';
 
-import { useCryptoToFiatContext } from '../../context/CryptoToFiatContext.ts';
 import BankDetailsModal from '../BankDetailsModal/index.ts';
 import RowItem from '../RowItem/index.ts';
 

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetails/consts.ts
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetails/consts.ts
@@ -1,12 +1,12 @@
 import { WarningCircle } from '@phosphor-icons/react';
 import { defineMessages } from 'react-intl';
 
+import { type KycStatusData } from '~frame/v5/pages/UserCryptoToFiatPage/types.ts';
 import { KycStatus } from '~gql';
 import { type BridgeBankAccount } from '~types/graphql.ts';
 import { formatText } from '~utils/intl.ts';
 import { type CryptoToFiatBadgeProps } from '~v5/common/Pills/CryptoToFiatBadge.tsx/types.ts';
 
-import { type KycStatusData } from '../../types.ts';
 import { type RowItemBodyProps } from '../RowItem/types.ts';
 
 import { BankDetailsStatus } from './types.ts';

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetails/partials/BankDetailsDescription/BankDetailsDescription.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetails/partials/BankDetailsDescription/BankDetailsDescription.tsx
@@ -2,11 +2,10 @@ import React from 'react';
 import { defineMessages } from 'react-intl';
 
 import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
+import { CurrencyLabel } from '~frame/v5/pages/UserCryptoToFiatPage/partials/CurrencyLabel.tsx';
 import { type SupportedCurrencies } from '~gql';
 import { type BridgeBankAccount } from '~types/graphql.ts';
 import { formatMessage } from '~utils/yup/tests/helpers.ts';
-
-import { CurrencyLabel } from '../../../CurrencyLabel.tsx';
 
 import { TABLE_TD_LOADER_STYLES } from './consts.ts';
 

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsForm/AccountDetailsInputs.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsForm/AccountDetailsInputs.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 
+import { CURRENCY_VALUES } from '~frame/v5/pages/UserCryptoToFiatPage/constants.ts';
 import { SupportedCurrencies } from '~gql';
 import { getCountries } from '~utils/countries.ts';
 import { formatText } from '~utils/intl.ts';
 
-import { CURRENCY_VALUES } from '../../constants.ts';
 import { FormInput } from '../FormInput.tsx';
 import { FormRow } from '../FormRow.tsx';
 import { FormSelect } from '../FormSelect.tsx';

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsForm/BankDetailsForm.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsForm/BankDetailsForm.tsx
@@ -1,10 +1,10 @@
 import React, { type FC } from 'react';
 
+import { CURRENCIES } from '~frame/v5/pages/UserCryptoToFiatPage/constants.ts';
+import { type BankDetailsFormValues } from '~frame/v5/pages/UserCryptoToFiatPage/types.ts';
 import { Form } from '~shared/Fields/index.ts';
 import { formatText } from '~utils/intl.ts';
 
-import { CURRENCIES } from '../../constants.ts';
-import { type BankDetailsFormValues } from '../../types.ts';
 import { FormInput } from '../FormInput.tsx';
 import { FormRow } from '../FormRow.tsx';
 import { FormSelect } from '../FormSelect.tsx';

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsForm/validation.ts
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsForm/validation.ts
@@ -1,10 +1,9 @@
 import { type InferType, object, string } from 'yup';
 
+import { CURRENCY_VALUES } from '~frame/v5/pages/UserCryptoToFiatPage/constants.ts';
 import { SupportedCurrencies } from '~gql';
 import { formErrorMessage, formatText } from '~utils/intl.ts';
 import { capitalizeFirstLetter } from '~utils/strings.ts';
-
-import { CURRENCY_VALUES } from '../../constants.ts';
 
 import {
   BANK_DETAILS_FORM_FIELD_VALUE_LENGTHS,

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsModal/useBankDetailsFields.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsModal/useBankDetailsFields.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { defineMessages } from 'react-intl';
 import { toast } from 'react-toastify';
 
+import { CURRENCY_VALUES } from '~frame/v5/pages/UserCryptoToFiatPage/constants.ts';
+import { type BankDetailsFormValues } from '~frame/v5/pages/UserCryptoToFiatPage/types.ts';
 import {
   CheckKycStatusDocument,
   SupportedCurrencies,
@@ -11,9 +13,6 @@ import {
 import Toast from '~shared/Extensions/Toast/Toast.tsx';
 import { type BridgeBankAccount } from '~types/graphql.ts';
 import { formatText } from '~utils/intl.ts';
-
-import { CURRENCY_VALUES } from '../../constants.ts';
-import { type BankDetailsFormValues } from '../../types.ts';
 
 const displayName = 'v5.pages.UserCryptoToFiatPage.partials.BankDetailsModal';
 

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/CurrencyLabel.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/CurrencyLabel.tsx
@@ -1,9 +1,8 @@
 import clsx from 'clsx';
 import React, { type FC } from 'react';
 
+import { currencyIcons } from '~common/Extensions/UserNavigation/partials/UserMenu/consts.ts';
 import { type SupportedCurrencies } from '~gql';
-
-import { currencyIcons } from '../../../../../common/Extensions/UserNavigation/partials/UserMenu/consts.ts';
 
 interface CurrencyLabelProps {
   currency: SupportedCurrencies;

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/Verification/Verification.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/Verification/Verification.tsx
@@ -2,10 +2,10 @@ import { Client as PersonaClient } from 'persona';
 import React, { useState } from 'react';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
+import { useCryptoToFiatContext } from '~frame/v5/pages/UserCryptoToFiatPage/context/CryptoToFiatContext.ts';
 import { useUpdateUserProfileMutation } from '~gql';
 import { formatText } from '~utils/intl.ts';
 
-import { useCryptoToFiatContext } from '../../context/CryptoToFiatContext.ts';
 import RowItem from '../RowItem/index.ts';
 
 import { MSG, displayName, getBadgeProps, getCTAProps } from './consts.ts';

--- a/src/components/shared/Extensions/Accordion/partials/AccordionNested/AccordionNestedHeader.tsx
+++ b/src/components/shared/Extensions/Accordion/partials/AccordionNested/AccordionNestedHeader.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import React, { type FC } from 'react';
 import { useIntl } from 'react-intl';
 
-import { type AccordionHeaderProps } from '../../types.ts';
+import { type AccordionHeaderProps } from '~shared/Extensions/Accordion/types.ts';
 
 const displayName =
   'Extensions.Accordion.partials.AccordionNested.AccordionNestedHeader';

--- a/src/components/shared/Extensions/Accordion/partials/AccordionNested/AccordionNestedItem.tsx
+++ b/src/components/shared/Extensions/Accordion/partials/AccordionNested/AccordionNestedItem.tsx
@@ -2,9 +2,8 @@ import { AnimatePresence, motion } from 'framer-motion';
 import React, { type FC, useState } from 'react';
 
 import { accordionAnimation } from '~constants/accordionAnimation.ts';
+import { type AccordionNestedItemProps } from '~shared/Extensions/Accordion/types.ts';
 import { formatText } from '~utils/intl.ts';
-
-import { type AccordionNestedItemProps } from '../../types.ts';
 
 import AccordionHeaderItem from './AccordionNestedHeader.tsx';
 

--- a/src/components/v5/common/ActionSidebar/hooks/permissions/helpers.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/helpers.ts
@@ -5,8 +5,7 @@ import { getAllUserRoles } from '~transformers/index.ts';
 import { type Colony } from '~types/graphql.ts';
 import { type Address } from '~types/index.ts';
 import { addressHasRoles } from '~utils/checks/index.ts';
-
-import { ModificationOption } from '../../partials/forms/ManageReputationForm/consts.ts';
+import { ModificationOption } from '~v5/common/ActionSidebar/partials/forms/ManageReputationForm/consts.ts';
 
 export const getPermissionsNeededForAction = (
   actionType: Action,

--- a/src/components/v5/common/ActionSidebar/hooks/permissions/useHasActionPermissions.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/useHasActionPermissions.ts
@@ -3,11 +3,10 @@ import { useFormContext } from 'react-hook-form';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { DecisionMethod } from '~types/actions.ts';
-
 import {
   ACTION_TYPE_FIELD_NAME,
   DECISION_METHOD_FIELD_NAME,
-} from '../../consts.ts';
+} from '~v5/common/ActionSidebar/consts.ts';
 
 import { getHasActionPermissions } from './helpers.ts';
 

--- a/src/components/v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts
@@ -6,8 +6,7 @@ import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useEnabledExtensions from '~hooks/useEnabledExtensions.ts';
 import { getAllUserRoles, getUserRolesForDomain } from '~transformers';
-
-import { ACTION_TYPE_FIELD_NAME } from '../../consts.ts';
+import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 
 import {
   getPermissionsDomainIdForAction,

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -16,21 +16,21 @@ import { DecisionMethod } from '~types/actions.ts';
 import { getDraftDecisionFromStore } from '~utils/decisions.ts';
 import { formatText } from '~utils/intl.ts';
 import { isQueryActive } from '~utils/isQueryActive.ts';
-import FormTextareaBase from '~v5/common/Fields/TextareaBase/FormTextareaBase.tsx';
-import NotificationBanner from '~v5/shared/NotificationBanner/index.ts';
-
-import ActionTypeSelect from '../../ActionTypeSelect.tsx';
+import ActionTypeSelect from '~v5/common/ActionSidebar/ActionTypeSelect.tsx';
 import {
   ACTION_TYPE_FIELD_NAME,
   CREATED_IN_FIELD_NAME,
   DECISION_METHOD_FIELD_NAME,
   DESCRIPTION_FIELD_NAME,
   TITLE_FIELD_NAME,
-} from '../../consts.ts';
-import useHasActionPermissions from '../../hooks/permissions/useHasActionPermissions.ts';
-import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
-import useActionFormProps from '../../hooks/useActionFormProps.ts';
-import useSidebarActionForm from '../../hooks/useSidebarActionForm.ts';
+} from '~v5/common/ActionSidebar/consts.ts';
+import useHasActionPermissions from '~v5/common/ActionSidebar/hooks/permissions/useHasActionPermissions.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
+import useActionFormProps from '~v5/common/ActionSidebar/hooks/useActionFormProps.ts';
+import useSidebarActionForm from '~v5/common/ActionSidebar/hooks/useSidebarActionForm.ts';
+import FormTextareaBase from '~v5/common/Fields/TextareaBase/FormTextareaBase.tsx';
+import NotificationBanner from '~v5/shared/NotificationBanner/index.ts';
+
 import ActionButtons from '../ActionButtons.tsx';
 import ActionSidebarDescription from '../ActionSidebarDescription/ActionSidebarDescription.tsx';
 import Motions from '../Motions/index.ts';

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/hooks.ts
@@ -2,8 +2,7 @@ import { useFormContext } from 'react-hook-form';
 
 import useFlatFormErrors from '~hooks/useFlatFormErrors.ts';
 import { uniqBy } from '~utils/lodash.ts';
-
-import { REPUTATION_VALIDATION_FIELD_NAME } from '../../hooks/useReputationValidation.ts';
+import { REPUTATION_VALIDATION_FIELD_NAME } from '~v5/common/ActionSidebar/hooks/useReputationValidation.ts';
 
 export const useGetFormActionErrors = () => {
   const {

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/SidebarBanner.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/SidebarBanner.tsx
@@ -11,14 +11,13 @@ import useExtensionsData from '~hooks/useExtensionsData.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { canColonyBeUpgraded } from '~utils/checks/canColonyBeUpgraded.ts';
 import { formatText } from '~utils/intl.ts';
-import ActionTypeNotification from '~v5/shared/ActionTypeNotification/ActionTypeNotification.tsx';
-import NotificationBanner from '~v5/shared/NotificationBanner/index.ts';
-
 import {
   ACTION_TYPE_FIELD_NAME,
   DECISION_METHOD_FIELD_NAME,
-} from '../../../consts.ts';
-import { useIsFieldDisabled } from '../../hooks.ts';
+} from '~v5/common/ActionSidebar/consts.ts';
+import { useIsFieldDisabled } from '~v5/common/ActionSidebar/partials/hooks.ts';
+import ActionTypeNotification from '~v5/shared/ActionTypeNotification/ActionTypeNotification.tsx';
+import NotificationBanner from '~v5/shared/NotificationBanner/index.ts';
 
 const displayName =
   'v5.common.ActionSidebar.ActionSidebarContent.SidebarBanner';

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/types.ts
@@ -1,8 +1,7 @@
 import { type UseFormReturn } from 'react-hook-form';
 
 import { type ActionFormProps } from '~shared/Fields/Form/index.ts';
-
-import { type ActionFormBaseProps } from '../../types.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 export interface ActionSidebarFormContentProps extends ActionFormBaseProps {
   isMotion?: boolean;

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/ActionSidebarDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/ActionSidebarDescription.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import { Action } from '~constants/actions.ts';
-
-import { useActiveActionType } from '../../hooks/useActiveActionType.ts';
+import { useActiveActionType } from '~v5/common/ActionSidebar/hooks/useActiveActionType.ts';
 
 import CreateDecisionDescription from './partials/CreateDecisionDescription.tsx';
 import CreateNewDomainDescription from './partials/CreateNewDomainDescription.tsx';

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/CreateNewDomainDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/CreateNewDomainDescription.tsx
@@ -3,8 +3,7 @@ import { useFormContext } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { ColonyActionType } from '~gql';
-
-import { type CreateNewTeamFormValues } from '../../forms/CreateNewTeamForm/consts.ts';
+import { type CreateNewTeamFormValues } from '~v5/common/ActionSidebar/partials/forms/CreateNewTeamForm/consts.ts';
 
 import CurrentUser from './CurrentUser.tsx';
 

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/EditDomainDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/EditDomainDescription.tsx
@@ -4,8 +4,7 @@ import { FormattedMessage } from 'react-intl';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { ColonyActionType } from '~gql';
-
-import { type EditTeamFormValues } from '../../forms/EditTeamForm/consts.ts';
+import { type EditTeamFormValues } from '~v5/common/ActionSidebar/partials/forms/EditTeamForm/consts.ts';
 
 import CurrentUser from './CurrentUser.tsx';
 

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/ManagePermissionsDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/ManagePermissionsDescription.tsx
@@ -6,9 +6,8 @@ import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { type ColonyActionRoles, ColonyActionType } from '~gql';
 import { formatRolesTitle } from '~utils/colonyActions.ts';
 import { formatText } from '~utils/intl.ts';
-
-import { type ManagePermissionsFormValues } from '../../forms/ManagePermissionsForm/consts.tsx';
-import { getPermissionsMap } from '../../forms/ManagePermissionsForm/utils.ts';
+import { type ManagePermissionsFormValues } from '~v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/consts.tsx';
+import { getPermissionsMap } from '~v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/utils.ts';
 
 import CurrentUser from './CurrentUser.tsx';
 import RecipientUser from './RecipientUser.tsx';

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/ManageReputationDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/ManageReputationDescription.tsx
@@ -12,9 +12,8 @@ import { toFinite } from '~utils/lodash.ts';
 import { formatReputationChange } from '~utils/reputation.ts';
 import { splitWalletAddress } from '~utils/splitWalletAddress.ts';
 import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
+import { ModificationOption } from '~v5/common/ActionSidebar/partials/forms/ManageReputationForm/consts.ts';
 import UserInfoPopover from '~v5/shared/UserInfoPopover/UserInfoPopover.tsx';
-
-import { ModificationOption } from '../../forms/ManageReputationForm/consts.ts';
 
 import CurrentUser from './CurrentUser.tsx';
 

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/ManageVerifiedMembersDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/ManageVerifiedMembersDescription.tsx
@@ -3,9 +3,8 @@ import { useFormContext } from 'react-hook-form';
 import { FormattedMessage, defineMessages } from 'react-intl';
 
 import { ColonyActionType } from '~types/graphql.ts';
-
-import { ManageMembersType } from '../../forms/ManageVerifiedMembersForm/consts.ts';
-import { type ManageVerifiedMembersFormValues } from '../../forms/ManageVerifiedMembersForm/utils.ts';
+import { ManageMembersType } from '~v5/common/ActionSidebar/partials/forms/ManageVerifiedMembersForm/consts.ts';
+import { type ManageVerifiedMembersFormValues } from '~v5/common/ActionSidebar/partials/forms/ManageVerifiedMembersForm/utils.ts';
 
 import CurrentUser from './CurrentUser.tsx';
 

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/MintTokensDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/MintTokensDescription.tsx
@@ -8,8 +8,7 @@ import { ColonyActionType } from '~gql';
 import Numeral from '~shared/Numeral/index.ts';
 import { formatText } from '~utils/intl.ts';
 import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
-
-import { type MintTokenFormValues } from '../../forms/MintTokenForm/consts.ts';
+import { type MintTokenFormValues } from '~v5/common/ActionSidebar/partials/forms/MintTokenForm/consts.ts';
 
 import CurrentUser from './CurrentUser.tsx';
 

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/PaymentBuilderDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/PaymentBuilderDescription.tsx
@@ -3,8 +3,7 @@ import { useFormContext } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { ColonyActionType } from '~types/graphql.ts';
-
-import { type PaymentBuilderFormValues } from '../../forms/PaymentBuilderForm/hooks.ts';
+import { type PaymentBuilderFormValues } from '~v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/hooks.ts';
 
 import CurrentUser from './CurrentUser.tsx';
 

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/SimplePaymentDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/SimplePaymentDescription.tsx
@@ -8,8 +8,7 @@ import { ColonyActionType } from '~gql';
 import Numeral from '~shared/Numeral/index.ts';
 import { formatText } from '~utils/intl.ts';
 import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
-
-import { type SimplePaymentFormValues } from '../../forms/SimplePaymentForm/hooks.ts';
+import { type SimplePaymentFormValues } from '~v5/common/ActionSidebar/partials/forms/SimplePaymentForm/hooks.ts';
 
 import CurrentUser from './CurrentUser.tsx';
 import RecipientUser from './RecipientUser.tsx';

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/TransferFundsDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/TransferFundsDescription.tsx
@@ -8,8 +8,7 @@ import { ColonyActionType } from '~gql';
 import Numeral from '~shared/Numeral/index.ts';
 import { formatText } from '~utils/intl.ts';
 import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
-
-import { type TransferFundsFormValues } from '../../forms/TransferFundsForm/hooks.ts';
+import { type TransferFundsFormValues } from '~v5/common/ActionSidebar/partials/forms/TransferFundsForm/hooks.ts';
 
 import CurrentUser from './CurrentUser.tsx';
 

--- a/src/components/v5/common/ActionSidebar/partials/AmountRow/AmountRow.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/AmountRow/AmountRow.tsx
@@ -4,9 +4,9 @@ import React from 'react';
 import { Action } from '~constants/actions.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
+import { useActiveActionType } from '~v5/common/ActionSidebar/hooks/useActiveActionType.ts';
 
-import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
-import { useActiveActionType } from '../../hooks/useActiveActionType.ts';
 import AmountField from '../AmountField/index.ts';
 
 import { type AmountRowProps } from './types.ts';

--- a/src/components/v5/common/ActionSidebar/partials/ColonyDetailsFields/ColonyDetailsFields.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ColonyDetailsFields/ColonyDetailsFields.tsx
@@ -7,10 +7,9 @@ import {
 } from '~constants/index.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import FormInputBase from '~v5/common/Fields/InputBase/FormInputBase.tsx';
 import FormTextareaBase from '~v5/common/Fields/TextareaBase/FormTextareaBase.tsx';
-
-import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
 
 import ColonyAvatarField from './partials/ColonyAvatarField/index.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/ColonyObjectiveFields/ColonyObjectiveFields.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ColonyObjectiveFields/ColonyObjectiveFields.tsx
@@ -10,10 +10,9 @@ import {
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import FormInputBase from '~v5/common/Fields/InputBase/FormInputBase.tsx';
 import FormTextareaBase from '~v5/common/Fields/TextareaBase/FormTextareaBase.tsx';
-
-import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
 
 const displayName = 'v5.common.ActionsContent.partials.ColonyObjectiveFields';
 

--- a/src/components/v5/common/ActionSidebar/partials/ColonyVersionField/ColonyVersionField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ColonyVersionField/ColonyVersionField.tsx
@@ -6,8 +6,7 @@ import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useColonyContractVersion from '~hooks/useColonyContractVersion.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
-
-import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 
 const displayName = 'v5.common.ActionsContent.partials.ColonyVersionField';
 

--- a/src/components/v5/common/ActionSidebar/partials/CreatedIn/CreatedIn.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/CreatedIn/CreatedIn.tsx
@@ -5,12 +5,12 @@ import { useWatch } from 'react-hook-form';
 import { DecisionMethod } from '~types/actions.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
-
 import {
   CREATED_IN_FIELD_NAME,
   DECISION_METHOD_FIELD_NAME,
-} from '../../consts.ts';
-import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
+} from '~v5/common/ActionSidebar/consts.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
+
 import TeamsSelect from '../TeamsSelect/index.ts';
 
 import { type CreatedInProps } from './types.ts';

--- a/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx
@@ -8,9 +8,8 @@ import { getAllUserRoles } from '~transformers/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import { FormCardSelect } from '~v5/common/Fields/CardSelect/index.ts';
-
-import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
 
 import {
   type DecisionMethodOption,

--- a/src/components/v5/common/ActionSidebar/partials/Description/Description.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Description/Description.tsx
@@ -5,9 +5,9 @@ import { useFormContext } from 'react-hook-form';
 import { useAdditionalFormOptionsContext } from '~context/AdditionalFormOptionsContext/AdditionalFormOptionsContext.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
+import { DESCRIPTION_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 
-import { DESCRIPTION_FIELD_NAME } from '../../consts.ts';
-import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
 import DescriptionField from '../DescriptionField/index.ts';
 
 import { type DescriptionProps } from './types.ts';

--- a/src/components/v5/common/ActionSidebar/partials/ManageReputationTable/ManageReputationTable.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ManageReputationTable/ManageReputationTable.tsx
@@ -5,8 +5,7 @@ import { useMobile } from '~hooks';
 import Numeral from '~shared/Numeral/index.ts';
 import { SpinnerLoader } from '~shared/Preloaders/index.ts';
 import { formatText } from '~utils/intl.ts';
-
-import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 
 import { type ManageReputationTableProps } from './types.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/OutcomeStep/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/OutcomeStep/hooks.ts
@@ -2,9 +2,11 @@ import { useMemo } from 'react';
 
 import { type ColonyMotion } from '~types/graphql.ts';
 import { MotionVote } from '~utils/colonyMotions.ts';
+import {
+  supportOption,
+  opposeOption,
+} from '~v5/common/ActionSidebar/partials/Motions/consts.ts';
 import { type UserAvatarsItem } from '~v5/shared/UserAvatars/types.ts';
-
-import { supportOption, opposeOption } from '../../consts.ts';
 
 import { type VoteStatuses } from './partials/VoteStatuses/types.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/StakingStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/StakingStep.tsx
@@ -8,12 +8,11 @@ import useToggle from '~hooks/useToggle/index.ts';
 import { SpinnerLoader } from '~shared/Preloaders/index.ts';
 import { SystemMessages } from '~types/actions.ts';
 import { formatText } from '~utils/intl.ts';
+import { useMotionContext } from '~v5/common/ActionSidebar/partials/Motions/partials/MotionProvider/hooks.ts';
 import AccordionItem from '~v5/shared/Accordion/partials/AccordionItem/index.ts';
 import MenuWithStatusText from '~v5/shared/MenuWithStatusText/index.ts';
 import { StatusTypes } from '~v5/shared/StatusText/consts.ts';
 import StatusText from '~v5/shared/StatusText/index.ts';
-
-import { useMotionContext } from '../../partials/MotionProvider/hooks.ts';
 
 import { useStakingStep } from './hooks.tsx';
 import NotEnoughTokensInfo from './partials/NotEnoughTokensInfo/index.ts';

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/hooks.tsx
@@ -3,8 +3,7 @@ import { BigNumber } from 'ethers';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useGetUserReputationQuery } from '~gql';
 import useEnoughTokensForStaking from '~hooks/useEnoughTokensForStaking.ts';
-
-import { useMotionContext } from '../../partials/MotionProvider/hooks.ts';
+import { useMotionContext } from '~v5/common/ActionSidebar/partials/Motions/partials/MotionProvider/hooks.ts';
 
 export const useStakingStep = () => {
   const { motionAction } = useMotionContext();

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/StakingForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/StakingForm.tsx
@@ -12,11 +12,11 @@ import Numeral from '~shared/Numeral/index.ts';
 import { MotionVote } from '~utils/colonyMotions.ts';
 import { formatText } from '~utils/intl.ts';
 import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
+import { useMotionContext } from '~v5/common/ActionSidebar/partials/Motions/partials/MotionProvider/hooks.ts';
 import FormFormattedInput from '~v5/common/Fields/InputBase/FormFormattedInput.tsx';
 import FormButtonRadioButtons from '~v5/common/Fields/RadioButtons/ButtonRadioButtons/FormButtonRadioButtons.tsx';
 import Button from '~v5/shared/Button/index.ts';
 
-import { useMotionContext } from '../../../../partials/MotionProvider/hooks.ts';
 import StakingChart from '../StakingChart/StakingChart.tsx';
 
 import { getMaxStakeAmount, getPredictedPercentage } from './helpers.ts';

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/hooks.ts
@@ -8,8 +8,7 @@ import { useUserTokenBalanceContext } from '~context/UserTokenBalanceContext/Use
 import { MotionVote } from '~utils/colonyMotions.ts';
 import { formatText } from '~utils/intl.ts';
 import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
-
-import { useMotionContext } from '../../../../partials/MotionProvider/hooks.ts';
+import { useMotionContext } from '~v5/common/ActionSidebar/partials/Motions/partials/MotionProvider/hooks.ts';
 
 import { getHandleStakeSuccessFn, getStakingTransformFn } from './helpers.ts';
 import { type StakingFormValues } from './types.ts';

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/VotingStep/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/VotingStep/utils.tsx
@@ -1,6 +1,8 @@
 import { MotionVote } from '~utils/colonyMotions.ts';
-
-import { opposeOption, supportOption } from '../../consts.ts';
+import {
+  opposeOption,
+  supportOption,
+} from '~v5/common/ActionSidebar/partials/Motions/consts.ts';
 
 export const renderVoteRadioButtons = (
   hasUserVoted: boolean,

--- a/src/components/v5/common/ActionSidebar/partials/SaveDraftButton/SaveDraftButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/SaveDraftButton/SaveDraftButton.tsx
@@ -9,9 +9,8 @@ import { useMobile } from '~hooks';
 import { createDecisionAction } from '~redux/actionCreators/index.ts';
 import { type DecisionDraft } from '~utils/decisions.ts';
 import { formatText } from '~utils/intl.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import Button from '~v5/shared/Button/index.ts';
-
-import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
 
 const SaveDraftButton: FC = () => {
   const [isDraftSaved, setIsDraftSaved] = useState(false);

--- a/src/components/v5/common/ActionSidebar/partials/TokensTable/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TokensTable/hooks.tsx
@@ -1,0 +1,53 @@
+import { createColumnHelper, type ColumnDef } from '@tanstack/react-table';
+import React, { useMemo } from 'react';
+
+import useWrapWithRef from '~hooks/useWrapWithRef.ts';
+import { formatText } from '~utils/intl.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
+
+import TokenSelect from '../TokenSelect/index.ts';
+import TokenSymbol from '../TokenSelect/partials/TokenSymbol/index.ts';
+
+import { type TokensTableModel } from './types.ts';
+
+export const useTokensTableColumns = (
+  name: string,
+  data,
+): ColumnDef<TokensTableModel, string>[] => {
+  const columnHelper = useMemo(
+    () => createColumnHelper<TokensTableModel>(),
+    [],
+  );
+  const dataRef = useWrapWithRef(data);
+
+  const hasNoDecisionMethods = useHasNoDecisionMethods();
+
+  const columns: ColumnDef<TokensTableModel, string>[] = useMemo(
+    () => [
+      columnHelper.display({
+        id: 'token',
+        header: () => formatText({ id: 'table.row.token' }),
+        cell: ({ row }) => (
+          <TokenSelect
+            name={`${name}.${row.index}.token`}
+            disabled={hasNoDecisionMethods}
+          />
+        ),
+      }),
+      columnHelper.display({
+        id: 'symbol',
+        header: () => formatText({ id: 'table.row.symbol' }),
+        cell: ({ row }) => (
+          <TokenSymbol
+            address={dataRef.current?.[row.index]?.token}
+            disabled={hasNoDecisionMethods}
+          />
+        ),
+      }),
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [columnHelper, name],
+  );
+
+  return columns;
+};

--- a/src/components/v5/common/ActionSidebar/partials/TokensTable/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TokensTable/hooks.tsx
@@ -5,10 +5,9 @@ import useWrapWithRef from '~hooks/useWrapWithRef.ts';
 import { formatText } from '~utils/intl.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 
+import { type TokensTableModel } from '../forms/ManageTokensForm/partials/TokensTable/types.ts';
 import TokenSelect from '../TokenSelect/index.ts';
 import TokenSymbol from '../TokenSelect/partials/TokenSymbol/index.ts';
-
-import { type TokensTableModel } from './types.ts';
 
 export const useTokensTableColumns = (
   name: string,

--- a/src/components/v5/common/ActionSidebar/partials/consts.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/consts.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { type CardSelectOption } from '../../Fields/CardSelect/types.ts';
+import { type CardSelectOption } from '~v5/common/Fields/CardSelect/types.ts';
 
 export enum DistributionMethod {
   Equal = 'equal',

--- a/src/components/v5/common/ActionSidebar/partials/forms/BatchPaymentForm/BatchPaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/BatchPaymentForm/BatchPaymentForm.tsx
@@ -4,13 +4,12 @@ import React, { type FC } from 'react';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
 import useFilterCreatedInField from '~v5/common/ActionSidebar/hooks/useFilterCreatedInField.ts';
+import BatchPaymentsTable from '~v5/common/ActionSidebar/partials/BatchPaymentsTable/index.ts';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
 import DescriptionField from '~v5/common/ActionSidebar/partials/DescriptionField/index.ts';
 import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/index.ts';
-
-import { type ActionFormBaseProps } from '../../../types.ts';
-import BatchPaymentsTable from '../../BatchPaymentsTable/index.ts';
-import CreatedIn from '../../CreatedIn/index.ts';
-import DecisionMethodField from '../../DecisionMethodField/index.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 const displayName = 'v5.common.ActionSidebar.partials.BatchPaymentForm';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/CreateDecisionForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/CreateDecisionForm.tsx
@@ -1,10 +1,10 @@
 import React, { type FC } from 'react';
 
-import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedIn from '../../CreatedIn/index.ts';
-import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import Description from '../../Description/index.ts';
-import { useIsFieldDisabled } from '../../hooks.ts';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
+import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
+import { useIsFieldDisabled } from '~v5/common/ActionSidebar/partials/hooks.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { useCreateDecision } from './hooks.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/hooks.ts
@@ -9,9 +9,8 @@ import { ActionTypes } from '~redux/index.ts';
 import { mapPayload, pipe } from '~utils/actions.ts';
 import { type DecisionDraft } from '~utils/decisions.ts';
 import { sanitizeHTML } from '~utils/strings.ts';
-
-import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
+import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { validationSchema, type CreateDecisionFormValues } from './consts.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateNewTeamForm/CreateNewTeamForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateNewTeamForm/CreateNewTeamForm.tsx
@@ -8,15 +8,14 @@ import {
 import { useAdditionalFormOptionsContext } from '~context/AdditionalFormOptionsContext/AdditionalFormOptionsContext.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
+import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
 import TeamColorField from '~v5/common/ActionSidebar/partials/TeamColorField/index.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 import FormInputBase from '~v5/common/Fields/InputBase/FormInputBase.tsx';
 import FormTextareaBase from '~v5/common/Fields/TextareaBase/FormTextareaBase.tsx';
-
-import useHasNoDecisionMethods from '../../../hooks/permissions/useHasNoDecisionMethods.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedIn from '../../CreatedIn/index.ts';
-import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import Description from '../../Description/index.ts';
 
 import { useCreateNewTeam } from './hooks.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateNewTeamForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateNewTeamForm/hooks.ts
@@ -8,9 +8,8 @@ import { ActionTypes } from '~redux/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { mapPayload, pipe } from '~utils/actions.ts';
 import { DECISION_METHOD_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
-
-import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
+import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { validationSchema, type CreateNewTeamFormValues } from './consts.ts';
 import { getCreateNewTeamPayload } from './utils.tsx';

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/EditColonyDetailsForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/EditColonyDetailsForm.tsx
@@ -1,11 +1,10 @@
 import React, { type FC } from 'react';
 
 import ColonyDetailsFields from '~v5/common/ActionSidebar/partials/ColonyDetailsFields/index.ts';
-
-import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedIn from '../../CreatedIn/index.ts';
-import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import Description from '../../Description/index.ts';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
+import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { useEditColonyDetails } from './hooks.ts';
 import SocialLinksTable from './partials/SocialLinksTable/index.ts';

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/hooks.ts
@@ -8,9 +8,8 @@ import { ActionTypes } from '~redux/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { mapPayload, pipe } from '~utils/actions.ts';
 import { DECISION_METHOD_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
-
-import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
+import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { getEditColonyDetailsValidationSchema } from './consts.ts';
 import { type EditColonyDetailsFormValues } from './types.ts';

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/SocialLinksTable.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/SocialLinksTable.tsx
@@ -11,10 +11,9 @@ import {
   type SocialLinksTableProps,
 } from '~types/colony.ts';
 import { formatText } from '~utils/intl.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import Table from '~v5/common/Table/index.ts';
 import Button from '~v5/shared/Button/Button.tsx';
-
-import useHasNoDecisionMethods from '../../../../../hooks/permissions/useHasNoDecisionMethods.ts';
 
 import SocialLinkModal from './partials/SocialLinkModal/index.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditTeamForm/EditTeamForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditTeamForm/EditTeamForm.tsx
@@ -14,17 +14,16 @@ import {
 import { useAdditionalFormOptionsContext } from '~context/AdditionalFormOptionsContext/AdditionalFormOptionsContext.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import useFilterCreatedInField from '~v5/common/ActionSidebar/hooks/useFilterCreatedInField.ts';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
+import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
 import TeamColorField from '~v5/common/ActionSidebar/partials/TeamColorField/index.ts';
 import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/index.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 import FormInputBase from '~v5/common/Fields/InputBase/FormInputBase.tsx';
 import FormTextareaBase from '~v5/common/Fields/TextareaBase/FormTextareaBase.tsx';
-
-import useHasNoDecisionMethods from '../../../hooks/permissions/useHasNoDecisionMethods.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedIn from '../../CreatedIn/index.ts';
-import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import Description from '../../Description/index.ts';
 
 import { useEditTeam } from './hooks.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditTeamForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditTeamForm/hooks.ts
@@ -8,10 +8,9 @@ import { ActionTypes } from '~redux/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { mapPayload, pipe } from '~utils/actions.ts';
 import { findDomainByNativeId } from '~utils/domains.ts';
-
-import { DECISION_METHOD_FIELD_NAME } from '../../../consts.ts';
-import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
+import { DECISION_METHOD_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
+import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { validationSchema, type EditTeamFormValues } from './consts.ts';
 import { getEditDomainPayload } from './utils.tsx';

--- a/src/components/v5/common/ActionSidebar/partials/forms/EnterRecoveryModeForm/EnterRecoveryModeForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EnterRecoveryModeForm/EnterRecoveryModeForm.tsx
@@ -4,8 +4,7 @@ import React, { type FC } from 'react';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
 import DescriptionField from '~v5/common/ActionSidebar/partials/DescriptionField/index.ts';
-
-import { type ActionFormBaseProps } from '../../../types.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { useEnterRecoveryMode } from './hooks.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/EnterRecoveryModeForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EnterRecoveryModeForm/hooks.ts
@@ -5,9 +5,8 @@ import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { ActionTypes } from '~redux/index.ts';
 import { mapPayload, pipe } from '~utils/actions.ts';
-
-import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
+import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import {
   type EnterRecoveryModeFormValues,

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/ManageColonyObjectivesForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/ManageColonyObjectivesForm.tsx
@@ -1,11 +1,10 @@
 import React, { type FC } from 'react';
 
 import ColonyObjectiveFields from '~v5/common/ActionSidebar/partials/ColonyObjectiveFields/index.ts';
-
-import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedIn from '../../CreatedIn/index.ts';
-import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import Description from '../../Description/index.ts';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
+import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { useManageColonyObjectives } from './hooks.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageColonyObjectivesForm/hooks.ts
@@ -8,9 +8,8 @@ import { ActionTypes } from '~redux/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { mapPayload, pipe } from '~utils/actions.ts';
 import { DECISION_METHOD_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
-
-import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
+import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import {
   validationSchema,

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/ManagePermissionsForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/ManagePermissionsForm.tsx
@@ -13,17 +13,16 @@ import { UserRole } from '~constants/permissions.ts';
 import useToggle from '~hooks/useToggle/index.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import useFilterCreatedInField from '~v5/common/ActionSidebar/hooks/useFilterCreatedInField.ts';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
+import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
+import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/index.ts';
+import UserSelect from '~v5/common/ActionSidebar/partials/UserSelect/index.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 import { FormCardSelect } from '~v5/common/Fields/CardSelect/index.ts';
 import { type CardSelectProps } from '~v5/common/Fields/CardSelect/types.ts';
-
-import useHasNoDecisionMethods from '../../../hooks/permissions/useHasNoDecisionMethods.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedIn from '../../CreatedIn/index.ts';
-import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import Description from '../../Description/index.ts';
-import TeamsSelect from '../../TeamsSelect/index.ts';
-import UserSelect from '../../UserSelect/index.ts';
 
 import {
   AuthorityOptions,

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/hooks.ts
@@ -11,9 +11,8 @@ import { ActionTypes } from '~redux/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { mapPayload, pipe } from '~utils/actions.ts';
 import { notMaybe } from '~utils/arrays/index.ts';
-
-import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
+import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import {
   type ManagePermissionsFormValues,

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/partials/PermissionsTable/PermissionsTable.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/partials/PermissionsTable/PermissionsTable.tsx
@@ -12,9 +12,8 @@ import {
   type PermissionsTableProps,
 } from '~types/permissions.ts';
 import { CUSTOM_PERMISSION_TABLE_CONTENT } from '~utils/colonyActions.ts';
+import { type ManagePermissionsFormValues } from '~v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/consts.ts';
 import Table from '~v5/common/Table/index.ts';
-
-import { type ManagePermissionsFormValues } from '../../consts.ts';
 
 import { useCustomPermissionsTableColumns } from './hooks.tsx';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/ManageReputationForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/ManageReputationForm.tsx
@@ -16,15 +16,14 @@ import {
 } from '~v5/common/ActionSidebar/consts.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import useFilterCreatedInField from '~v5/common/ActionSidebar/hooks/useFilterCreatedInField.ts';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
+import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
+import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/index.ts';
+import { useUserSelect } from '~v5/common/ActionSidebar/partials/UserSelect/hooks.ts';
+import UserSelect from '~v5/common/ActionSidebar/partials/UserSelect/index.ts';
 import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 import { FormCardSelect } from '~v5/common/Fields/CardSelect/index.ts';
-
-import CreatedIn from '../../CreatedIn/index.ts';
-import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import Description from '../../Description/index.ts';
-import TeamsSelect from '../../TeamsSelect/index.ts';
-import { useUserSelect } from '../../UserSelect/hooks.ts';
-import UserSelect from '../../UserSelect/index.ts';
 
 import { ModificationOption, modificationOptions } from './consts.ts';
 import { useManageReputation } from './hooks.ts';

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/hooks.ts
@@ -16,8 +16,7 @@ import {
   DECISION_METHOD_FIELD_NAME,
 } from '~v5/common/ActionSidebar/consts.ts';
 import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
-
-import { type ActionFormBaseProps } from '../../../types.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import {
   getManageReputationPayload,

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/hooks.ts
@@ -13,8 +13,7 @@ import {
   getFormattedTokenValue,
   getTokenDecimalsWithFallback,
 } from '~utils/tokens.ts';
-
-import { ModificationOption } from '../../consts.ts';
+import { ModificationOption } from '~v5/common/ActionSidebar/partials/forms/ManageReputationForm/consts.ts';
 
 import { calculateNewValue } from './utils.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageTokensForm/ManageTokensForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageTokensForm/ManageTokensForm.tsx
@@ -1,10 +1,10 @@
 import React, { type FC } from 'react';
 
-import useHasNoDecisionMethods from '../../../hooks/permissions/useHasNoDecisionMethods.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedIn from '../../CreatedIn/index.ts';
-import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import Description from '../../Description/index.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
+import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { useManageTokens } from './hooks.ts';
 import TokensTable from './partials/TokensTable/TokensTable.tsx';

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageTokensForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageTokensForm/hooks.ts
@@ -10,10 +10,9 @@ import { DecisionMethod } from '~types/actions.ts';
 import { mapPayload, pipe } from '~utils/actions.ts';
 import { notNull } from '~utils/arrays/index.ts';
 import { DECISION_METHOD_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
+import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 import { TokenStatus } from '~v5/common/types.ts';
-
-import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
 
 import { validationSchema, type ManageTokensFormValues } from './consts.ts';
 import { getManageTokensPayload } from './utils.ts';

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageVerifiedMembersForm/ManageVerifiedMembersForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageVerifiedMembersForm/ManageVerifiedMembersForm.tsx
@@ -5,13 +5,12 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/CreatedIn.tsx';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx';
+import Description from '~v5/common/ActionSidebar/partials/Description/Description.tsx';
+import VerifiedMembersTable from '~v5/common/ActionSidebar/partials/MembersTable/index.ts';
 import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 import { FormCardSelect } from '~v5/common/Fields/CardSelect/index.ts';
-
-import CreatedIn from '../../CreatedIn/CreatedIn.tsx';
-import DecisionMethodField from '../../DecisionMethodField/DecisionMethodField.tsx';
-import Description from '../../Description/Description.tsx';
-import VerifiedMembersTable from '../../MembersTable/index.ts';
 
 import { type ManageMembersType, getManageMembersOptions } from './consts.ts';
 import { useManageVerifiedMembers } from './hooks.ts';

--- a/src/components/v5/common/ActionSidebar/partials/forms/MintTokenForm/MintTokenForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/MintTokenForm/MintTokenForm.tsx
@@ -1,12 +1,11 @@
 import React, { type FC } from 'react';
 
 import { formatText } from '~utils/intl.ts';
-
-import { type ActionFormBaseProps } from '../../../types.ts';
-import AmountRow from '../../AmountRow/AmountRow.tsx';
-import CreatedIn from '../../CreatedIn/index.ts';
-import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import Description from '../../Description/index.ts';
+import AmountRow from '~v5/common/ActionSidebar/partials/AmountRow/AmountRow.tsx';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
+import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { useMintToken } from './hooks.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/MintTokenForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/MintTokenForm/hooks.ts
@@ -8,9 +8,8 @@ import { ActionTypes } from '~redux/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { mapPayload, pipe } from '~utils/actions.ts';
 import { DECISION_METHOD_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
-
-import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
+import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { type MintTokenFormValues, validationSchema } from './consts.ts';
 import { getMintTokenPayload } from './utils.tsx';

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/PaymentBuilderForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/PaymentBuilderForm.tsx
@@ -6,12 +6,11 @@ import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import useFilterCreatedInField from '~v5/common/ActionSidebar/hooks/useFilterCreatedInField.ts';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
+import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
 import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/index.ts';
-
-import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedIn from '../../CreatedIn/index.ts';
-import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import Description from '../../Description/index.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { usePaymentBuilder } from './hooks.ts';
 import PaymentBuilderRecipientsField from './partials/PaymentBuilderRecipientsField/index.ts';

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/hooks.ts
@@ -22,9 +22,8 @@ import {
   ACTION_BASE_VALIDATION_SCHEMA,
   DECISION_METHOD_FIELD_NAME,
 } from '~v5/common/ActionSidebar/consts.ts';
-
-import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
+import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { CLAIM_DELAY_MAX_VALUE } from './partials/ClaimDelayField/consts.ts';
 import {

--- a/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/SimplePaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/SimplePaymentForm.tsx
@@ -4,16 +4,15 @@ import { useFormContext } from 'react-hook-form';
 
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import useFilterCreatedInField from '~v5/common/ActionSidebar/hooks/useFilterCreatedInField.ts';
-
-import useHasNoDecisionMethods from '../../../hooks/permissions/useHasNoDecisionMethods.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
-import AmountRow from '../../AmountRow/AmountRow.tsx';
-import CreatedIn from '../../CreatedIn/CreatedIn.tsx';
-import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import Description from '../../Description/index.ts';
-import TeamsSelect from '../../TeamsSelect/index.ts';
-import UserSelect from '../../UserSelect/index.ts';
+import AmountRow from '~v5/common/ActionSidebar/partials/AmountRow/AmountRow.tsx';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/CreatedIn.tsx';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
+import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
+import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/index.ts';
+import UserSelect from '~v5/common/ActionSidebar/partials/UserSelect/index.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { useSimplePayment } from './hooks.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/hooks.ts
@@ -20,9 +20,8 @@ import {
   ACTION_BASE_VALIDATION_SCHEMA,
   DECISION_METHOD_FIELD_NAME,
 } from '~v5/common/ActionSidebar/consts.ts';
-
-import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
+import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { getSimplePaymentPayload } from './utils.tsx';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/SplitPaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/SplitPaymentForm.tsx
@@ -5,14 +5,13 @@ import { useFormContext } from 'react-hook-form';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
 import useFilterCreatedInField from '~v5/common/ActionSidebar/hooks/useFilterCreatedInField.ts';
+import AmountRow from '~v5/common/ActionSidebar/partials/AmountRow/AmountRow.tsx';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
+import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
 import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/index.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 import { FormCardSelect } from '~v5/common/Fields/CardSelect/index.ts';
-
-import { type ActionFormBaseProps } from '../../../types.ts';
-import AmountRow from '../../AmountRow/AmountRow.tsx';
-import CreatedIn from '../../CreatedIn/index.ts';
-import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import Description from '../../Description/index.ts';
 
 import { useSplitPayment } from './hooks.ts';
 import SplitPaymentRecipientsField from './partials/SplitPaymentRecipientsField/index.ts';

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/hooks.ts
@@ -17,9 +17,8 @@ import {
   ACTION_BASE_VALIDATION_SCHEMA,
   DECISION_METHOD_FIELD_NAME,
 } from '~v5/common/ActionSidebar/consts.ts';
-
-import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
+import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 export const useValidationSchema = () => {
   const { colony } = useColonyContext();

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/SplitPaymentRecipientsField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/SplitPaymentRecipientsField.tsx
@@ -6,10 +6,9 @@ import { FormattedMessage } from 'react-intl';
 
 import { useMobile } from '~hooks/index.ts';
 import { formatText } from '~utils/intl.ts';
+import { DistributionMethod } from '~v5/common/ActionSidebar/partials/consts.tsx';
 import Table from '~v5/common/Table/index.ts';
 import Button from '~v5/shared/Button/Button.tsx';
-
-import { DistributionMethod } from '../../../../consts.tsx';
 
 import {
   useRecipientsFieldTableColumns,

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/types.ts
@@ -1,6 +1,5 @@
 import { type Token } from '~types/graphql.ts';
-
-import { type DistributionMethod } from '../../../../consts.tsx';
+import { type DistributionMethod } from '~v5/common/ActionSidebar/partials/consts.tsx';
 
 export interface SplitPaymentRecipientsFieldProps {
   name: string;

--- a/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/TransferFundsForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/TransferFundsForm.tsx
@@ -4,15 +4,14 @@ import { useFormContext } from 'react-hook-form';
 
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import useFilterCreatedInField from '~v5/common/ActionSidebar/hooks/useFilterCreatedInField.ts';
+import AmountRow from '~v5/common/ActionSidebar/partials/AmountRow/AmountRow.tsx';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
+import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
 import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/index.ts';
-
-import useHasNoDecisionMethods from '../../../hooks/permissions/useHasNoDecisionMethods.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
-import AmountRow from '../../AmountRow/AmountRow.tsx';
-import CreatedIn from '../../CreatedIn/index.ts';
-import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import Description from '../../Description/index.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { useTransferFunds } from './hooks.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/hooks.ts
@@ -17,9 +17,8 @@ import {
   ACTION_BASE_VALIDATION_SCHEMA,
   DECISION_METHOD_FIELD_NAME,
 } from '~v5/common/ActionSidebar/consts.ts';
-
-import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
+import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { getTransferFundsPayload } from './utils.tsx';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/UnlockTokenForm/UnlockTokenForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/UnlockTokenForm/UnlockTokenForm.tsx
@@ -7,11 +7,10 @@ import { TX_SEARCH_PARAM } from '~routes/index.ts';
 import { formatText } from '~utils/intl.ts';
 import { multiLineTextEllipsis } from '~utils/strings.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/ActionFormRow.tsx';
-
-import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedIn from '../../CreatedIn/index.ts';
-import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import Description from '../../Description/index.ts';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
+import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { useUnlockToken } from './hooks.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/UnlockTokenForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/UnlockTokenForm/hooks.ts
@@ -8,9 +8,8 @@ import { ActionTypes } from '~redux/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { mapPayload, pipe, withKey } from '~utils/actions.ts';
 import { DECISION_METHOD_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
-
-import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
+import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { type UnlockTokenFormValues, validationSchema } from './consts.ts';
 import { getUnlockTokenPayload } from './utils.tsx';

--- a/src/components/v5/common/ActionSidebar/partials/forms/UpgradeColonyForm/UpgradeColonyForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/UpgradeColonyForm/UpgradeColonyForm.tsx
@@ -1,11 +1,10 @@
 import React, { type FC } from 'react';
 
 import ColonyVersionField from '~v5/common/ActionSidebar/partials/ColonyVersionField/index.ts';
-
-import { type ActionFormBaseProps } from '../../../types.ts';
-import CreatedIn from '../../CreatedIn/index.ts';
-import DecisionMethodField from '../../DecisionMethodField/index.ts';
-import Description from '../../Description/index.ts';
+import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
+import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
+import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { useUpgradeColony } from './hooks.ts';
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/UpgradeColonyForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/UpgradeColonyForm/hooks.ts
@@ -8,9 +8,8 @@ import { ActionTypes } from '~redux/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { mapPayload, pipe } from '~utils/actions.ts';
 import { DECISION_METHOD_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
-
-import useActionFormBaseHook from '../../../hooks/useActionFormBaseHook.ts';
-import { type ActionFormBaseProps } from '../../../types.ts';
+import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { validationSchema, type UpgradeColonyFormValues } from './consts.ts';
 import { getUpgradeColonyPayload } from './utils.tsx';

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/CancelModal/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/CancelModal/types.ts
@@ -1,7 +1,6 @@
 import { type Expenditure } from '~types/graphql.ts';
+import { type RefetchExpenditureType } from '~v5/common/CompletedAction/partials/PaymentBuilder/types.ts';
 import { type ModalProps } from '~v5/shared/Modal/types.ts';
-
-import { type RefetchExpenditureType } from '../../types.ts';
 
 export interface CancelModalProps extends ModalProps {
   expenditure: Expenditure;

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderTable/partials/AmountField/AmountField.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderTable/partials/AmountField/AmountField.tsx
@@ -3,9 +3,8 @@ import React, { type FC } from 'react';
 import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { getSelectedToken } from '~utils/tokens.ts';
+import { getFormattedTokenAmount } from '~v5/common/CompletedAction/partials/utils.ts';
 import { TokenAvatar } from '~v5/shared/TokenAvatar/TokenAvatar.tsx';
-
-import { getFormattedTokenAmount } from '../../../../../utils.ts';
 
 import { type AmountFieldProps } from './types.ts';
 

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderTable/partials/ClaimStatusBadge/ClaimStatusBadge.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderTable/partials/ClaimStatusBadge/ClaimStatusBadge.tsx
@@ -3,9 +3,8 @@ import React, { type FC } from 'react';
 import { defineMessages } from 'react-intl';
 
 import { formatText } from '~utils/intl.ts';
+import PaymentCounter from '~v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentCounter/PaymentCounter.tsx';
 import PillsBase from '~v5/common/Pills/PillsBase.tsx';
-
-import PaymentCounter from '../../../PaymentCounter/PaymentCounter.tsx';
 
 import { type ClaimStatusBadgeProps } from './types.ts';
 

--- a/src/components/v5/common/CompletedAction/partials/UpgradeColonyObjective/UpgradeColonyObjective.tsx
+++ b/src/components/v5/common/CompletedAction/partials/UpgradeColonyObjective/UpgradeColonyObjective.tsx
@@ -4,9 +4,9 @@ import { defineMessages } from 'react-intl';
 
 import { type ColonyAction } from '~types/graphql.ts';
 import { formatText } from '~utils/intl.ts';
+import { ICON_SIZE } from '~v5/common/CompletedAction/consts.ts';
 import UserInfoPopover from '~v5/shared/UserInfoPopover/index.ts';
 
-import { ICON_SIZE } from '../../consts.ts';
 import {
   ActionDataGrid,
   ActionSubtitle,

--- a/src/components/v5/common/CompletedAction/partials/rows/ActionData.tsx
+++ b/src/components/v5/common/CompletedAction/partials/rows/ActionData.tsx
@@ -4,8 +4,10 @@ import React from 'react';
 import Tooltip from '~shared/Extensions/Tooltip/index.ts';
 import { type Message } from '~types';
 import { formatText } from '~utils/intl.ts';
-
-import { DEFAULT_TOOLTIP_POSITION, ICON_SIZE } from '../../consts.ts';
+import {
+  DEFAULT_TOOLTIP_POSITION,
+  ICON_SIZE,
+} from '~v5/common/CompletedAction/consts.ts';
 
 const displayName = 'v5.common.CompletedAction.partials.ActionData';
 

--- a/src/components/v5/common/CompletedAction/partials/rows/Description.tsx
+++ b/src/components/v5/common/CompletedAction/partials/rows/Description.tsx
@@ -4,9 +4,8 @@ import DOMPurify from 'dompurify';
 import React, { useState } from 'react';
 
 import { formatText } from '~utils/intl.ts';
+import { ICON_SIZE } from '~v5/common/CompletedAction/consts.ts';
 import RichTextDisplay from '~v5/shared/RichTextDisplay/index.ts';
-
-import { ICON_SIZE } from '../../consts.ts';
 
 const displayName = 'v5.common.CompletedAction.partials.DescriptionRow';
 

--- a/src/components/v5/common/Fields/Select/partials/CustomOption/CustomOption.tsx
+++ b/src/components/v5/common/Fields/Select/partials/CustomOption/CustomOption.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
+import { type SelectOption } from '~v5/common/Fields/Select/types.ts';
 import Link from '~v5/shared/Link/index.ts';
-
-import { type SelectOption } from '../../types.ts';
 
 const displayName = 'v5.common.Fields.Select.partials.CustomOption';
 

--- a/src/components/v5/common/Fields/datepickers/Datepicker/partials/DatepickerCustomHeader/DatepickerCustomHeader.tsx
+++ b/src/components/v5/common/Fields/datepickers/Datepicker/partials/DatepickerCustomHeader/DatepickerCustomHeader.tsx
@@ -5,9 +5,8 @@ import React, { type FC, useState, useLayoutEffect } from 'react';
 
 import { formatText } from '~utils/intl.ts';
 import { range } from '~utils/lodash.ts';
+import DatepickerYearDropdown from '~v5/common/Fields/datepickers/common/DatepickerYearDropdown/index.ts';
 import InputBase from '~v5/common/Fields/InputBase/index.ts';
-
-import DatepickerYearDropdown from '../../../common/DatepickerYearDropdown/index.ts';
 
 import { type DatepickerCustomHeaderProps } from './types.ts';
 

--- a/src/components/v5/common/Fields/datepickers/RangeDatepicker/partials/DatepickerCustomHeader/DatepickerCustomHeader.tsx
+++ b/src/components/v5/common/Fields/datepickers/RangeDatepicker/partials/DatepickerCustomHeader/DatepickerCustomHeader.tsx
@@ -6,9 +6,8 @@ import React, { type FC, useState, useLayoutEffect } from 'react';
 
 import { formatText } from '~utils/intl.ts';
 import { range } from '~utils/lodash.ts';
+import DatepickerYearDropdown from '~v5/common/Fields/datepickers/common/DatepickerYearDropdown/index.ts';
 import InputBase from '~v5/common/Fields/InputBase/index.ts';
-
-import DatepickerYearDropdown from '../../../common/DatepickerYearDropdown/index.ts';
 
 import { type DatepickerCustomHeaderProps } from './types.ts';
 

--- a/src/components/v5/common/Navigation/partials/NavItem/NavItem.tsx
+++ b/src/components/v5/common/Navigation/partials/NavItem/NavItem.tsx
@@ -1,9 +1,8 @@
 import React, { type FC } from 'react';
 import { useIntl } from 'react-intl';
 
+import { type NavItemProps } from '~v5/common/Navigation/types.ts';
 import NavLink from '~v5/shared/NavLink/index.ts';
-
-import { type NavItemProps } from '../../types.ts';
 
 const displayName = 'v5.common.Navigation.partials.NavItem';
 

--- a/src/components/v5/common/TokensModal/TokensModal.tsx
+++ b/src/components/v5/common/TokensModal/TokensModal.tsx
@@ -9,9 +9,8 @@ import { formatText } from '~utils/intl.ts';
 import FormFormattedInput from '~v5/common/Fields/InputBase/FormFormattedInput.tsx';
 import IconButton from '~v5/shared/Button/IconButton.tsx';
 import Button from '~v5/shared/Button/index.ts';
+import Modal from '~v5/shared/Modal/Modal.tsx';
 import { TokenAvatar } from '~v5/shared/TokenAvatar/TokenAvatar.tsx';
-
-import Modal from '../../shared/Modal/Modal.tsx';
 
 import { useTokensModal } from './hooks.ts';
 import { type TokensModalProps } from './types.ts';

--- a/src/components/v5/common/TokensModal/types.ts
+++ b/src/components/v5/common/TokensModal/types.ts
@@ -2,8 +2,7 @@ import { type ObjectSchema } from 'yup';
 
 import { type ActionTypes } from '~redux/index.ts';
 import { type Token } from '~types/graphql.ts';
-
-import { type ModalProps } from '../../shared/Modal/types.ts';
+import { type ModalProps } from '~v5/shared/Modal/types.ts';
 
 import { type TokensModalType } from './consts.ts';
 

--- a/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarThirdLevel/NavigationSidebarThirdLevel.tsx
+++ b/src/components/v5/frame/NavigationSidebar/partials/NavigationSidebarThirdLevel/NavigationSidebarThirdLevel.tsx
@@ -6,9 +6,9 @@ import React, { type FC } from 'react';
 import { accordionAnimation } from '~constants/accordionAnimation.ts';
 import { useTablet } from '~hooks/index.ts';
 import useToggle from '~hooks/useToggle/index.ts';
+import { thirdLevelContentAnimation } from '~v5/frame/NavigationSidebar/consts.ts';
 import Link from '~v5/shared/Link/index.ts';
 
-import { thirdLevelContentAnimation } from '../../consts.ts';
 import useNavigationSidebarContext from '../NavigationSidebarContext/hooks.ts';
 
 import { type NavigationSidebarThirdLevelProps } from './types.ts';

--- a/src/components/v5/shared/CardWithBios/partials/CardPermissions/CardPermission.tsx
+++ b/src/components/v5/shared/CardWithBios/partials/CardPermissions/CardPermission.tsx
@@ -1,8 +1,7 @@
 import React, { type FC } from 'react';
 
 import Tooltip from '~shared/Extensions/Tooltip/index.ts';
-
-import { type CardPermissionProps } from '../../types.ts';
+import { type CardPermissionProps } from '~v5/shared/CardWithBios/types.ts';
 
 const displayName = 'v5.CardWithBios.partials.CardPermission';
 

--- a/src/components/v5/shared/CardWithBios/partials/CardPermissions/CardPermissions.tsx
+++ b/src/components/v5/shared/CardWithBios/partials/CardPermissions/CardPermissions.tsx
@@ -1,6 +1,6 @@
 import React, { type FC } from 'react';
 
-import { type CardPermissionsProps } from '../../types.ts';
+import { type CardPermissionsProps } from '~v5/shared/CardWithBios/types.ts';
 
 import CardPermission from './CardPermission.tsx';
 

--- a/src/components/v5/shared/CardWithBios/partials/CardPermissions/consts.ts
+++ b/src/components/v5/shared/CardWithBios/partials/CardPermissions/consts.ts
@@ -6,7 +6,7 @@ import {
   Scales,
 } from '@phosphor-icons/react';
 
-import { type Permissions } from '../../types.ts';
+import { type Permissions } from '~v5/shared/CardWithBios/types.ts';
 
 export const permissions: Permissions[] = [
   {

--- a/src/components/v5/shared/MembersSelect/partials/CustomOption/CustomOption.tsx
+++ b/src/components/v5/shared/MembersSelect/partials/CustomOption/CustomOption.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
+import { type MembersSelectOption } from '~v5/shared/MembersSelect/types.ts';
 import { UserAvatar } from '~v5/shared/UserAvatar/UserAvatar.tsx';
-
-import { type MembersSelectOption } from '../../types.ts';
 
 const CustomOption: React.FC<MembersSelectOption> = ({ label, avatar }) => (
   <span className="flex w-full items-center gap-2 text-md">

--- a/src/components/v5/shared/SearchSelect/partials/CheckboxSearchItem/CheckboxSearchItem.tsx
+++ b/src/components/v5/shared/SearchSelect/partials/CheckboxSearchItem/CheckboxSearchItem.tsx
@@ -9,10 +9,9 @@ import { formatText } from '~utils/intl.ts';
 import { getTeamColor } from '~utils/teams.ts';
 import Checkbox from '~v5/common/Checkbox/Checkbox.tsx';
 import ExtensionsStatusBadge from '~v5/common/Pills/ExtensionStatusBadge/index.ts';
+import { sortDisabled } from '~v5/shared/SearchSelect/utils.ts';
 import { TokenAvatar } from '~v5/shared/TokenAvatar/TokenAvatar.tsx';
 import UserAvatar from '~v5/shared/UserAvatar/index.ts';
-
-import { sortDisabled } from '../../utils.ts';
 
 import { type CheckboxSearchItemProps } from './types.ts';
 

--- a/src/components/v5/shared/SearchSelect/partials/CheckboxSearchItem/types.ts
+++ b/src/components/v5/shared/SearchSelect/partials/CheckboxSearchItem/types.ts
@@ -1,4 +1,4 @@
-import { type SearchSelectOption } from '../../types.ts';
+import { type SearchSelectOption } from '~v5/shared/SearchSelect/types.ts';
 
 export interface CheckboxSearchItemProps {
   checkboxesList?: string[];

--- a/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
+++ b/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
@@ -8,10 +8,9 @@ import { getEnumValueFromKey } from '~utils/getEnumValueFromKey.ts';
 import { formatText } from '~utils/intl.ts';
 import { getTeamColor } from '~utils/teams.ts';
 import ExtensionsStatusBadge from '~v5/common/Pills/ExtensionStatusBadge/index.ts';
+import { sortDisabled } from '~v5/shared/SearchSelect/utils.ts';
 import { TokenAvatar } from '~v5/shared/TokenAvatar/TokenAvatar.tsx';
 import { UserAvatar } from '~v5/shared/UserAvatar/UserAvatar.tsx';
-
-import { sortDisabled } from '../../utils.ts';
 
 import { type SearchItemProps } from './types.ts';
 

--- a/src/components/v5/shared/SearchSelect/partials/SearchItem/types.ts
+++ b/src/components/v5/shared/SearchSelect/partials/SearchItem/types.ts
@@ -1,4 +1,4 @@
-import { type SearchSelectOption } from '../../types.ts';
+import { type SearchSelectOption } from '~v5/shared/SearchSelect/types.ts';
 
 export interface SearchItemProps {
   options: SearchSelectOption[];

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -10,8 +10,8 @@ import { Network } from '~types/network.ts';
 
 import { version } from '../../package.json';
 
-export * from './externalUrls.ts';
-export * from './extensions.ts';
+export * from '~constants/externalUrls.ts';
+export * from '~constants/extensions.ts';
 
 export type TokenInfo = {
   name: string;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -10,8 +10,8 @@ import { Network } from '~types/network.ts';
 
 import { version } from '../../package.json';
 
-export * from '~constants/externalUrls.ts';
-export * from '~constants/extensions.ts';
+export * from './externalUrls.ts';
+export * from './extensions.ts';
 
 export type TokenInfo = {
   name: string;

--- a/src/redux/sagas/actions/editColony.ts
+++ b/src/redux/sagas/actions/editColony.ts
@@ -8,12 +8,12 @@ import {
   type UpdateColonyMetadataMutation,
   type UpdateColonyMetadataMutationVariables,
 } from '~gql';
+import { transactionPending } from '~redux/actionCreators/index.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 import { transactionSetParams } from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { isEqual } from '~utils/lodash.ts';
 
-import { transactionPending } from '../../actionCreators/index.ts';
 import {
   createGroupTransaction,
   createTransactionChannels,

--- a/src/redux/sagas/actions/editDomain.ts
+++ b/src/redux/sagas/actions/editDomain.ts
@@ -12,12 +12,12 @@ import {
   type UpdateDomainMetadataMutation,
   type UpdateDomainMetadataMutationVariables,
 } from '~gql';
+import { transactionPending } from '~redux/actionCreators/index.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 import { transactionSetParams } from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { getDomainDatabaseId } from '~utils/databaseId.ts';
 
-import { transactionPending } from '../../actionCreators/index.ts';
 import {
   createGroupTransaction,
   createTransactionChannels,

--- a/src/redux/sagas/actions/managePermissions.ts
+++ b/src/redux/sagas/actions/managePermissions.ts
@@ -7,13 +7,13 @@ import {
 import { call, put, takeEvery } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context/index.ts';
+import { transactionPending } from '~redux/actionCreators/index.ts';
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions, type Action } from '~redux/types/actions/index.ts';
 import { transactionSetParams } from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { intArrayToBytes32 } from '~utils/web3/index.ts';
 
-import { transactionPending } from '../../actionCreators/index.ts';
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions, type Action } from '../../types/actions/index.ts';
 import {
   createGroupTransaction,
   createTransactionChannels,

--- a/src/redux/sagas/actions/moveFunds.ts
+++ b/src/redux/sagas/actions/moveFunds.ts
@@ -1,11 +1,11 @@
 import { ClientType } from '@colony/colony-js';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
+import { transactionPending } from '~redux/actionCreators/index.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 import { transactionSetParams } from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
-import { transactionPending } from '../../actionCreators/index.ts';
 import {
   createTransaction,
   createTransactionChannels,

--- a/src/redux/sagas/actions/payment.ts
+++ b/src/redux/sagas/actions/payment.ts
@@ -3,12 +3,12 @@ import { BigNumber } from 'ethers';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context/index.ts';
+import { transactionPending } from '~redux/actionCreators/index.ts';
 import { ActionTypes, type Action, type AllActions } from '~redux/index.ts';
 import { type OneTxPaymentPayload } from '~redux/types/actions/colonyActions.ts';
 import { transactionSetParams } from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
-import { transactionPending } from '../../actionCreators/index.ts';
 import {
   createTransaction,
   createTransactionChannels,

--- a/src/redux/sagas/colony/colonyCreate.ts
+++ b/src/redux/sagas/colony/colonyCreate.ts
@@ -33,6 +33,7 @@ import {
   type GetFullColonyByNameQuery,
   type GetFullColonyByNameQueryVariables,
 } from '~gql';
+import { transactionPending } from '~redux/actionCreators/index.ts';
 import { ActionTypes, type Action, type AllActions } from '~redux/index.ts';
 import {
   transactionSetIdentifier,
@@ -42,7 +43,6 @@ import {
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { createAddress } from '~utils/web3/index.ts';
 
-import { transactionPending } from '../../actionCreators/index.ts';
 import {
   type ChannelDefinition,
   createGroupTransaction,

--- a/src/redux/sagas/colony/index.ts
+++ b/src/redux/sagas/colony/index.ts
@@ -1,10 +1,10 @@
 import { ClientType } from '@colony/colony-js';
 import { all, call, fork, put, takeEvery } from 'redux-saga/effects';
 
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions, type Action } from '~redux/types/actions/index.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions, type Action } from '../../types/actions/index.ts';
 import {
   type TransactionChannelMap,
   createTransaction,

--- a/src/redux/sagas/extensions/extensionDeprecate.ts
+++ b/src/redux/sagas/extensions/extensionDeprecate.ts
@@ -1,10 +1,10 @@
 import { ClientType, getExtensionHash } from '@colony/colony-js';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions, type Action } from '~redux/types/actions/index.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions, type Action } from '../../types/actions/index.ts';
 import {
   createTransaction,
   getTxChannel,

--- a/src/redux/sagas/extensions/extensionEnable.ts
+++ b/src/redux/sagas/extensions/extensionEnable.ts
@@ -7,11 +7,11 @@ import {
 import { fork, put, takeEvery } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context/index.ts';
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type Action } from '~redux/types/actions/index.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { intArrayToBytes32 } from '~utils/web3/index.ts';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type Action } from '../../types/actions/index.ts';
 import {
   type ChannelDefinition,
   createTransaction,

--- a/src/redux/sagas/messages/index.ts
+++ b/src/redux/sagas/messages/index.ts
@@ -2,10 +2,10 @@ import { nanoid } from 'nanoid';
 import { call, put } from 'redux-saga/effects';
 
 import { ContextModule, getContext } from '~context/index.ts';
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions } from '~redux/types/actions/index.ts';
 import { isFullWallet } from '~types/wallet.ts';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions } from '../../types/actions/index.ts';
 import { putError, initiateMessageSigning } from '../utils/index.ts';
 
 export function* signMessage(purpose, message) {

--- a/src/redux/sagas/motions/claimAllMotionRewards.ts
+++ b/src/redux/sagas/motions/claimAllMotionRewards.ts
@@ -17,11 +17,11 @@ import {
   type GetColonyMotionQuery,
   type GetColonyMotionQueryVariables,
 } from '~gql';
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions, type Action } from '~redux/types/actions/index.ts';
 import { type ColonyMotion } from '~types/graphql.ts';
 import { type Address } from '~types/index.ts';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions, type Action } from '../../types/actions/index.ts';
 import {
   type ChannelDefinition,
   createGroupTransaction,

--- a/src/redux/sagas/motions/claimMotionRewards.ts
+++ b/src/redux/sagas/motions/claimMotionRewards.ts
@@ -13,9 +13,9 @@ import {
   type GetColonyActionQuery,
   type GetColonyActionQueryVariables,
 } from '~gql';
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions, type Action } from '~redux/types/actions/index.ts';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions, type Action } from '../../types/actions/index.ts';
 import {
   type ChannelDefinition,
   createGroupTransaction,

--- a/src/redux/sagas/motions/createEditDomainMotion.ts
+++ b/src/redux/sagas/motions/createEditDomainMotion.ts
@@ -15,11 +15,11 @@ import {
   type CreateDomainMetadataMutationVariables,
   DomainColor,
 } from '~gql';
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions, type Action } from '~redux/types/actions/index.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { getPendingMetadataDatabaseId } from '~utils/databaseId.ts';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions, type Action } from '../../types/actions/index.ts';
 import {
   createTransaction,
   createTransactionChannels,

--- a/src/redux/sagas/motions/escalateMotion.ts
+++ b/src/redux/sagas/motions/escalateMotion.ts
@@ -9,11 +9,11 @@ import { call, put, takeEvery } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context/index.ts';
 import { transactionPending } from '~redux/actionCreators/index.ts';
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions, type Action } from '~redux/types/actions/index.ts';
 import { transactionSetParams } from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions, type Action } from '../../types/actions/index.ts';
 import {
   createGroupTransaction,
   createTransactionChannels,

--- a/src/redux/sagas/motions/finalizeMotion.ts
+++ b/src/redux/sagas/motions/finalizeMotion.ts
@@ -1,10 +1,10 @@
 import { ClientType } from '@colony/colony-js';
 import { call, put, takeEvery } from 'redux-saga/effects';
 
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions, type Action } from '~redux/types/actions/index.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions, type Action } from '../../types/actions/index.ts';
 import {
   createGroupTransaction,
   createTransactionChannels,

--- a/src/redux/sagas/motions/manageReputationMotion.ts
+++ b/src/redux/sagas/motions/manageReputationMotion.ts
@@ -8,10 +8,10 @@ import {
 import { AddressZero } from '@ethersproject/constants';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions, type Action } from '~redux/types/actions/index.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions, type Action } from '../../types/actions/index.ts';
 import {
   createTransaction,
   createTransactionChannels,

--- a/src/redux/sagas/motions/manageTokens.ts
+++ b/src/redux/sagas/motions/manageTokens.ts
@@ -3,10 +3,10 @@ import { AddressZero } from '@ethersproject/constants';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context/index.ts';
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions, type Action } from '~redux/types/actions/index.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions, type Action } from '../../types/actions/index.ts';
 import {
   createTransaction,
   createTransactionChannels,

--- a/src/redux/sagas/motions/moveFundsMotion.ts
+++ b/src/redux/sagas/motions/moveFundsMotion.ts
@@ -10,10 +10,10 @@ import { AddressZero } from '@ethersproject/constants';
 import { constants } from 'ethers';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions, type Action } from '~redux/types/actions/index.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions, type Action } from '../../types/actions/index.ts';
 import {
   createTransaction,
   createTransactionChannels,

--- a/src/redux/sagas/motions/paymentMotion.ts
+++ b/src/redux/sagas/motions/paymentMotion.ts
@@ -7,10 +7,10 @@ import {
 import { AddressZero } from '@ethersproject/constants';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions, type Action } from '~redux/types/actions/index.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions, type Action } from '../../types/actions/index.ts';
 import { sortAndCombinePayments } from '../actions/payment.ts';
 import {
   createTransaction,

--- a/src/redux/sagas/motions/revealVoteMotion.ts
+++ b/src/redux/sagas/motions/revealVoteMotion.ts
@@ -7,9 +7,9 @@ import { utils, providers } from 'ethers';
 import { call, put, takeEvery } from 'redux-saga/effects';
 
 import { GANACHE_LOCAL_RPC_URL, isDev } from '~constants/index.ts';
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions, type Action } from '~redux/types/actions/index.ts';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions, type Action } from '../../types/actions/index.ts';
 import { signMessage } from '../messages/index.ts';
 import {
   createGroupTransaction,

--- a/src/redux/sagas/motions/rootMotion.ts
+++ b/src/redux/sagas/motions/rootMotion.ts
@@ -3,10 +3,10 @@ import { AddressZero } from '@ethersproject/constants';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context/index.ts';
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions, type Action } from '~redux/types/actions/index.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions, type Action } from '../../types/actions/index.ts';
 import {
   createTransaction,
   createTransactionChannels,

--- a/src/redux/sagas/motions/stakeMotion.ts
+++ b/src/redux/sagas/motions/stakeMotion.ts
@@ -8,12 +8,12 @@ import {
 import { call, put, takeEvery } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context/index.ts';
+import { transactionPending } from '~redux/actionCreators/index.ts';
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions, type Action } from '~redux/types/actions/index.ts';
 import { transactionSetParams } from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
-import { transactionPending } from '../../actionCreators/index.ts';
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions, type Action } from '../../types/actions/index.ts';
 import {
   createGroupTransaction,
   createTransactionChannels,

--- a/src/redux/sagas/motions/voteMotion.ts
+++ b/src/redux/sagas/motions/voteMotion.ts
@@ -2,8 +2,9 @@ import { type AnyVotingReputationClient, ClientType } from '@colony/colony-js';
 import { utils } from 'ethers';
 import { call, put, takeEvery } from 'redux-saga/effects';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type AllActions, type Action } from '../../types/actions/index.ts';
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type AllActions, type Action } from '~redux/types/actions/index.ts';
+
 import { signMessage } from '../messages/index.ts';
 import {
   createGroupTransaction,

--- a/src/redux/sagas/transactions/createTransaction.ts
+++ b/src/redux/sagas/transactions/createTransaction.ts
@@ -13,12 +13,12 @@ import {
 
 import { getContext, ContextModule } from '~context/index.ts';
 import { TransactionStatus } from '~gql';
+import { createTransactionAction } from '~redux/actionCreators/index.ts';
+import { ActionTypes } from '~redux/actionTypes.ts';
 import { addTransactionToDb } from '~state/transactionState.ts';
 import { type ExtendedClientType, type TxConfig } from '~types/transactions.ts';
 import { filterUniqueAction } from '~utils/actions.ts';
 
-import { createTransactionAction } from '../../actionCreators/index.ts';
-import { ActionTypes } from '../../actionTypes.ts';
 import { takeFrom, metatransactionsEnabled } from '../utils/index.ts';
 
 import estimateGasCost from './estimateGasCost.ts';

--- a/src/redux/sagas/transactions/estimateGasCost.ts
+++ b/src/redux/sagas/transactions/estimateGasCost.ts
@@ -2,16 +2,16 @@ import { ClientType } from '@colony/colony-js';
 import { BigNumber, type Contract } from 'ethers';
 import { call, put } from 'redux-saga/effects';
 
-import { getTransaction } from '~state/transactionState.ts';
-
 import {
   transactionUpdateGas,
   transactionEstimateError,
   transactionSend,
   transactionUpdateOptions,
-} from '../../actionCreators/index.ts';
-import { type ActionTypes } from '../../actionTypes.ts';
-import { type Action } from '../../types/actions/index.ts';
+} from '~redux/actionCreators/index.ts';
+import { type ActionTypes } from '~redux/actionTypes.ts';
+import { type Action } from '~redux/types/actions/index.ts';
+import { getTransaction } from '~state/transactionState.ts';
+
 import { getGasPrices, getColonyManager } from '../utils/index.ts';
 
 /*

--- a/src/redux/sagas/transactions/getMetatransactionPromise.ts
+++ b/src/redux/sagas/transactions/getMetatransactionPromise.ts
@@ -3,6 +3,7 @@ import { type TransactionResponse } from '@ethersproject/providers';
 import { Contract, type BigNumberish, utils } from 'ethers';
 
 import { ContextModule, getContext } from '~context/index.ts';
+import { type TransactionType } from '~redux/immutable/index.ts';
 import {
   type MethodParams,
   MetatransactionFlavour,
@@ -17,7 +18,6 @@ import {
   generateMetamaskTypedDataSignatureErrorMessage,
 } from '~utils/web3/index.ts';
 
-import { type TransactionType } from '../../immutable/index.ts';
 import {
   generateEIP2612TypedData,
   generateMetatransactionMessage,

--- a/src/redux/sagas/transactions/getTransactionPromise.ts
+++ b/src/redux/sagas/transactions/getTransactionPromise.ts
@@ -2,7 +2,7 @@ import { type ContractClient } from '@colony/colony-js';
 import { type TransactionResponse } from '@ethersproject/providers';
 import { type Overrides } from 'ethers';
 
-import { type TransactionType } from '../../immutable/index.ts';
+import { type TransactionType } from '~redux/immutable/index.ts';
 
 /*
  * Given a method and a transaction record, create a promise for sending the

--- a/src/redux/sagas/transactions/sendTransaction.ts
+++ b/src/redux/sagas/transactions/sendTransaction.ts
@@ -2,13 +2,13 @@ import { ClientType } from '@colony/colony-js';
 import { call, put, take } from 'redux-saga/effects';
 
 import { TransactionStatus } from '~gql';
+import { transactionSendError } from '~redux/actionCreators/index.ts';
+import { type ActionTypes } from '~redux/actionTypes.ts';
+import { type Action } from '~redux/types/actions/index.ts';
 import { getTransaction } from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { mergePayload } from '~utils/actions.ts';
 
-import { transactionSendError } from '../../actionCreators/index.ts';
-import { type ActionTypes } from '../../actionTypes.ts';
-import { type Action } from '../../types/actions/index.ts';
 import { getColonyManager, metatransactionsEnabled } from '../utils/index.ts';
 
 import getMetatransactionPromise from './getMetatransactionPromise.ts';

--- a/src/redux/sagas/transactions/transactionChannel.ts
+++ b/src/redux/sagas/transactions/transactionChannel.ts
@@ -7,9 +7,6 @@ import {
 import { type LogDescription, poll } from 'ethers/lib/utils';
 import { buffers, END, eventChannel, type Buffer } from 'redux-saga';
 
-import { type RequireProps } from '~types/index.ts';
-import { type MethodParams } from '~types/transactions.ts';
-
 import {
   transactionSendError,
   transactionEventDataError,
@@ -19,8 +16,10 @@ import {
   transactionSent,
   transactionHashReceived,
   transactionSucceeded,
-} from '../../actionCreators/index.ts';
-import { type TransactionType } from '../../immutable/index.ts';
+} from '~redux/actionCreators/index.ts';
+import { type TransactionType } from '~redux/immutable/index.ts';
+import { type RequireProps } from '~types/index.ts';
+import { type MethodParams } from '~types/transactions.ts';
 
 type TransactionResponseWithHash = RequireProps<TransactionResponse, 'hash'>;
 // @TODO typing here is not great but I have no idea how to improve it atm

--- a/src/redux/sagas/users/index.ts
+++ b/src/redux/sagas/users/index.ts
@@ -19,12 +19,12 @@ import {
   GetProfileByEmailDocument,
   GetUserByNameDocument,
 } from '~gql';
+import { ActionTypes } from '~redux/actionTypes.ts';
+import { type Action, type AllActions } from '~redux/types/actions/index.ts';
 import { LANDING_PAGE_ROUTE } from '~routes/index.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { clearLastWallet } from '~utils/autoLogin.ts';
 
-import { ActionTypes } from '../../actionTypes.ts';
-import { type Action, type AllActions } from '../../types/actions/index.ts';
 import {
   createGroupTransaction,
   createTransaction,

--- a/src/redux/sagas/utils/effects.ts
+++ b/src/redux/sagas/utils/effects.ts
@@ -7,13 +7,12 @@ import {
   transactionSend,
   messageSign,
 } from '~redux/actionCreators/index.ts';
-import { transactionSetReady } from '~state/transactionState.ts';
-
 import {
   type ErrorActionType,
   type TakeFilter,
   type Action,
-} from '../../types/actions/index.ts';
+} from '~redux/types/actions/index.ts';
+import { transactionSetReady } from '~state/transactionState.ts';
 
 import { metatransactionsEnabled } from './getCanUserSendMetatransactions.ts';
 

--- a/src/redux/sagas/utils/getGasPrices.ts
+++ b/src/redux/sagas/utils/getGasPrices.ts
@@ -4,12 +4,11 @@ import { call, put, select } from 'redux-saga/effects';
 import { ETH_GAS_STATION, XDAI_GAS_STATION } from '~constants/externalUrls.ts';
 import { DEFAULT_NETWORK } from '~constants/index.ts';
 import { ContextModule, getContext } from '~context/index.ts';
+import { updateGasPrices } from '~redux/actionCreators/index.ts';
+import { type GasPricesProps } from '~redux/immutable/index.ts';
+import { gasPrices as gasPricesSelector } from '~redux/selectors/index.ts';
 import { Network } from '~types/network.ts';
 import { RpcMethods } from '~types/rpcMethods.ts';
-
-import { updateGasPrices } from '../../actionCreators/index.ts';
-import { type GasPricesProps } from '../../immutable/index.ts';
-import { gasPrices as gasPricesSelector } from '../../selectors/index.ts';
 
 interface EthGasStationAPIResponse {
   average: number;

--- a/src/redux/types/actions/gasPrices.ts
+++ b/src/redux/types/actions/gasPrices.ts
@@ -1,6 +1,5 @@
+import { type ActionTypes } from '~redux/actionTypes.ts';
 import { type GasPricesProps } from '~redux/immutable/index.ts';
-
-import { type ActionTypes } from '../../actionTypes.ts';
 
 import { type ActionTypeWithPayload } from './index.ts';
 

--- a/src/redux/types/actions/ipfs.ts
+++ b/src/redux/types/actions/ipfs.ts
@@ -1,4 +1,4 @@
-import { type ActionTypes } from '../../index.ts';
+import { type ActionTypes } from '~redux/index.ts';
 
 import { type ErrorActionType, type UniqueActionType } from './index.ts';
 

--- a/src/redux/types/actions/message.ts
+++ b/src/redux/types/actions/message.ts
@@ -1,4 +1,4 @@
-import { type ActionTypes } from '../../actionTypes.ts';
+import { type ActionTypes } from '~redux/actionTypes.ts';
 
 import {
   type ActionTypeWithPayload,

--- a/src/redux/types/actions/motion.ts
+++ b/src/redux/types/actions/motion.ts
@@ -3,6 +3,7 @@ import { type BigNumber } from 'ethers';
 
 import { type NetworkInfo } from '~constants/index.ts';
 import { type ExternalLink } from '~gql';
+import { type ActionTypes } from '~redux/actionTypes.ts';
 import { type ExpenditurePayoutFieldValue } from '~types/expenditures.ts';
 import {
   type Expenditure,
@@ -14,8 +15,6 @@ import {
   type SafeTransactionData,
 } from '~types/graphql.ts';
 import { type Address } from '~types/index.ts';
-
-import { type ActionTypes } from '../../actionTypes.ts';
 
 import { type OneTxPaymentPayload } from './colonyActions.ts';
 import {

--- a/src/redux/types/actions/transaction.ts
+++ b/src/redux/types/actions/transaction.ts
@@ -1,12 +1,11 @@
 import { type TransactionReceipt } from '@ethersproject/providers';
 
+import { type ActionTypes } from '~redux/actionTypes.ts';
 import {
   type TransactionError,
   type TransactionType,
 } from '~redux/immutable/index.ts';
 import { type TxConfig, type MethodParams } from '~types/transactions.ts';
-
-import { type ActionTypes } from '../../actionTypes.ts';
 
 import {
   type ActionTypeWithMeta,

--- a/src/redux/types/actions/user.ts
+++ b/src/redux/types/actions/user.ts
@@ -1,7 +1,6 @@
 import { type CreateUserFormValues } from '~common/Onboarding/wizardSteps/StepCreateUser/types.ts';
+import { type ActionTypes } from '~redux/actionTypes.ts';
 import { type Address } from '~types/index.ts';
-
-import { type ActionTypes } from '../../actionTypes.ts';
 
 import {
   type ActionType,

--- a/src/redux/types/actions/vesting.ts
+++ b/src/redux/types/actions/vesting.ts
@@ -1,4 +1,4 @@
-import { type ActionTypes } from '../../actionTypes.ts';
+import { type ActionTypes } from '~redux/actionTypes.ts';
 
 import { type ErrorActionType, type UniqueActionType } from './index.ts';
 

--- a/src/redux/types/actions/wallet.ts
+++ b/src/redux/types/actions/wallet.ts
@@ -1,4 +1,4 @@
-import { type ActionTypes } from '../../actionTypes.ts';
+import { type ActionTypes } from '~redux/actionTypes.ts';
 
 import { type ErrorActionType, type ActionType } from './index.ts';
 

--- a/src/utils/yup/customMethods.ts
+++ b/src/utils/yup/customMethods.ts
@@ -2,9 +2,10 @@ import { isEqual } from 'lodash';
 import { addMethod, string, type TestOptionsMessage, array, object } from 'yup';
 
 import { isAddress } from '~utils/web3/index.ts';
-import { createValidationComparableObject } from '~utils/yup/utils.ts';
 
 import en from '../../i18n/en-validation.json';
+
+import { createValidationComparableObject } from './utils.ts';
 
 /*
  * Hex String Regex Test

--- a/src/utils/yup/customMethods.ts
+++ b/src/utils/yup/customMethods.ts
@@ -2,10 +2,9 @@ import { isEqual } from 'lodash';
 import { addMethod, string, type TestOptionsMessage, array, object } from 'yup';
 
 import { isAddress } from '~utils/web3/index.ts';
+import { createValidationComparableObject } from '~utils/yup/utils.ts';
 
 import en from '../../i18n/en-validation.json';
-
-import { createValidationComparableObject } from './utils.ts';
 
 /*
  * Hex String Regex Test


### PR DESCRIPTION
## Description

Add an eslint rule to enforce absolute imports with aliases. These are preferred over relative imports as they are easier to read and maintain. Since we use aliases to make imports simpler, the lint rule must also handle these, and use these when autofixing. We do allow sibling imports, and one level deep relative imports (parent folders).

I researched a few different lint rules which were available to do this, and also tried making a custom rule. Here's why I avoided certain rules:
- Making a custom rule was adding too much overhead, and while we could have a lot of control, it was too much work to maintain for such a small thing, especially when there's a lot of good options available.
- Using [this rule](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-relative-parent-imports.md) from the import plugin that we already use did throw the correct errors, but does not allow auto fixing, which would get very annoying very quickly.
- Using a simple and popular plugin such as [absolute-imports](https://www.npmjs.com/package/eslint-plugin-absolute-imports) or [no-relative-import-paths](https://www.npmjs.com/package/eslint-plugin-no-relative-import-paths) solved only half the problem. It fixed the relative imports, but didn't use aliases.
- Using a package like [eslint-plugin-import-alias](https://www.npmjs.com/package/eslint-plugin-import-alias) worked great, and was very lightweight and easy to audit/read the code. There were a few problems however. Firstly, I was concerned about the fact that the latest publish was six years ago, it seemed it wasn't being maintained. Secondly, you had to manually pass an object of aliases to the lint rule, which adds maintenance on our end.

After all the testing, I landed on [@limegrass/eslint-plugin-import-alias](https://www.npmjs.com/package/@limegrass/eslint-plugin-import-alias). Not only does it solve the issue, but it is also actively maintained (last publish 3 months ago) and has almost 7k weekly downloads. It also simply reads the aliases/paths from our tsconfig file, which makes it super simple to use. It even has a configurable depth, so we can allow sibling and parent imports as preferred.

## Testing

Shouldn't need much testing, just a basic check that the app still runs, but if you spot any fishy import changes then maybe check the part of the app which that file is used in.

## Diffs

**New stuff** ✨

* New eslint rule to enforce absolute imports where relevant, and the use of aliases.
