### PR TITLE
[Multi-sig] fix: use native domainId for getting domain from multisig extension params

### DIFF
--- a/src/hooks/multiSig/useDomainThreshold.ts
+++ b/src/hooks/multiSig/useDomainThreshold.ts
@@ -1,6 +1,5 @@
 import { type ColonyRole, Extension } from '@colony/colony-js';
 
-import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useExtensionData from '~hooks/useExtensionData.ts';
 import { type Threshold } from '~types/multiSig.ts';
 import { isInstalledExtensionData } from '~utils/extensions.ts';
@@ -21,10 +20,6 @@ export const useDomainThreshold = ({
   requiredRoles,
   domainId,
 }: UseDomainThresholdParams): UseDomainThresholdResult => {
-  const {
-    colony: { colonyAddress },
-  } = useColonyContext();
-
   const { extensionData, loading: loadingExtension } = useExtensionData(
     Extension.MultisigPermissions,
   );
@@ -55,7 +50,7 @@ export const useDomainThreshold = ({
     const matchingDomain = (domainThresholds ?? []).find(
       (thresholdEntry) =>
         thresholdEntry !== null &&
-        thresholdEntry.domainId === `${colonyAddress}_${domainId}`,
+        thresholdEntry.domainId === domainId.toString(),
     );
 
     // if we didn't find domain config, let's just assume we inherit from the colony


### PR DESCRIPTION
## Description

Long story short, somehow we changed the format of the domainId in multisig's installed params from `<COLONY_ADDRESS>_<DOMAIN_NATIVE_ID>` to just use it's native id. This means that all subdomain's just used the global threshold :D 

## Testing

1. Install Multi-Sig extension
2. Set the global threshold to 2, threshold in Andromeda to 1
![image](https://github.com/user-attachments/assets/c4e9d3fa-b794-4bc5-ae9f-b143eedcf468)
3. Refresh the page and open the action sidebar
4. Verify that you can't create a `Manage reputation` action in General (since there aren't 2 permission holders there)
![image](https://github.com/user-attachments/assets/7f770606-cdb7-4b96-be91-70e044a89ae6)
5. Verify that however, this would work in Andromeda
![image](https://github.com/user-attachments/assets/765983de-0a59-4d43-8daa-b7133ed28390)

## Diffs

**Changes** 🏗

* `useDomainThreshold` now checks the nativeId instead of constructing the full id (also added a note to remove nullish coalescence once we merge #2800 


Contributes to #2658 (point 23)
