### PR TITLE
[Multi-sig] refactor: remove action form from multisig voting buttons, fix behaviour with metamask

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/CancelButton/CancelButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/CancelButton/CancelButton.tsx
@@ -6,16 +6,16 @@ import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { ActionTypes } from '~redux/actionTypes.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionButton from '~v5/shared/Button/ActionButton.tsx';
-
-import { VoteExpectedStep } from '../MultiSigWidget/types.ts';
+import { type ButtonProps } from '~v5/shared/Button/types.ts';
 
 const displayName =
   'v5.common.ActionSidebar.partials.MultiSig.partials.CancelButton';
 
 interface CancelButtonProps {
   multiSigId: string;
-  isPending: boolean;
-  setExpectedStep: (step: VoteExpectedStep) => void;
+  handleLoadingChange: (isLoading: boolean) => void;
+  isLoading: boolean;
+  buttonProps?: ButtonProps;
 }
 
 const MSG = defineMessages({
@@ -27,27 +27,33 @@ const MSG = defineMessages({
 
 const CancelButton: FC<CancelButtonProps> = ({
   multiSigId,
-  isPending,
-  setExpectedStep,
+  handleLoadingChange,
+  isLoading,
+  buttonProps,
 }) => {
   const { colony } = useColonyContext();
 
-  const cancelPayload = {
-    colonyAddress: colony.colonyAddress,
-    motionId: multiSigId,
+  const getCancelPayload = () => {
+    handleLoadingChange(true);
+
+    return {
+      colonyAddress: colony.colonyAddress,
+      motionId: multiSigId,
+    };
   };
 
   return (
     <ActionButton
       isFullSize
       useTxLoader
-      isLoading={isPending}
+      isLoading={isLoading}
       actionType={ActionTypes.MULTISIG_CANCEL}
-      onSuccess={() => {
-        setExpectedStep(VoteExpectedStep.cancel);
+      values={getCancelPayload}
+      onError={() => {
+        handleLoadingChange(false);
       }}
-      values={cancelPayload}
       mode="primaryOutline"
+      {...buttonProps}
     >
       {formatText(MSG.buttonReject)}
     </ActionButton>

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/CancelButton/CancelButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/CancelButton/CancelButton.tsx
@@ -1,15 +1,11 @@
-import { SpinnerGap } from '@phosphor-icons/react';
 import React from 'react';
 import { type FC } from 'react';
 import { defineMessages } from 'react-intl';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { ActionTypes } from '~redux/actionTypes.ts';
-import { ActionForm } from '~shared/Fields/index.ts';
-import { mapPayload } from '~utils/actions.ts';
 import { formatText } from '~utils/intl.ts';
-import Button from '~v5/shared/Button/Button.tsx';
-import IconButton from '~v5/shared/Button/IconButton.tsx';
+import ActionButton from '~v5/shared/Button/ActionButton.tsx';
 
 import { VoteExpectedStep } from '../MultiSigWidget/types.ts';
 
@@ -36,37 +32,25 @@ const CancelButton: FC<CancelButtonProps> = ({
 }) => {
   const { colony } = useColonyContext();
 
-  const transform = mapPayload(() => ({
+  const cancelPayload = {
     colonyAddress: colony.colonyAddress,
     motionId: multiSigId,
-  }));
+  };
 
   return (
-    <ActionForm
+    <ActionButton
+      isFullSize
+      useTxLoader
+      isLoading={isPending}
       actionType={ActionTypes.MULTISIG_CANCEL}
-      transform={transform}
-      onSuccess={() => setExpectedStep(VoteExpectedStep.cancel)}
+      onSuccess={() => {
+        setExpectedStep(VoteExpectedStep.cancel);
+      }}
+      values={cancelPayload}
+      mode="primaryOutline"
     >
-      {({ formState: { isSubmitting } }) =>
-        isPending || isSubmitting ? (
-          <IconButton
-            rounded="s"
-            isFullSize
-            text={{ id: 'button.pending' }}
-            icon={
-              <span className="ml-2 flex shrink-0">
-                <SpinnerGap size={18} className="animate-spin" />
-              </span>
-            }
-            className="!px-4 !text-md"
-          />
-        ) : (
-          <Button type="submit" mode="primaryOutline" isFullSize>
-            {formatText(MSG.buttonReject)}
-          </Button>
-        )
-      }
-    </ActionForm>
+      {formatText(MSG.buttonReject)}
+    </ActionButton>
   );
 };
 

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
@@ -395,10 +395,7 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
                       {isOwner || isMotionOlderThanWeek ? (
                         <CancelButton
                           multiSigId={multiSigData.nativeMultiSigId}
-                          isPending={
-                            expectedStep === VoteExpectedStep.cancel &&
-                            currentVote === MultiSigVote.Reject
-                          }
+                          isPending={expectedStep === VoteExpectedStep.cancel}
                           setExpectedStep={setExpectedStep}
                         />
                       ) : (
@@ -410,7 +407,7 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
                           )}
                           isPending={
                             expectedStep === VoteExpectedStep.cancel &&
-                            currentVote !== MultiSigVote.Approve
+                            currentVote === MultiSigVote.Reject
                           }
                           setExpectedStep={setExpectedStep}
                           setCurrentVote={setCurrentVote}

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/RemoveVoteButton/RemoveVoteButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/RemoveVoteButton/RemoveVoteButton.tsx
@@ -11,8 +11,6 @@ import { formatText } from '~utils/intl.ts';
 import { getRolesNeededForMultiSigAction } from '~utils/multiSig/index.ts';
 import ActionButton from '~v5/shared/Button/ActionButton.tsx';
 
-import { VoteExpectedStep } from '../MultiSigWidget/types.ts';
-
 const displayName =
   'v5.common.ActionSidebar.partials.MultiSig.partials.RemoveVoteButton';
 
@@ -20,8 +18,8 @@ interface RemoveVoteButtonProps {
   actionType: ColonyActionType;
   multiSigId: string;
   multiSigDomainId: number;
-  isPending: boolean;
-  setExpectedStep: (step: VoteExpectedStep) => void;
+  handleLoadingChange: (isLoading: boolean) => void;
+  isLoading: boolean;
 }
 
 const MSG = defineMessages({
@@ -35,33 +33,39 @@ const RemoveVoteButton: FC<RemoveVoteButtonProps> = ({
   actionType,
   multiSigId,
   multiSigDomainId,
-  isPending,
-  setExpectedStep,
+  handleLoadingChange,
+  isLoading,
 }) => {
   const { colony } = useColonyContext();
 
-  const removeVotePayload = {
-    colonyAddress: colony.colonyAddress,
-    colonyDomains: extractColonyDomains(colony.domains),
-    colonyRoles: extractColonyRoles(colony.roles),
-    vote: MultiSigVote.None,
-    domainId: multiSigDomainId,
-    multiSigId,
-    roles:
-      getRolesNeededForMultiSigAction({
-        actionType,
-        createdIn: multiSigDomainId,
-      }) || [],
+  const getRemoveVotePayload = () => {
+    handleLoadingChange(true);
+
+    return {
+      colonyAddress: colony.colonyAddress,
+      colonyDomains: extractColonyDomains(colony.domains),
+      colonyRoles: extractColonyRoles(colony.roles),
+      vote: MultiSigVote.None,
+      domainId: multiSigDomainId,
+      multiSigId,
+      roles:
+        getRolesNeededForMultiSigAction({
+          actionType,
+          createdIn: multiSigDomainId,
+        }) || [],
+    };
   };
 
   return (
     <ActionButton
       useTxLoader
       isFullSize
-      isLoading={isPending}
       actionType={ActionTypes.MULTISIG_VOTE}
-      onSuccess={() => setExpectedStep(VoteExpectedStep.vote)}
-      values={removeVotePayload}
+      isLoading={isLoading}
+      onError={() => {
+        handleLoadingChange(false);
+      }}
+      values={getRemoveVotePayload}
     >
       {formatText(MSG.remove)}
     </ActionButton>

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/RemoveVoteButton/RemoveVoteButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/RemoveVoteButton/RemoveVoteButton.tsx
@@ -1,4 +1,3 @@
-import { SpinnerGap } from '@phosphor-icons/react';
 import React from 'react';
 import { type FC } from 'react';
 import { defineMessages } from 'react-intl';
@@ -6,14 +5,11 @@ import { defineMessages } from 'react-intl';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { MultiSigVote, type ColonyActionType } from '~gql';
 import { ActionTypes } from '~redux/actionTypes.ts';
-import { ActionForm } from '~shared/Fields/index.ts';
-import { mapPayload } from '~utils/actions.ts';
 import { extractColonyRoles } from '~utils/colonyRoles.ts';
 import { extractColonyDomains } from '~utils/domains.ts';
 import { formatText } from '~utils/intl.ts';
 import { getRolesNeededForMultiSigAction } from '~utils/multiSig/index.ts';
-import Button from '~v5/shared/Button/Button.tsx';
-import IconButton from '~v5/shared/Button/IconButton.tsx';
+import ActionButton from '~v5/shared/Button/ActionButton.tsx';
 
 import { VoteExpectedStep } from '../MultiSigWidget/types.ts';
 
@@ -44,7 +40,7 @@ const RemoveVoteButton: FC<RemoveVoteButtonProps> = ({
 }) => {
   const { colony } = useColonyContext();
 
-  const transform = mapPayload(() => ({
+  const removeVotePayload = {
     colonyAddress: colony.colonyAddress,
     colonyDomains: extractColonyDomains(colony.domains),
     colonyRoles: extractColonyRoles(colony.roles),
@@ -56,34 +52,19 @@ const RemoveVoteButton: FC<RemoveVoteButtonProps> = ({
         actionType,
         createdIn: multiSigDomainId,
       }) || [],
-  }));
+  };
 
   return (
-    <ActionForm
+    <ActionButton
+      useTxLoader
+      isFullSize
+      isLoading={isPending}
       actionType={ActionTypes.MULTISIG_VOTE}
-      transform={transform}
       onSuccess={() => setExpectedStep(VoteExpectedStep.vote)}
+      values={removeVotePayload}
     >
-      {({ formState: { isSubmitting } }) =>
-        isSubmitting || isPending ? (
-          <IconButton
-            rounded="s"
-            isFullSize
-            text={{ id: 'button.pending' }}
-            icon={
-              <span className="ml-2 flex shrink-0">
-                <SpinnerGap size={18} className="animate-spin" />
-              </span>
-            }
-            className="!px-4 !text-md"
-          />
-        ) : (
-          <Button type="submit" isFullSize>
-            {formatText(MSG.remove)}
-          </Button>
-        )
-      }
-    </ActionForm>
+      {formatText(MSG.remove)}
+    </ActionButton>
   );
 };
 

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/VoteButton/VoteButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/VoteButton/VoteButton.tsx
@@ -1,4 +1,3 @@
-import { SpinnerGap } from '@phosphor-icons/react';
 import React from 'react';
 import { type FC } from 'react';
 import { defineMessages } from 'react-intl';
@@ -6,14 +5,11 @@ import { defineMessages } from 'react-intl';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { type ColonyActionType, MultiSigVote } from '~gql';
 import { ActionTypes } from '~redux/actionTypes.ts';
-import { ActionForm } from '~shared/Fields/index.ts';
-import { mapPayload } from '~utils/actions.ts';
 import { extractColonyRoles } from '~utils/colonyRoles.ts';
 import { extractColonyDomains } from '~utils/domains.ts';
 import { formatText } from '~utils/intl.ts';
 import { getRolesNeededForMultiSigAction } from '~utils/multiSig/index.ts';
-import Button from '~v5/shared/Button/Button.tsx';
-import IconButton from '~v5/shared/Button/IconButton.tsx';
+import ActionButton from '~v5/shared/Button/ActionButton.tsx';
 import { type ButtonProps } from '~v5/shared/Button/types.ts';
 
 import { VoteExpectedStep } from '../MultiSigWidget/types.ts';
@@ -60,56 +56,41 @@ const VoteButton: FC<VoteButtonProps> = ({
     [MultiSigVote.Reject]: MSG.reject,
   };
 
-  const transform = mapPayload(() => ({
-    colonyAddress: colony.colonyAddress,
-    colonyDomains: extractColonyDomains(colony.domains),
-    colonyRoles: extractColonyRoles(colony.roles),
-    vote: voteType,
-    domainId: multiSigDomainId,
-    multiSigId,
-    roles:
-      getRolesNeededForMultiSigAction({
-        actionType,
-        createdIn: multiSigDomainId,
-      }) || [],
-  }));
+  const getVotePayload = () => {
+    setCurrentVote(voteType);
+
+    return {
+      colonyAddress: colony.colonyAddress,
+      colonyDomains: extractColonyDomains(colony.domains),
+      colonyRoles: extractColonyRoles(colony.roles),
+      vote: voteType,
+      domainId: multiSigDomainId,
+      multiSigId,
+      roles:
+        getRolesNeededForMultiSigAction({
+          actionType,
+          createdIn: multiSigDomainId,
+        }) || [],
+    };
+  };
 
   return (
-    <ActionForm
+    <ActionButton
+      isFullSize
+      useTxLoader
+      isLoading={isPending}
       actionType={ActionTypes.MULTISIG_VOTE}
-      transform={transform}
       onSuccess={() => {
         setExpectedStep(VoteExpectedStep.cancel);
       }}
       onError={() => {
         setExpectedStep(null);
       }}
+      values={getVotePayload}
+      {...buttonProps}
     >
-      {({ formState: { isSubmitting } }) =>
-        isPending || isSubmitting ? (
-          <IconButton
-            rounded="s"
-            isFullSize
-            text={{ id: 'button.pending' }}
-            icon={
-              <span className="ml-2 flex shrink-0">
-                <SpinnerGap size={18} className="animate-spin" />
-              </span>
-            }
-            className="!px-4 !text-md"
-          />
-        ) : (
-          <Button
-            type="submit"
-            {...buttonProps}
-            isFullSize
-            onClick={() => setCurrentVote(voteType)}
-          >
-            {formatText(buttonText[voteType])}
-          </Button>
-        )
-      }
-    </ActionForm>
+      {formatText(buttonText[voteType])}
+    </ActionButton>
   );
 };
 

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/VoteButton/VoteButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/VoteButton/VoteButton.tsx
@@ -12,8 +12,6 @@ import { getRolesNeededForMultiSigAction } from '~utils/multiSig/index.ts';
 import ActionButton from '~v5/shared/Button/ActionButton.tsx';
 import { type ButtonProps } from '~v5/shared/Button/types.ts';
 
-import { VoteExpectedStep } from '../MultiSigWidget/types.ts';
-
 const displayName =
   'v5.common.ActionSidebar.partials.MultiSig.partials.VoteButton';
 
@@ -22,9 +20,8 @@ interface VoteButtonProps {
   multiSigId: string;
   multiSigDomainId: number;
   voteType: Exclude<MultiSigVote, MultiSigVote.None>;
-  isPending: boolean;
-  setExpectedStep: (step: VoteExpectedStep | null) => void;
-  setCurrentVote: (vote: MultiSigVote | null) => void;
+  handleLoadingChange: (isLoading: boolean) => void;
+  isLoading: boolean;
   buttonProps?: ButtonProps;
 }
 
@@ -45,9 +42,8 @@ const VoteButton: FC<VoteButtonProps> = ({
   multiSigDomainId,
   voteType,
   buttonProps,
-  setExpectedStep,
-  setCurrentVote,
-  isPending,
+  handleLoadingChange,
+  isLoading,
 }) => {
   const { colony } = useColonyContext();
 
@@ -57,7 +53,7 @@ const VoteButton: FC<VoteButtonProps> = ({
   };
 
   const getVotePayload = () => {
-    setCurrentVote(voteType);
+    handleLoadingChange(true);
 
     return {
       colonyAddress: colony.colonyAddress,
@@ -78,13 +74,10 @@ const VoteButton: FC<VoteButtonProps> = ({
     <ActionButton
       isFullSize
       useTxLoader
-      isLoading={isPending}
       actionType={ActionTypes.MULTISIG_VOTE}
-      onSuccess={() => {
-        setExpectedStep(VoteExpectedStep.cancel);
-      }}
+      isLoading={isLoading}
       onError={() => {
-        setExpectedStep(null);
+        handleLoadingChange(false);
       }}
       values={getVotePayload}
       {...buttonProps}

--- a/src/components/v5/shared/Button/ActionButton.tsx
+++ b/src/components/v5/shared/Button/ActionButton.tsx
@@ -54,7 +54,7 @@ const ActionButton: FC<ActionButtonProps> = ({
   return useTxLoader && (isLoading || loading) ? (
     <IconButton
       rounded="s"
-      isFullSize={isMobile}
+      isFullSize={props.isFullSize || isMobile}
       text={{ id: 'button.pending' }}
       icon={
         <span className="ml-2 flex shrink-0">


### PR DESCRIPTION
## Description

A small code improvement to reduce some complexity, we should use the new and improved `ActionButton` with `useTxLoader` instead of hacking our way through life with the `ActionForm`.

## Testing

Basically a regression test of voting buttons, but try it out with `leela` as your Metamask user.
I highly suggest using Chrome for this, as I've had issues using Brave/Firefox in the past.
Go to `http://localhost:3006/ganache-accounts.json` and copy the private key for `0xb77D57F4959eAfA0339424b83FcFaf9c15407461`, import that account into Metamask and try it out.

1. Install the Multi-Sig extension
2. Set the global threshold to 2
3. Give `amy` and `leela` `Owner` Multi-Sig permissions
4. Create a mint tokens motion as `leela`, copy the URL/open the action as `amy` in another browser, click Approve and verify that the button displays a loader which disappears only when the user's vote is registered. Also the Reject button should be disabled this entire time
![image](https://github.com/user-attachments/assets/c9865ff1-daed-4300-bc36-e3e8072634e5)
![image](https://github.com/user-attachments/assets/0a72aa2e-180a-44a1-9374-81fd3d08089d)
5. Click the Approval step to bring up your vote again, this time click the Remove button, verify it loads until the vote disappears
![image](https://github.com/user-attachments/assets/05d0c8eb-971e-4f91-aef2-738f12a3d4f9)
![image](https://github.com/user-attachments/assets/a83f95f5-1580-4baa-b68c-14443095343f)
6. Now click the Reject button, verify that it loads until the rejection vote is registered and that the Approve button is disabled this entire time
![image](https://github.com/user-attachments/assets/26625fd1-3e3b-4c7a-a01f-648f618eba79)
![image](https://github.com/user-attachments/assets/a482f9fd-cb6d-484e-b439-8e709fc6ce5f)
7. And finally, go back to `leela`, remove your vote and click the Reject button (this will reject it as an owner). Verify that the button loads until the motion is cancelled.
![image](https://github.com/user-attachments/assets/dcac2e87-00dd-4cb6-abf5-f07b7fef0a84)
![image](https://github.com/user-attachments/assets/7449f0ef-a2a3-460e-9073-8a5d6e2757fc)
![image](https://github.com/user-attachments/assets/a6a22151-4823-4710-80ec-8cf779995772)

## Diffs

**Changes** 🏗

* `RemoveVoteButton`, `CancelButton` and `VoteButton` now use the new `ActionButton` component instead of the `ActionForm`
* `ActionButton` now displays the TxLoader full size if the underlying button is full size too
* `ActionButton` also displays the loader via a controlled prop `isLoading`
* Adding a vote, removing a vote and rejecting a motion now all have their respective loading states

Contributes to #2658 point 8 and [#2914](https://github.com/JoinColony/colonyCDapp/issues/2914)
