### PR TITLE
Fix: Fetch validated tokens limit

### DIFF
--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -235,10 +235,8 @@ export enum ClientType {
   TokenClient = 'TokenClient',
   TokenLockingClient = 'TokenLockingClient',
   TokenSupplierClient = 'TokenSupplierClient',
-  VestingSimpleClient = 'VestingSimpleClient',
   VotingReputationClient = 'VotingReputationClient',
-  WhitelistClient = 'WhitelistClient',
-  WrappedTokenClient = 'WrappedTokenClient'
+  WhitelistClient = 'WhitelistClient'
 }
 
 /** Represents a Colony within the Colony Network */
@@ -8135,9 +8133,9 @@ export type Transaction = {
   gasLimit?: Maybe<Scalars['String']>;
   /** The transaction's gas price */
   gasPrice?: Maybe<Scalars['String']>;
-  /** The group to which the transaction belongs, if any */
+  /** The group to which the transaction belongs */
   group: TransactionGroup;
-  /** The id of the group to which the transaction belongs, if any */
+  /** The id of the group to which the transaction belongs */
   groupId: Scalars['ID'];
   /** The transaction hash */
   hash?: Maybe<Scalars['String']>;
@@ -9523,7 +9521,7 @@ export type GetTokensListQueryVariables = Exact<{
 }>;
 
 
-export type GetTokensListQuery = { __typename?: 'Query', listTokens?: { __typename?: 'ModelTokenConnection', items: Array<{ __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } | null> } | null };
+export type GetTokensListQuery = { __typename?: 'Query', listTokens?: { __typename?: 'ModelTokenConnection', nextToken?: string | null, items: Array<{ __typename?: 'Token', decimals: number, name: string, symbol: string, type?: TokenType | null, avatar?: string | null, thumbnail?: string | null, tokenAddress: string } | null> } | null };
 
 export type GetUserTransactionsQueryVariables = Exact<{
   userAddress: Scalars['ID'];
@@ -13186,6 +13184,7 @@ export const GetTokensListDocument = gql`
     items {
       ...Token
     }
+    nextToken
   }
 }
     ${TokenFragmentDoc}`;

--- a/src/graphql/queries/token.graphql
+++ b/src/graphql/queries/token.graphql
@@ -29,5 +29,6 @@ query GetTokensList($isValidated: Boolean, $nextToken: String, $limit: Int) {
     items {
       ...Token
     }
+    nextToken
   }
 }


### PR DESCRIPTION
## Description

The `GetTokensList` is hitting the query limit due to the images for each token. This PR uses nextToken to continue to fetch all "validated" tokens.

## Testing

This is a bit hard to test without creating a whole bunch of tokens. Instead edit the query on line 25 in this file to include `limit: 1`: `src/context/TokenSelectContext/TokenSelectContextProvider.tsx`

```
    variables: {
      isValidated: true,
      limit: 1
    },
```

Step 1: Open the action sidebar and select manage tokens
Step 2: Add a new row and confirm you can see the 3 "validated" tokens

## Diffs

**Changes** 🏗

* `GetTokensList` uses nextToken to fetch all validated tokens
