### PR TITLE
Hotfix for metatransaction checks

### DIFF
--- a/amplify/backend/api/colonycdapp/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema.graphql
@@ -1812,10 +1812,6 @@ type Transaction @model {
       sortKeyFields: ["from"]
     )
   """
-  True if the transaction is a metatransaction
-  """
-  metatransaction: Boolean!
-  """
   A title to show in the UI
   """
   title: String # JSON string

--- a/scripts/create-data.js
+++ b/scripts/create-data.js
@@ -289,7 +289,6 @@ const addTxToDb = async ({
     methodContext: null,
     methodName,
     status: 'SUCCEEDED',
-    metatransaction: false,
     title: null,
     titleValues: null,
     params: JSON.stringify(params),

--- a/src/graphql/fragments/transactions.graphql
+++ b/src/graphql/fragments/transactions.graphql
@@ -25,7 +25,6 @@ fragment Transaction on Transaction {
   methodContext
   methodName
   status
-  metatransaction
   title
   titleValues
   options

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -1681,7 +1681,6 @@ export type CreateTransactionInput = {
   id?: InputMaybe<Scalars['ID']>;
   identifier?: InputMaybe<Scalars['String']>;
   loadingRelated?: InputMaybe<Scalars['Boolean']>;
-  metatransaction: Scalars['Boolean'];
   methodContext?: InputMaybe<Scalars['String']>;
   methodName: Scalars['String'];
   options?: InputMaybe<Scalars['String']>;
@@ -4164,7 +4163,6 @@ export type ModelSubscriptionTransactionFilterInput = {
   id?: InputMaybe<ModelSubscriptionIdInput>;
   identifier?: InputMaybe<ModelSubscriptionStringInput>;
   loadingRelated?: InputMaybe<ModelSubscriptionBooleanInput>;
-  metatransaction?: InputMaybe<ModelSubscriptionBooleanInput>;
   methodContext?: InputMaybe<ModelSubscriptionStringInput>;
   methodName?: InputMaybe<ModelSubscriptionStringInput>;
   options?: InputMaybe<ModelSubscriptionStringInput>;
@@ -4267,7 +4265,6 @@ export type ModelTransactionConditionInput = {
   hash?: InputMaybe<ModelStringInput>;
   identifier?: InputMaybe<ModelStringInput>;
   loadingRelated?: InputMaybe<ModelBooleanInput>;
-  metatransaction?: InputMaybe<ModelBooleanInput>;
   methodContext?: InputMaybe<ModelStringInput>;
   methodName?: InputMaybe<ModelStringInput>;
   not?: InputMaybe<ModelTransactionConditionInput>;
@@ -4304,7 +4301,6 @@ export type ModelTransactionFilterInput = {
   id?: InputMaybe<ModelIdInput>;
   identifier?: InputMaybe<ModelStringInput>;
   loadingRelated?: InputMaybe<ModelBooleanInput>;
-  metatransaction?: InputMaybe<ModelBooleanInput>;
   methodContext?: InputMaybe<ModelStringInput>;
   methodName?: InputMaybe<ModelStringInput>;
   not?: InputMaybe<ModelTransactionFilterInput>;
@@ -8145,8 +8141,6 @@ export type Transaction = {
   identifier?: Maybe<Scalars['String']>;
   /** True if a related transaction is loading */
   loadingRelated?: Maybe<Scalars['Boolean']>;
-  /** True if the transaction is a metatransaction */
-  metatransaction: Scalars['Boolean'];
   /** Context in which method is used e.g. setOneTxRole */
   methodContext?: Maybe<Scalars['String']>;
   /** The name of the contract method used */
@@ -8658,7 +8652,6 @@ export type UpdateTransactionInput = {
   id: Scalars['ID'];
   identifier?: InputMaybe<Scalars['String']>;
   loadingRelated?: InputMaybe<Scalars['Boolean']>;
-  metatransaction?: InputMaybe<Scalars['Boolean']>;
   methodContext?: InputMaybe<Scalars['String']>;
   methodName?: InputMaybe<Scalars['String']>;
   options?: InputMaybe<Scalars['String']>;
@@ -8992,7 +8985,7 @@ export type UserTokenBalanceDataFragment = { __typename?: 'GetUserTokenBalanceRe
 
 export type NativeTokenStatusFragment = { __typename?: 'NativeTokenStatus', mintable?: boolean | null, unlockable?: boolean | null, unlocked?: boolean | null };
 
-export type TransactionFragment = { __typename?: 'Transaction', id: string, context: ClientType, createdAt: string, from: string, colonyAddress: string, identifier?: string | null, params?: string | null, groupId: string, hash?: string | null, methodContext?: string | null, methodName: string, status: TransactionStatus, metatransaction: boolean, title?: string | null, titleValues?: string | null, options?: string | null, error?: { __typename?: 'TransactionError', type: TransactionErrors, message: string } | null, group: { __typename?: 'TransactionGroup', id: string, groupId: string, key: string, index: number, description?: string | null, descriptionValues?: string | null, title?: string | null, titleValues?: string | null } };
+export type TransactionFragment = { __typename?: 'Transaction', id: string, context: ClientType, createdAt: string, from: string, colonyAddress: string, identifier?: string | null, params?: string | null, groupId: string, hash?: string | null, methodContext?: string | null, methodName: string, status: TransactionStatus, title?: string | null, titleValues?: string | null, options?: string | null, error?: { __typename?: 'TransactionError', type: TransactionErrors, message: string } | null, group: { __typename?: 'TransactionGroup', id: string, groupId: string, key: string, index: number, description?: string | null, descriptionValues?: string | null, title?: string | null, titleValues?: string | null } };
 
 export type UserFragment = { __typename?: 'User', bridgeCustomerId?: string | null, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, displayNameChanged?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null, preferredCurrency?: SupportedCurrencies | null, isAutoOfframpEnabled?: boolean | null, meta?: { __typename?: 'ProfileMetadata', metatransactionsEnabled?: boolean | null, decentralizedModeEnabled?: boolean | null, customRpc?: string | null } | null } | null, privateBetaInviteCode?: { __typename?: 'PrivateBetaInviteCode', id: string, shareableInvites?: number | null } | null };
 
@@ -9173,7 +9166,7 @@ export type CreateTransactionMutationVariables = Exact<{
 }>;
 
 
-export type CreateTransactionMutation = { __typename?: 'Mutation', createTransaction?: { __typename?: 'Transaction', id: string, context: ClientType, createdAt: string, from: string, colonyAddress: string, identifier?: string | null, params?: string | null, groupId: string, hash?: string | null, methodContext?: string | null, methodName: string, status: TransactionStatus, metatransaction: boolean, title?: string | null, titleValues?: string | null, options?: string | null, error?: { __typename?: 'TransactionError', type: TransactionErrors, message: string } | null, group: { __typename?: 'TransactionGroup', id: string, groupId: string, key: string, index: number, description?: string | null, descriptionValues?: string | null, title?: string | null, titleValues?: string | null } } | null };
+export type CreateTransactionMutation = { __typename?: 'Mutation', createTransaction?: { __typename?: 'Transaction', id: string, context: ClientType, createdAt: string, from: string, colonyAddress: string, identifier?: string | null, params?: string | null, groupId: string, hash?: string | null, methodContext?: string | null, methodName: string, status: TransactionStatus, title?: string | null, titleValues?: string | null, options?: string | null, error?: { __typename?: 'TransactionError', type: TransactionErrors, message: string } | null, group: { __typename?: 'TransactionGroup', id: string, groupId: string, key: string, index: number, description?: string | null, descriptionValues?: string | null, title?: string | null, titleValues?: string | null } } | null };
 
 export type UpdateTransactionMutationVariables = Exact<{
   input: UpdateTransactionInput;
@@ -9530,7 +9523,7 @@ export type GetUserTransactionsQueryVariables = Exact<{
 }>;
 
 
-export type GetUserTransactionsQuery = { __typename?: 'Query', getTransactionsByUser?: { __typename?: 'ModelTransactionConnection', nextToken?: string | null, items: Array<{ __typename?: 'Transaction', id: string, context: ClientType, createdAt: string, from: string, colonyAddress: string, identifier?: string | null, params?: string | null, groupId: string, hash?: string | null, methodContext?: string | null, methodName: string, status: TransactionStatus, metatransaction: boolean, title?: string | null, titleValues?: string | null, options?: string | null, error?: { __typename?: 'TransactionError', type: TransactionErrors, message: string } | null, group: { __typename?: 'TransactionGroup', id: string, groupId: string, key: string, index: number, description?: string | null, descriptionValues?: string | null, title?: string | null, titleValues?: string | null } } | null> } | null };
+export type GetUserTransactionsQuery = { __typename?: 'Query', getTransactionsByUser?: { __typename?: 'ModelTransactionConnection', nextToken?: string | null, items: Array<{ __typename?: 'Transaction', id: string, context: ClientType, createdAt: string, from: string, colonyAddress: string, identifier?: string | null, params?: string | null, groupId: string, hash?: string | null, methodContext?: string | null, methodName: string, status: TransactionStatus, title?: string | null, titleValues?: string | null, options?: string | null, error?: { __typename?: 'TransactionError', type: TransactionErrors, message: string } | null, group: { __typename?: 'TransactionGroup', id: string, groupId: string, key: string, index: number, description?: string | null, descriptionValues?: string | null, title?: string | null, titleValues?: string | null } } | null> } | null };
 
 export type GetTransactionsByGroupQueryVariables = Exact<{
   userAddress: Scalars['ID'];
@@ -9538,14 +9531,14 @@ export type GetTransactionsByGroupQueryVariables = Exact<{
 }>;
 
 
-export type GetTransactionsByGroupQuery = { __typename?: 'Query', getTransactionsByUserAndGroup?: { __typename?: 'ModelTransactionConnection', items: Array<{ __typename?: 'Transaction', id: string, context: ClientType, createdAt: string, from: string, colonyAddress: string, identifier?: string | null, params?: string | null, groupId: string, hash?: string | null, methodContext?: string | null, methodName: string, status: TransactionStatus, metatransaction: boolean, title?: string | null, titleValues?: string | null, options?: string | null, error?: { __typename?: 'TransactionError', type: TransactionErrors, message: string } | null, group: { __typename?: 'TransactionGroup', id: string, groupId: string, key: string, index: number, description?: string | null, descriptionValues?: string | null, title?: string | null, titleValues?: string | null } } | null> } | null };
+export type GetTransactionsByGroupQuery = { __typename?: 'Query', getTransactionsByUserAndGroup?: { __typename?: 'ModelTransactionConnection', items: Array<{ __typename?: 'Transaction', id: string, context: ClientType, createdAt: string, from: string, colonyAddress: string, identifier?: string | null, params?: string | null, groupId: string, hash?: string | null, methodContext?: string | null, methodName: string, status: TransactionStatus, title?: string | null, titleValues?: string | null, options?: string | null, error?: { __typename?: 'TransactionError', type: TransactionErrors, message: string } | null, group: { __typename?: 'TransactionGroup', id: string, groupId: string, key: string, index: number, description?: string | null, descriptionValues?: string | null, title?: string | null, titleValues?: string | null } } | null> } | null };
 
 export type GetTransactionQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
 
-export type GetTransactionQuery = { __typename?: 'Query', getTransaction?: { __typename?: 'Transaction', id: string, context: ClientType, createdAt: string, from: string, colonyAddress: string, identifier?: string | null, params?: string | null, groupId: string, hash?: string | null, methodContext?: string | null, methodName: string, status: TransactionStatus, metatransaction: boolean, title?: string | null, titleValues?: string | null, options?: string | null, error?: { __typename?: 'TransactionError', type: TransactionErrors, message: string } | null, group: { __typename?: 'TransactionGroup', id: string, groupId: string, key: string, index: number, description?: string | null, descriptionValues?: string | null, title?: string | null, titleValues?: string | null } } | null };
+export type GetTransactionQuery = { __typename?: 'Query', getTransaction?: { __typename?: 'Transaction', id: string, context: ClientType, createdAt: string, from: string, colonyAddress: string, identifier?: string | null, params?: string | null, groupId: string, hash?: string | null, methodContext?: string | null, methodName: string, status: TransactionStatus, title?: string | null, titleValues?: string | null, options?: string | null, error?: { __typename?: 'TransactionError', type: TransactionErrors, message: string } | null, group: { __typename?: 'TransactionGroup', id: string, groupId: string, key: string, index: number, description?: string | null, descriptionValues?: string | null, title?: string | null, titleValues?: string | null } } | null };
 
 export type GetPendingTransactionsQueryVariables = Exact<{
   userAddress: Scalars['ID'];
@@ -10564,7 +10557,6 @@ export const TransactionFragmentDoc = gql`
   methodContext
   methodName
   status
-  metatransaction
   title
   titleValues
   options

--- a/src/redux/actionCreators/transactions.ts
+++ b/src/redux/actionCreators/transactions.ts
@@ -27,7 +27,6 @@ export const createTransactionAction = (
     options,
     params = [],
     ready,
-    metatransaction = false,
     title,
     titleValues,
   }: TxConfig,
@@ -45,7 +44,6 @@ export const createTransactionAction = (
     params,
     status:
       ready === false ? TransactionStatus.Created : TransactionStatus.Ready,
-    metatransaction,
     title,
     titleValues,
   },
@@ -124,11 +122,10 @@ export const transactionHashReceived = (
 export const transactionSucceeded = (
   id: string,
   payload: TransactionSucceededPayload,
-  metatransaction = false,
 ): AllActions => ({
   type: ActionTypes.TRANSACTION_SUCCEEDED,
   payload,
-  meta: { id, metatransaction },
+  meta: { id },
 });
 
 export const transactionPending = (id: string): AllActions => ({

--- a/src/redux/immutable/Transaction.ts
+++ b/src/redux/immutable/Transaction.ts
@@ -51,7 +51,6 @@ interface TransactionRecordProps {
   receipt?: TransactionReceipt;
   status: TransactionStatus;
   loadingRelated?: boolean;
-  metatransaction: boolean;
   title?: MessageDescriptor;
   titleValues?: SimpleMessageValues;
 }

--- a/src/redux/sagas/transactions/transactionChannel.ts
+++ b/src/redux/sagas/transactions/transactionChannel.ts
@@ -124,7 +124,7 @@ const channelGetTransactionReceipt = async ({
 };
 
 const channelGetEventData = async ({
-  tx: { id, params = [], metatransaction },
+  tx: { id, params = [] },
   receipt,
   client,
   emit,
@@ -144,7 +144,7 @@ const channelGetEventData = async ({
     if (receipt.contractAddress) {
       txSucceededEvent.deployedContractAddress = receipt.contractAddress;
     }
-    emit(transactionSucceeded(id, txSucceededEvent, metatransaction));
+    emit(transactionSucceeded(id, txSucceededEvent));
     return eventData;
   } catch (caughtError) {
     console.error(caughtError);

--- a/src/redux/sagas/utils/effects.ts
+++ b/src/redux/sagas/utils/effects.ts
@@ -15,7 +15,7 @@ import {
   type Action,
 } from '../../types/actions/index.ts';
 
-import { getCanUserSendMetatransactions } from './getCanUserSendMetatransactions.ts';
+import { metatransactionsEnabled } from './getCanUserSendMetatransactions.ts';
 
 /*
  * Effect to take a specific action from a channel.
@@ -100,7 +100,7 @@ export const takeLatestCancellable = (
 };
 
 export function* initiateTransaction(id: string) {
-  const shouldSendMetatransaction = yield getCanUserSendMetatransactions();
+  const shouldSendMetatransaction = yield metatransactionsEnabled();
 
   yield transactionSetReady(id);
 

--- a/src/redux/sagas/utils/getCanUserSendMetatransactions.ts
+++ b/src/redux/sagas/utils/getCanUserSendMetatransactions.ts
@@ -8,7 +8,7 @@ import {
 } from '~gql';
 import { canUseMetatransactions } from '~utils/checks/index.ts';
 
-export function* getCanUserSendMetatransactions() {
+export function* metatransactionsEnabled() {
   const metatransactionsAvailable = canUseMetatransactions();
 
   if (!metatransactionsAvailable) {

--- a/src/redux/types/actions/transaction.ts
+++ b/src/redux/types/actions/transaction.ts
@@ -24,7 +24,6 @@ export type TransactionCreatedPayload = Pick<
   | 'identifier'
   | 'methodContext'
   | 'methodName'
-  | 'metatransaction'
   | 'options'
   | 'params'
   | 'status'

--- a/src/state/transactionState.ts
+++ b/src/state/transactionState.ts
@@ -49,7 +49,6 @@ export const convertTransactionType = ({
   hash,
   id,
   identifier,
-  metatransaction,
   methodContext,
   methodName,
   params,
@@ -77,7 +76,6 @@ export const convertTransactionType = ({
     from,
     id,
     identifier: identifier as AddressOrENSName,
-    metatransaction,
     methodName,
     status,
     group: txGroup,
@@ -258,7 +256,6 @@ export const addTransactionToDb = async (
     status,
     title,
     titleValues,
-    metatransaction,
   }: TransactionCreatedPayload,
 ) => {
   let colonyAddress = '0x';
@@ -302,7 +299,6 @@ export const addTransactionToDb = async (
     methodContext: methodContext || null,
     methodName,
     status,
-    metatransaction,
     title: JSON.stringify(title) || null,
     titleValues: JSON.stringify(titleValues) || null,
     params: txParams,

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -29,7 +29,6 @@ export interface TxConfig {
   options?: Overrides;
   params?: MethodParams;
   ready?: boolean;
-  metatransaction?: boolean;
   title?: MessageDescriptor;
   titleValues?: SimpleMessageValues;
 }


### PR DESCRIPTION
## Description

Metatransactions are now checked on a general basis (e.g. if the user has them enabled, they are being used). This enables the users to retry transactions as metatransactions and the other way round.

I removed a metatransaction check that was mainly used for the vesting contracts. If we still have methods that don't support metatransactions this needs to be reinstated (it wasn't used though as far as I can tell).

## Testing

1) Enable metatransactions for a user
2) Try to send a transaction

## Diffs

**Changes** 🏗

* Check whether user has metatransactions enabled on transaction sending not on creation

**Deletions** ⚰️

* Removed metatransaction property from transactions
* Removed forced non-metatransactions

