### PR TITLE
Fix/2530 agreements pagination

### DIFF
--- a/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
@@ -25,6 +25,7 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
     initiatorUser: user,
     initiatorAddress,
     metadata,
+    decisionData,
     isMotion,
     motionData,
     motionState,
@@ -94,7 +95,10 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
               },
             )}
           >
-            {metadata?.customTitle || actionMetadataDescription || '-'}
+            {metadata?.customTitle ||
+              decisionData?.title ||
+              actionMetadataDescription ||
+              '-'}
           </p>
           {colony && (
             <p

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -15,6 +15,7 @@ import { ActionForm } from '~shared/Fields/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { getDraftDecisionFromStore } from '~utils/decisions.ts';
 import { formatText } from '~utils/intl.ts';
+import { isQueryActive } from '~utils/isQueryActive.ts';
 import FormTextareaBase from '~v5/common/Fields/TextareaBase/FormTextareaBase.tsx';
 import NotificationBanner from '~v5/shared/NotificationBanner/index.ts';
 
@@ -222,9 +223,11 @@ const ActionSidebarContent: FC<ActionSidebarContentProps> = ({
           className="flex h-full flex-col"
           innerRef={formRef}
           onSuccess={() => {
-            client.refetchQueries({
-              include: [SearchActionsDocument],
-            });
+            if (isQueryActive('SearchActions')) {
+              client.refetchQueries({
+                include: [SearchActionsDocument],
+              });
+            }
           }}
         >
           <ActionSidebarFormContent

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
@@ -81,15 +81,18 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
     return stopPollingAction;
   }, [isClaimed, stopPollingAction]);
 
-  /* Update colony object when motion gets finalized. */
+  /* Update colony object when motion gets finalized or is agreement. */
   useEffect(() => {
-    if (actionData.motionData.isFinalized && !hasFinalizedHandlerRun.current) {
+    if (
+      (isMotionAgreement || isMotionFinalized) &&
+      !hasFinalizedHandlerRun.current
+    ) {
       refetchColony();
       setIsPolling(false);
       handleMotionFinalized(actionData);
       hasFinalizedHandlerRun.current = true;
     }
-  }, [actionData, refetchColony]);
+  }, [isMotionAgreement, isMotionFinalized, actionData, refetchColony]);
 
   let action = {
     actionType: ActionTypes.MOTION_FINALIZE,

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/utils.ts
@@ -1,6 +1,7 @@
 import { apolloClient } from '~apollo';
 import { ColonyActionType, SearchActionsDocument } from '~gql';
 import { type MotionAction } from '~types/motions.ts';
+import { isQueryActive } from '~utils/isQueryActive.ts';
 import { updateContributorVerifiedStatus } from '~utils/members.ts';
 
 export const handleMotionFinalized = (action: MotionAction) => {
@@ -26,7 +27,9 @@ export const handleMotionFinalized = (action: MotionAction) => {
       break;
     }
     case ColonyActionType.CreateDecisionMotion: {
-      apolloClient.refetchQueries({ include: [SearchActionsDocument] });
+      if (isQueryActive('SearchActions')) {
+        apolloClient.refetchQueries({ include: [SearchActionsDocument] });
+      }
 
       break;
     }

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/utils.ts
@@ -1,4 +1,5 @@
-import { ColonyActionType } from '~gql';
+import { apolloClient } from '~apollo';
+import { ColonyActionType, SearchActionsDocument } from '~gql';
 import { type MotionAction } from '~types/motions.ts';
 import { updateContributorVerifiedStatus } from '~utils/members.ts';
 
@@ -22,6 +23,11 @@ export const handleMotionFinalized = (action: MotionAction) => {
           false,
         );
       }
+      break;
+    }
+    case ColonyActionType.CreateDecisionMotion: {
+      apolloClient.refetchQueries({ include: [SearchActionsDocument] });
+
       break;
     }
     default: {

--- a/src/components/v5/common/CompletedAction/partials/CreateDecision/CreateDecision.tsx
+++ b/src/components/v5/common/CompletedAction/partials/CreateDecision/CreateDecision.tsx
@@ -26,11 +26,11 @@ interface CreateDecisionProps {
 const MSG = defineMessages({
   defaultTitle: {
     id: `${displayName}.defaultTitle`,
-    defaultMessage: 'Create decision',
+    defaultMessage: 'Create agreement',
   },
   subtitle: {
     id: `${displayName}.subtitle`,
-    defaultMessage: 'Decision by {user}',
+    defaultMessage: 'Agreement by {user}',
   },
 });
 

--- a/src/hooks/useActivityFeed/helpers.ts
+++ b/src/hooks/useActivityFeed/helpers.ts
@@ -141,9 +141,6 @@ export const getBaseSearchActionsFilterVariable = (
   showInActionsList: {
     eq: true,
   },
-  colonyDecisionId: {
-    exists: false,
-  },
   isMotionFinalization: {
     ne: true,
   },

--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -80,7 +80,7 @@ const actionsMessageDescriptors = {
       ${ColonyActionType.EmitDomainReputationPenaltyMotion} {Manage reputation}
       ${ColonyActionType.EmitDomainReputationReward} {Manage reputation}
       ${ColonyActionType.EmitDomainReputationRewardMotion} {Manage reputation}
-      ${ColonyActionType.CreateDecisionMotion} {Decision}
+      ${ColonyActionType.CreateDecisionMotion} {Agreement}
       ${ColonyActionType.AddVerifiedMembers} {Manage verified members}
       ${ColonyActionType.AddVerifiedMembersMotion} {Manage verified members}
       ${ColonyActionType.RemoveVerifiedMembers} {Manage verified members}

--- a/src/utils/isQueryActive.ts
+++ b/src/utils/isQueryActive.ts
@@ -1,0 +1,8 @@
+import { apolloClient } from '~apollo';
+
+export const isQueryActive = (queryName: string) => {
+  const activeQueries = apolloClient.getObservableQueries();
+  return Array.from(activeQueries.values()).some((query) => {
+    return query.queryName?.includes(queryName);
+  });
+};


### PR DESCRIPTION
## Description

**Expected behaviour**
All agreements that have passed the staking threshold, should appear on the agreements page. - _The problem was caused due to pagination issues, so this PR includes the mechanism to fetch all agreements_
At the same time, we would like to ensure that Agreements appear in the activity feed.
It would also be good if these worked off of subscriptions, so new ones show up without having to reload.


## Testing

TODO: Check all created agreements appear on the agreements page. 
Check agreements having a stake of 10% are showing up in the activity feed.
Currently the `QUERY_PAGE_SIZE = 20`, so if you want to check the pagination works properly, you can manually set it to `2`.

* Step 1. Install the **Reputation Weighted (Lazy Consensus method)** extension
* Step 2. Create 3 Agreements
![Screenshot 2024-07-31 at 14 06 36](https://github.com/user-attachments/assets/ebee1ee4-5a12-49d3-9eca-bd5f30aadbbe)
* Step 2.1. Support one with > 10%
* Step 2.2. Oppose one with > 10%
* Step 2.3. Support/Oppose one with < 10%
If you want to forward time please use 
`curl -X POST --data '{"jsonrpc":"2.0","method":"evm_increaseTime","params":[3600],"id":1}' localhost:8545`

* Step 3. Check activity feed shows the agreements with > 10% stake
* Step 4. Check Agreements page display all 3 agreements


Resolves #2530 
