### PR TITLE
Add new auth proxy docker hash

### DIFF
--- a/docker/colony-cdapp-dev-env-auth-proxy
+++ b/docker/colony-cdapp-dev-env-auth-proxy
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV AUTH_PROXY_HASH=0ca1fa78d55e2f2fdd9177fa526ae937855d7874
+ENV AUTH_PROXY_HASH=f1d5e35271358946ec65e9a0f7d27fa66c2b878a
 
 # Add dependencies from the host
 # Note: these are listed individually so that if they change, they won't affect


### PR DESCRIPTION
## Description

- Add new auth proxy hash (for [this commit](https://github.com/JoinColony/colonyCDappAuthProxy/commit/f1d5e35271358946ec65e9a0f7d27fa66c2b878a))

## Testing

Just make sure your docker can still run with that hash!

## Diffs

**New stuff** ✨

* New auth proxy hash

Resolves #2813 
