### PR TITLE
Update caniuse-lite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18153,7 +18153,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001588",
+      "version": "1.0.30001645",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001645.tgz",
+      "integrity": "sha512-GFtY2+qt91kzyMk6j48dJcwJVq5uTkk71XxE3RtScx7XWRLsO7bU44LOFkOZYR8w9YMS0UhPSYpN/6rAMImmLw==",
       "dev": true,
       "funding": [
         {
@@ -18168,8 +18170,7 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/capital-case": {
       "version": "1.0.4",
@@ -28516,11 +28517,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/ganache-core/node_modules/caniuse-lite": {
-      "version": "1.0.30001174",
-      "dev": true,
-      "license": "CC-BY-4.0"
     },
     "node_modules/ganache-core/node_modules/caseless": {
       "version": "0.12.0",


### PR DESCRIPTION
## Description

This error message was annoying me when starting vite:

```txt
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```

So I did what it told me to do.

## Testing

This should _not_ have any implications on the functionality of the CDapp. It mainly just removes unnecessary CSS-prefixes (if any) as it is used by autoprefixer (and a bunch of other dev tools that don't have a big impact on our build output).

## Diffs

**Changes** 🏗

* Updated caniuse-lite to v1.0.30001645
