### PR TITLE
fix: use paging to fail all pending user transactions

### DIFF
--- a/scripts/create-data.js
+++ b/scripts/create-data.js
@@ -264,6 +264,7 @@ const addTxToDb = async ({
   hash,
   methodName,
   params,
+  status,
   userAddress,
 }) => {
   const txGroup = {
@@ -288,7 +289,7 @@ const addTxToDb = async ({
     hash,
     methodContext: null,
     methodName,
-    status: 'SUCCEEDED',
+    status,
     title: null,
     titleValues: null,
     params: JSON.stringify(params),
@@ -510,6 +511,7 @@ const mintTokens = async (
     hash: mintTokens.hash,
     methodName: 'mintTokens',
     params: [amount],
+    status: 'SUCCEEDED',
     userAddress: signerOrWallet.address,
   });
 
@@ -528,6 +530,7 @@ const mintTokens = async (
     hash: claimColonyFunds.hash,
     methodName: 'claimColonyFunds',
     params: [amount],
+    status: 'SUCCEEDED',
     userAddress: signerOrWallet.address,
   });
 
@@ -658,6 +661,7 @@ const createColony = async (
     hash: colonyDeploymentTransaction.transactionHash,
     methodName: 'createColonyForFrontend',
     params,
+    status: 'SUCCEEDED',
     userAddress: signerOrWallet.address,
   });
 
@@ -772,6 +776,7 @@ const createColony = async (
         hash: subdomainTransactions.transactionHash,
         methodName: 'addDomain(uint256,uint256,uint256)',
         params: [rootDomainId],
+        status: 'SUCCEEDED',
         userAddress: signerOrWallet.address,
       });
 
@@ -827,6 +832,7 @@ const createColony = async (
     hash: setOwnerTransaction.transactionHash,
     methodName: 'setOwner',
     params: [colonyAddress],
+    status: 'SUCCEEDED',
     userAddress: signerOrWallet.address,
   });
 
@@ -879,6 +885,7 @@ const createColony = async (
     hash: installExtensionsTx.transactionHash,
     methodName: 'multicall.installExtensions',
     params: [],
+    status: 'SUCCEEDED',
     userAddress: signerOrWallet.address,
   });
 
@@ -980,6 +987,7 @@ const createColony = async (
     hash: setExtensionRolesTx.transactionHash,
     methodName: 'setUserRoles',
     params: [],
+    status: 'SUCCEEDED',
     userAddress: signerOrWallet.address,
   });
 
@@ -1016,6 +1024,7 @@ const createColony = async (
     hash: stakedExpenditureInitTx.transactionHash,
     methodName: 'initialise',
     params: [stakeFraction],
+    status: 'SUCCEEDED',
     userAddress: signerOrWallet.address,
   });
 
@@ -1207,6 +1216,7 @@ const transferFundsBetweenPots = async (
         methodName:
           'moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)',
         params,
+        status: 'SUCCEEDED',
         userAddress: signerOrWallet.address,
       });
 
@@ -1320,6 +1330,7 @@ const userPayments = async (
             hash: oneTxPaymentTransaction.transactionHash,
             methodName: 'makePaymentFundedFromDomain',
             params,
+            status: 'SUCCEEDED',
             userAddress: signerOrWallet.address,
           });
 
@@ -1654,9 +1665,7 @@ const createUserAndColonyData = async () => {
     }
   }
 
-  const colonies = Object.keys(availableColonies).map(
-    (colonyAddress) => availableColonies[colonyAddress],
-  );
+  const colonies = Object.values(availableColonies);
   const coloniesTokens = colonies
     .map(({ colonyName, tokenAddress }) => {
       if (colonyName !== 'Planet Express') {

--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransactionContent.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransactionContent.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import React, { type FC } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
+import { TX_RETRY_TIMEOUT } from '~state/transactionState.ts';
 import { formatText } from '~utils/intl.ts';
 import NotificationBanner from '~v5/shared/NotificationBanner/index.ts';
 
@@ -12,8 +13,6 @@ import { useGroupedTransactionContent } from './hooks.tsx';
 import transactionsItemClasses from './TransactionsItem/TransactionsItem.styles.ts';
 import TransactionStatus from './TransactionStatus.tsx';
 import { shortErrorMessage } from './utils.ts';
-
-const TX_RETRY_TIMEOUT = 1000 * 60 * 10;
 
 const displayName =
   'common.Extensions.UserHub.partials.TransactionsTab.partials.GroupedTransactionContent';
@@ -78,7 +77,7 @@ const GroupedTransactionContent: FC<GroupedTransactionContentProps> = ({
 
   // Whether a retry of the transaction is possible
   const retryable =
-    createdAt.valueOf() > new Date().valueOf() - TX_RETRY_TIMEOUT;
+    createdAt.valueOf() > Date.now() - TX_RETRY_TIMEOUT * 60 * 1000;
 
   return (
     <li

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -9542,10 +9542,11 @@ export type GetTransactionQuery = { __typename?: 'Query', getTransaction?: { __t
 
 export type GetPendingTransactionsQueryVariables = Exact<{
   userAddress: Scalars['ID'];
+  nextToken?: InputMaybe<Scalars['String']>;
 }>;
 
 
-export type GetPendingTransactionsQuery = { __typename?: 'Query', getTransactionsByUserAndStatus?: { __typename?: 'ModelTransactionConnection', items: Array<{ __typename?: 'Transaction', id: string } | null> } | null };
+export type GetPendingTransactionsQuery = { __typename?: 'Query', getTransactionsByUserAndStatus?: { __typename?: 'ModelTransactionConnection', nextToken?: string | null, items: Array<{ __typename?: 'Transaction', id: string } | null> } | null };
 
 export type GetUserByAddressQueryVariables = Exact<{
   address: Scalars['ID'];
@@ -13330,11 +13331,16 @@ export type GetTransactionQueryHookResult = ReturnType<typeof useGetTransactionQ
 export type GetTransactionLazyQueryHookResult = ReturnType<typeof useGetTransactionLazyQuery>;
 export type GetTransactionQueryResult = Apollo.QueryResult<GetTransactionQuery, GetTransactionQueryVariables>;
 export const GetPendingTransactionsDocument = gql`
-    query GetPendingTransactions($userAddress: ID!) {
-  getTransactionsByUserAndStatus(from: {eq: $userAddress}, status: PENDING) {
+    query GetPendingTransactions($userAddress: ID!, $nextToken: String) {
+  getTransactionsByUserAndStatus(
+    from: {eq: $userAddress}
+    status: PENDING
+    nextToken: $nextToken
+  ) {
     items {
       id
     }
+    nextToken
   }
 }
     `;
@@ -13352,6 +13358,7 @@ export const GetPendingTransactionsDocument = gql`
  * const { data, loading, error } = useGetPendingTransactionsQuery({
  *   variables: {
  *      userAddress: // value for 'userAddress'
+ *      nextToken: // value for 'nextToken'
  *   },
  * });
  */

--- a/src/graphql/queries/transactions.graphql
+++ b/src/graphql/queries/transactions.graphql
@@ -27,10 +27,15 @@ query GetTransaction($id: ID!) {
   }
 }
 
-query GetPendingTransactions($userAddress: ID!) {
-  getTransactionsByUserAndStatus(from: { eq: $userAddress }, status: PENDING) {
+query GetPendingTransactions($userAddress: ID!, $nextToken: String) {
+  getTransactionsByUserAndStatus(
+    from: { eq: $userAddress }
+    status: PENDING
+    nextToken: $nextToken
+  ) {
     items {
       id
     }
+    nextToken
   }
 }


### PR DESCRIPTION
## Description

There was a problem with pending transactions not being put into a failed state properly. This usually happens when a proper user wallet is initialized.

This PR uses Apollo paging to put _all_ pending transactions into a failed state.

![image](https://github.com/user-attachments/assets/56de3614-7c91-47f0-b721-28bd070b5757)

## Testing

1) Stop your dev environment
2) Apply this patch (it will create 120 pending transactions during the `create-data` script.

```diff
diff --git a/scripts/create-data.js b/scripts/create-data.js
index f0ed7968e..f0a528dd9 100644
--- a/scripts/create-data.js
+++ b/scripts/create-data.js
@@ -300,6 +300,27 @@ const addTxToDb = async ({
   return graphqlRequest(createTransaction, { input }, GRAPHQL_URI, API_KEY);
 };
 
+const create120Transactions = async (userAddress, colonyAddress) => {
+  const domainBatchKey = 'createDomain';
+  for(let i=0; i<120; i++) {
+    const domainGroupId = nanoid();
+    console.log(`Adding pending transaction number ${i} with id ${domainGroupId}`);
+    await addTxToDb({
+      colonyAddress,
+      context: ClientType.ColonyClient,
+      groupId: domainGroupId,
+      groupIndex: 0,
+      groupKey: domainBatchKey,
+      hash: '0xdeadcafe',
+      methodName: 'addDomain(uint256,uint256,uint256)',
+      params: [1],
+      status: 'PENDING',
+      userAddress,
+    });
+    await delay(5);
+  }
+}
+
 /*
  * User
  */
@@ -1715,6 +1736,8 @@ const createUserAndColonyData = async () => {
     validatedTokensOwner
   );
 
+  await create120Transactions(leelaWallet.address, Object.keys(availableColonies)[0]);
+
   if (reputationMining) {
     console.log(
       "Reputation mining should now be disabled. Make sure you check this manually, otherwise you'll get chain time skips",
```
3) Restart your dev environment
4) Run the `create-data` script
5) Open the CDapp and see 120 failed transactions

## Diffs

**Changes** 🏗

* Use paging to fail pending transactions on refresh
