### PR TITLE
Feat: Handle batch payment limit

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/FileUploadModal/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/FileUploadModal/hooks.ts
@@ -108,7 +108,8 @@ export const useUploadCSVFile = (
 
           const truncatedData = result.data.slice(dataDelimiterIndex + 2);
 
-          if (truncatedData.length > 400) {
+          // Max number of payments is 400, but the format requires two header rows
+          if (truncatedData.length > 402) {
             setError(DropzoneErrors.STRUCTURE);
             return;
           }

--- a/src/redux/sagas/utils/expenditures.ts
+++ b/src/redux/sagas/utils/expenditures.ts
@@ -1,12 +1,6 @@
-import {
-  type AnyColonyClient,
-  ClientType,
-  type Network,
-  Tokens,
-} from '@colony/colony-js';
+import { type AnyColonyClient, type Network, Tokens } from '@colony/colony-js';
 import { BigNumber } from 'ethers';
 import { getAddress } from 'ethers/lib/utils';
-import { fork } from 'redux-saga/effects';
 
 import { apolloClient } from '~apollo';
 import { DEV_USDC_ADDRESS, isDev } from '~constants';
@@ -18,7 +12,6 @@ import {
   type GetUserByAddressQueryVariables,
   GetUserByAddressDocument,
 } from '~gql';
-import { ActionTypes } from '~redux/index.ts';
 import { type Address } from '~types';
 import {
   type ExpenditurePayoutWithSlotId,
@@ -27,17 +20,10 @@ import {
 } from '~types/expenditures.ts';
 import { type Expenditure } from '~types/graphql.ts';
 import { type MethodParams } from '~types/transactions.ts';
-import { chunkArray } from '~utils/arrays/index.ts';
 import { getExpenditureDatabaseId } from '~utils/databaseId.ts';
 import { calculateFee, getTokenDecimalsWithFallback } from '~utils/tokens.ts';
 
-import {
-  createTransaction,
-  createTransactionChannels,
-  waitForTxResult,
-} from '../transactions/index.ts';
-
-import { initiateTransaction, takeFrom } from './effects.ts';
+import { chunkedMulticall } from './multicall.ts';
 
 const MAX_CLAIM_DELAY_VALUE = BigNumber.from(2).pow(128).sub(1);
 
@@ -211,47 +197,41 @@ export function* claimExpenditurePayouts({
     return;
   }
 
-  const batchKey = 'claimExpenditurePayouts';
+  const {
+    createMulticallChannels,
+    createMulticallTransactions,
+    processMulticallTransactions,
+    closeMulticallChannels,
+  } = chunkedMulticall({
+    colonyAddress,
+    items: claimablePayouts,
+    // In testing, this multicall would fail with more than 78 payouts
+    chunkSize: 78,
+    metaId,
+    batchKey: 'claimExpenditurePayouts',
+    channelId: 'claimPayouts',
+  });
 
-  // In testing, this multicall would fail with more than 78 payouts
-  const chunks = chunkArray({ array: claimablePayouts, chunkSize: 78 });
+  yield createMulticallChannels();
 
-  for (let index = 0; index < chunks.length; index += 1) {
-    // Create a new transaction channel for each chunk
-    const { claimPayouts } = yield createTransactionChannels(
-      `${metaId}-${index}`,
-      ['claimPayouts'],
-    );
+  try {
+    yield* createMulticallTransactions();
+    yield processMulticallTransactions({
+      colonyClient,
+      encodeFunctionData: (payouts: ExpenditurePayoutWithSlotId[]) => {
+        const multicallData = payouts.map((payout) =>
+          colonyClient.interface.encodeFunctionData('claimExpenditurePayout', [
+            nativeExpenditureId,
+            payout.slotId,
+            payout.tokenAddress,
+          ]),
+        );
 
-    try {
-      const multicallData = chunks[index].map((payout) =>
-        colonyClient.interface.encodeFunctionData('claimExpenditurePayout', [
-          nativeExpenditureId,
-          payout.slotId,
-          payout.tokenAddress,
-        ]),
-      );
-
-      yield fork(createTransaction, claimPayouts.id, {
-        context: ClientType.ColonyClient,
-        methodName: 'multicall',
-        identifier: colonyAddress,
-        params: [multicallData],
-        group: {
-          key: batchKey,
-          id: `${metaId}-${index}`, // Use the chunk index to ensure uniqueness
-          index,
-        },
-        ready: false,
-      });
-
-      yield takeFrom(claimPayouts.channel, ActionTypes.TRANSACTION_CREATED);
-
-      yield initiateTransaction(claimPayouts.id);
-      yield waitForTxResult(claimPayouts.channel);
-    } finally {
-      claimPayouts.channel.close();
-    }
+        return multicallData;
+      },
+    });
+  } finally {
+    closeMulticallChannels();
   }
 }
 

--- a/src/redux/sagas/utils/multicall.ts
+++ b/src/redux/sagas/utils/multicall.ts
@@ -1,0 +1,107 @@
+import { type AnyColonyClient, ClientType } from '@colony/colony-js';
+import { fork } from 'redux-saga/effects';
+
+import { ActionTypes } from '~redux/index.ts';
+import { transactionSetParams } from '~state/transactionState.ts';
+import { type Address } from '~types';
+import { chunkArray } from '~utils/arrays/index.ts';
+
+import {
+  type TransactionChannelMap,
+  createTransaction,
+  createTransactionChannels,
+  waitForTxResult,
+} from '../transactions/index.ts';
+
+import { initiateTransaction, takeFrom } from './effects.ts';
+
+interface ChunkedMulticallParams<T> {
+  colonyAddress: Address;
+  items: T[];
+  chunkSize: number;
+  metaId: string;
+  batchKey: string;
+  channelId: string;
+  startIndex?: number;
+}
+
+/**
+ * Helper function to split multicalls into multiple chunks
+ * To be used when a single multicall would be too big for a single transaction
+ * Returns multiple functions to be called at different points in the saga
+ */
+export function chunkedMulticall<T>({
+  colonyAddress,
+  items,
+  chunkSize,
+  metaId,
+  batchKey,
+  channelId,
+  startIndex = 0,
+}: ChunkedMulticallParams<T>) {
+  const chunks = chunkArray({ array: items, chunkSize });
+  const channelIds = chunks.map((_, index) => `${channelId}-${index}`);
+  let channels: TransactionChannelMap = {};
+
+  // Function to create and store channels
+  function* createMulticallChannels() {
+    channels = yield createTransactionChannels(metaId, channelIds);
+  }
+
+  // Function to create transactions using the stored channels
+  // Intended to be called inside a try catch
+  function* createMulticallTransactions() {
+    for (let index = 0; index < chunks.length; index += 1) {
+      const channel = channels[channelIds[index]];
+
+      yield fork(createTransaction, channel.id, {
+        context: ClientType.ColonyClient,
+        methodName: 'multicall',
+        identifier: colonyAddress,
+        group: {
+          key: batchKey,
+          id: metaId,
+          index: startIndex + index,
+        },
+        ready: false,
+      });
+    }
+  }
+
+  // Function to process transactions using the stored channels and chunks
+  // Intended to be called inside a try catch
+  function* processMulticallTransactions({
+    encodeFunctionData,
+    colonyClient,
+  }: {
+    encodeFunctionData: (chunk: T[], colonyClient: AnyColonyClient) => string[];
+    colonyClient: AnyColonyClient;
+  }) {
+    for (let index = 0; index < chunks.length; index += 1) {
+      const channel = channels[channelIds[index]];
+      const multicallData = encodeFunctionData(chunks[index], colonyClient);
+
+      yield takeFrom(channel.channel, ActionTypes.TRANSACTION_CREATED);
+
+      yield transactionSetParams(channel.id, [multicallData]);
+      yield initiateTransaction(channel.id);
+      yield waitForTxResult(channel.channel);
+    }
+  }
+
+  // Function to close all channels
+  // Intended to be called in finally
+  function closeMulticallChannels() {
+    for (const id of channelIds) {
+      channels[id].channel.close();
+    }
+  }
+
+  return {
+    createMulticallChannels,
+    createMulticallTransactions,
+    processMulticallTransactions,
+    closeMulticallChannels,
+    finalMulticallGroupIndex: startIndex + chunks.length - 1,
+  };
+}

--- a/src/utils/arrays/index.ts
+++ b/src/utils/arrays/index.ts
@@ -183,3 +183,32 @@ export type UnionOfArraysToArrayOfUnions<T extends unknown[]> = ItemType<T>[];
 export const unionOfArraysToArrayOfUnions = <T extends unknown[]>(
   array: T,
 ): UnionOfArraysToArrayOfUnions<T> => array;
+
+// Helper function to split the array into chunks
+export const chunkArray = <T>({
+  array,
+  chunkSize,
+}: {
+  array: T[];
+  chunkSize: number;
+}): T[][] => {
+  if (!Array.isArray(array)) {
+    throw new TypeError('Input should be an array');
+  }
+
+  if (typeof chunkSize !== 'number' || chunkSize <= 0) {
+    throw new TypeError('chunkSize should be a positive number');
+  }
+
+  const result: T[][] = new Array(Math.ceil(array.length / chunkSize));
+
+  for (
+    let index = 0, resultIndex = 0;
+    index < array.length;
+    index += chunkSize, resultIndex += 1
+  ) {
+    result[resultIndex] = array.slice(index, index + chunkSize);
+  }
+
+  return result;
+};


### PR DESCRIPTION
## Description

When creating an advanced payment we hit a limit on the transaction size when creating a large number of payments in one go.

This PR adds a `chunkedMulticall` helper function to split large multicalls which are too big for a single transaction, into smaller chunks.

The `claimExpenditurePayouts` function has been refactored to make use of this. A limit of 78 payouts has been set as the multicall was failing with more than this.

The `createExpenditure` saga has been refactored to use the new helper. A limit of 164 payouts has been set, when creating multicalls with more than this the multicall function would work fine, but the resulting transaction receipt was too big to update the transaction in the db.

## Testing

Step 1 - Create an advanced payment action
Step 2 - Upload this csv with 400 rows (feel free to change the values if you like) [https://drive.google.com/file/d/1iMFNpRtMwyc3teh2mVPeBlRPEyZBRwFQ/view?usp=sharing](https://drive.google.com/file/d/1iMFNpRtMwyc3teh2mVPeBlRPEyZBRwFQ/view?usp=sharing)
Step 3 - Check you can go through the entire flow through to claiming the payouts

Further testing: Increase the chunkSize values in `claimExpenditurePayouts` and `createExpenditure` by 1 to verify they are the correct limit.

Note: I have noticed issues with very slow loading of all the transactions on the completed action screen (including in the action subtitle). I have also had issues when locking / funding the transaction `Transaction is not ready to send` - refreshing and trying the transaction again will resolve this. These are both out of scope for this PR.

## Diffs

**New stuff** ✨

* `chunkedMulticall` helper function 

**Changes** 🏗

* `claimExpenditurePayouts` refactored
* `createExpenditure` refactored
* CSV file upload now allows 402 rows to accommodate for the two header rows required by the template

Resolves #2250
