### PR TITLE
Use proper styling and copy for tx paging end message

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/TransactionsTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/TransactionsTab.tsx
@@ -1,4 +1,4 @@
-import { Binoculars } from '@phosphor-icons/react';
+import { Binoculars, Smiley } from '@phosphor-icons/react';
 import { useInView } from 'framer-motion';
 import React, { useRef, type FC, useEffect, useState } from 'react';
 import { defineMessages } from 'react-intl';
@@ -16,7 +16,7 @@ const displayName = 'common.Extensions.UserHub.partials.TransactionsTab';
 const MSG = defineMessages({
   thisIsTheEnd: {
     id: `${displayName}.thisIsTheEnd`,
-    defaultMessage: "😎 You've reached the end",
+    defaultMessage: 'No more results',
   },
 });
 
@@ -75,7 +75,12 @@ const TransactionsTab: FC<TransactionsProps> = () => {
               </span>
             </>
           ) : (
-            !onePageOnly && <span>{formatText(MSG.thisIsTheEnd)}</span>
+            !onePageOnly && (
+              <div className="text-gray-400">
+                <Smiley className="mr-1 inline-block" />
+                <span className="text-xs">{formatText(MSG.thisIsTheEnd)}</span>
+              </div>
+            )
           )}
         </div>
       </div>


### PR DESCRIPTION
## Description

This PR solves a little annoyance with the paging end element of the transaction list.

It looks like this now:

![image](https://github.com/user-attachments/assets/52efcda7-e0d5-4d62-bfd8-ce64bdfe3d0e)


## Testing

1) Start the CDapp
2) Go to a Colony, to the UserHub, click transactions
3) Scroll all the way down
4) You should see this little fella.

Here's the Figma: https://www.figma.com/design/l1dOM5qiQYwF0ElvKDqqjg/Design-System---Colony-v3?node-id=1782-50890&t=oNC6Rrhij7U9pY3p-0

## Diffs

**Changes** 🏗

* Changed styling and copy of the tx end element
