### PR TITLE
Open UserHub on pending button click

### DIFF
--- a/src/components/common/Extensions/UserHub/UserHub.tsx
+++ b/src/components/common/Extensions/UserHub/UserHub.tsx
@@ -13,12 +13,16 @@ import CryptoToFiatTab from './partials/CryptoToFiatTab/CryptoToFiatTab.tsx';
 import ReputationTab from './partials/ReputationTab/index.ts';
 import StakesTab from './partials/StakesTab/index.ts';
 import TransactionsTab from './partials/TransactionsTab/index.ts';
-import { type UserHubProps, UserHubTabs } from './types.ts';
+import { UserHubTab } from './types.ts';
 
 // @BETA: Disabled for now
 // import { COLONY_HOME_ROUTE } from '~routes';
 // @BETA: Disabled for now
 // import ButtonLink from '~v5/shared/Button/ButtonLink';
+
+interface Props {
+  initialOpenTab?: UserHubTab;
+}
 
 const displayName = 'common.Extensions.UserHub.partials.UserHub';
 
@@ -33,12 +37,10 @@ const MSG = defineMessages({
   },
 });
 
-const UserHub: FC<UserHubProps> = ({
-  defaultOpenedTab = UserHubTabs.Balance,
-}) => {
+const UserHub: FC<Props> = ({ initialOpenTab = UserHubTab.Balance }) => {
   const isMobile = useMobile();
   const featureFlags = useContext(FeatureFlagsContext);
-  const [selectedTab, setSelectedTab] = useState(defaultOpenedTab);
+  const [selectedTab, setSelectedTab] = useState(initialOpenTab);
 
   const filteredTabList = tabList.filter(
     (tabItem) =>
@@ -47,7 +49,7 @@ const UserHub: FC<UserHubProps> = ({
         featureFlags[tabItem.featureFlag]?.isEnabled),
   );
 
-  const handleTabChange = (newTab: UserHubTabs) => {
+  const handleTabChange = (newTab: UserHubTab) => {
     setSelectedTab(newTab);
   };
 
@@ -62,9 +64,9 @@ const UserHub: FC<UserHubProps> = ({
     <div
       className={clsx('flex h-full flex-col sm:w-[42.625rem] sm:flex-row', {
         'sm:h-[27.75rem]':
-          selectedTab !== UserHubTabs.Balance &&
-          selectedTab !== UserHubTabs.CryptoToFiat,
-        'sm:min-h-[27.75rem]': selectedTab === UserHubTabs.Balance,
+          selectedTab !== UserHubTab.Balance &&
+          selectedTab !== UserHubTab.CryptoToFiat,
+        'sm:min-h-[27.75rem]': selectedTab === UserHubTab.Balance,
       })}
     >
       <div className="sticky left-0 right-0 top-0 flex shrink-0 flex-col justify-between border-b border-b-gray-200 bg-base-white px-6 pb-6 pt-4 sm:static sm:left-auto sm:right-auto sm:top-auto sm:w-[13.85rem] sm:border-b-0 sm:border-r sm:border-gray-100 sm:bg-transparent sm:p-6 sm:px-6">
@@ -73,7 +75,7 @@ const UserHub: FC<UserHubProps> = ({
             options={filteredTabList}
             defaultValue={selectedTab}
             value={selectedTab}
-            onChange={(value) => handleTabChange(value?.value as UserHubTabs)}
+            onChange={(value) => handleTabChange(value?.value as UserHubTab)}
             className="w-full"
             hideSelectedOptions
           />
@@ -124,14 +126,14 @@ const UserHub: FC<UserHubProps> = ({
         )}
       </div>
       <div className="relative h-full w-full min-w-0">
-        {selectedTab === UserHubTabs.Balance && (
+        {selectedTab === UserHubTab.Balance && (
           <ReputationTab onTabChange={handleTabChange} />
         )}
-        {selectedTab === UserHubTabs.Stakes && <StakesTab />}
-        {selectedTab === UserHubTabs.Transactions && (
+        {selectedTab === UserHubTab.Stakes && <StakesTab />}
+        {selectedTab === UserHubTab.Transactions && (
           <TransactionsTab appearance={{ interactive: true }} />
         )}
-        {selectedTab === UserHubTabs.CryptoToFiat && <CryptoToFiatTab />}
+        {selectedTab === UserHubTab.CryptoToFiat && <CryptoToFiatTab />}
       </div>
       {/* @BETA: Disabled for now */}
       {/* {isMobile && ( */}

--- a/src/components/common/Extensions/UserHub/consts.ts
+++ b/src/components/common/Extensions/UserHub/consts.ts
@@ -9,7 +9,7 @@ import { defineMessages } from 'react-intl';
 import { FeatureFlag } from '~context/FeatureFlagsContext/types.ts';
 import { formatText } from '~utils/intl.ts';
 
-import { type UserHubTabList, UserHubTabs } from './types.ts';
+import { type UserHubTabList, UserHubTab } from './types.ts';
 
 export const menuMessages = defineMessages({
   balance: {
@@ -32,27 +32,27 @@ export const menuMessages = defineMessages({
 
 export const tabList: UserHubTabList = [
   {
-    id: UserHubTabs.Balance,
+    id: UserHubTab.Balance,
     label: formatText(menuMessages.balance),
-    value: UserHubTabs.Balance,
+    value: UserHubTab.Balance,
     icon: Invoice,
   },
   {
-    id: UserHubTabs.Stakes,
+    id: UserHubTab.Stakes,
     label: formatText(menuMessages.stakes),
-    value: UserHubTabs.Stakes,
+    value: UserHubTab.Stakes,
     icon: CoinVertical,
   },
   {
-    id: UserHubTabs.Transactions,
+    id: UserHubTab.Transactions,
     label: formatText(menuMessages.transactions),
-    value: UserHubTabs.Transactions,
+    value: UserHubTab.Transactions,
     icon: Receipt,
   },
   {
-    id: UserHubTabs.CryptoToFiat,
+    id: UserHubTab.CryptoToFiat,
     label: formatText(menuMessages.cryptoToFiat),
-    value: UserHubTabs.CryptoToFiat,
+    value: UserHubTab.CryptoToFiat,
     icon: CreditCard,
     featureFlag: FeatureFlag.CRYPTO_TO_FIAT_WITHDRAWALS,
   },

--- a/src/components/common/Extensions/UserHub/partials/ReputationTab/partials/Balance.tsx
+++ b/src/components/common/Extensions/UserHub/partials/ReputationTab/partials/Balance.tsx
@@ -6,7 +6,7 @@ import {
 import React, { type FC, useMemo } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
-import { UserHubTabs } from '~common/Extensions/UserHub/types.ts';
+import { UserHubTab } from '~common/Extensions/UserHub/types.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useTokensModalContext } from '~context/TokensModalContext/TokensModalContext.ts';
 import { useGetUserTokenBalanceQuery } from '~gql';
@@ -170,7 +170,7 @@ const Balance: FC<BalanceProps> = ({ nativeToken, wallet, onTabChange }) => {
               </span>
               {!isMobile && (
                 <ViewStakedButton
-                  onClick={() => onTabChange(UserHubTabs.Stakes)}
+                  onClick={() => onTabChange(UserHubTab.Stakes)}
                 />
               )}
             </div>
@@ -185,7 +185,7 @@ const Balance: FC<BalanceProps> = ({ nativeToken, wallet, onTabChange }) => {
           {isMobile && (
             <div className="mt-3">
               <ViewStakedButton
-                onClick={() => onTabChange(UserHubTabs.Stakes)}
+                onClick={() => onTabChange(UserHubTab.Stakes)}
                 isFullSize
               />
             </div>

--- a/src/components/common/Extensions/UserHub/partials/ReputationTab/types.ts
+++ b/src/components/common/Extensions/UserHub/partials/ReputationTab/types.ts
@@ -1,10 +1,10 @@
 import { type Token } from '~types/graphql.ts';
 import { type ColonyWallet } from '~types/wallet.ts';
 
-import { type UserHubTabs } from '../../types.ts';
+import { type UserHubTab } from '../../types.ts';
 
 export interface ReputationTabProps {
-  onTabChange: (newTab: UserHubTabs) => void;
+  onTabChange: (newTab: UserHubTab) => void;
 }
 
 export interface BalanceProps extends Pick<ReputationTabProps, 'onTabChange'> {

--- a/src/components/common/Extensions/UserHub/types.ts
+++ b/src/components/common/Extensions/UserHub/types.ts
@@ -3,20 +3,16 @@ import { type Icon } from '@phosphor-icons/react';
 import { type FeatureFlag } from '~context/FeatureFlagsContext/types.ts';
 
 export type UserHubTabList = {
-  id: UserHubTabs;
+  id: UserHubTab;
   label: string;
-  value: UserHubTabs;
+  value: UserHubTab;
   icon: Icon;
   featureFlag?: FeatureFlag;
 }[];
 
-export enum UserHubTabs {
+export enum UserHubTab {
   Balance = 0,
   Stakes = 1,
   Transactions = 2,
   CryptoToFiat = 3,
-}
-
-export interface UserHubProps {
-  defaultOpenedTab?: UserHubTabs;
 }

--- a/src/components/frame/Extensions/layouts/ColonyLayout.tsx
+++ b/src/components/frame/Extensions/layouts/ColonyLayout.tsx
@@ -5,13 +5,14 @@ import React, {
   type PropsWithChildren,
   useCallback,
   useEffect,
-  // useState,
+  useState,
 } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 //* Hide Initially */
 // import { defineMessages } from 'react-intl';
 // import { PaperPlaneTilt } from '@phosphor-icons/react';
 
+import { UserHubTab } from '~common/Extensions/UserHub/types.ts';
 import UserHubButton from '~common/Extensions/UserHubButton/index.ts';
 import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
@@ -58,6 +59,18 @@ const ColonyLayout: FC<PropsWithChildren> = ({ children }) => {
     actionSidebarToggle;
   const isTablet = useTablet();
 
+  const [userHubTab, setUserHubTab] = useState<UserHubTab>();
+  const openUserHub = useCallback((tab?: UserHubTab) => {
+    if (tab) {
+      setUserHubTab(tab);
+    } else {
+      setUserHubTab(UserHubTab.Balance);
+    }
+  }, []);
+  const clearTab = useCallback(() => {
+    setUserHubTab(undefined);
+  }, []);
+
   const {
     isMemberModalOpen,
     setIsMemberModalOpen,
@@ -91,8 +104,10 @@ const ColonyLayout: FC<PropsWithChildren> = ({ children }) => {
   const getUserNavigation = useCallback(
     (isHidden?: boolean) => (
       <UserNavigationWrapper
-        txButton={<TxButton />}
-        userHub={<UserHubButton />}
+        txButton={
+          <TxButton onClick={() => openUserHub(UserHubTab.Transactions)} />
+        }
+        userHub={<UserHubButton openTab={userHubTab} onOpen={clearTab} />}
         className={clsx(
           'modal-blur-navigation [.show-header-in-modal_&]:z-userNavModal',
           {
@@ -118,7 +133,7 @@ const ColonyLayout: FC<PropsWithChildren> = ({ children }) => {
         }
       />
     ),
-    [isTablet],
+    [isTablet, userHubTab, openUserHub, clearTab],
   );
 
   return (
@@ -149,8 +164,10 @@ const ColonyLayout: FC<PropsWithChildren> = ({ children }) => {
         }}
         sidebar={
           <ColonySidebar
-            txButton={<TxButton />}
-            userHub={<UserHubButton />}
+            txButton={
+              <TxButton onClick={() => openUserHub(UserHubTab.Transactions)} />
+            }
+            userHub={<UserHubButton openTab={userHubTab} onOpen={clearTab} />}
             transactionId={transactionId || undefined}
           />
         }

--- a/src/components/v5/shared/TxButton/TxButton.tsx
+++ b/src/components/v5/shared/TxButton/TxButton.tsx
@@ -14,9 +14,13 @@ import noop from '~utils/noop.ts';
 
 import IconButton from '../Button/IconButton.tsx';
 
+interface Props {
+  onClick: () => void;
+}
+
 const displayName = 'v5.TxButton';
 
-const TxButton: FC = () => {
+const TxButton: FC<Props> = ({ onClick }) => {
   const isMobile = useMobile();
 
   const { transactions, groupState } = useGroupedTransactions();
@@ -76,6 +80,7 @@ const TxButton: FC = () => {
         className={clsx({
           '!min-w-0': isMobile,
         })}
+        onClick={onClick}
         icon={
           <span
             className={clsx('flex shrink-0', {
@@ -118,7 +123,6 @@ const TxButton: FC = () => {
             <Check className="text-base-white" size={14} />
           </span>
         }
-        data-openhubifclicked
       />
     );
   }

--- a/src/components/v5/shared/TxButton/TxButton.tsx
+++ b/src/components/v5/shared/TxButton/TxButton.tsx
@@ -80,7 +80,6 @@ const TxButton: FC<Props> = ({ onClick }) => {
         className={clsx({
           '!min-w-0': isMobile,
         })}
-        onClick={onClick}
         icon={
           <span
             className={clsx('flex shrink-0', {
@@ -90,6 +89,7 @@ const TxButton: FC<Props> = ({ onClick }) => {
             <SpinnerGap className="animate-spin" size={14} />
           </span>
         }
+        onClick={onClick}
       >
         {isMobile ? undefined : (
           <span>
@@ -123,6 +123,7 @@ const TxButton: FC<Props> = ({ onClick }) => {
             <Check className="text-base-white" size={14} />
           </span>
         }
+        onClick={onClick}
       />
     );
   }

--- a/src/stories/common/Select.stories.tsx
+++ b/src/stories/common/Select.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { tabList } from '~common/Extensions/UserHub/consts.ts';
-import { type UserHubTabs } from '~common/Extensions/UserHub/types.ts';
+import { type UserHubTab } from '~common/Extensions/UserHub/types.ts';
 import Select from '~v5/common/Fields/Select/index.ts';
 
 import type { Meta, StoryObj } from '@storybook/react';
@@ -22,7 +22,7 @@ const SelectWithLogic = () => {
       options={tabList}
       defaultValue={selectedTab}
       value={selectedTab}
-      onChange={(value) => setSelectedTab(value?.value as UserHubTabs)}
+      onChange={(value) => setSelectedTab(value?.value as UserHubTab)}
     />
   );
 };


### PR DESCRIPTION
## Description

This PR tries to solve the UserHub opening/closing issues by just using a single state for the visibility of the UserHub. This sadly makes things a little more complicated but there are ambitions to try to solve these issues on the UX side of things (using an improved Modal flow).

For now this should do it. We got rid of the dual state and of the ominous `data-openhubifclicked` attribute by adding some state management wizardry. We basically set the tab that should open in the UserHub from outside and then reset it once it's visible.

## Testing
1. Try to have a pending TX (e.g. use MetaMask and don't confirm)
2. Click the pending TX button and hope that the UserHub opens, showing the transactions list
3. Click outside the UserHub, it should close
4. Also click some other buttons within the UserHub (e.g. Activate tokens) and check if it behaves like it does on `master`.

## Diffs

**Changes** 🏗

- Fix UserHub open state

Resolves #2834