### PR TITLE
Actually clear Apollo cache on logout

### DIFF
--- a/src/redux/sagas/users/index.ts
+++ b/src/redux/sagas/users/index.ts
@@ -180,9 +180,11 @@ export const disconnectWallet = (walletLabel: string) => {
 function* userLogout() {
   try {
     removeContext(ContextModule.ColonyManager);
+    const apolloClient = getContext(ContextModule.ApolloClient);
     const wallet = getContext(ContextModule.Wallet);
     disconnectWallet(wallet.label);
     yield deauthenticateWallet();
+    apolloClient.clearStore();
     yield put<AllActions>({
       type: ActionTypes.USER_LOGOUT_SUCCESS,
     });


### PR DESCRIPTION
## Description

The Apollo cache wasn't cleared on logout/disconnect wallet. This fixes it.

## Testing

Follow the steps in #2864. The transactions should be cleared out.

## Diffs

**Changes** 🏗

* Clear Apollo store cache when logging out

Resolves #2864 
