### PR TITLE
Fix: Motion status showing as unknown

### DIFF
--- a/src/hooks/useNetworkMotionStates.ts
+++ b/src/hooks/useNetworkMotionStates.ts
@@ -1,5 +1,4 @@
 import { type MotionState, VotingReputationFactory } from '@colony/colony-js';
-import { type Provider } from '@ethersproject/providers';
 import { useEffect, useState } from 'react';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
@@ -24,7 +23,7 @@ const useNetworkMotionStates = (nativeMotionIds: string[], skip?: boolean) => {
   );
 
   useEffect(() => {
-    const { ethersProvider } = wallet || {};
+    const { ethersProvider, address } = wallet || {};
     if (
       skip ||
       !nativeMotionIds.length ||
@@ -44,9 +43,12 @@ const useNetworkMotionStates = (nativeMotionIds: string[], skip?: boolean) => {
       return;
     }
 
+    // Properly initialize the signer with the current wallet address
+    const signer = ethersProvider.getSigner(address);
+
     const votingRepClient = VotingReputationFactory.connect(
       votingReputationAddress,
-      ethersProvider as unknown as Provider,
+      signer,
     );
 
     const fetchMotionStates = async () => {


### PR DESCRIPTION
## Description

This PR fixes an issue on the local dev environment where motion status could not be properly fetched after disconnecting and reconnecting your wallet. Thanks to some digging with @rdig and @Nortsova the culprit was found.

## Testing

Step 1 - Install the voting reputation extension
Step 2 - Create a motion and stake to support it
Step 3 - Disconnect your wallet
Step 4 - Connect your wallet again
Step 5 - Check the motions in the activity feed and the userhub have the correct status

(On master they will have the "Unknown" status)

Test with both a metamask wallet and a dev wallet.

## Diffs

**Changes** 🏗

* Properly initialize signer for VotingReputationFactory

Resolves #2643
