### PR TITLE
Fix: transaction list logic fixes

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransactionContent.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransactionContent.tsx
@@ -68,7 +68,6 @@ const GroupedTransactionContent: FC<GroupedTransactionContentProps> = ({
     isShowingCancelConfirmation,
     toggleCancelConfirmation,
     handleCancelTransaction,
-    canBeSigned,
   } = useGroupedTransactionContent({
     id,
     status,
@@ -93,15 +92,7 @@ const GroupedTransactionContent: FC<GroupedTransactionContentProps> = ({
           {`${(group?.index || idx) + 1}. `} {titleText}
         </div>
 
-        {isCancelable && canBeSigned ? (
-          <CancelTransaction
-            isShowingCancelConfirmation={isShowingCancelConfirmation}
-            handleCancelTransaction={handleCancelTransaction}
-            toggleCancelConfirmation={toggleCancelConfirmation}
-          />
-        ) : (
-          <TransactionStatus status={status} hasError={!!error} />
-        )}
+        <TransactionStatus status={status} hasError={!!error} />
       </div>
       {failed && error && retryable && (
         <div className="mt-2 md:mr-2">

--- a/src/redux/sagas/transactions/transactionChannel.ts
+++ b/src/redux/sagas/transactions/transactionChannel.ts
@@ -168,12 +168,6 @@ const channelStart = async ({
   try {
     const sentTx = await channelSendTransaction(tx, txPromise, emit);
     if (!sentTx) {
-      emit(
-        transactionUnsuccessfulError(
-          tx.id,
-          new Error('The transaction was unsuccessful'),
-        ),
-      );
       return null;
     }
 
@@ -192,16 +186,6 @@ const channelStart = async ({
         client,
         emit,
       });
-    } else {
-      /**
-       * @todo Use revert reason strings (once supported) in transactions.
-       */
-      emit(
-        transactionUnsuccessfulError(
-          tx.id,
-          new Error('The transaction was unsuccessful'),
-        ),
-      );
     }
 
     return null;

--- a/src/state/transactionState.ts
+++ b/src/state/transactionState.ts
@@ -95,12 +95,6 @@ export const convertTransactionType = ({
   };
 };
 
-export enum TransactionGroupStatus {
-  Loading = 'Loading',
-  Pending = 'Pending',
-  Done = 'Done',
-}
-
 // Get the joint status of one transaction group
 export const getGroupStatus = (txGroup: TransactionType[]) => {
   if (txGroup.some((tx) => tx.status === TransactionStatus.Failed)) {
@@ -110,31 +104,6 @@ export const getGroupStatus = (txGroup: TransactionType[]) => {
     return TransactionStatus.Succeeded;
   }
   return TransactionStatus.Pending;
-};
-
-// Get the joint status of all transaction groups (not failed or succeeded)
-export const getGroupStatusAll = (
-  transactions: TransactionType[][],
-  loading: boolean,
-) => {
-  if (loading) {
-    return TransactionGroupStatus.Loading;
-  }
-  if (
-    transactions.some((txGroup) => {
-      const groupStatus = getGroupStatus(txGroup);
-      if (
-        groupStatus !== TransactionStatus.Succeeded &&
-        groupStatus !== TransactionStatus.Failed
-      ) {
-        return true;
-      }
-      return false;
-    })
-  ) {
-    return TransactionGroupStatus.Pending;
-  }
-  return TransactionGroupStatus.Done;
 };
 
 // Get the index of the first transaction in a group that is ready to sign
@@ -172,11 +141,7 @@ export const transactionCount = (transactions: TransactionType[]) =>
 export const useGroupedTransactions = () => {
   const { user } = useAppContext();
   const userAddress = utils.getAddress(user?.walletAddress as string);
-  const {
-    data,
-    loading,
-    fetchMore: fetchMoreApollo,
-  } = useGetUserTransactionsQuery({
+  const { data, fetchMore: fetchMoreApollo } = useGetUserTransactionsQuery({
     variables: {
       userAddress,
       limit: TX_PAGE_SIZE,
@@ -205,8 +170,6 @@ export const useGroupedTransactions = () => {
     );
   }, [data?.getTransactionsByUser?.items]);
 
-  const groupState = getGroupStatusAll(transactions, loading);
-
   const fetchMore = async () => {
     const nextToken = data?.getTransactionsByUser?.nextToken;
     if (!nextToken) {
@@ -222,7 +185,6 @@ export const useGroupedTransactions = () => {
   return {
     canFetchMore: !!data?.getTransactionsByUser?.nextToken,
     fetchMore,
-    groupState,
     onePageOnly: transactions.length <= TX_PAGE_SIZE,
     transactions,
   };


### PR DESCRIPTION
## Note

Maybe it'd make sense to wait for #2867 to be merged so that the whole flow can be tested in an integrated way.

## Description

This PR fixes a few bugs raised in #2835. The TxButton now only shows "Completed" if the first transaction group in the list just was successful.
Furthermore we now show a detailed error message for the transaction that was failed. This is currently very rough still but @arrenv is creating an issue to improve the situation.
I also removed the cancel button that was showing for a brief second before the transaction goes into pending.

## Testing

Send and fail a single transaction. A more detailed error message should now be shown. Also the "Completed" TxButton should not show.

## Diffs

**Changes** 🏗

* Do not show "Completed" TxButton when a transaction fails
* Show more detailed error messages on fail
* Remove "cancel" button for a pending transaction

Closes #2835.
