### PR TITLE
Crypto-to-fiat: Payments to liquidation address should show relevant member

### DIFF
--- a/amplify/backend/api/colonycdapp/schema/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema/schema.graphql
@@ -3116,12 +3116,6 @@ type ExpenditureSlotChanges {
 type ColonyActionMetadata @model {
   id: ID!
   customTitle: String!
-  """
-  In case of crypto-to-fiat payment actions,
-  the address of the recipient whose liquidation address
-  the funds were sent to
-  """
-  originalRecipientAddress: ID
 }
 
 type ColonyDecision @model {

--- a/amplify/backend/api/colonycdapp/schema/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema/schema.graphql
@@ -1857,6 +1857,10 @@ type User @model {
     @hasMany(indexName: "byUserAddress", fields: ["id"])
 }
 
+"""
+NOTE: This model should only be used to lookup users by liquidation address
+To get the liquidation address of a user, use the `bridgeGetUserLiquidationAddress` query instead
+"""
 type LiquidationAddress @model {
   """
   Unique identifier for the liquidation address entry
@@ -3112,6 +3116,12 @@ type ExpenditureSlotChanges {
 type ColonyActionMetadata @model {
   id: ID!
   customTitle: String!
+  """
+  In case of crypto-to-fiat payment actions,
+  the address of the recipient whose liquidation address
+  the funds were sent to
+  """
+  originalRecipientAddress: ID
 }
 
 type ColonyDecision @model {

--- a/amplify/backend/function/bridgeXYZMutation/src/handlers/checkKyc.js
+++ b/amplify/backend/function/bridgeXYZMutation/src/handlers/checkKyc.js
@@ -176,16 +176,12 @@ const checkKYCHandler = async (
         },
       );
 
-      console.log('hello world');
-
       const liquidationAddressCreationRes =
         await liquidationAddressCreation.json();
 
       if (liquidationAddressCreation.status === 201) {
         externalAccountLiquidationAddress =
           liquidationAddressCreationRes.address;
-
-        console.log({ externalAccountLiquidationAddress });
 
         // create liquidation address entry in the database
         await graphqlRequest(
@@ -200,8 +196,6 @@ const checkKYCHandler = async (
           graphqlURL,
           appSyncApiKey,
         );
-
-        console.log('created');
       } else {
         console.error(
           'Failed to create liquidation address: ',

--- a/amplify/backend/function/bridgeXYZMutation/src/handlers/kycLinks.js
+++ b/amplify/backend/function/bridgeXYZMutation/src/handlers/kycLinks.js
@@ -51,12 +51,16 @@ const kycLinksHandler = async (
      */
     const tosLink = data?.tos_link ?? data?.existing_kyc_link?.tos_link;
     if (!tosLink) {
-      throw new Error('TOS link missing from Bridge XYZ response');
+      throw new Error(
+        `TOS link missing from Bridge XYZ response: ${data.toString()}`,
+      );
     }
 
     const customerId = extractCustomerId(tosLink);
     if (!customerId) {
-      throw new Error('Could not extract customer ID from TOS link');
+      throw new Error(
+        `Could not extract customer ID from TOS link: ${tosLink}`,
+      );
     }
 
     const userByCustomerIdQuery = await graphqlRequest(

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsModal/useBankDetailsFields.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsModal/useBankDetailsFields.tsx
@@ -3,6 +3,7 @@ import { defineMessages } from 'react-intl';
 import { toast } from 'react-toastify';
 
 import {
+  CheckKycStatusDocument,
   SupportedCurrencies,
   useCreateBankAccountMutation,
   useUpdateBankAccountMutation,
@@ -42,8 +43,12 @@ export const useBankDetailsFields = ({
   redirectToSecondTab,
   data,
 }: UseBankDetailsParams) => {
-  const [createBankAccount] = useCreateBankAccountMutation();
-  const [updateBankAccount] = useUpdateBankAccountMutation();
+  const [createBankAccount] = useCreateBankAccountMutation({
+    refetchQueries: [CheckKycStatusDocument],
+  });
+  const [updateBankAccount] = useUpdateBankAccountMutation({
+    refetchQueries: [CheckKycStatusDocument],
+  });
 
   const [bankDetailsFields, setBankDetailsFields] =
     useState<BankDetailsFormValues>({

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderTable/PaymentBuilderTable.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderTable/PaymentBuilderTable.tsx
@@ -61,14 +61,12 @@ const useGetPaymentBuilderColumns = ({
       paymentBuilderColumnHelper.accessor('recipient', {
         enableSorting: false,
         header: formatText({ id: 'table.row.recipient' }),
-        cell: ({ row }) =>
-          isLoading ? (
-            <div className="flex w-full items-center">
-              <div className="h-4 w-full overflow-hidden rounded skeleton" />
-            </div>
-          ) : (
-            <RecipientField address={row.original.recipient} />
-          ),
+        cell: ({ row }) => (
+          <RecipientField
+            isLoading={!!isLoading}
+            address={row.original.recipient}
+          />
+        ),
         footer: hasMoreThanOneToken
           ? () => (
               <span className="flex min-h-[1.875rem] items-center text-xs text-gray-400">

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderTable/partials/RecipientField/RecipientField.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderTable/partials/RecipientField/RecipientField.tsx
@@ -1,11 +1,28 @@
 import React, { type FC } from 'react';
 
+import useUserByAddress from '~hooks/useUserByAddress.ts';
 import UserPopover from '~v5/shared/UserPopover/UserPopover.tsx';
 
 import { type RecipientFieldProps } from './types.ts';
 
-const RecipientField: FC<RecipientFieldProps> = ({ address }) => (
-  <UserPopover size={18} walletAddress={address} withVerifiedBadge />
-);
+const RecipientField: FC<RecipientFieldProps> = ({ address, isLoading }) => {
+  const { user, loading: isUserLoading } = useUserByAddress(address, true);
+
+  if (isLoading || isUserLoading) {
+    return (
+      <div className="flex w-full items-center">
+        <div className="h-4 w-full overflow-hidden rounded skeleton" />
+      </div>
+    );
+  }
+
+  return (
+    <UserPopover
+      size={18}
+      walletAddress={user?.walletAddress ?? address}
+      withVerifiedBadge
+    />
+  );
+};
 
 export default RecipientField;

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderTable/partials/RecipientField/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderTable/partials/RecipientField/types.ts
@@ -1,3 +1,4 @@
 export interface RecipientFieldProps {
   address: string;
+  isLoading: boolean;
 }

--- a/src/components/v5/common/CompletedAction/partials/SimplePayment/SimplePayment.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SimplePayment/SimplePayment.tsx
@@ -85,7 +85,7 @@ const SimplePayment = ({ action }: SimplePaymentProps) => {
     getTokenDecimalsWithFallback(token?.decimals),
   );
 
-  const { user } = useUserByAddress(actionRecipientAddress as string, true);
+  const { user } = useUserByAddress(actionRecipientAddress ?? '', true);
   const recipientAddress = user?.walletAddress ?? actionRecipientAddress;
   const recipientUser = user ?? actionRecipientUser;
 

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -494,6 +494,12 @@ export type ColonyActionMetadata = {
   createdAt: Scalars['AWSDateTime'];
   customTitle: Scalars['String'];
   id: Scalars['ID'];
+  /**
+   * In case of crypto-to-fiat payment actions,
+   * the address of the recipient whose liquidation address
+   * the funds were sent to
+   */
+  originalRecipientAddress?: Maybe<Scalars['ID']>;
   updatedAt: Scalars['AWSDateTime'];
 };
 
@@ -1292,6 +1298,7 @@ export type CreateColonyActionInput = {
 export type CreateColonyActionMetadataInput = {
   customTitle: Scalars['String'];
   id?: InputMaybe<Scalars['ID']>;
+  originalRecipientAddress?: InputMaybe<Scalars['ID']>;
 };
 
 export type CreateColonyContributorInput = {
@@ -2406,6 +2413,10 @@ export enum KycStatus {
   UnderReview = 'UNDER_REVIEW'
 }
 
+/**
+ * NOTE: This model should only be used to lookup users by liquidation address
+ * To get the liquidation address of a user, use the `bridgeGetUserLiquidationAddress` query instead
+ */
 export type LiquidationAddress = {
   __typename?: 'LiquidationAddress';
   /** The chain id the colony is on */
@@ -2554,6 +2565,7 @@ export type ModelColonyActionMetadataConditionInput = {
   customTitle?: InputMaybe<ModelStringInput>;
   not?: InputMaybe<ModelColonyActionMetadataConditionInput>;
   or?: InputMaybe<Array<InputMaybe<ModelColonyActionMetadataConditionInput>>>;
+  originalRecipientAddress?: InputMaybe<ModelIdInput>;
 };
 
 export type ModelColonyActionMetadataConnection = {
@@ -2568,6 +2580,7 @@ export type ModelColonyActionMetadataFilterInput = {
   id?: InputMaybe<ModelIdInput>;
   not?: InputMaybe<ModelColonyActionMetadataFilterInput>;
   or?: InputMaybe<Array<InputMaybe<ModelColonyActionMetadataFilterInput>>>;
+  originalRecipientAddress?: InputMaybe<ModelIdInput>;
 };
 
 export type ModelColonyActionTypeInput = {
@@ -3714,6 +3727,7 @@ export type ModelSubscriptionColonyActionMetadataFilterInput = {
   customTitle?: InputMaybe<ModelSubscriptionStringInput>;
   id?: InputMaybe<ModelSubscriptionIdInput>;
   or?: InputMaybe<Array<InputMaybe<ModelSubscriptionColonyActionMetadataFilterInput>>>;
+  originalRecipientAddress?: InputMaybe<ModelSubscriptionIdInput>;
 };
 
 export type ModelSubscriptionColonyContributorFilterInput = {
@@ -8255,6 +8269,7 @@ export type UpdateColonyActionInput = {
 export type UpdateColonyActionMetadataInput = {
   customTitle?: InputMaybe<Scalars['String']>;
   id: Scalars['ID'];
+  originalRecipientAddress?: InputMaybe<Scalars['ID']>;
 };
 
 export type UpdateColonyContributorInput = {
@@ -9415,6 +9430,7 @@ export type GetExtensionInstallationsCountQuery = { __typename?: 'Query', getExt
 
 export type GetUserByUserOrLiquidationAddressQueryVariables = Exact<{
   userOrLiquidationAddress: Scalars['ID'];
+  chainId: Scalars['Int'];
 }>;
 
 
@@ -12703,13 +12719,16 @@ export type GetExtensionInstallationsCountQueryHookResult = ReturnType<typeof us
 export type GetExtensionInstallationsCountLazyQueryHookResult = ReturnType<typeof useGetExtensionInstallationsCountLazyQuery>;
 export type GetExtensionInstallationsCountQueryResult = Apollo.QueryResult<GetExtensionInstallationsCountQuery, GetExtensionInstallationsCountQueryVariables>;
 export const GetUserByUserOrLiquidationAddressDocument = gql`
-    query GetUserByUserOrLiquidationAddress($userOrLiquidationAddress: ID!) {
+    query GetUserByUserOrLiquidationAddress($userOrLiquidationAddress: ID!, $chainId: Int!) {
   getUserByAddress(id: $userOrLiquidationAddress) {
     items {
       ...User
     }
   }
-  getUserByLiquidationAddress(liquidationAddress: $userOrLiquidationAddress) {
+  getUserByLiquidationAddress(
+    liquidationAddress: $userOrLiquidationAddress
+    filter: {chainId: {eq: $chainId}}
+  ) {
     items {
       ...LiquidationAddress
     }
@@ -12731,6 +12750,7 @@ ${LiquidationAddressFragmentDoc}`;
  * const { data, loading, error } = useGetUserByUserOrLiquidationAddressQuery({
  *   variables: {
  *      userOrLiquidationAddress: // value for 'userOrLiquidationAddress'
+ *      chainId: // value for 'chainId'
  *   },
  * });
  */

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -494,12 +494,6 @@ export type ColonyActionMetadata = {
   createdAt: Scalars['AWSDateTime'];
   customTitle: Scalars['String'];
   id: Scalars['ID'];
-  /**
-   * In case of crypto-to-fiat payment actions,
-   * the address of the recipient whose liquidation address
-   * the funds were sent to
-   */
-  originalRecipientAddress?: Maybe<Scalars['ID']>;
   updatedAt: Scalars['AWSDateTime'];
 };
 
@@ -1298,7 +1292,6 @@ export type CreateColonyActionInput = {
 export type CreateColonyActionMetadataInput = {
   customTitle: Scalars['String'];
   id?: InputMaybe<Scalars['ID']>;
-  originalRecipientAddress?: InputMaybe<Scalars['ID']>;
 };
 
 export type CreateColonyContributorInput = {
@@ -2565,7 +2558,6 @@ export type ModelColonyActionMetadataConditionInput = {
   customTitle?: InputMaybe<ModelStringInput>;
   not?: InputMaybe<ModelColonyActionMetadataConditionInput>;
   or?: InputMaybe<Array<InputMaybe<ModelColonyActionMetadataConditionInput>>>;
-  originalRecipientAddress?: InputMaybe<ModelIdInput>;
 };
 
 export type ModelColonyActionMetadataConnection = {
@@ -2580,7 +2572,6 @@ export type ModelColonyActionMetadataFilterInput = {
   id?: InputMaybe<ModelIdInput>;
   not?: InputMaybe<ModelColonyActionMetadataFilterInput>;
   or?: InputMaybe<Array<InputMaybe<ModelColonyActionMetadataFilterInput>>>;
-  originalRecipientAddress?: InputMaybe<ModelIdInput>;
 };
 
 export type ModelColonyActionTypeInput = {
@@ -3727,7 +3718,6 @@ export type ModelSubscriptionColonyActionMetadataFilterInput = {
   customTitle?: InputMaybe<ModelSubscriptionStringInput>;
   id?: InputMaybe<ModelSubscriptionIdInput>;
   or?: InputMaybe<Array<InputMaybe<ModelSubscriptionColonyActionMetadataFilterInput>>>;
-  originalRecipientAddress?: InputMaybe<ModelSubscriptionIdInput>;
 };
 
 export type ModelSubscriptionColonyContributorFilterInput = {
@@ -8269,7 +8259,6 @@ export type UpdateColonyActionInput = {
 export type UpdateColonyActionMetadataInput = {
   customTitle?: InputMaybe<Scalars['String']>;
   id: Scalars['ID'];
-  originalRecipientAddress?: InputMaybe<Scalars['ID']>;
 };
 
 export type UpdateColonyContributorInput = {

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -9436,14 +9436,6 @@ export type GetUserByUserOrLiquidationAddressQueryVariables = Exact<{
 
 export type GetUserByUserOrLiquidationAddressQuery = { __typename?: 'Query', getUserByAddress?: { __typename?: 'ModelUserConnection', items: Array<{ __typename?: 'User', bridgeCustomerId?: string | null, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, displayNameChanged?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null, preferredCurrency?: SupportedCurrencies | null, isAutoOfframpEnabled?: boolean | null, meta?: { __typename?: 'ProfileMetadata', metatransactionsEnabled?: boolean | null, decentralizedModeEnabled?: boolean | null, customRpc?: string | null } | null } | null, privateBetaInviteCode?: { __typename?: 'PrivateBetaInviteCode', id: string, shareableInvites?: number | null } | null } | null> } | null, getUserByLiquidationAddress?: { __typename?: 'ModelLiquidationAddressConnection', items: Array<{ __typename?: 'LiquidationAddress', id: string, chainId: number, userAddress: string, liquidationAddress: string, user?: { __typename?: 'User', bridgeCustomerId?: string | null, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, displayNameChanged?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null, preferredCurrency?: SupportedCurrencies | null, isAutoOfframpEnabled?: boolean | null, meta?: { __typename?: 'ProfileMetadata', metatransactionsEnabled?: boolean | null, decentralizedModeEnabled?: boolean | null, customRpc?: string | null } | null } | null, privateBetaInviteCode?: { __typename?: 'PrivateBetaInviteCode', id: string, shareableInvites?: number | null } | null } | null } | null> } | null };
 
-export type GetUserLiquidationAddressesQueryVariables = Exact<{
-  userAddress: Scalars['ID'];
-  chainId: Scalars['Int'];
-}>;
-
-
-export type GetUserLiquidationAddressesQuery = { __typename?: 'Query', getLiquidationAddressesByUserAddress?: { __typename?: 'ModelLiquidationAddressConnection', items: Array<{ __typename?: 'LiquidationAddress', id: string, chainId: number, userAddress: string, liquidationAddress: string, user?: { __typename?: 'User', bridgeCustomerId?: string | null, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, displayNameChanged?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null, preferredCurrency?: SupportedCurrencies | null, isAutoOfframpEnabled?: boolean | null, meta?: { __typename?: 'ProfileMetadata', metatransactionsEnabled?: boolean | null, decentralizedModeEnabled?: boolean | null, customRpc?: string | null } | null } | null, privateBetaInviteCode?: { __typename?: 'PrivateBetaInviteCode', id: string, shareableInvites?: number | null } | null } | null } | null> } | null };
-
 export type GetReputationMiningCycleMetadataQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -12765,47 +12757,6 @@ export function useGetUserByUserOrLiquidationAddressLazyQuery(baseOptions?: Apol
 export type GetUserByUserOrLiquidationAddressQueryHookResult = ReturnType<typeof useGetUserByUserOrLiquidationAddressQuery>;
 export type GetUserByUserOrLiquidationAddressLazyQueryHookResult = ReturnType<typeof useGetUserByUserOrLiquidationAddressLazyQuery>;
 export type GetUserByUserOrLiquidationAddressQueryResult = Apollo.QueryResult<GetUserByUserOrLiquidationAddressQuery, GetUserByUserOrLiquidationAddressQueryVariables>;
-export const GetUserLiquidationAddressesDocument = gql`
-    query GetUserLiquidationAddresses($userAddress: ID!, $chainId: Int!) {
-  getLiquidationAddressesByUserAddress(
-    userAddress: $userAddress
-    filter: {chainId: {eq: $chainId}}
-  ) {
-    items {
-      ...LiquidationAddress
-    }
-  }
-}
-    ${LiquidationAddressFragmentDoc}`;
-
-/**
- * __useGetUserLiquidationAddressesQuery__
- *
- * To run a query within a React component, call `useGetUserLiquidationAddressesQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetUserLiquidationAddressesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetUserLiquidationAddressesQuery({
- *   variables: {
- *      userAddress: // value for 'userAddress'
- *      chainId: // value for 'chainId'
- *   },
- * });
- */
-export function useGetUserLiquidationAddressesQuery(baseOptions: Apollo.QueryHookOptions<GetUserLiquidationAddressesQuery, GetUserLiquidationAddressesQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetUserLiquidationAddressesQuery, GetUserLiquidationAddressesQueryVariables>(GetUserLiquidationAddressesDocument, options);
-      }
-export function useGetUserLiquidationAddressesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetUserLiquidationAddressesQuery, GetUserLiquidationAddressesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetUserLiquidationAddressesQuery, GetUserLiquidationAddressesQueryVariables>(GetUserLiquidationAddressesDocument, options);
-        }
-export type GetUserLiquidationAddressesQueryHookResult = ReturnType<typeof useGetUserLiquidationAddressesQuery>;
-export type GetUserLiquidationAddressesLazyQueryHookResult = ReturnType<typeof useGetUserLiquidationAddressesLazyQuery>;
-export type GetUserLiquidationAddressesQueryResult = Apollo.QueryResult<GetUserLiquidationAddressesQuery, GetUserLiquidationAddressesQueryVariables>;
 export const GetReputationMiningCycleMetadataDocument = gql`
     query GetReputationMiningCycleMetadata {
   getReputationMiningCycleMetadata(id: "REPUTATION_MINING_CYCLE_METADATA") {

--- a/src/graphql/queries/liquidationAddress.graphql
+++ b/src/graphql/queries/liquidationAddress.graphql
@@ -1,10 +1,16 @@
-query GetUserByUserOrLiquidationAddress($userOrLiquidationAddress: ID!) {
+query GetUserByUserOrLiquidationAddress(
+  $userOrLiquidationAddress: ID!
+  $chainId: Int!
+) {
   getUserByAddress(id: $userOrLiquidationAddress) {
     items {
       ...User
     }
   }
-  getUserByLiquidationAddress(liquidationAddress: $userOrLiquidationAddress) {
+  getUserByLiquidationAddress(
+    liquidationAddress: $userOrLiquidationAddress
+    filter: { chainId: { eq: $chainId } }
+  ) {
     items {
       ...LiquidationAddress
     }

--- a/src/graphql/queries/liquidationAddress.graphql
+++ b/src/graphql/queries/liquidationAddress.graphql
@@ -16,14 +16,3 @@ query GetUserByUserOrLiquidationAddress(
     }
   }
 }
-
-query GetUserLiquidationAddresses($userAddress: ID!, $chainId: Int!) {
-  getLiquidationAddressesByUserAddress(
-    userAddress: $userAddress
-    filter: { chainId: { eq: $chainId } }
-  ) {
-    items {
-      ...LiquidationAddress
-    }
-  }
-}

--- a/src/hooks/useUserByAddress.ts
+++ b/src/hooks/useUserByAddress.ts
@@ -3,6 +3,7 @@ import {
   useGetUserByUserOrLiquidationAddressQuery,
 } from '~gql';
 import { type Address } from '~types/index.ts';
+import { getChainId } from '~utils/chainId.ts';
 
 const useUserByAddress = (
   address: Address,
@@ -20,6 +21,7 @@ const useUserByAddress = (
     useGetUserByUserOrLiquidationAddressQuery({
       variables: {
         userOrLiquidationAddress: address,
+        chainId: Number(getChainId()),
       },
       fetchPolicy: 'cache-and-network',
       skip: !tryLiquidationAddress || !address,

--- a/src/redux/sagas/transactions/getMetatransactionPromise.ts
+++ b/src/redux/sagas/transactions/getMetatransactionPromise.ts
@@ -11,6 +11,7 @@ import {
   ExtendedClientType,
 } from '~types/transactions.ts';
 import { isFullWallet } from '~types/wallet.ts';
+import { getChainId } from '~utils/chainId.ts';
 import {
   generateMetatransactionErrorMessage,
   generateMetamaskTypedDataSignatureErrorMessage,
@@ -18,7 +19,6 @@ import {
 
 import { type TransactionType } from '../../immutable/index.ts';
 import {
-  getChainId,
   generateEIP2612TypedData,
   generateMetatransactionMessage,
   broadcastMetatransaction,

--- a/src/redux/sagas/users/index.ts
+++ b/src/redux/sagas/users/index.ts
@@ -333,6 +333,7 @@ function* userCryptoToFiatTransfer({
 
     const { chainId } = yield colonyManager.provider.getNetwork();
 
+    // @TODO: Needs to be replaced with bridgeGetUserLiquidationAddress query
     const { data } = yield apolloClient.query<
       GetUserLiquidationAddressesQuery,
       GetUserLiquidationAddressesQueryVariables

--- a/src/redux/sagas/users/index.ts
+++ b/src/redux/sagas/users/index.ts
@@ -18,9 +18,6 @@ import {
   type CreateUniqueUserMutationVariables,
   GetProfileByEmailDocument,
   GetUserByNameDocument,
-  type GetUserLiquidationAddressesQuery,
-  type GetUserLiquidationAddressesQueryVariables,
-  GetUserLiquidationAddressesDocument,
 } from '~gql';
 import { LANDING_PAGE_ROUTE } from '~routes/index.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
@@ -329,21 +326,18 @@ function* userCryptoToFiatTransfer({
       throw new Error(`USDC token address not found on network ${network}`);
     }
 
-    const apolloClient = getContext(ContextModule.ApolloClient);
-
-    const { chainId } = yield colonyManager.provider.getNetwork();
-
     // @TODO: Needs to be replaced with bridgeGetUserLiquidationAddress query
-    const { data } = yield apolloClient.query<
-      GetUserLiquidationAddressesQuery,
-      GetUserLiquidationAddressesQueryVariables
-    >({
-      query: GetUserLiquidationAddressesDocument,
-      variables: {
-        userAddress: utils.getAddress(wallet.address),
-        chainId,
-      },
-    });
+    // const { data } = yield apolloClient.query<
+    //   GetUserLiquidationAddressesQuery,
+    //   GetUserLiquidationAddressesQueryVariables
+    // >({
+    //   query: GetUserLiquidationAddressesDocument,
+    //   variables: {
+    //     userAddress: utils.getAddress(wallet.address),
+    //     chainId,
+    //   },
+    // });
+    const data = {} as any;
 
     const liquidationAddress =
       data.getLiquidationAddressesByUserAddress?.items[0]?.liquidationAddress;

--- a/src/redux/sagas/utils/metatransactions.ts
+++ b/src/redux/sagas/utils/metatransactions.ts
@@ -1,13 +1,10 @@
 import { type BigNumberish, utils, type TypedDataField } from 'ethers';
 
-import { DEFAULT_NETWORK_INFO } from '~constants/index.ts';
 import { ContextModule, getContext } from '~context/index.ts';
 import { type Address } from '~types/index.ts';
 import { isFullWallet } from '~types/wallet.ts';
 
 import { generateBroadcasterHumanReadableError } from './errorMessages.ts';
-
-export const getChainId = (): string => DEFAULT_NETWORK_INFO.chainId;
 
 export const signTypedData = async ({
   domain,

--- a/src/utils/chainId.ts
+++ b/src/utils/chainId.ts
@@ -1,5 +1,9 @@
 import { BigNumber } from 'ethers';
 
+import { DEFAULT_NETWORK_INFO } from '~constants';
+
+export const getChainId = (): string => DEFAULT_NETWORK_INFO.chainId;
+
 /**
  * web3-onboard stores chainId as hex strings. E.g. ganache id of 2656691 is stored as "0x2889b3".
  * This utility converts the chain id to its hex equivalent.


### PR DESCRIPTION
## Description

This PR fixes a number of issues around displaying the relevant user whose liquidation address a payment was made to. 

When payment is made to the liquidation address, it should be swapped with relevant user in the following places:
- Simple payment action (action description, recipient field)
- Advanced payment action (recipients in the table)
- Activity feed action descriptions

## Testing

Unless you're testing against Bridge production, there's no way to test this properly as the sandbox generated addresses are not valid ETH addresses.

For that reason, we'll create a liquidation address in the DB manually. In production, this will be done by the `checkKyc` handler whenever it finds that a user doesn't have an address linked to their bank account already.

```gql
mutation CreateLiqAdd {
  createLiquidationAddress(
    input: {
      chainId: 265669100,
      userAddress: "0xb77D57F4959eAfA0339424b83FcFaf9c15407461", # Change if not using Dev Wallet 1
      liquidationAddress: "0x87bDe603bF318B2eb2C88B161CA5c1718e712137" # Use any address you want
    }
  ) {
    id
  }
}
```

Make simple and advanced payments to the created liquidation address. In each of the places listed above, it should be replaced with your user's details.

https://github.com/user-attachments/assets/dbd7243a-f2a1-4d71-b75f-d23c44e781b0


https://github.com/user-attachments/assets/70e83485-7ec0-4663-981c-48e4c754cddd


**Note:** The recipient field's user popover will show the address twice instead of the username, it's an existing issue tracked by #2891.

Resolves #2733

