### PR TITLE
Fix: UserPopover shows username instead of address

### DIFF
--- a/src/components/v5/shared/UserInfoPopover/UserInfoPopover.tsx
+++ b/src/components/v5/shared/UserInfoPopover/UserInfoPopover.tsx
@@ -32,8 +32,6 @@ const UserInfoPopover: FC<UserInfoPopoverProps> = ({
 }) => {
   const isMobile = useMobile();
   const [isOpen, setIsOpen] = useState(false);
-  const { profile } = user || {};
-  const { avatar, displayName: userName } = profile || {};
 
   const {
     colony: { colonyAddress },
@@ -63,6 +61,9 @@ const UserInfoPopover: FC<UserInfoPopoverProps> = ({
   const { bio } = contributor?.user?.profile || {};
   const { isVerified, type: contributorType } = contributor || {};
   const domains = useContributorBreakdown(contributor);
+  const resolvedUser = contributor?.user ?? user;
+  const { profile } = resolvedUser || {};
+  const { avatar, displayName: userName } = profile || {};
 
   const onOpenModal = useCallback(() => {
     setIsOpen(true);
@@ -107,7 +108,7 @@ const UserInfoPopover: FC<UserInfoPopoverProps> = ({
       disabled={isColonyMembersDataLoading || isColonyContributorDataLoading}
     >
       {typeof children === 'function'
-        ? children((contributor?.user || user) ?? undefined)
+        ? children(resolvedUser ?? undefined)
         : children}
 
       {withVerifiedBadge && isVerified && (


### PR DESCRIPTION
Fix: update used profile for avatar, displayName and userName in UserInfoPopover

## Description

There were instances of the UserPopover where the wallet address was shown instead of the username.

eg.
Install any extension.
Click on the UserPopover shown next to the "Installed by" label.
![image](https://github.com/user-attachments/assets/ff1dd37a-59f9-4107-9a62-a3c8dfff7645)

## Testing

* Step 1. Install any extension
* Step 2. Click on the user pill next to `Installed by`
* Step 3. Check user name is displayed properly
* Step 4. Go to the activity table -> open an action -> click on the user pill -> check username is displayed instead of wallet address
* Step 5. Check the members/contributors pages

Resolves #2891
