### PR TITLE
[Multi-sig] fix: display correct permissions on motion completed actions

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=6ae5442fe466774428dc5c971eb46be367c236bc
+ENV BLOCK_INGESTOR_HASH=421610a71ddae59f176a890aad4e1895e3734a9c
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/v5/common/CompletedAction/partials/SetUserRoles/SetUserRoles.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SetUserRoles/SetUserRoles.tsx
@@ -9,6 +9,7 @@ import {
   ColonyActionType,
   useGetColonyHistoricRoleRolesQuery,
   type GetColonyHistoricRoleRolesQuery,
+  type ColonyActionRoles,
 } from '~gql';
 import { Authority } from '~types/authority.ts';
 import { type ColonyAction } from '~types/graphql.ts';
@@ -50,14 +51,16 @@ interface Props {
 }
 
 const transformActionRolesToColonyRoles = (
-  historicRoles: GetColonyHistoricRoleRolesQuery['getColonyHistoricRole'],
+  roles:
+    | GetColonyHistoricRoleRolesQuery['getColonyHistoricRole']
+    | ColonyActionRoles,
 ): ColonyRole[] => {
-  if (!historicRoles) return [];
+  if (!roles) return [];
 
-  const roleKeys = Object.keys(historicRoles);
+  const roleKeys = Object.keys(roles);
 
   const colonyRoles: ColonyRole[] = roleKeys
-    .filter((key) => historicRoles[key])
+    .filter((key) => roles[key])
     .map((key) => {
       const match = key.match(/role_(\d+)/); // Extract the role number
       if (match && match[1]) {
@@ -111,8 +114,9 @@ const SetUserRoles = ({ action }: Props) => {
     fetchPolicy: 'cache-and-network',
   });
 
+  // if it's the first time assigning roles, we use the action roles
   const userColonyRoles = transformActionRolesToColonyRoles(
-    historicRoles?.getColonyHistoricRole,
+    historicRoles?.getColonyHistoricRole || roles,
   );
 
   const rolesTitle = formatRolesTitle(roles);


### PR DESCRIPTION
## Description

All multisig and voting reputation motions were showing up as `Remove permissions`, that's because we tried to use historical roles before they get created. We now create them on motions too.
[Block ingestor PR](https://github.com/JoinColony/block-ingestor/pull/266)

## Testing

We need to check if all of the completed action views still function correctly.

1. Install the Multi-Sig extension and give `leela` `Owner` permissions. Set the global threshold to 1.
2. Give `amy` `Payer` Multi-Sig permissions via Multi-Sig, the action should show exactly that
![image](https://github.com/user-attachments/assets/a4703b40-965c-4f6f-a005-61c430e9e123)
3. Finalize the motion, the completed action should show the same data 
![image](https://github.com/user-attachments/assets/e6fe9287-f4bb-4d51-a8e9-236ae6b0b624)
4. Redo the action, take away her `Funding` permissions via permissions
![image](https://github.com/user-attachments/assets/f0153be7-1abb-4334-b2b9-9fff3bc31bcb)
5. The action should show only the impacted data
![image](https://github.com/user-attachments/assets/153f99ef-6c17-4923-89b7-0628f2dca613)
6. Redo the action again, and now toggle on the `Architecture` role
![image](https://github.com/user-attachments/assets/ea47c28e-b7c7-4ec4-bc31-2cc79e78e54e)
7. The correct 3 radio buttons should show and stay the same after finalization
![image](https://github.com/user-attachments/assets/09a0403e-e041-4a73-8cd6-98d7f44cf6b0)
![image](https://github.com/user-attachments/assets/2977513b-5cec-4074-a629-d07033555026)
8. For good measure now test that if you give `amy` `Owner` Multi-Sig permissions that should show up
![image](https://github.com/user-attachments/assets/29d10384-73f0-475b-91c1-8721b0d76ef5)
![image](https://github.com/user-attachments/assets/b835f765-b094-4366-9d73-178d1e86fbb7)
![image](https://github.com/user-attachments/assets/1691141a-35a6-4a3c-ba29-360f9753b8ac)
9. last but not least, create an action to remove `amy`'s permissions
![image](https://github.com/user-attachments/assets/80e89b97-ddeb-4db5-91e5-df45f6eb135f)
![image](https://github.com/user-attachments/assets/328ed8ac-4029-4047-b825-5e6394580d69)
![image](https://github.com/user-attachments/assets/640dc34b-bde3-41ec-b6b0-c60f2ca954f3)

Alternatively, if you don't want to test everything it should be enough to do steps 1-5 and just 9, I just included the extra check juuuuust in case.

Next we can test out the exact same test cases with Lazy consensus! Sorry :sweat_smile: 
Go ahead and install the extension and let's use `fry` instead of `amy` as the target user, and `Take actions on their own` instead of `Take actions via Multi-Sig`.

(I am not going to post all the cases here, just always stake, `npm run forward time 1`, Finalize, Claim and see if everything works in the same way!

## Diffs

**Changes** 🏗

* Block ingestor now correctly checks the event source address
* Historic roles now get created for both Multi-Sig and Voting reputation motions
* If we don't have historic roles, we just display the assigned roles
* 
Resolves #2912 and #2672
