### PR TITLE
feat: added redo action to adv payments

### DIFF
--- a/src/components/common/ColonyActionsTable/ColonyActionsTable.tsx
+++ b/src/components/common/ColonyActionsTable/ColonyActionsTable.tsx
@@ -1,5 +1,6 @@
-import React, { type FC } from 'react';
+import React, { type FC, useEffect } from 'react';
 
+import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { type ColonyAction } from '~types/graphql.ts';
 import { formatText } from '~utils/intl.ts';
 import Table from '~v5/common/Table/index.ts';
@@ -13,9 +14,31 @@ const displayName = 'common.ColonyActionsTable';
 
 const ColonyActionsTable: FC<ColonyActionsTableProps> = ({
   withHeader = true,
+  actionProps,
   ...rest
 }) => {
-  const { tableProps, renderSubComponent } = useActionsTableProps(rest);
+  const { tableProps, renderSubComponent } = useActionsTableProps(
+    rest,
+    actionProps.setSelectedAction,
+  );
+  const {
+    actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
+  } = useActionSidebarContext();
+
+  useEffect(() => {
+    if (actionProps.defaultValues && actionProps.selectedAction) {
+      toggleActionSidebarOn({ ...actionProps.defaultValues });
+
+      setTimeout(() => {
+        actionProps.setSelectedAction(undefined);
+      }, 50);
+    }
+  }, [
+    actionProps.defaultValues,
+    toggleActionSidebarOn,
+    actionProps.selectedAction,
+    actionProps,
+  ]);
 
   return (
     <>

--- a/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
@@ -3,6 +3,7 @@ import {
   FilePlus,
   ShareNetwork,
   Binoculars,
+  Repeat,
 } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React from 'react';
@@ -36,7 +37,8 @@ import useRenderRowLink from './useRenderRowLink.tsx';
 import useRenderSubComponent from './useRenderSubComponent.tsx';
 
 export const useActionsTableProps = (
-  props: Omit<ColonyActionsTableProps, 'withHeader'>,
+  props: Omit<ColonyActionsTableProps, 'withHeader' | 'actionProps'>,
+  setAction: (actionHash: string) => void,
 ) => {
   const {
     className,
@@ -119,6 +121,12 @@ export const useActionsTableProps = (
         ),
         icon: ShareNetwork,
         onClick: () => false,
+      },
+      {
+        key: '4',
+        label: formatText({ id: 'completedAction.redoAction' }),
+        icon: Repeat,
+        onClick: () => setAction(transactionHash),
       },
     ],
   });

--- a/src/components/common/ColonyActionsTable/types.ts
+++ b/src/components/common/ColonyActionsTable/types.ts
@@ -1,3 +1,5 @@
+import { type FieldValues } from 'react-hook-form';
+
 import { type ActivityFeedColonyAction } from '~hooks/useActivityFeed/types.ts';
 import { type TableProps } from '~v5/common/Table/types.ts';
 
@@ -5,4 +7,9 @@ export interface ColonyActionsTableProps
   extends Partial<TableProps<ActivityFeedColonyAction>> {
   pageSize?: number;
   withHeader?: boolean;
+  actionProps: {
+    selectedAction?: string;
+    setSelectedAction: (actionHash: string | undefined) => void;
+    defaultValues?: FieldValues;
+  };
 }

--- a/src/components/frame/v5/pages/ActivityPage/ActivityPage.tsx
+++ b/src/components/frame/v5/pages/ActivityPage/ActivityPage.tsx
@@ -1,4 +1,4 @@
-import React, { type FC } from 'react';
+import React, { useState, type FC } from 'react';
 
 import FiltersContextProvider from '~common/ColonyActionsTable/FiltersContext/FiltersContextProvider.tsx';
 import ColonyActionsTable from '~common/ColonyActionsTable/index.ts';
@@ -8,6 +8,7 @@ import {
 } from '~context/PageHeadingContext/PageHeadingContext.ts';
 import { useCreateTeamBreadcrumbs } from '~hooks/useTeamsBreadcrumbs.ts';
 import { formatText } from '~utils/intl.ts';
+import useGetActionData from '~v5/common/ActionSidebar/hooks/useGetActionData.ts';
 import WidgetBoxList from '~v5/common/WidgetBoxList/index.ts';
 
 import { useActivityFeedWidgets } from './hooks.tsx';
@@ -22,12 +23,24 @@ const ActivityPage: FC = () => {
 
   const widgets = useActivityFeedWidgets();
 
+  const [selectedAction, setSelectedAction] = useState<string | undefined>(
+    undefined,
+  );
+  const { defaultValues } = useGetActionData(selectedAction || undefined);
+
   return (
     <div className="flex w-full flex-col gap-4 sm:gap-6">
       <WidgetBoxList items={widgets} />
       <div>
         <FiltersContextProvider>
-          <ColonyActionsTable className="[&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none" />
+          <ColonyActionsTable
+            actionProps={{
+              selectedAction,
+              setSelectedAction,
+              defaultValues,
+            }}
+            className="[&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none"
+          />
         </FiltersContextProvider>
       </div>
     </div>

--- a/src/components/v5/common/ActionSidebar/hooks/useActionFormProps.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useActionFormProps.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { type Action } from '~constants/actions.ts';
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { ActionTypes } from '~redux/index.ts';
 import { type ActionFormProps } from '~shared/Fields/Form/ActionForm.tsx';
 import { mapPayload, pipe, withMeta } from '~utils/actions.ts';
@@ -26,6 +27,7 @@ const useActionFormProps = (
     mode: 'onChange',
     validationSchema: ACTION_BASE_VALIDATION_SCHEMA,
   });
+  const { colony } = useColonyContext();
 
   const getFormOptions = useCallback<ActionFormBaseProps['getFormOptions']>(
     async (formOptions, form) => {
@@ -34,7 +36,11 @@ const useActionFormProps = (
       }
 
       const { defaultValues: formDefaultValues, transform } = formOptions;
-      const { title, [ACTION_TYPE_FIELD_NAME]: actionType } = form.getValues();
+      const {
+        title,
+        [ACTION_TYPE_FIELD_NAME]: actionType,
+        tokenAddress,
+      } = form.getValues();
 
       const formOptionsWithDefaults = {
         ...(typeof formDefaultValues === 'function'
@@ -43,6 +49,10 @@ const useActionFormProps = (
         ...(defaultValues || {}),
         title,
         [ACTION_TYPE_FIELD_NAME]: actionType,
+        tokenAddress:
+          tokenAddress ||
+          defaultValues?.tokenAddress ||
+          colony.nativeToken.tokenAddress,
       };
 
       setActionFormProps({
@@ -90,7 +100,7 @@ const useActionFormProps = (
         keepDirtyValues: true,
       });
     },
-    [isReadonly, defaultValues, navigate],
+    [defaultValues, colony.nativeToken.tokenAddress, isReadonly, navigate],
   );
 
   return {

--- a/src/components/v5/common/ActionSidebar/hooks/useGetActionData.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useGetActionData.ts
@@ -1,24 +1,35 @@
 import { Id } from '@colony/colony-js';
+import { BigNumber } from 'ethers';
 import moveDecimal from 'move-decimal-point';
 import { useMemo } from 'react';
 
 import { Action } from '~constants/actions.ts';
 import { getRole, UserRole } from '~constants/permissions.ts';
-import { ColonyActionType } from '~gql';
+import { ColonyActionType, ExpenditureType } from '~gql';
+import { useGetAllTokens } from '~hooks/useGetAllTokens.ts';
 import { convertRolesToArray } from '~transformers/index.ts';
 import { DecisionMethod, ExtendedColonyActionType } from '~types/actions.ts';
 import { getExtendedActionType } from '~utils/colonyActions.ts';
+import { convertToDecimal } from '~utils/convertToDecimal.ts';
 import {
   getSelectedToken,
   getTokenDecimalsWithFallback,
 } from '~utils/tokens.ts';
 import { getFormattedTokenAmount } from '~v5/common/CompletedAction/partials/utils.ts';
 
-import { ACTION_TYPE_FIELD_NAME } from '../consts.ts';
+import {
+  ACTION_TYPE_FIELD_NAME,
+  AMOUNT_FIELD_NAME,
+  FROM_FIELD_NAME,
+  RECIPIENT_FIELD_NAME,
+  TEAM_FIELD_NAME,
+  TOKEN_FIELD_NAME,
+} from '../consts.ts';
 import {
   Authority,
   AVAILABLE_ROLES,
 } from '../partials/forms/ManagePermissionsForm/consts.ts';
+import { calculatePercentageValue } from '../partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/utils.ts';
 
 import useGetColonyAction from './useGetColonyAction.ts';
 import { useGetExpenditureData } from './useGetExpenditureData.ts';
@@ -36,6 +47,7 @@ const useGetActionData = (transactionId: string | undefined) => {
   const { expenditure, loadingExpenditure } = useGetExpenditureData(
     action?.expenditureId,
   );
+  const allTokens = useGetAllTokens();
 
   const defaultValues = useMemo(() => {
     if (!action) {
@@ -64,13 +76,21 @@ const useGetActionData = (transactionId: string | undefined) => {
     const extendedType = getExtendedActionType(action, colony.metadata);
     const { metadata } = colony;
 
+    let decisionMethod: DecisionMethod | undefined;
+
+    if (action.isMotion) {
+      decisionMethod = DecisionMethod.Reputation;
+    } else if (expenditure?.isStaked) {
+      decisionMethod = DecisionMethod.Staking;
+    } else {
+      decisionMethod = DecisionMethod.Permissions;
+    }
+
     const repeatableFields = {
       createdIn: isMotion ? motionData?.motionDomain.nativeId : Id.RootDomain,
       description: annotation?.message,
       title: action.metadata?.customTitle,
-      decisionMethod: action.isMotion
-        ? DecisionMethod.Reputation
-        : DecisionMethod.Permissions,
+      decisionMethod,
     };
 
     switch (extendedType) {
@@ -78,23 +98,22 @@ const useGetActionData = (transactionId: string | undefined) => {
       case ColonyActionType.MintTokensMotion:
         return {
           [ACTION_TYPE_FIELD_NAME]: Action.MintTokens,
-          amount: {
-            amount,
-            tokenAddress: token?.tokenAddress,
-          },
+          amount: convertToDecimal(
+            amount || '',
+            getTokenDecimalsWithFallback(token?.decimals),
+          )?.toString(),
+          tokenAddress: token?.tokenAddress,
           ...repeatableFields,
         };
       case ColonyActionType.Payment:
       case ColonyActionType.PaymentMotion: {
         return {
           [ACTION_TYPE_FIELD_NAME]: Action.SimplePayment,
-          amount: {
-            amount: moveDecimal(
-              amount,
-              -getTokenDecimalsWithFallback(token?.decimals),
-            ),
-            tokenAddress: token?.tokenAddress,
-          },
+          amount: moveDecimal(
+            amount,
+            -getTokenDecimalsWithFallback(token?.decimals),
+          ),
+          tokenAddress: token?.tokenAddress,
           from: fromDomain?.nativeId,
           recipient: recipientAddress,
           ...repeatableFields,
@@ -107,23 +126,19 @@ const useGetActionData = (transactionId: string | undefined) => {
         return {
           [ACTION_TYPE_FIELD_NAME]: Action.SimplePayment,
           from: fromDomain?.nativeId,
-          amount: {
-            amount: moveDecimal(
-              firstPayment.amount,
-              -getTokenDecimalsWithFallback(token?.decimals),
-            ),
-            tokenAddress: firstPayment.tokenAddress,
-          },
+          amount: moveDecimal(
+            firstPayment.amount,
+            -getTokenDecimalsWithFallback(token?.decimals),
+          ),
+          tokenAddress: firstPayment.tokenAddress,
           recipient: firstPayment.recipientAddress,
           payments: additionalPayments.map((additionalPayment) => {
             return {
-              amount: {
-                amount: moveDecimal(
-                  additionalPayment.amount,
-                  -getTokenDecimalsWithFallback(token?.decimals),
-                ),
-                tokenAddress: additionalPayment.tokenAddress,
-              },
+              amount: moveDecimal(
+                additionalPayment.amount,
+                -getTokenDecimalsWithFallback(token?.decimals),
+              ),
+              tokenAddress: additionalPayment.tokenAddress,
               recipient: additionalPayment.recipientAddress,
             };
           }),
@@ -136,10 +151,11 @@ const useGetActionData = (transactionId: string | undefined) => {
           [ACTION_TYPE_FIELD_NAME]: Action.TransferFunds,
           from: fromDomain?.nativeId,
           to: toDomain?.nativeId,
-          amount: {
-            amount,
-            tokenAddress: token?.tokenAddress,
-          },
+          amount: convertToDecimal(
+            amount || '',
+            getTokenDecimalsWithFallback(token?.decimals),
+          )?.toString(),
+          tokenAddress: token?.tokenAddress,
           recipient: recipientAddress,
           ...repeatableFields,
         };
@@ -235,9 +251,37 @@ const useGetActionData = (transactionId: string | undefined) => {
           ...repeatableFields,
         };
       case ColonyActionType.CreateExpenditure: {
+        if (expenditure && expenditure.type === ExpenditureType.Staged) {
+          return {
+            [ACTION_TYPE_FIELD_NAME]: Action.StagedPayment,
+            [FROM_FIELD_NAME]: fromDomain?.nativeId,
+            [RECIPIENT_FIELD_NAME]: expenditure?.slots?.[0]?.recipientAddress,
+            stages: (expenditure.metadata?.stages || []).map((stage) => {
+              const currentSlot = slots?.find(
+                (slot) => slot.id === stage.slotId,
+              );
+              const stagedToken = allTokens.find(
+                ({ token: currentToken }) =>
+                  currentToken.tokenAddress ===
+                  currentSlot?.payouts?.[0].tokenAddress,
+              );
+
+              return {
+                milestone: stage.name,
+                amount: moveDecimal(
+                  currentSlot?.payouts?.[0].amount,
+                  -getTokenDecimalsWithFallback(stagedToken?.token.decimals),
+                ),
+                tokenAddress: currentSlot?.payouts?.[0].tokenAddress,
+              };
+            }),
+            ...repeatableFields,
+          };
+        }
+
         return {
           [ACTION_TYPE_FIELD_NAME]: Action.PaymentBuilder,
-          from: expenditureMetadata?.fundFromDomainNativeId,
+          [FROM_FIELD_NAME]: expenditureMetadata?.fundFromDomainNativeId,
           payments: slots?.map((slot) => {
             if (!slot) {
               return undefined;
@@ -260,6 +304,47 @@ const useGetActionData = (transactionId: string | undefined) => {
                 slot.claimDelay && Math.floor(Number(slot.claimDelay) / 3600),
             };
           }),
+          ...repeatableFields,
+        };
+      }
+      case ExtendedColonyActionType.SplitPayment: {
+        const splitToken =
+          !!slots?.length &&
+          !!slots[0].payouts?.length &&
+          slots[0].payouts[0].tokenAddress
+            ? getSelectedToken(colony, slots[0].payouts[0].tokenAddress)
+            : undefined;
+        const splitAmount = slots
+          ?.flatMap((slot) => slot.payouts || [])
+          .reduce((acc, curr) => {
+            return BigNumber.from(acc)
+              .add(BigNumber.from(curr?.amount || '0'))
+              .toString();
+          }, '0');
+        const formattedAmount = moveDecimal(
+          splitAmount,
+          -getTokenDecimalsWithFallback(splitToken?.decimals),
+        );
+
+        return {
+          [ACTION_TYPE_FIELD_NAME]: Action.SplitPayment,
+          distributionMethod: expenditure?.metadata?.distributionType,
+          [TEAM_FIELD_NAME]: expenditure?.metadata?.fundFromDomainNativeId,
+          [AMOUNT_FIELD_NAME]: formattedAmount,
+          payments: slots?.map((slot) => {
+            const currentAmount = moveDecimal(
+              slot.payouts?.[0].amount,
+              -getTokenDecimalsWithFallback(splitToken?.decimals),
+            );
+
+            return {
+              recipient: slot.recipientAddress,
+              amount: currentAmount,
+              tokenAddress: slot.payouts?.[0].tokenAddress,
+              percent: calculatePercentageValue(currentAmount, formattedAmount),
+            };
+          }),
+          [TOKEN_FIELD_NAME]: splitToken?.tokenAddress,
           ...repeatableFields,
         };
       }
@@ -290,7 +375,7 @@ const useGetActionData = (transactionId: string | undefined) => {
       default:
         return undefined;
     }
-  }, [action, expenditure]);
+  }, [action, expenditure, allTokens]);
 
   return {
     action,

--- a/src/components/v5/common/ActionSidebar/hooks/useGetActionData.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useGetActionData.ts
@@ -11,11 +11,11 @@ import { convertRolesToArray } from '~transformers/index.ts';
 import { DecisionMethod, ExtendedColonyActionType } from '~types/actions.ts';
 import { getExtendedActionType } from '~utils/colonyActions.ts';
 import { convertToDecimal } from '~utils/convertToDecimal.ts';
+import { convertPeriodToHours } from '~utils/extensions.ts';
 import {
   getSelectedToken,
   getTokenDecimalsWithFallback,
 } from '~utils/tokens.ts';
-import { getFormattedTokenAmount } from '~v5/common/CompletedAction/partials/utils.ts';
 
 import {
   ACTION_TYPE_FIELD_NAME,
@@ -283,25 +283,19 @@ const useGetActionData = (transactionId: string | undefined) => {
           [ACTION_TYPE_FIELD_NAME]: Action.PaymentBuilder,
           [FROM_FIELD_NAME]: expenditureMetadata?.fundFromDomainNativeId,
           payments: slots?.map((slot) => {
-            if (!slot) {
-              return undefined;
-            }
-            const currentToken = getSelectedToken(
-              colony,
-              slot.payouts?.[0].tokenAddress || '',
-            );
-
-            const currentAmount = getFormattedTokenAmount(
-              slot?.payouts?.[0].amount || '0',
-              currentToken?.decimals,
+            const paymentToken = allTokens.find(
+              ({ token: currentToken }) =>
+                currentToken.tokenAddress === slot.payouts?.[0].tokenAddress,
             );
 
             return {
               recipient: slot.recipientAddress,
-              amount: currentAmount.toString(),
+              amount: moveDecimal(
+                slot.payouts?.[0].amount,
+                -getTokenDecimalsWithFallback(paymentToken?.token.decimals),
+              ),
               tokenAddress: slot.payouts?.[0].tokenAddress,
-              delay:
-                slot.claimDelay && Math.floor(Number(slot.claimDelay) / 3600),
+              delay: convertPeriodToHours(slot.claimDelay || '0'),
             };
           }),
           ...repeatableFields,

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/SimplePaymentDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/SimplePaymentDescription.tsx
@@ -20,15 +20,15 @@ const displayName =
 export const SimplePaymentDescription = () => {
   const formValues = useFormContext<SimplePaymentFormValues>().getValues();
   const { colony } = useColonyContext();
-  const { amount, tokenAddress, recipientAddress } = formValues;
+  const { amount, tokenAddress, recipient } = formValues;
 
   const { nativeToken } = colony;
   const matchingColonyToken = colony.tokens?.items.find(
     (colonyToken) => colonyToken?.token?.tokenAddress === tokenAddress,
   );
 
-  const recipientUser = recipientAddress ? (
-    <RecipientUser userAddress={recipientAddress} />
+  const recipientUser = recipient ? (
+    <RecipientUser userAddress={recipient} />
   ) : (
     formatText({
       id: 'actionSidebar.metadataDescription.recipient',

--- a/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/SimplePaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/SimplePaymentForm.tsx
@@ -48,7 +48,7 @@ const SimplePaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       </ActionFormRow>
       <ActionFormRow
         icon={UserFocus}
-        fieldName="recipientAddress"
+        fieldName="recipient"
         tooltips={{
           label: {
             tooltipContent: formatText({
@@ -59,7 +59,7 @@ const SimplePaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
         title={formatText({ id: 'actionSidebar.recipient' })}
         isDisabled={hasNoDecisionMethods}
       >
-        <UserSelect name="recipientAddress" disabled={hasNoDecisionMethods} />
+        <UserSelect name="recipient" disabled={hasNoDecisionMethods} />
       </ActionFormRow>
       <AmountRow
         domainId={selectedTeam}

--- a/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/SimplePaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/SimplePaymentForm.tsx
@@ -74,6 +74,8 @@ const SimplePaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       <DecisionMethodField />
       <CreatedIn filterOptionsFn={createdInFilterFn} />
       <Description />
+      {/* This input is needed for default values when changing the action */}
+      <input name="payments" className="hidden" />
       {/* Disabled for now */}
       {/* <TransactionTable name="payments" /> */}
     </>

--- a/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/hooks.ts
@@ -81,14 +81,14 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
                 ),
             ),
           createdIn: number().defined(),
-          recipientAddress: string().address().required(),
+          recipient: string().address().required(),
           from: number().required(),
           decisionMethod: string().defined(),
           payments: array()
             .of(
               object()
                 .shape({
-                  recipientAddress: string().required(),
+                  recipient: string().required(),
                   amount: number()
                     .required(() => formatText({ id: 'errors.amount' }))
                     .transform((value) => toFinite(value))

--- a/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/utils.tsx
@@ -52,7 +52,7 @@ export const getSimplePaymentPayload = (
     title,
     amount,
     tokenAddress,
-    recipientAddress,
+    recipient,
     payments,
   } = values;
   const fromDomainId = Number(from);
@@ -65,16 +65,13 @@ export const getSimplePaymentPayload = (
     payments: [
       getPaymentPayload({
         colony,
-        recipientAddress,
+        recipientAddress: recipient,
         amount: amount.toString(),
         tokenAddress,
         networkInverseFee,
       }),
       ...payments.map(
-        ({
-          recipientAddress: paymentRecipientAddress,
-          amount: paymentAmount,
-        }) =>
+        ({ recipient: paymentRecipientAddress, amount: paymentAmount }) =>
           getPaymentPayload({
             colony,
             recipientAddress: paymentRecipientAddress,

--- a/src/components/v5/common/CompletedAction/partials/CompletedExpenditureContent/CompletedExpenditureContent.tsx
+++ b/src/components/v5/common/CompletedAction/partials/CompletedExpenditureContent/CompletedExpenditureContent.tsx
@@ -1,8 +1,10 @@
-import { UserFocus } from '@phosphor-icons/react';
+import { Repeat, UserFocus } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { type FC } from 'react';
+import { type FieldValues } from 'react-hook-form';
 
 import { ADDRESS_ZERO } from '~constants';
+import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { ExpenditureType } from '~gql';
 import { useMobile } from '~hooks';
 import { type AnyActionType, DecisionMethod } from '~types/actions.ts';
@@ -43,6 +45,7 @@ interface CompletedExpenditureContentProps {
   expenditure: Expenditure;
   expenditureMeatballOptions: MeatBallMenuItem[];
   tokensCount?: number;
+  redoActionValues: FieldValues;
 }
 
 const CompletedExpenditureContent: FC<CompletedExpenditureContentProps> = ({
@@ -57,8 +60,15 @@ const CompletedExpenditureContent: FC<CompletedExpenditureContentProps> = ({
   expenditure,
   expenditureMeatballOptions,
   tokensCount,
+  redoActionValues,
 }) => {
   const isMobile = useMobile();
+  const {
+    actionSidebarToggle: [
+      ,
+      { toggleOn: toggleActionSidebarOn, toggleOff: toggleActionSidebarOff },
+    ],
+  } = useActionSidebarContext();
 
   return (
     <>
@@ -71,7 +81,21 @@ const CompletedExpenditureContent: FC<CompletedExpenditureContentProps> = ({
           dropdownPlacementProps={{
             top: 12,
           }}
-          items={expenditureMeatballOptions}
+          items={[
+            {
+              key: '3',
+              label: formatText({ id: 'completedAction.redoAction' }),
+              icon: Repeat,
+              onClick: () => {
+                toggleActionSidebarOff();
+
+                setTimeout(() => {
+                  toggleActionSidebarOn({ ...redoActionValues });
+                }, 500);
+              },
+            },
+            ...expenditureMeatballOptions,
+          ]}
         />
       </div>
       <ActionSubtitle>

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/PaymentBuilder.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/PaymentBuilder.tsx
@@ -1,14 +1,17 @@
 import { ColonyRole } from '@colony/colony-js';
 import { Copy, Prohibit } from '@phosphor-icons/react';
+import moveDecimal from 'move-decimal-point';
 import React from 'react';
 import { defineMessages } from 'react-intl';
 import { generatePath } from 'react-router-dom';
 
 import MeatballMenuCopyItem from '~common/ColonyActionsTable/partials/MeatballMenuCopyItem/MeatballMenuCopyItem.tsx';
 import { APP_URL } from '~constants';
+import { Action } from '~constants/actions.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { ExpenditureStatus, ExpenditureType } from '~gql';
+import { useGetAllTokens } from '~hooks/useGetAllTokens.ts';
 import useToggle from '~hooks/useToggle/index.ts';
 import useUserByAddress from '~hooks/useUserByAddress.ts';
 import {
@@ -17,11 +20,22 @@ import {
   TX_SEARCH_PARAM,
 } from '~routes';
 import SpinnerLoader from '~shared/Preloaders/SpinnerLoader.tsx';
-import { ExtendedColonyActionType } from '~types/actions.ts';
+import { DecisionMethod, ExtendedColonyActionType } from '~types/actions.ts';
 import { ColonyActionType, type ColonyAction } from '~types/graphql.ts';
 import { addressHasRoles } from '~utils/checks/userHasRoles.ts';
 import { findDomainByNativeId } from '~utils/domains.ts';
+import { convertPeriodToHours } from '~utils/extensions.ts';
 import { formatText } from '~utils/intl.ts';
+import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
+import {
+  ACTION_TYPE_FIELD_NAME,
+  CREATED_IN_FIELD_NAME,
+  DECISION_METHOD_FIELD_NAME,
+  DESCRIPTION_FIELD_NAME,
+  FROM_FIELD_NAME,
+  RECIPIENT_FIELD_NAME,
+  TITLE_FIELD_NAME,
+} from '~v5/common/ActionSidebar/consts.ts';
 import { useGetExpenditureData } from '~v5/common/ActionSidebar/hooks/useGetExpenditureData.ts';
 import { type MeatBallMenuItem } from '~v5/shared/MeatBallMenu/types.ts';
 
@@ -50,11 +64,12 @@ const PaymentBuilder = ({ action }: PaymentBuilderProps) => {
   const { user } = useAppContext();
   const { colony } = useColonyContext();
   const { customTitle = formatText(MSG.defaultTitle) } = action?.metadata || {};
-  const { initiatorUser, transactionHash } = action;
+  const { initiatorUser, transactionHash, fromDomain, annotation } = action;
   const [
     isCancelModalOpen,
     { toggleOn: toggleCancelModalOn, toggleOff: toggleCancelModalOff },
   ] = useToggle();
+  const allTokens = useGetAllTokens();
 
   const { expenditure, loadingExpenditure, refetchExpenditure } =
     useGetExpenditureData(action.expenditureId);
@@ -150,6 +165,36 @@ const PaymentBuilder = ({ action }: PaymentBuilderProps) => {
           expenditure={expenditure}
           isStaked={isStaked}
           slots={slots}
+          redoActionValues={{
+            [TITLE_FIELD_NAME]: customTitle,
+            [ACTION_TYPE_FIELD_NAME]: Action.StagedPayment,
+            [FROM_FIELD_NAME]: fromDomain?.nativeId,
+            [RECIPIENT_FIELD_NAME]: recipient?.walletAddress,
+            [DECISION_METHOD_FIELD_NAME]: isStaked
+              ? DecisionMethod.Staking
+              : DecisionMethod.Permissions,
+            [CREATED_IN_FIELD_NAME]: fromDomain?.nativeId,
+            [DESCRIPTION_FIELD_NAME]: annotation?.message,
+            stages: (expenditure.metadata?.stages || []).map((stage) => {
+              const currentSlot = slots.find(
+                (slot) => slot.id === stage.slotId,
+              );
+              const token = allTokens.find(
+                ({ token: currentToken }) =>
+                  currentToken.tokenAddress ===
+                  currentSlot?.payouts?.[0].tokenAddress,
+              );
+
+              return {
+                milestone: stage.name,
+                amount: moveDecimal(
+                  currentSlot?.payouts?.[0].amount,
+                  -getTokenDecimalsWithFallback(token?.token.decimals),
+                ),
+                tokenAddress: currentSlot?.payouts?.[0].tokenAddress,
+              };
+            }),
+          }}
         />
         <StagedPaymentTable
           stages={expenditure.metadata?.stages || []}
@@ -175,6 +220,32 @@ const PaymentBuilder = ({ action }: PaymentBuilderProps) => {
         isStaked={isStaked}
         slots={slots}
         tokensCount={tokensCount}
+        redoActionValues={{
+          [TITLE_FIELD_NAME]: customTitle,
+          [ACTION_TYPE_FIELD_NAME]: Action.PaymentBuilder,
+          [FROM_FIELD_NAME]: fromDomain?.nativeId,
+          [DECISION_METHOD_FIELD_NAME]: isStaked
+            ? DecisionMethod.Staking
+            : DecisionMethod.Permissions,
+          [CREATED_IN_FIELD_NAME]: fromDomain?.nativeId,
+          [DESCRIPTION_FIELD_NAME]: annotation?.message,
+          payments: slots.map((slot) => {
+            const token = allTokens.find(
+              ({ token: currentToken }) =>
+                currentToken.tokenAddress === slot.payouts?.[0].tokenAddress,
+            );
+
+            return {
+              recipient: slot.recipientAddress,
+              amount: moveDecimal(
+                slot.payouts?.[0].amount,
+                -getTokenDecimalsWithFallback(token?.token.decimals),
+              ),
+              tokenAddress: slot.payouts?.[0].tokenAddress,
+              delay: convertPeriodToHours(slot.claimDelay || '0'),
+            };
+          }),
+        }}
       />
       <PaymentBuilderTable
         items={slots}

--- a/src/components/v5/common/CompletedAction/partials/SplitPayment/SplitPayment.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SplitPayment/SplitPayment.tsx
@@ -63,6 +63,7 @@ import {
   DescriptionRow,
   TeamFromRow,
 } from '../rows/index.ts';
+import { getFormattedTokenAmount } from '../utils.ts';
 
 import SplitPaymentTable from './partials/SplitPaymentTable/SplitPaymentTable.tsx';
 
@@ -167,7 +168,10 @@ const SplitPayment = ({ action }: SplitPaymentProps) => {
             [ACTION_TYPE_FIELD_NAME]: Action.SplitPayment,
             distributionMethod: distributionType,
             [TEAM_FIELD_NAME]: fundFromDomainNativeId,
-            [AMOUNT_FIELD_NAME]: formattedAmount,
+            [AMOUNT_FIELD_NAME]: getFormattedTokenAmount(
+              amount,
+              splitToken?.decimals,
+            ),
             payments: slots.map((slot) => {
               const currentAmount = moveDecimal(
                 slot.payouts?.[0].amount,

--- a/src/components/v5/common/CompletedAction/partials/SplitPayment/SplitPayment.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SplitPayment/SplitPayment.tsx
@@ -1,13 +1,16 @@
 import { ColonyRole } from '@colony/colony-js';
-import { ChartPieSlice, Copy, Prohibit } from '@phosphor-icons/react';
+import { ChartPieSlice, Copy, Prohibit, Repeat } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import { BigNumber } from 'ethers';
+import moveDecimal from 'move-decimal-point';
 import React from 'react';
 import { defineMessages } from 'react-intl';
 import { generatePath } from 'react-router-dom';
 
 import MeatballMenuCopyItem from '~common/ColonyActionsTable/partials/MeatballMenuCopyItem/MeatballMenuCopyItem.tsx';
 import { APP_URL } from '~constants';
+import { Action } from '~constants/actions.ts';
+import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { ExpenditureStatus } from '~gql';
@@ -25,9 +28,22 @@ import { type ColonyAction } from '~types/graphql.ts';
 import { addressHasRoles } from '~utils/checks/userHasRoles.ts';
 import { findDomainByNativeId } from '~utils/domains.ts';
 import { formatText } from '~utils/intl.ts';
-import { getSelectedToken } from '~utils/tokens.ts';
+import {
+  getSelectedToken,
+  getTokenDecimalsWithFallback,
+} from '~utils/tokens.ts';
+import {
+  ACTION_TYPE_FIELD_NAME,
+  AMOUNT_FIELD_NAME,
+  DECISION_METHOD_FIELD_NAME,
+  DESCRIPTION_FIELD_NAME,
+  TEAM_FIELD_NAME,
+  TITLE_FIELD_NAME,
+  TOKEN_FIELD_NAME,
+} from '~v5/common/ActionSidebar/consts.ts';
 import { useGetExpenditureData } from '~v5/common/ActionSidebar/hooks/useGetExpenditureData.ts';
 import { distributionMethodOptions } from '~v5/common/ActionSidebar/partials/consts.tsx';
+import { calculatePercentageValue } from '~v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/utils.ts';
 import MeatBallMenu from '~v5/shared/MeatBallMenu/index.ts';
 import { type MeatBallMenuItem } from '~v5/shared/MeatBallMenu/types.ts';
 import UserInfoPopover from '~v5/shared/UserInfoPopover/UserInfoPopover.tsx';
@@ -71,12 +87,18 @@ const SplitPayment = ({ action }: SplitPaymentProps) => {
   const { user } = useAppContext();
   const { colony } = useColonyContext();
   const { customTitle = formatText(MSG.defaultTitle) } = action?.metadata || {};
-  const { initiatorUser, transactionHash } = action;
+  const { initiatorUser, transactionHash, annotation } = action;
   const isMobile = useMobile();
   const [
     isCancelModalOpen,
     { toggleOn: toggleCancelModalOn, toggleOff: toggleCancelModalOff },
   ] = useToggle();
+  const {
+    actionSidebarToggle: [
+      ,
+      { toggleOn: toggleActionSidebarOn, toggleOff: toggleActionSidebarOff },
+    ],
+  } = useActionSidebarContext();
 
   const { expenditure, loadingExpenditure, refetchExpenditure } =
     useGetExpenditureData(action.expenditureId);
@@ -112,34 +134,6 @@ const SplitPayment = ({ action }: SplitPaymentProps) => {
     expenditure?.status !== ExpenditureStatus.Finalized &&
     (user?.walletAddress === initiatorUser?.walletAddress || hasPermissions);
 
-  const expenditureMeatballOptions: MeatBallMenuItem[] = [
-    ...(showCancelOption
-      ? [
-          {
-            key: '1',
-            label: formatText({ id: 'expenditure.cancelPayment' }),
-            icon: Prohibit,
-            onClick: toggleCancelModalOn,
-          },
-        ]
-      : []),
-    {
-      key: '2',
-      label: formatText({ id: 'expenditure.copyLink' }),
-      renderItemWrapper: (itemWrapperProps, children) => (
-        <MeatballMenuCopyItem
-          textToCopy={`${APP_URL.origin}/${generatePath(COLONY_HOME_ROUTE, {
-            colonyName: colony.name,
-          })}${COLONY_ACTIVITY_ROUTE}?${TX_SEARCH_PARAM}=${transactionHash}`}
-          {...itemWrapperProps}
-        >
-          {children}
-        </MeatballMenuCopyItem>
-      ),
-      icon: Copy,
-    },
-  ];
-
   const splitToken =
     !!slots.length &&
     !!slots[0].payouts?.length &&
@@ -154,6 +148,77 @@ const SplitPayment = ({ action }: SplitPaymentProps) => {
         .add(BigNumber.from(curr?.amount || '0'))
         .toString();
     }, '0');
+  const formattedAmount = moveDecimal(
+    amount,
+    -getTokenDecimalsWithFallback(splitToken?.decimals),
+  );
+
+  const expenditureMeatballOptions: MeatBallMenuItem[] = [
+    {
+      key: '1',
+      label: formatText({ id: 'completedAction.redoAction' }),
+      icon: Repeat,
+      onClick: () => {
+        toggleActionSidebarOff();
+
+        setTimeout(() => {
+          toggleActionSidebarOn({
+            [TITLE_FIELD_NAME]: customTitle,
+            [ACTION_TYPE_FIELD_NAME]: Action.SplitPayment,
+            distributionMethod: distributionType,
+            [TEAM_FIELD_NAME]: fundFromDomainNativeId,
+            [AMOUNT_FIELD_NAME]: formattedAmount,
+            payments: slots.map((slot) => {
+              const currentAmount = moveDecimal(
+                slot.payouts?.[0].amount,
+                -getTokenDecimalsWithFallback(splitToken?.decimals),
+              );
+
+              return {
+                recipient: slot.recipientAddress,
+                amount: currentAmount,
+                tokenAddress: slot.payouts?.[0].tokenAddress,
+                percent: calculatePercentageValue(
+                  currentAmount,
+                  formattedAmount,
+                ),
+              };
+            }),
+            [TOKEN_FIELD_NAME]: splitToken?.tokenAddress,
+            [DECISION_METHOD_FIELD_NAME]: isStaked
+              ? DecisionMethod.Staking
+              : DecisionMethod.Permissions,
+            [DESCRIPTION_FIELD_NAME]: annotation?.message,
+          });
+        }, 500);
+      },
+    },
+    ...(showCancelOption
+      ? [
+          {
+            key: '2',
+            label: formatText({ id: 'expenditure.cancelPayment' }),
+            icon: Prohibit,
+            onClick: toggleCancelModalOn,
+          },
+        ]
+      : []),
+    {
+      key: '3',
+      label: formatText({ id: 'expenditure.copyLink' }),
+      renderItemWrapper: (itemWrapperProps, children) => (
+        <MeatballMenuCopyItem
+          textToCopy={`${APP_URL.origin}/${generatePath(COLONY_HOME_ROUTE, {
+            colonyName: colony.name,
+          })}${COLONY_ACTIVITY_ROUTE}?${TX_SEARCH_PARAM}=${transactionHash}`}
+          {...itemWrapperProps}
+        >
+          {children}
+        </MeatballMenuCopyItem>
+      ),
+      icon: Copy,
+    },
+  ];
 
   return (
     <>

--- a/src/components/v5/frame/ColonyHome/ColonyHome.tsx
+++ b/src/components/v5/frame/ColonyHome/ColonyHome.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import FiltersContextProvider from '~common/ColonyActionsTable/FiltersContext/FiltersContextProvider.tsx';
 import ColonyActionsTable from '~common/ColonyActionsTable/index.ts';
@@ -15,6 +15,7 @@ import {
 import { formatText } from '~utils/intl.ts';
 import { setQueryParamOnUrl } from '~utils/urls.ts';
 // import TmpAdvancedPayments from '~v5/payments/TmpAdvancedPayments.tsx';
+import useGetActionData from '~v5/common/ActionSidebar/hooks/useGetActionData.ts';
 import Link from '~v5/shared/Link/index.ts';
 
 import Agreements from './partials/Agreements/index.ts';
@@ -32,6 +33,10 @@ const ColonyHome = () => {
   const isMobile = useMobile();
   const selectedDomain = useGetSelectedDomainFilter();
   const teamsBreadcrumbs = useCreateTeamBreadcrumbs();
+  const [selectedAction, setSelectedAction] = useState<string | undefined>(
+    undefined,
+  );
+  const { defaultValues } = useGetActionData(selectedAction || undefined);
 
   useSetPageBreadcrumbs(teamsBreadcrumbs);
 
@@ -57,6 +62,11 @@ const ColonyHome = () => {
         <div className="w-full">
           <FiltersContextProvider>
             <ColonyActionsTable
+              actionProps={{
+                selectedAction,
+                setSelectedAction,
+                defaultValues,
+              }}
               className="w-full [&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none [&_tr:last-child_td>*:not(.expandable)]:!py-[.9375rem] [&_tr:not(last-child)_td>*:not(.expandable)]:!pb-[.875rem] [&_tr:not(last-child)_td>*:not(.expandable)]:!pt-[.9375rem]"
               pageSize={7}
               withHeader={false}


### PR DESCRIPTION
## Description

- The member field should also be copied over when redoing an simple payment action.
- Redo action should be visible in the activity feed kebab menu as well.
- Redo action should be available for all Advanced payment options, including Staged and Split.

## Testing

* Check if the action is 'copied' after selecting redo action option from meatball menu in activity table

## Diffs

**New stuff** ✨

* Added redo action option to activity table on homepage and activity page

Resolves https://github.com/JoinColony/colonyCDapp/issues/2840
