### PR TITLE
Fix: remove auto-enabling for MultisigPermissions extension in PermissionsNeededBanner

### DIFF
--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/PermissionsNeededBanner.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/PermissionsNeededBanner.tsx
@@ -1,6 +1,6 @@
-import { ColonyRole, Extension, Id } from '@colony/colony-js';
+import { ColonyRole, Id } from '@colony/colony-js';
 import { CheckCircle, WarningCircle } from '@phosphor-icons/react';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
@@ -37,8 +37,6 @@ interface Props {
 }
 
 const PermissionsNeededBanner = ({ extensionData }: Props) => {
-  const shouldDisplay =
-    extensionData.extensionId !== Extension.MultisigPermissions;
   const { colony } = useColonyContext();
   const { user } = useAppContext();
   const { checkExtensionEnabled } = useCheckExtensionEnabled(
@@ -75,16 +73,6 @@ const PermissionsNeededBanner = ({ extensionData }: Props) => {
     }
   };
 
-  useEffect(() => {
-    if (extensionData.extensionId === Extension.MultisigPermissions) {
-      if (colony.colonyAddress) {
-        // Enable Extension.MultisigPermissions by default
-        enableAndCheckStatus();
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [extensionData.extensionId, colony.colonyAddress]);
-
   const getBanner = () => {
     if (isPermissionEnabled) {
       return (
@@ -111,7 +99,7 @@ const PermissionsNeededBanner = ({ extensionData }: Props) => {
     );
   };
 
-  return shouldDisplay ? <div className="mb-6">{getBanner()}</div> : null;
+  return <div className="mb-6">{getBanner()}</div>;
 };
 
 PermissionsNeededBanner.displayName = displayName;


### PR DESCRIPTION
Fix: remove auto-enabling for MultisigPermissions extension in PermissionsNeededBanner

## Description

> [!IMPORTANT]
> This PR only handles showing back the banner; enabling the permissions in a multi-transaction after the extension is installed will be tackled in issue [#2909](https://github.com/JoinColony/colonyCDapp/issues/2909)

You should see the missing permissions banner if there are permissions missing, that only users with the right permissions can trigger.


## Testing

TODO: Check the multi-sig permissions banner shows up after installing the Multi-Sig extension

* Step 1. Login as `leela` and go to Multi-Sig extension page
* Step 2. Install extension 
![Screenshot 2024-08-12 at 15 37 35](https://github.com/user-attachments/assets/cd7a7724-6410-4a44-8e0c-073123c60a6d)
* Step 3. Check permissions banner shows up but **don't** enable the permissions yet
![Screenshot 2024-08-12 at 15 37 47](https://github.com/user-attachments/assets/14ae4ba8-6ddc-4228-a6ab-4432b1001d2c)
* Step 4. Login as `fry` and check permissions banner shows up, but the `Enable permissions` link doesn't show up
![Screenshot 2024-08-12 at 15 38 05](https://github.com/user-attachments/assets/95692d43-ff00-4903-b552-ff4ba2ae1c66)
* Step 5. Login as `leela` and enable the permissions for the extension
* Step 6. Check the banner doesn't show up
![Screenshot 2024-08-12 at 15 38 23](https://github.com/user-attachments/assets/dabe3b72-5ba5-4bc9-b3a8-a98dde78cc18)

## Diffs

**Changes** 🏗

* Permissions banner is back in place for Multi-Sig extension

Resolves #2919 
