### PR TITLE
Fix: enforce transparent background for the tabs

### DIFF
--- a/src/components/shared/Extensions/Tabs/Tabs.tsx
+++ b/src/components/shared/Extensions/Tabs/Tabs.tsx
@@ -38,7 +38,7 @@ const Tabs: FC<PropsWithChildren<TabsProps>> = ({
       {items.map(({ id, title, notificationNumber }) => (
         <Tab
           key={id}
-          className={clsx({
+          className={clsx('!bg-transparent', {
             '!font-semibold': id === activeTab,
             'text-gray-700': id !== activeTab,
           })}

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -15,6 +15,7 @@
     77
   ); /* Used for colony name display (colony simplified) */
 
+  --rts-primary-color: transparent !important; /* Besides using the bg-transparent for a Tab item, we enforce rts to use transparent as primary color */
   --grey-dark: rgb(47, 47, 47);
   --text-disabled: rgb(194, 204, 204);
   --colony-light-blue: rgb(238, 242, 245);


### PR DESCRIPTION
## Description

- In order to not encounter anymore the orange background for the tabs, this PR enforces a transparent background

## Testing

Please check the background for an active tab is transparent.

Places to check: 
- Extensions page
- User Account page
- Members page
- Permissions page
- User hub -> Stakes 

Resolves #2839 
