### PR TITLE
fix: simulate OR logic when filtering activity table by date

### DIFF
--- a/src/components/common/ColonyActionsTable/FiltersContext/FiltersContextProvider.tsx
+++ b/src/components/common/ColonyActionsTable/FiltersContext/FiltersContextProvider.tsx
@@ -115,7 +115,8 @@ const FiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
   );
 
   const activeFilters: ActivityFeedFilters = useMemo(() => {
-    const date = getDateFilter(dateFilters);
+    const dateFiltersData = getDateFilter(dateFilters);
+
     const actionTypes = actionTypesFilters.reduce<AnyActionType[]>(
       (result, actionType) => {
         const apiActionTypes = ACTION_TYPE_TO_API_ACTION_TYPES_MAP[actionType];
@@ -132,7 +133,7 @@ const FiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
     return {
       ...(motionStates.length ? { motionStates } : {}),
       ...(actionTypes.length ? { actionTypes } : {}),
-      ...(date || {}),
+      ...(dateFiltersData ? { dates: dateFiltersData } : {}),
       ...(decisionMethod
         ? {
             decisionMethod,

--- a/src/components/common/ColonyActionsTable/hooks/useActionsTableData.ts
+++ b/src/components/common/ColonyActionsTable/hooks/useActionsTableData.ts
@@ -22,7 +22,6 @@ const useActionsTableData = (pageSize: number) => {
     },
   ]);
   const { activeFilters } = useFiltersContext();
-
   const {
     actions,
     pageNumber,

--- a/src/components/common/ColonyActionsTable/hooks/useActionsTableData.ts
+++ b/src/components/common/ColonyActionsTable/hooks/useActionsTableData.ts
@@ -22,6 +22,7 @@ const useActionsTableData = (pageSize: number) => {
     },
   ]);
   const { activeFilters } = useFiltersContext();
+
   const {
     actions,
     pageNumber,

--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/DateFilters/DateFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/DateFilters/DateFilters.tsx
@@ -32,6 +32,7 @@ const DateFilters: FC = () => {
                 name={name}
                 isChecked={isChecked}
                 onChange={handleDateFilterChange}
+                disabled={!!dateFilters.custom}
               >
                 {label}
               </Checkbox>
@@ -52,6 +53,10 @@ const DateFilters: FC = () => {
             '!fixed !inset-auto !left-1/2 !top-1/2 w-full !-translate-x-1/2 !-translate-y-1/2':
               isMobile,
           })}
+          // I can't just use Object.values().some(Boolean) since I really need to specifically check if it's true, and not if it's truthy
+          disabled={Object.values(dateFilters).find(
+            (dateFilter) => dateFilter === true,
+          )}
         />
       </div>
     </div>

--- a/src/components/common/ColonyActionsTable/utils.ts
+++ b/src/components/common/ColonyActionsTable/utils.ts
@@ -44,7 +44,7 @@ export const makeLoadingRows = (pageSize: number): ActivityFeedColonyAction[] =>
 
 export const getDateFilter = (
   dateFilter: DateOptions | undefined,
-): Pick<ActivityFeedFilters, 'dateFrom' | 'dateTo'> | undefined => {
+): Pick<ActivityFeedFilters, 'dateFrom' | 'dateTo'>[] | undefined => {
   if (!dateFilter) {
     return undefined;
   }
@@ -54,57 +54,80 @@ export const getDateFilter = (
     dateTo: now,
   };
 
-  switch (true) {
-    case dateFilter.pastHour: {
-      return {
+  let filter = undefined as
+    | Pick<ActivityFeedFilters, 'dateFrom' | 'dateTo'>[]
+    | undefined;
+
+  if (dateFilter.pastHour) {
+    filter = [
+      {
         dateFrom: sub(now, { hours: 1 }),
         ...baseFilter,
-      };
-    }
-    case dateFilter.pastDay: {
-      return {
+      },
+    ];
+  }
+
+  if (dateFilter.pastDay) {
+    filter = [
+      {
         dateFrom: sub(now, { days: 1 }),
         ...baseFilter,
-      };
-    }
-    case dateFilter.pastWeek: {
-      return {
+      },
+      {
+        dateFrom: sub(now, { days: 1 }),
+        ...baseFilter,
+      },
+    ];
+  }
+
+  if (dateFilter.pastWeek) {
+    filter = [
+      {
         dateFrom: sub(now, { weeks: 1 }),
         ...baseFilter,
-      };
-    }
-    case dateFilter.pastMonth: {
-      return {
+      },
+    ];
+  }
+
+  if (dateFilter.pastMonth) {
+    filter = [
+      {
         dateFrom: sub(now, { months: 1 }),
         ...baseFilter,
-      };
-    }
-    case dateFilter.pastYear: {
-      return {
+      },
+    ];
+  }
+
+  if (dateFilter.pastYear) {
+    filter = [
+      {
         dateFrom: sub(now, { years: 1 }),
         ...baseFilter,
-      };
-    }
-    case !!dateFilter.custom: {
-      const filteredDates = dateFilter.custom?.filter(
-        (date): date is string => !!date,
-      );
+      },
+    ];
+  }
 
-      if (!filteredDates) {
-        return undefined;
-      }
+  if (dateFilter.custom) {
+    const filteredDates = dateFilter.custom?.filter(
+      (date): date is string => !!date,
+    );
 
-      const [from, to] = filteredDates;
-
-      return {
-        dateFrom: new Date(from),
-        dateTo: new Date(to),
-      };
-    }
-    default: {
+    if (!filteredDates) {
       return undefined;
     }
+
+    const [from, to] = filteredDates;
+
+    filter = [
+      ...(filter ?? []),
+      {
+        dateFrom: new Date(from),
+        dateTo: new Date(to),
+      },
+    ];
   }
+
+  return filter;
 };
 
 export const getCustomDateLabel = (dateRange?: DateOptions['custom']) => {

--- a/src/components/v5/common/Fields/datepickers/RangeDatepicker/partials/DatepickerCustomRangeInput/DatepickerCustomRangeInput.tsx
+++ b/src/components/v5/common/Fields/datepickers/RangeDatepicker/partials/DatepickerCustomRangeInput/DatepickerCustomRangeInput.tsx
@@ -12,7 +12,7 @@ const DatepickerCustomRangeInput = React.forwardRef<
   // ref has to be there to avoid a warning in a console:
   // Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
->(({ onClick, onFocus, startDate, endDate, dateFormat }, ref) => {
+>(({ onClick, onFocus, startDate, endDate, dateFormat, disabled }, ref) => {
   return (
     <div className="flex w-full items-center justify-between gap-2">
       <InputBase
@@ -21,6 +21,7 @@ const DatepickerCustomRangeInput = React.forwardRef<
         onClick={onClick}
         onFocus={onFocus}
         value={startDate ? format(startDate, dateFormat) : ''}
+        disabled={disabled}
       />
       <span className="flex w-6 flex-shrink-0 items-center justify-center text-center text-gray-900 text-2">
         -
@@ -31,6 +32,7 @@ const DatepickerCustomRangeInput = React.forwardRef<
         onClick={onClick}
         onFocus={onFocus}
         value={endDate ? format(endDate, dateFormat) : ''}
+        disabled={disabled}
       />
     </div>
   );

--- a/src/components/v5/common/Fields/datepickers/RangeDatepicker/partials/DatepickerCustomRangeInput/types.ts
+++ b/src/components/v5/common/Fields/datepickers/RangeDatepicker/partials/DatepickerCustomRangeInput/types.ts
@@ -1,7 +1,7 @@
 import { type InputBaseProps } from '~v5/common/Fields/InputBase/types.ts';
 
 export interface DatepickerCustomRangeInputProps
-  extends Pick<InputBaseProps, 'onClick' | 'onFocus'> {
+  extends Pick<InputBaseProps, 'onClick' | 'onFocus' | 'disabled'> {
   dateFormat: string;
   startDate?: Date | null;
   endDate?: Date | null;

--- a/src/hooks/useActivityFeed/types.ts
+++ b/src/hooks/useActivityFeed/types.ts
@@ -20,6 +20,7 @@ export interface ActivityFeedFilters {
   dateTo?: Date;
   decisionMethod?: ActivityDecisionMethod;
   search?: string;
+  dates?: { dateFrom?: Date; dateTo?: Date }[];
 }
 
 export type ActivityFeedSort = SearchActionsQueryVariables['sort'];


### PR DESCRIPTION
## Description

This is a more invasive approach that allows you to combine both the custom date range and the predefined range, by leveraging GraphQL's OR operator.

## Testing

TODO: High level overview of what reviewers are testing with your pr. 

TODO: Followed by step-by-step instructions for testing your branch so reviewers can easily jump straight in and start testing. 

* Step 1. E.g. add reputation
* Step 2. E.g. install Governance extension
* Step 3. E.g. Create motion

## Diffs

**New stuff** ✨

* New stuff goes here

**Changes** 🏗

* Changes go here

**Deletions** ⚰️

* Deletions go here

## TODO

- [ ] Add TODOs

(Resolves | Contributes to) #31415
