### PR TITLE
Fix: Return the correct list of actions based on the `createdAt` filter

### DIFF
--- a/docker/colony-cdapp-dev-env-auth-proxy
+++ b/docker/colony-cdapp-dev-env-auth-proxy
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV AUTH_PROXY_HASH=646d498db30e0d3cbd1a62a4d522260624e6340e
+ENV AUTH_PROXY_HASH=f1d5e35271358946ec65e9a0f7d27fa66c2b878a
 
 # Add dependencies from the host
 # Note: these are listed individually so that if they change, they won't affect

--- a/src/components/common/ColonyActionsTable/FiltersContext/FiltersContextProvider.tsx
+++ b/src/components/common/ColonyActionsTable/FiltersContext/FiltersContextProvider.tsx
@@ -12,6 +12,7 @@ import {
   type ActivityFeedFilters,
   type ActivityDecisionMethod,
 } from '~hooks/useActivityFeed/types.ts';
+import useCurrentBlockTime from '~hooks/useCurrentBlockTime.ts';
 import { type AnyActionType } from '~types/actions.ts';
 import { type MotionState } from '~utils/colonyMotions.ts';
 
@@ -36,6 +37,7 @@ const FiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
     pastYear: false,
     custom: undefined,
   });
+  const { dateFromCurrentBlockTime } = useCurrentBlockTime();
 
   const handleActionTypesFilterChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -115,7 +117,9 @@ const FiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
   );
 
   const activeFilters: ActivityFeedFilters = useMemo(() => {
-    const date = getDateFilter(dateFilters);
+    const date = dateFromCurrentBlockTime
+      ? getDateFilter(dateFilters, dateFromCurrentBlockTime)
+      : null;
     const actionTypes = actionTypesFilters.reduce<AnyActionType[]>(
       (result, actionType) => {
         const apiActionTypes = ACTION_TYPE_TO_API_ACTION_TYPES_MAP[actionType];
@@ -142,6 +146,7 @@ const FiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
     };
   }, [
     actionTypesFilters,
+    dateFromCurrentBlockTime,
     dateFilters,
     decisionMethod,
     motionStates,

--- a/src/components/common/ColonyActionsTable/utils.ts
+++ b/src/components/common/ColonyActionsTable/utils.ts
@@ -46,47 +46,17 @@ export const makeLoadingRows = (pageSize: number): ActivityFeedColonyAction[] =>
 
 export const getDateFilter = (
   dateFilter: DateOptions | undefined,
+  dateFromCurrentBlockTime: Date,
 ): Pick<ActivityFeedFilters, 'dateFrom' | 'dateTo'> | undefined => {
   if (!dateFilter) {
     return undefined;
   }
 
-  const now = new Date();
   const baseFilter = {
-    dateTo: now,
+    dateTo: dateFromCurrentBlockTime,
   };
 
   switch (true) {
-    case dateFilter.pastHour: {
-      return {
-        dateFrom: sub(now, { hours: 1 }),
-        ...baseFilter,
-      };
-    }
-    case dateFilter.pastDay: {
-      return {
-        dateFrom: sub(now, { days: 1 }),
-        ...baseFilter,
-      };
-    }
-    case dateFilter.pastWeek: {
-      return {
-        dateFrom: sub(now, { weeks: 1 }),
-        ...baseFilter,
-      };
-    }
-    case dateFilter.pastMonth: {
-      return {
-        dateFrom: sub(now, { months: 1 }),
-        ...baseFilter,
-      };
-    }
-    case dateFilter.pastYear: {
-      return {
-        dateFrom: sub(now, { years: 1 }),
-        ...baseFilter,
-      };
-    }
     case !!dateFilter.custom: {
       const filteredDates = dateFilter.custom?.filter(
         (date): date is string => !!date,
@@ -101,6 +71,36 @@ export const getDateFilter = (
       return {
         dateFrom: new Date(from),
         dateTo: new Date(to),
+      };
+    }
+    case dateFilter.pastYear: {
+      return {
+        dateFrom: sub(dateFromCurrentBlockTime, { years: 1 }),
+        ...baseFilter,
+      };
+    }
+    case dateFilter.pastMonth: {
+      return {
+        dateFrom: sub(dateFromCurrentBlockTime, { months: 1 }),
+        ...baseFilter,
+      };
+    }
+    case dateFilter.pastWeek: {
+      return {
+        dateFrom: sub(dateFromCurrentBlockTime, { weeks: 1 }),
+        ...baseFilter,
+      };
+    }
+    case dateFilter.pastDay: {
+      return {
+        dateFrom: sub(dateFromCurrentBlockTime, { days: 1 }),
+        ...baseFilter,
+      };
+    }
+    case dateFilter.pastHour: {
+      return {
+        dateFrom: sub(dateFromCurrentBlockTime, { hours: 1 }),
+        ...baseFilter,
       };
     }
     default: {

--- a/src/hooks/useCurrentBlockTime.ts
+++ b/src/hooks/useCurrentBlockTime.ts
@@ -26,7 +26,11 @@ const useCurrentBlockTime = () => {
     fetchCurrentBlockTime();
   }, [fetchCurrentBlockTime]);
 
-  return { currentBlockTime, fetchCurrentBlockTime };
+  const dateFromCurrentBlockTime = currentBlockTime
+    ? new Date(currentBlockTime * 1000)
+    : null;
+
+  return { currentBlockTime, fetchCurrentBlockTime, dateFromCurrentBlockTime };
 };
 
 export default useCurrentBlockTime;


### PR DESCRIPTION
## Description

We have the following predefined date filters:
- past hour
- past 24 hours
- past week
- past month
- past year

The filter wasn't working properly because our logic was basically:

```js
case dateFilter.pastHour: return data;
case dateFilter.pastDay: return data;
case dateFilter.pastWeek return data;
case dateFilter.pastMonth: return data;
case dateFilter.pastYear: return data; 
```

So if you applied the past hour filter + the past year filter, it will first enter the `case` block for `pastHour`. If there are actions in the past hour, it will return those actions without ever having the chance to check the `case` block for `pastYear`.

But luckily, we can easily re-order the checks and start with the most all-encompassing range:

```js
case dateFilter.pastYear: return data;
case dateFilter.pastMonth: return data;
case dateFilter.pastWeek return data;
case dateFilter.pastDay return data;
case dateFilter.pastHour return data;
```

Technically speaking, checking for `pastHour` data when you've already selected `pastYear` data is irrelevant because `pastYear` already covers `pastHour`. 

## Actionable Item

Create a separate issue to use a radio button when setting a date filter as per Arren's suggestion, because as I have mentioned in the Description section and how @Nortsova has observed, it's quite redundant to have multiple selected dates set. As a business rule, the app is only meant to use a custom date range if it's applied even though you have applied other predefined dates. And setting `pastHour` and `pastYear` at the same time will only use `pastYear` anyway.

| Before (date: Aug 13 2024) | After (date: Aug 13 2024) |
| ---- | ---- |
| ![Screenshot 2024-08-13 at 15 29 04](https://github.com/user-attachments/assets/b3e01c94-af40-4626-bcab-616cdd360d57) | ![Screenshot 2024-08-13 at 15 28 37](https://github.com/user-attachments/assets/a255df20-d773-4421-b897-404e57068af5) |

## Testing

1. Create a Simple Payment
2. Go to the Activity page http://localhost:9091/planex/activity
3. Filter the date by past hour
4. Verify that you can see the Simple Payment action you just made
5. Keep track its date field, this represents the block time
6. Click this Action
7. When the Completed Action component comes up, copy the transaction hash from the URL bar
![Screenshot 2024-08-13 at 15 39 43](https://github.com/user-attachments/assets/f286a739-4fe3-4355-9ac6-e5c40bdc89e8)
8. Open the [GraphQL Playground](http://localhost:20002/)
9. Run the following query to update its `createdAt` date to some time within the past 24 hours

> [!WARNING]
> You might not experience it but sometimes, I find that it takes a couple of minutes for the update to be picked up in the app so if your transaction isn't showing up immediately after you've mutated the `createdAt` date, give it like 3-5mins.

> [!INFO]
> On my machine, the current block time is April 20 2023 13:15. Adjust your `createdAt` value accordingly

```gql
mutation UpdateCreatedAt {
  updateColonyAction(
    input: {
      // replace this with the hash you just copied
      id: "0xc611ea533df3da3be76fab8338158f9eb51744e9cfdb80be02d3c68b6ad09743",
      createdAt: "2023-04-20T12:50:47.000Z"
    }
  ) {
    createdAt
  }
}
```
10. Verify that you can see the Transaction if you turned on the `Past 24 hours` filter:
11. This is the part where I need to apologise because you'll have to do the same steps for the following filters ❤️ :
- Past week
- Past month
- Past year

Resolves #2792 