### PR TITLE
Fix: Prevent filename from overflowing

### DIFF
--- a/src/components/v5/common/AvatarUploader/partials/ErrorContent.tsx
+++ b/src/components/v5/common/AvatarUploader/partials/ErrorContent.tsx
@@ -41,7 +41,7 @@ const ErrorContent: FC<ErrorContentProps> = ({
             <Trash size={18} />
           </button>
         </div>
-        <span className="text-left text-sm text-gray-600">
+        <span className="break-all text-left text-sm text-gray-600">
           {fileRejections}
         </span>
         <TextButton


### PR DESCRIPTION
## Description

Just a good ol' break ol'

![break-all](https://github.com/user-attachments/assets/fd7821a2-339e-4695-ae66-b13b3fa2bfea)

## Testing

1. Find an image greater than 1MB
2. Give it the following filename: `theevilgalacticempirehasfallenandanewrepublichasrisentotakeitsplacehoweversinisteragentsarealreadyatworktounderminethefragilepeace`
3. Bring up the Action Form and set it to Edit Colony Details
4. Upload the photo
5. Verify that the filename doesn't overflow

Resolves #2777 