### PR TITLE
Fix: Make the tokens list scrollable

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
@@ -184,7 +184,7 @@ const AmountField: FC<AmountFieldProps> = ({
         {isTokenSelectVisible && (
           <Portal>
             <MenuContainer
-              className="absolute z-sidebar w-full max-w-[calc(100%-2.25rem)] px-2 py-6 sm:w-auto sm:max-w-none"
+              className="absolute z-sidebar w-full max-w-[calc(100%-2.25rem)] overflow-y-auto px-2 py-6 sm:w-auto sm:max-w-none"
               hasShadow
               rounded="s"
               ref={(ref) => {


### PR DESCRIPTION
## Description

Following the Members list scroll behaviour whereby the header is also added to the scroll layer (validated by Arren)

![thisb](https://github.com/user-attachments/assets/d74e1da0-41f9-403d-b4eb-797fc32a4f97)

## Testing

1. Visit your planex colony
2. Bring up the Action Form
3. Set the Action type field to Manage tokens
4. Add all the suggested tokens:
![image](https://github.com/user-attachments/assets/7ce0b2f7-b9a4-4cbe-bf5c-351f9248f4a1)
5. At this point, you should already have 6 tokens (my screenshot shows 5, ignore that)
6. We need to more tokens to make the Tokens list overflow so please create 2 colonies, which effectively makes you create 2 more tokens
```console
node scripts/create-colony-url.js
```
7. Visit each of the newly created colonies and copy their token addresses
![Screenshot 2024-08-13 at 17 36 09](https://github.com/user-attachments/assets/8c07482e-3719-4797-8ca6-0938855728fa)
8. Go back to the planex Colony
9. Add the two tokens you've just created
10. Bring up the Action form and set the Action type to Transfer funds
11. Open dev tools and choose the iPhone SE viewport
12. Click the Amount field, this should bring up the tokens list
13. Verify that Tokens list is scrollable and that it doesn't overflow outside its container

Resolves #2804 