### PR TITLE
Fix: Reveal domain for manage tokens action

### DIFF
--- a/docker/colony-cdapp-dev-env-auth-proxy
+++ b/docker/colony-cdapp-dev-env-auth-proxy
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV AUTH_PROXY_HASH=646d498db30e0d3cbd1a62a4d522260624e6340e
+ENV AUTH_PROXY_HASH=f1d5e35271358946ec65e9a0f7d27fa66c2b878a
 
 # Add dependencies from the host
 # Note: these are listed individually so that if they change, they won't affect

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=1721cdf20875a3b8e4b181a76eb3eed75cfde76d
+ENV BLOCK_INGESTOR_HASH=ec7eb9aa8230fbbfd6a41b167e9053e30bb5fa8f
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]


### PR DESCRIPTION
## Description

![Screenshot 2024-08-13 at 18 13 58](https://github.com/user-attachments/assets/90a2b2c7-0ea6-4762-8190-5eb411622c58)

## Testing

> [!IMPORTANT]
> This requires the following block ingestor changes: [block-ingestor#267 Fix: Reveal domain for manage tokens action](https://github.com/JoinColony/block-ingestor/pull/267)

1. Bring up the Action form
2. Set the Action type to Manage tokens
3. Add a token
4. Visit the Activity page `/{colonyName}/activity`
5. Verify that the the entry for Manage tokens is showing the domain

Resolves #2830 