### PR TITLE
Fix: Display user reputation in its non-scientific notation format

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/ReputationTab/partials/TotalReputation.tsx
+++ b/src/components/common/Extensions/UserHub/partials/ReputationTab/partials/TotalReputation.tsx
@@ -3,7 +3,6 @@ import Decimal from 'decimal.js';
 import React, { type FC } from 'react';
 import { useIntl } from 'react-intl';
 
-import { DEFAULT_TOKEN_DECIMALS } from '~constants/index.ts';
 import useUserReputation from '~hooks/useUserReputation.ts';
 import Numeral from '~shared/Numeral/index.ts';
 import { calculatePercentageReputation, ZeroValue } from '~utils/reputation.ts';
@@ -37,7 +36,7 @@ const TotalReputation: FC<TotalReputationProps> = ({
 
   const formattedReputationPoints = getFormattedTokenValue(
     new Decimal(userReputation || 0).toString(),
-    getTokenDecimalsWithFallback(nativeToken.decimals, DEFAULT_TOKEN_DECIMALS),
+    getTokenDecimalsWithFallback(nativeToken.decimals),
   );
 
   return (

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/ManageReputationDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/ManageReputationDescription.tsx
@@ -2,7 +2,6 @@ import React, { type FC } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
-import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { ColonyActionType } from '~gql';
 import useUserByAddress from '~hooks/useUserByAddress.ts';
@@ -62,10 +61,7 @@ const ManageReputationDescription: FC = () => {
         initiator: <CurrentUser />,
         reputationChange: formatReputationChange(
           toFinite(amount),
-          getTokenDecimalsWithFallback(
-            nativeToken.decimals,
-            DEFAULT_TOKEN_DECIMALS,
-          ),
+          getTokenDecimalsWithFallback(nativeToken.decimals),
         ),
         reputationChangeNumeral: amount ? (
           <Numeral value={toFinite(amount)} />

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/hooks.ts
@@ -4,7 +4,6 @@ import moveDecimal from 'move-decimal-point';
 import { useRef } from 'react';
 import { useWatch } from 'react-hook-form';
 
-import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useUserReputation from '~hooks/useUserReputation.ts';
 import { getInputTextWidth } from '~utils/elements.ts';
@@ -26,10 +25,7 @@ export const useReputationAmountField = (maxWidth: number | undefined) => {
   const formattingOptions: FormatNumeralOptions = {
     delimiter: ',',
     numeralPositiveOnly: true,
-    numeralDecimalScale: getTokenDecimalsWithFallback(
-      nativeToken.decimals,
-      DEFAULT_TOKEN_DECIMALS,
-    ),
+    numeralDecimalScale: getTokenDecimalsWithFallback(nativeToken.decimals),
   };
 
   const adjustInputWidth = () => {
@@ -83,7 +79,7 @@ export const useReputationFields = () => {
 
   const formattedReputationPoints = getFormattedTokenValue(
     BigNumber.from(userReputation || '0').toString(),
-    getTokenDecimalsWithFallback(nativeToken.decimals, DEFAULT_TOKEN_DECIMALS),
+    getTokenDecimalsWithFallback(nativeToken.decimals),
   );
 
   const isSmite = selectedModification === ModificationOption.RemoveReputation;
@@ -91,10 +87,7 @@ export const useReputationFields = () => {
   const amountValueCalculated = BigNumber.from(
     moveDecimal(
       amount || '0',
-      getTokenDecimalsWithFallback(
-        nativeToken.decimals,
-        DEFAULT_TOKEN_DECIMALS,
-      ),
+      getTokenDecimalsWithFallback(nativeToken.decimals),
     ),
   ).toString();
 
@@ -115,7 +108,7 @@ export const useReputationFields = () => {
 
   const formattedNewReputationPoints = getFormattedTokenValue(
     newReputation || 0,
-    getTokenDecimalsWithFallback(nativeToken.decimals, DEFAULT_TOKEN_DECIMALS),
+    getTokenDecimalsWithFallback(nativeToken.decimals),
   );
 
   const amountPercentageValue =

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/utils.ts
@@ -3,7 +3,6 @@ import { BigNumber } from 'ethers';
 import moveDecimal from 'move-decimal-point';
 import { type TestContext } from 'yup';
 
-import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { type ManageReputationMotionPayload } from '~redux/sagas/motions/manageReputationMotion.ts';
 import { type Colony } from '~types/graphql.ts';
 import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
@@ -65,10 +64,7 @@ export const reputationAmountChangeValidation = ({
   const amountValueCalculated = BigNumber.from(
     moveDecimal(
       value !== '' ? value : '0',
-      getTokenDecimalsWithFallback(
-        nativeToken.decimals,
-        DEFAULT_TOKEN_DECIMALS,
-      ),
+      getTokenDecimalsWithFallback(nativeToken.decimals),
     ),
   ).toString();
 
@@ -90,12 +86,6 @@ export const moreThanZeroAmountValidation = (
   const { nativeToken } = colony;
 
   return BigNumber.from(
-    moveDecimal(
-      value,
-      getTokenDecimalsWithFallback(
-        nativeToken.decimals,
-        DEFAULT_TOKEN_DECIMALS,
-      ),
-    ),
+    moveDecimal(value, getTokenDecimalsWithFallback(nativeToken.decimals)),
   ).gt(0);
 };

--- a/src/components/v5/common/CompletedAction/partials/ManageReputation/ManageReputation.tsx
+++ b/src/components/v5/common/CompletedAction/partials/ManageReputation/ManageReputation.tsx
@@ -136,19 +136,13 @@ const ManageReputation: FC<ManageReputationProps> = ({ action }) => {
             reputationChange: amount
               ? formatReputationChange(
                   amount,
-                  getTokenDecimalsWithFallback(
-                    nativeToken.decimals,
-                    DEFAULT_TOKEN_DECIMALS,
-                  ),
+                  getTokenDecimalsWithFallback(nativeToken.decimals),
                 )
               : '0',
             reputationChangeNumeral: positiveAmountValue ? (
               <Numeral
                 value={positiveAmountValue}
-                decimals={getTokenDecimalsWithFallback(
-                  nativeToken.decimals,
-                  DEFAULT_TOKEN_DECIMALS,
-                )}
+                decimals={getTokenDecimalsWithFallback(nativeToken.decimals)}
               />
             ) : (
               formatText({

--- a/src/components/v5/common/CompletedAction/partials/ManageReputation/partials/ManageReputationTableCompletedState/ManageReputationTableCompletedState.tsx
+++ b/src/components/v5/common/CompletedAction/partials/ManageReputation/partials/ManageReputationTableCompletedState/ManageReputationTableCompletedState.tsx
@@ -2,7 +2,6 @@ import clsx from 'clsx';
 import { BigNumber } from 'ethers';
 import React, { type FC } from 'react';
 
-import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useMobile } from '~hooks/index.ts';
 import useUserReputation from '~hooks/useUserReputation.ts';
@@ -65,10 +64,7 @@ const ManageReputationTableCompletedState: FC<
     <p className="text-md font-normal text-gray-900">
       <Numeral
         value={amount}
-        decimals={getTokenDecimalsWithFallback(
-          nativeToken.decimals,
-          DEFAULT_TOKEN_DECIMALS,
-        )}
+        decimals={getTokenDecimalsWithFallback(nativeToken.decimals)}
         suffix={` ${formatText({
           id: 'actionSidebar.manageReputation.points',
         })}`}

--- a/src/components/v5/common/CompletedAction/partials/ManageReputation/partials/ManageReputationTableInMotion/ManageReputationTableInMotion.tsx
+++ b/src/components/v5/common/CompletedAction/partials/ManageReputation/partials/ManageReputationTableInMotion/ManageReputationTableInMotion.tsx
@@ -1,6 +1,5 @@
 import React, { type FC } from 'react';
 
-import { DEFAULT_TOKEN_DECIMALS } from '~constants/index.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import Numeral from '~shared/Numeral/index.ts';
 import { formatText } from '~utils/intl.ts';
@@ -40,10 +39,7 @@ const ManageReputationTableInMotion: FC<ManageReputationTableInMotionProps> = ({
         <p className="flex flex-wrap items-center gap-x-2 text-md font-normal text-gray-900">
           <Numeral
             value={amount}
-            decimals={getTokenDecimalsWithFallback(
-              nativeToken.decimals,
-              DEFAULT_TOKEN_DECIMALS,
-            )}
+            decimals={getTokenDecimalsWithFallback(nativeToken.decimals)}
           />
           <span className="flex-shrink-0">
             {formatText(

--- a/src/components/v5/common/CompletedAction/partials/ManageReputation/partials/ManageReputationTableInMotion/hooks.ts
+++ b/src/components/v5/common/CompletedAction/partials/ManageReputation/partials/ManageReputationTableInMotion/hooks.ts
@@ -1,6 +1,5 @@
 import { BigNumber } from 'ethers';
 
-import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useUserReputation from '~hooks/useUserReputation.ts';
 import { calculatePercentageReputation } from '~utils/reputation.ts';
@@ -42,7 +41,7 @@ export const useManageReputationTableData = ({
 
   const formattedReputationPoints = getFormattedTokenValue(
     BigNumber.from(userReputation || 0).toString(),
-    getTokenDecimalsWithFallback(nativeToken.decimals, DEFAULT_TOKEN_DECIMALS),
+    getTokenDecimalsWithFallback(nativeToken.decimals),
   );
 
   const newReputation = calculateNewValue(userReputation, amount, isSmite);
@@ -58,7 +57,7 @@ export const useManageReputationTableData = ({
 
   const formattedNewReputationPoints = getFormattedTokenValue(
     newReputation || 0,
-    getTokenDecimalsWithFallback(nativeToken.decimals, DEFAULT_TOKEN_DECIMALS),
+    getTokenDecimalsWithFallback(nativeToken.decimals),
   );
   const amountPercentageValue =
     typeof newPercentageReputation === 'number' &&

--- a/src/components/v5/shared/UserInfoPopover/partials/UserInfo.tsx
+++ b/src/components/v5/shared/UserInfoPopover/partials/UserInfo.tsx
@@ -3,12 +3,15 @@ import { Star, User } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { type FC } from 'react';
 
+import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { getRole } from '~constants/permissions.ts';
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { ContributorType } from '~gql';
 import Tooltip from '~shared/Extensions/Tooltip/Tooltip.tsx';
 import Numeral from '~shared/Numeral/index.ts';
 import { formatText } from '~utils/intl.ts';
 import { multiLineTextEllipsis } from '~utils/strings.ts';
+import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
 import PermissionsBadge from '~v5/common/Pills/PermissionsBadge/index.ts';
 import UserStatus from '~v5/common/Pills/UserStatus/index.ts';
 import TitleLabel from '~v5/shared/TitleLabel/index.ts';
@@ -26,6 +29,7 @@ const UserInfo: FC<UserInfoProps> = ({
 }) => {
   const aboutDescriptionText = formatText(aboutDescription);
   const isTopContributorType = contributorType === ContributorType.Top;
+  const { colony } = useColonyContext();
 
   return (
     <div
@@ -134,7 +138,14 @@ const UserInfo: FC<UserInfoProps> = ({
                         <Tooltip
                           className="flex min-w-[4.5rem] items-center justify-end text-sm text-blue-400"
                           tooltipContent={
-                            <Numeral value={reputationRaw} suffix=" pts" />
+                            <Numeral
+                              value={reputationRaw}
+                              suffix=" pts"
+                              decimals={getTokenDecimalsWithFallback(
+                                colony.nativeToken.decimals,
+                                DEFAULT_TOKEN_DECIMALS,
+                              )}
+                            />
                           }
                         >
                           <Star size={12} />

--- a/src/components/v5/shared/UserInfoPopover/partials/UserInfo.tsx
+++ b/src/components/v5/shared/UserInfoPopover/partials/UserInfo.tsx
@@ -3,7 +3,6 @@ import { Star, User } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { type FC } from 'react';
 
-import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { getRole } from '~constants/permissions.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { ContributorType } from '~gql';
@@ -143,7 +142,6 @@ const UserInfo: FC<UserInfoProps> = ({
                               suffix=" pts"
                               decimals={getTokenDecimalsWithFallback(
                                 colony.nativeToken.decimals,
-                                DEFAULT_TOKEN_DECIMALS,
                               )}
                             />
                           }


### PR DESCRIPTION
## Description

| Before | After |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/1f2c2f57-c295-4833-ab5f-09eee80379d9) | ![image](https://github.com/user-attachments/assets/d48fe68a-1efc-4550-9336-354a3878e42d) |

## Testing

1. Visit the Members page
2. Click on leela, the User Info popover should come up
3. Hover on the Reputation percentage
4. Verify that reputation value in the tooltip is not being shown in scientific notation anymore

Resolves #2706 