### PR TITLE
Fix: Update nested table styles in the incoming funds table

### DIFF
--- a/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
@@ -124,7 +124,8 @@ const TokenTable: FC<TokenTableProps> = ({ token }) => {
           data={currentClaims}
           getSortedRowModel={getSortedRowModel()}
           columns={columns}
-          className="-mx-[1.125rem] !w-[calc(100%+2.25rem)] rounded-none border-0 border-gray-200 px-[1.125rem] [&_td]:px-[1.125rem] [&_td]:py-4 [&_th]:border-y"
+          className="-mx-[1.125rem] !w-[calc(100%+2.25rem)] px-[1.125rem] [&_td]:px-[1.125rem] [&_td]:py-4 [&_th]:!rounded-none [&_th]:border-y"
+          tableClassName="rounded-none border-none"
           initialState={{
             sorting: [
               {


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/a6145f82-94dd-4812-b088-6949d3016b6a)

## Testing

1. Visit the Incoming Funds page
2. Expand the accordions on the table
3. Verify that they are following the Figma designs

Resolves #2788 