### PR TITLE
Feat: show titled section for not connected wallet or no joined colony

### DIFF
--- a/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesList.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesList.tsx
@@ -5,12 +5,14 @@ import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { usePageLayoutContext } from '~context/PageLayoutContext/PageLayoutContext.ts';
 
 import JoinedColonyItem from './JoinedColonyItem/index.ts';
+import { NoColoniesJoinedSection } from './TitleSections/NoColoniesJoinedSection.tsx';
 
 const displayName =
   'v5.common.Navigation.ColonySwitcher.partials.JoinedColoniesList';
 
 export const JoinedColoniesList = () => {
   const { joinedColonies } = useAppContext();
+  const hasJoinedColonies = !!joinedColonies.length;
 
   const { setShowTabletColonyPicker } = usePageLayoutContext();
 
@@ -21,7 +23,7 @@ export const JoinedColoniesList = () => {
     navigate(`/${colonyName}`);
   };
 
-  return (
+  return hasJoinedColonies ? (
     <>
       {joinedColonies.map(
         ({ colonyAddress, metadata, name, nativeToken }, index) => (
@@ -38,6 +40,8 @@ export const JoinedColoniesList = () => {
         ),
       )}
     </>
+  ) : (
+    <NoColoniesJoinedSection />
   );
 };
 

--- a/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesList.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesList.tsx
@@ -5,7 +5,7 @@ import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { usePageLayoutContext } from '~context/PageLayoutContext/PageLayoutContext.ts';
 
 import JoinedColonyItem from './JoinedColonyItem/index.ts';
-import { NoColoniesJoinedSection } from './TitleSections/NoColoniesJoinedSection.tsx';
+import { EmptyJoinedColoniesSection } from './TitleSections/EmptyJoinedColoniesSection.tsx';
 
 const displayName =
   'v5.common.Navigation.ColonySwitcher.partials.JoinedColoniesList';
@@ -41,7 +41,7 @@ export const JoinedColoniesList = () => {
       )}
     </>
   ) : (
-    <NoColoniesJoinedSection />
+    <EmptyJoinedColoniesSection />
   );
 };
 

--- a/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesPopover/JoinedColoniesPopover.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesPopover/JoinedColoniesPopover.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 
+import { useAppContext } from '~context/AppContext/AppContext.ts';
 import Button from '~v5/shared/Button/Button.tsx';
 import PopoverBase from '~v5/shared/PopoverBase/index.ts';
 
 import JoinedColoniesList from '../JoinedColoniesList.tsx';
+import { ConnectWalletSection } from '../TitleSections/ConnectWalletSection.tsx';
 
 import { type JoinedColoniesPopoverProps } from './types.ts';
 
@@ -15,19 +17,32 @@ const JoinedColoniesPopover = ({
   setTooltipRef,
   getTooltipProps,
 }: JoinedColoniesPopoverProps) => {
+  const { wallet, connectWallet } = useAppContext();
+
   return visible ? (
     <PopoverBase
       setTooltipRef={setTooltipRef}
       tooltipProps={getTooltipProps}
       classNames="z-top bg-white w-[252px] py-4 px-2 rounded-lg border-gray-200 border-[1px] shadow-none mt-4 gap-2"
     >
-      <JoinedColoniesList />
+      {wallet ? <JoinedColoniesList /> : <ConnectWalletSection />}
       <section className="w-full px-2 pt-2">
-        <Button
-          mode="primaryOutlineFull"
-          text={{ id: 'button.createNewColony' }}
-          className="w-full border-gray-300"
-        />
+        {wallet ? (
+          <Button
+            mode="primaryOutlineFull"
+            text={{ id: 'button.createNewColony' }}
+            size="medium"
+            className="w-full border-gray-300"
+          />
+        ) : (
+          <Button
+            mode="primaryOutlineFull"
+            text={{ id: 'button.connectWallet' }}
+            size="medium"
+            className="w-full border-gray-300"
+            onClick={connectWallet}
+          />
+        )}
       </section>
     </PopoverBase>
   ) : null;

--- a/src/components/v5/shared/Navigation/ColonySwitcher/partials/MobileJoinedColonies/MobileJoinedColonies.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/partials/MobileJoinedColonies/MobileJoinedColonies.tsx
@@ -1,13 +1,18 @@
+import { Plus } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import { AnimatePresence, motion } from 'framer-motion';
 import React, { useRef } from 'react';
 
+import { LEARN_MORE_PAYMENTS } from '~constants/externalUrls.ts';
+import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { usePageLayoutContext } from '~context/PageLayoutContext/PageLayoutContext.ts';
 import { useTablet } from '~hooks';
 import useDisableBodyScroll from '~hooks/useDisableBodyScroll/index.ts';
+import LearnMore from '~shared/Extensions/LearnMore/LearnMore.tsx';
 import Button from '~v5/shared/Button/index.ts';
 
 import JoinedColoniesList from '../JoinedColoniesList.tsx';
+import { ConnectWalletSection } from '../TitleSections/ConnectWalletSection.tsx';
 
 import { motionVariants } from './consts.ts';
 
@@ -18,6 +23,8 @@ const MobileJoinedColonies = () => {
   const isTablet = useTablet();
 
   const ref = useRef<HTMLDivElement>(null);
+
+  const { wallet, connectWallet } = useAppContext();
 
   const { showTabletColonyPicker } = usePageLayoutContext();
 
@@ -38,18 +45,36 @@ const MobileJoinedColonies = () => {
           /** Unfortunately, it's a bit tricky to string interpolate tailwind classes */
           className={clsx(
             'top-[calc(var(--header-nav-section-height)+var(--top-content-height))]',
-            'fixed left-0 z-userNavModal flex h-[calc(100vh-var(--header-nav-section-height)-var(--top-content-height))] w-full flex-col justify-between overflow-y-auto rounded-none bg-base-white p-[10px] no-scrollbar',
+            'fixed left-0 z-userNavModal flex h-[calc(100vh-var(--header-nav-section-height)-var(--top-content-height))] w-full flex-col justify-between overflow-y-auto rounded-none bg-base-white px-[10px] py-6 no-scrollbar',
             'md:static md:h-full md:w-[216px] md:rounded-lg',
           )}
         >
           <div className="flex h-fit w-full flex-col gap-3">
-            <JoinedColoniesList />
+            {wallet ? <JoinedColoniesList /> : <ConnectWalletSection />}
           </div>
-          <section className="w-full px-2 pt-2">
-            <Button
-              mode="primaryOutlineFull"
-              text={{ id: 'button.createNewColony' }}
-              className="w-full border-gray-300"
+          <section className="flex w-full flex-col gap-6 px-2">
+            <div className="border-b border-gray-200" />
+            {wallet ? (
+              <Button
+                mode="primarySolid"
+                text={{ id: 'button.createNewColony' }}
+                className="w-full border-gray-300"
+                icon={Plus}
+              />
+            ) : (
+              <Button
+                mode="primarySolid"
+                text={{ id: 'button.connectWallet' }}
+                className="w-full border-gray-300"
+                onClick={connectWallet}
+              />
+            )}
+            <LearnMore
+              message={{
+                id: `${displayName}.helpText`,
+                defaultMessage: 'Need help and guidance? <a>Visit our docs</a>',
+              }}
+              href={LEARN_MORE_PAYMENTS}
             />
           </section>
         </motion.div>

--- a/src/components/v5/shared/Navigation/ColonySwitcher/partials/TitleSections/BaseTitleSection.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/partials/TitleSections/BaseTitleSection.tsx
@@ -1,0 +1,28 @@
+import { type IconProps } from '@phosphor-icons/react';
+import React, { type ComponentType, type FC } from 'react';
+
+interface BaseTitleSectionProps {
+  title: string;
+  description: string;
+  icon: ComponentType<IconProps>;
+}
+
+export const BaseTitleSection: FC<BaseTitleSectionProps> = ({
+  title,
+  description,
+  icon: Icon,
+}) => {
+  return (
+    <section className="mx-1.5 flex flex-col gap-0 sm:m-0">
+      <div className="mx-0.5 inline-block w-fit rounded-full border-[6px] border-gray-50 bg-gray-200 p-1.5">
+        <Icon size={22} className="text-gray-600" />
+      </div>
+      <div className="mt-2 px-2">
+        <p className="text-md font-medium">{title}</p>
+        <p className="mt-1.5 text-sm font-normal text-gray-600">
+          {description}
+        </p>
+      </div>
+    </section>
+  );
+};

--- a/src/components/v5/shared/Navigation/ColonySwitcher/partials/TitleSections/ConnectWalletSection.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/partials/TitleSections/ConnectWalletSection.tsx
@@ -1,0 +1,31 @@
+import { Plugs } from '@phosphor-icons/react';
+import React from 'react';
+import { defineMessages } from 'react-intl';
+
+import { formatText } from '~utils/intl.ts';
+
+import { BaseTitleSection } from './BaseTitleSection.tsx';
+
+const displayName =
+  'v5.common.Navigation.ColonySwitcher.partials.ConnectWalletSection';
+
+const MSG = defineMessages({
+  walletNotConnectedTitle: {
+    id: `${displayName}.walletNotConnectedTitle`,
+    defaultMessage: 'Connect your wallet',
+  },
+  walletNotConnectedDescription: {
+    id: `${displayName}.walletNotConnectedDescription`,
+    defaultMessage: 'In order to see your colonies, connect your wallet.',
+  },
+});
+
+export const ConnectWalletSection = () => {
+  return (
+    <BaseTitleSection
+      icon={Plugs}
+      title={formatText(MSG.walletNotConnectedTitle)}
+      description={formatText(MSG.walletNotConnectedDescription)}
+    />
+  );
+};

--- a/src/components/v5/shared/Navigation/ColonySwitcher/partials/TitleSections/EmptyJoinedColoniesSection.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/partials/TitleSections/EmptyJoinedColoniesSection.tsx
@@ -7,25 +7,25 @@ import { formatText } from '~utils/intl.ts';
 import { BaseTitleSection } from './BaseTitleSection.tsx';
 
 const displayName =
-  'v5.common.Navigation.ColonySwitcher.partials.NoColoniesJoinedSection';
+  'v5.common.Navigation.ColonySwitcher.partials.EmptyJoinedColoniesSection';
 
 const MSG = defineMessages({
-  noColoniesJoinedSectionTitle: {
-    id: `${displayName}.noColoniesJoinedSectionTitle`,
+  emptyJoinedColoniesSectionTitle: {
+    id: `${displayName}.emptyJoinedColoniesSectionTitle`,
     defaultMessage: 'No colonies joined',
   },
-  noColoniesJoinedSectionDescription: {
-    id: `${displayName}.noColoniesJoinedSectionDescription`,
+  emptyJoinedColoniesSectionDescription: {
+    id: `${displayName}.emptyJoinedColoniesSectionDescription`,
     defaultMessage: 'Once you join or create a colony, they will appear here.',
   },
 });
 
-export const NoColoniesJoinedSection = () => {
+export const EmptyJoinedColoniesSection = () => {
   return (
     <BaseTitleSection
       icon={SmileyMelting}
-      title={formatText(MSG.noColoniesJoinedSectionTitle)}
-      description={formatText(MSG.noColoniesJoinedSectionDescription)}
+      title={formatText(MSG.emptyJoinedColoniesSectionTitle)}
+      description={formatText(MSG.emptyJoinedColoniesSectionDescription)}
     />
   );
 };

--- a/src/components/v5/shared/Navigation/ColonySwitcher/partials/TitleSections/NoColoniesJoinedSection.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/partials/TitleSections/NoColoniesJoinedSection.tsx
@@ -1,0 +1,31 @@
+import { SmileyMelting } from '@phosphor-icons/react';
+import React from 'react';
+import { defineMessages } from 'react-intl';
+
+import { formatText } from '~utils/intl.ts';
+
+import { BaseTitleSection } from './BaseTitleSection.tsx';
+
+const displayName =
+  'v5.common.Navigation.ColonySwitcher.partials.NoColoniesJoinedSection';
+
+const MSG = defineMessages({
+  noColoniesJoinedSectionTitle: {
+    id: `${displayName}.noColoniesJoinedSectionTitle`,
+    defaultMessage: 'No colonies joined',
+  },
+  noColoniesJoinedSectionDescription: {
+    id: `${displayName}.noColoniesJoinedSectionDescription`,
+    defaultMessage: 'Once you join or create a colony, they will appear here.',
+  },
+});
+
+export const NoColoniesJoinedSection = () => {
+  return (
+    <BaseTitleSection
+      icon={SmileyMelting}
+      title={formatText(MSG.noColoniesJoinedSectionTitle)}
+      description={formatText(MSG.noColoniesJoinedSectionDescription)}
+    />
+  );
+};

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -3,6 +3,7 @@
     "action.manageColony": "Manage colony",
     "actionSidebar.colonyName": "Colony name",
     "button.createNewColony": "Create new colony",
+    "button.connectWallet": "Connect wallet",
     "button.createNewAction": "Create new action",
     "navigation.colonySwitcher.title": "Select a Colony",
     "navigation.newAction": "Create action",


### PR DESCRIPTION
## Description

- This PR aims to add the proper section in the ColonySwitcher when either a wallet is not connected or there is no colonies joined

## Testing

TODO: Check styling for both **no wallet connected** and **no joined colonies** on mobile/desktop are as in the [Figma designs](https://www.figma.com/design/uKxVl441Wnn02SNiOA24De/Navigation?node-id=3931-21252&t=hFhuCB862SULJVIc-0)

* Step 1. Go to `http://localhost:9091/`
* Step 2. Make sure no wallet is connected
* Step 3. Click on the colony.io logo in the sidebar
* Step 4. Check Connect your wallet appears + styling
![Screenshot 2024-08-14 at 17 11 29](https://github.com/user-attachments/assets/6715c943-bcf8-49a3-b3f1-b064671d2042)
* Step 5. Switch to a screen size >= `1024px`
* Step 6. Click on the colony.io logo in the header
* Step 7. Check Connect your wallet appears + styling
![Screenshot 2024-08-14 at 17 11 43](https://github.com/user-attachments/assets/55c06909-702a-49c6-896d-f5680e51ed90)
* Step 8. Connect to wallet 15
* Step 9. Click on the colony.io logo in the sidebar
* Step 10. Check No colonies joined appears & check styling
![Screenshot 2024-08-14 at 17 12 05](https://github.com/user-attachments/assets/7a205e14-8911-4787-b610-e699772bf694)
* Step 11. Switch to a screen size >= `1024px`
* Step 12. Click on the colony.io logo in the header
* Step 13. Check No colonies joined appears & check styling
![Screenshot 2024-08-14 at 17 11 55](https://github.com/user-attachments/assets/8fb573b6-4040-4e4f-878c-928c866a6902)
* Step 14. As a sanity check, please connect with `leela` and check the joined colonies are showing up




## Diffs

**New stuff** ✨

* ConnectWalletSection and NoColoniesJoinedSection components

Resolves #2873 and Resolves #2888 
