### PR TITLE
Fix: Conditionally show the KYC Card in the Crypto-to-Fiat tab

### DIFF
--- a/src/components/common/Extensions/UserHub/UserHub.tsx
+++ b/src/components/common/Extensions/UserHub/UserHub.tsx
@@ -125,7 +125,7 @@ const UserHub: FC<Props> = ({ initialOpenTab = UserHubTab.Balance }) => {
           </>
         )}
       </div>
-      <div className="relative h-full w-full min-w-0">
+      <div className="relative h-full w-full min-w-0 overflow-y-auto">
         {selectedTab === UserHubTab.Balance && (
           <ReputationTab onTabChange={handleTabChange} />
         )}

--- a/src/components/common/Extensions/UserHub/UserHub.tsx
+++ b/src/components/common/Extensions/UserHub/UserHub.tsx
@@ -69,7 +69,7 @@ const UserHub: FC<Props> = ({ initialOpenTab = UserHubTab.Balance }) => {
         'sm:min-h-[27.75rem]': selectedTab === UserHubTab.Balance,
       })}
     >
-      <div className="sticky left-0 right-0 top-0 flex shrink-0 flex-col justify-between border-b border-b-gray-200 bg-base-white px-6 pb-6 pt-4 sm:static sm:left-auto sm:right-auto sm:top-auto sm:w-[13.85rem] sm:border-b-0 sm:border-r sm:border-gray-100 sm:bg-transparent sm:p-6 sm:px-6">
+      <div className="sticky left-0 right-0 top-0 flex shrink-0 flex-col justify-between border-b border-b-gray-200 bg-base-white px-6 pb-6 pt-4 sm:static sm:left-auto sm:right-auto sm:top-auto sm:w-[216px] sm:border-b-0 sm:border-r sm:border-gray-100 sm:bg-transparent sm:p-6 sm:px-6">
         {isMobile ? (
           <Select
             options={filteredTabList}

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/CryptoToFiatTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/CryptoToFiatTab.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 
+import { KycStatus, useCheckKycStatusQuery } from '~gql';
 import { ActionTypes } from '~redux';
 import { USER_HOME_ROUTE } from '~routes';
 import { ActionForm } from '~shared/Fields/index.ts';
@@ -26,17 +27,22 @@ const MSG = defineMessages({
 });
 
 const CryptoToFiatTab = () => {
+  const { data } = useCheckKycStatusQuery();
+
   const { formatMessage } = useIntl();
   const { transform, validationSchema } = useTransferForm();
   // @TODO: Check this correctly updates on submission
   const [success, setSuccess] = useState(false);
 
-  // @TODO: Get verification status from user context
-  const verificationRequired = false;
+  const verificationRequired =
+    data?.bridgeCheckKYC?.kycStatus !== KycStatus.Approved ||
+    !data?.bridgeCheckKYC?.liquidationAddress;
 
   const handleReset = () => {
     setSuccess(false);
   };
+
+  // @TODO add a loader
 
   return (
     <div className="px-6">

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/CryptoToFiatTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/CryptoToFiatTab.tsx
@@ -2,9 +2,10 @@ import React, { useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 
+import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
 import { KycStatus, useCheckKycStatusQuery } from '~gql';
 import { ActionTypes } from '~redux';
-import { USER_HOME_ROUTE } from '~routes';
+import { USER_CRYPTO_TO_FIAT_ROUTE, USER_HOME_ROUTE } from '~routes';
 import { ActionForm } from '~shared/Fields/index.ts';
 import { formatText } from '~utils/intl.ts';
 
@@ -27,7 +28,7 @@ const MSG = defineMessages({
 });
 
 const CryptoToFiatTab = () => {
-  const { data } = useCheckKycStatusQuery();
+  const { data, loading: isKycStatusLoading } = useCheckKycStatusQuery();
 
   const { formatMessage } = useIntl();
   const { transform, validationSchema } = useTransferForm();
@@ -42,22 +43,27 @@ const CryptoToFiatTab = () => {
     setSuccess(false);
   };
 
-  // @TODO add a loader
+  const showKycCard = isKycStatusLoading || verificationRequired;
 
   return (
     <div className="px-6">
       <div className="flex justify-between pt-6">
         <p className="heading-5">{formatText(MSG.cryptoToFiat)}</p>
         {/* @TODO: Update to complete link */}
-        <Link
-          to={`${USER_HOME_ROUTE}`}
-          className="text-xs text-blue-400 hover:underline"
+        <LoadingSkeleton
+          isLoading={isKycStatusLoading}
+          className="h-[18px] w-[59px] rounded"
         >
-          {formatMessage(MSG.updateDetails)}
-        </Link>
+          <Link
+            to={`${USER_HOME_ROUTE}/${USER_CRYPTO_TO_FIAT_ROUTE}`}
+            className="text-xs text-blue-400 hover:underline"
+          >
+            {formatMessage(MSG.updateDetails)}
+          </Link>
+        </LoadingSkeleton>
       </div>
       <div className="pt-4">
-        {verificationRequired && <KycCard />}
+        {showKycCard && <KycCard isKycStatusLoading={isKycStatusLoading} />}
         {!success ? (
           <ActionForm
             actionType={ActionTypes.USER_CRYPTO_TO_FIAT_TRANSFER}
@@ -71,7 +77,10 @@ const CryptoToFiatTab = () => {
               setSuccess(true);
             }}
           >
-            <TransferForm isFormDisabled={verificationRequired} />
+            <TransferForm
+              isFormDisabled={verificationRequired}
+              isKycStatusLoading={isKycStatusLoading}
+            />
           </ActionForm>
         ) : (
           <Success resetForm={handleReset} />

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/CardHeader.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/CardHeader.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import React, { type FC, type PropsWithChildren } from 'react';
 import { defineMessages } from 'react-intl';
 
+import LoadingSkeleton from '~common/LoadingSkeleton/index.ts';
 import { formatMessage } from '~utils/yup/tests/helpers.ts';
 
 const displayName = 'common.Extensions.UserHub.partials.CardWrapper';
@@ -17,6 +18,7 @@ interface CardWrapperProps {
   title: string;
   isFormDisabled: boolean;
   handleSetMax: () => void;
+  isLoading: boolean;
 }
 
 const CardWrapper: FC<PropsWithChildren<CardWrapperProps>> = ({
@@ -24,17 +26,23 @@ const CardWrapper: FC<PropsWithChildren<CardWrapperProps>> = ({
   isFormDisabled,
   handleSetMax,
   children,
+  isLoading,
 }) => {
   return (
     <div className="flex justify-between">
-      <p
-        className={clsx('text-sm', {
-          'text-gray-600': !isFormDisabled,
-          'text-gray-300': isFormDisabled,
-        })}
+      <LoadingSkeleton
+        isLoading={isLoading}
+        className="h-[18px] w-[55px] rounded"
       >
-        {title}
-      </p>
+        <p
+          className={clsx('text-sm', {
+            'text-gray-600': !isFormDisabled,
+            'text-gray-300': isFormDisabled,
+          })}
+        >
+          {title}
+        </p>
+      </LoadingSkeleton>
       <div className="flex gap-2 text-sm">
         <div
           className={clsx({
@@ -44,17 +52,19 @@ const CardWrapper: FC<PropsWithChildren<CardWrapperProps>> = ({
         >
           {children}
         </div>
-        <button
-          type="button"
-          onClick={handleSetMax}
-          className={clsx('font-semibold', {
-            'text-blue-400': !isFormDisabled,
-            'text-gray-300': isFormDisabled,
-          })}
-          disabled={isFormDisabled}
-        >
-          {formatMessage(MSG.max)}
-        </button>
+        <LoadingSkeleton isLoading={isLoading} className="h-4 w-[21px] rounded">
+          <button
+            type="button"
+            onClick={handleSetMax}
+            className={clsx('font-semibold', {
+              'text-blue-400': !isFormDisabled,
+              'text-gray-300': isFormDisabled,
+            })}
+            disabled={isFormDisabled}
+          >
+            {formatMessage(MSG.max)}
+          </button>
+        </LoadingSkeleton>
       </div>
     </div>
   );

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/CardInput.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/CardInput.tsx
@@ -6,6 +6,8 @@ import React, {
   type FC,
 } from 'react';
 
+import LoadingSkeleton from '~common/LoadingSkeleton/index.ts';
+
 const displayName = 'common.Extensions.UserHub.partials.CardInput';
 
 interface CardInputProps {
@@ -15,6 +17,7 @@ interface CardInputProps {
   name: string;
   value: string;
   onChange: ChangeEventHandler<HTMLInputElement>;
+  isLoading: boolean;
 }
 
 const CardInput: FC<CardInputProps> = ({
@@ -24,19 +27,22 @@ const CardInput: FC<CardInputProps> = ({
   name,
   value,
   onChange,
+  isLoading,
 }) => {
   return (
-    <div className="relative flex">
-      <input
-        name={name}
-        value={value}
-        onChange={onChange}
-        className={clsx('w-full pr-16 text-xl outline-none', {
-          'bg-transparent text-gray-300': isFormDisabled,
-          'bg-base-white text-gray-900': !isFormDisabled,
-        })}
-        disabled={isFormDisabled}
-      />
+    <div className={clsx('relative flex', { 'pt-2': isLoading })}>
+      <LoadingSkeleton isLoading={isLoading} className="h-5 w-[26px] rounded">
+        <input
+          name={name}
+          value={value}
+          onChange={onChange}
+          className={clsx('w-full pr-16 text-xl outline-none', {
+            'bg-transparent text-gray-300': isFormDisabled,
+            'text-gray-900': !isFormDisabled,
+          })}
+          disabled={isFormDisabled}
+        />
+      </LoadingSkeleton>
       <div
         className={clsx(
           'absolute right-0 top-1 flex items-center gap-1 text-md font-medium',
@@ -46,8 +52,15 @@ const CardInput: FC<CardInputProps> = ({
           },
         )}
       >
-        <Icon size={18} />
-        <p>{symbol}</p>
+        <LoadingSkeleton
+          className="aspect-square w-[18px] rounded-full"
+          isLoading={isLoading}
+        >
+          <Icon size={18} />
+        </LoadingSkeleton>
+        <LoadingSkeleton className="h-5 w-10 rounded" isLoading={isLoading}>
+          <p>{symbol}</p>
+        </LoadingSkeleton>
       </div>
     </div>
   );

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/CardWrapper.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/CardWrapper.tsx
@@ -6,18 +6,21 @@ const displayName = 'common.Extensions.UserHub.partials.CardWrapper';
 interface CardWrapperProps {
   isFormDisabled: boolean;
   hasError: boolean;
+  isLoading: boolean;
 }
 
 const CardWrapper: FC<PropsWithChildren<CardWrapperProps>> = ({
   isFormDisabled,
   hasError,
   children,
+  isLoading,
 }) => {
   return (
     <div
       className={clsx('rounded-lg border border-gray-200 p-4', {
         'bg-gray-50': isFormDisabled,
         'border-negative-400': hasError,
+        'bg-transparent': isLoading,
       })}
     >
       {children}

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/KycCard.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/KycCard.tsx
@@ -1,7 +1,9 @@
 import { WarningCircle } from '@phosphor-icons/react';
+import clsx from 'clsx';
 import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
+import LoadingSkeleton from '~common/LoadingSkeleton/index.ts';
 import { USER_CRYPTO_TO_FIAT_ROUTE, USER_HOME_ROUTE } from '~routes';
 import PillsBase from '~v5/common/Pills/PillsBase.tsx';
 import ButtonLink from '~v5/shared/Button/ButtonLink.tsx';
@@ -28,25 +30,57 @@ const MSG = defineMessages({
   },
 });
 
-const KycCard = () => {
+const KycCard = ({ isKycStatusLoading }: { isKycStatusLoading: boolean }) => {
   const { formatMessage } = useIntl();
 
   return (
-    <div className="mb-4 rounded-lg border border-warning-400 p-4">
-      <PillsBase
-        className="bg-warning-100 text-warning-400"
-        text={formatMessage(MSG.verificationRequired)}
-        icon={WarningCircle}
+    <div
+      className={clsx(
+        'mb-4 rounded-lg border border-warning-400 px-[17px] py-4',
+        {
+          '!border-gray-200': isKycStatusLoading,
+        },
+      )}
+    >
+      <LoadingSkeleton
+        isLoading={isKycStatusLoading}
+        className="mb-2 h-[26px] w-[157px] rounded-3xl"
+      >
+        <PillsBase
+          className="mb-2 bg-warning-100 text-warning-400"
+          text={formatMessage(MSG.verificationRequired)}
+          icon={WarningCircle}
+        />
+      </LoadingSkeleton>
+      <LoadingSkeleton
+        className="mb-2 h-5 w-full rounded"
+        isLoading={isKycStatusLoading}
+      >
+        <p className="mb-2 text-md font-medium">{formatMessage(MSG.title)}</p>
+      </LoadingSkeleton>
+      <LoadingSkeleton
+        className="mb-2 h-[11px] w-full rounded"
+        isLoading={isKycStatusLoading}
+      >
+        <p className="mb-3.5 text-sm text-gray-600">
+          {formatMessage(MSG.message)}
+        </p>
+      </LoadingSkeleton>
+      <LoadingSkeleton
+        className="mb-3.5 h-[11px] w-full rounded"
+        isLoading={isKycStatusLoading}
       />
-      <p className="mt-2 text-md font-medium">{formatMessage(MSG.title)}</p>
-      <p className="text-sm text-gray-600">{formatMessage(MSG.message)}</p>
-      <ButtonLink
-        mode="primarySolid"
-        to={`${USER_HOME_ROUTE}/${USER_CRYPTO_TO_FIAT_ROUTE}`}
-        className="mt-3.5"
-        size="small"
-        text={formatMessage(MSG.completeVerification)}
-      />
+      <LoadingSkeleton
+        className="h-[34px] w-full rounded-lg"
+        isLoading={isKycStatusLoading}
+      >
+        <ButtonLink
+          mode="primarySolid"
+          to={`${USER_HOME_ROUTE}/${USER_CRYPTO_TO_FIAT_ROUTE}`}
+          size="small"
+          text={formatMessage(MSG.completeVerification)}
+        />
+      </LoadingSkeleton>
     </div>
   );
 };

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/KycCard.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/KycCard.tsx
@@ -2,7 +2,7 @@ import { WarningCircle } from '@phosphor-icons/react';
 import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
-import { USER_HOME_ROUTE } from '~routes';
+import { USER_CRYPTO_TO_FIAT_ROUTE, USER_HOME_ROUTE } from '~routes';
 import PillsBase from '~v5/common/Pills/PillsBase.tsx';
 import ButtonLink from '~v5/shared/Button/ButtonLink.tsx';
 
@@ -20,7 +20,7 @@ const MSG = defineMessages({
   message: {
     id: `${displayName}.message`,
     defaultMessage:
-      'Regulatory compliance requires users to fiat off-ramp must complete KYC/AML checks. It only takes a couple of minutes (up to 1 business day if a manual check is required).',
+      'Regulatory compliance requires users to verify their account by completing KYC/AML checks. It only takes a couple of minutes.',
   },
   completeVerification: {
     id: `${displayName}.completeVerification`,
@@ -42,8 +42,7 @@ const KycCard = () => {
       <p className="text-sm text-gray-600">{formatMessage(MSG.message)}</p>
       <ButtonLink
         mode="primarySolid"
-        // @TODO: Update to complete link
-        to={USER_HOME_ROUTE}
+        to={`${USER_HOME_ROUTE}/${USER_CRYPTO_TO_FIAT_ROUTE}`}
         className="mt-3.5"
         size="small"
         text={formatMessage(MSG.completeVerification)}

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/ReceiveCard.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/ReceiveCard.tsx
@@ -2,6 +2,7 @@ import React, { type ChangeEvent, type FC } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { defineMessages } from 'react-intl';
 
+import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
 import EthereumIcon from '~icons/EthereumIcon.tsx';
 import { formatMessage } from '~utils/yup/tests/helpers.ts';
 
@@ -26,11 +27,13 @@ const MSG = defineMessages({
 interface ReceiveCardProps {
   isFormDisabled: boolean;
   handleSetMax: () => void;
+  isLoading: boolean;
 }
 
 const ReceiveCard: FC<ReceiveCardProps> = ({
   isFormDisabled,
   handleSetMax,
+  isLoading,
 }) => {
   const name = 'convertedAmount';
 
@@ -57,18 +60,28 @@ const ReceiveCard: FC<ReceiveCardProps> = ({
 
   return (
     <>
-      <CardWrapper isFormDisabled={isFormDisabled} hasError={hasError}>
+      <CardWrapper
+        isFormDisabled={isFormDisabled}
+        hasError={hasError}
+        isLoading={isLoading}
+      >
         <CardHeader
           title={formatMessage(MSG.receive)}
           isFormDisabled={isFormDisabled}
           handleSetMax={handleSetMax}
+          isLoading={isLoading}
         >
-          <p>
-            {formatMessage(MSG.oneUSDC)}
-            <span className="font-medium">
-              {conversionRate} {selectedCurrency}
-            </span>
-          </p>
+          <LoadingSkeleton
+            className="h-4 w-[70px] rounded"
+            isLoading={isLoading}
+          >
+            <p>
+              {formatMessage(MSG.oneUSDC)}
+              <span className="font-medium">
+                {conversionRate} {selectedCurrency}
+              </span>
+            </p>
+          </LoadingSkeleton>
         </CardHeader>
         <CardInput
           isFormDisabled={isFormDisabled}
@@ -78,6 +91,7 @@ const ReceiveCard: FC<ReceiveCardProps> = ({
           onChange={handleChange}
           symbol={selectedCurrency}
           name={name}
+          isLoading={isLoading}
         />
       </CardWrapper>
       {hasError && <p className="text-sm text-negative-400">{error.message}</p>}

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/SummaryCard.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/SummaryCard.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import React, { type FC } from 'react';
 import { defineMessages } from 'react-intl';
 
+import LoadingSkeleton from '~common/LoadingSkeleton/index.ts';
 import { formatMessage } from '~utils/yup/tests/helpers.ts';
 
 const displayName = 'common.Extensions.UserHub.partials.SummaryCard';
@@ -38,9 +39,10 @@ const MSG = defineMessages({
 
 interface SummaryCardProps {
   isFormDisabled: boolean;
+  isLoading: boolean;
 }
 
-const SummaryCard: FC<SummaryCardProps> = ({ isFormDisabled }) => {
+const SummaryCard: FC<SummaryCardProps> = ({ isFormDisabled, isLoading }) => {
   // @TODO: Calculate proper values
   const gatewayAmount = 0;
 
@@ -56,31 +58,52 @@ const SummaryCard: FC<SummaryCardProps> = ({ isFormDisabled }) => {
         'mt-5 flex flex-col gap-2 rounded-lg border border-gray-200 px-4 py-5 text-sm',
         {
           'bg-gray-50 text-gray-300': isFormDisabled,
+          'bg-transparent': isLoading,
         },
       )}
     >
       <div className="flex justify-between">
-        <p>{formatMessage(MSG.gatewayFee)}</p>
+        <LoadingSkeleton
+          className="h-[18px] w-[99px] rounded"
+          isLoading={isLoading}
+        >
+          <p>{formatMessage(MSG.gatewayFee)}</p>
+        </LoadingSkeleton>
         <div className="flex items-center gap-2">
-          <p className="font-semibold">{gatewayAmount} USDC</p>
+          <LoadingSkeleton
+            className="h-[18px] w-[59px] rounded"
+            isLoading={isLoading}
+          >
+            <p className="font-semibold">{gatewayAmount} USDC</p>
+          </LoadingSkeleton>
           {/* @TODO: This should have a tooltip */}
           <Info
             size={12}
             className={clsx('text-gray-400', {
-              'text-gray-300': isFormDisabled,
+              '!text-gray-300': isFormDisabled || isLoading,
             })}
           />
         </div>
       </div>
       <div className="flex justify-between">
-        <p>{formatMessage(MSG[feeType])}</p>
+        <LoadingSkeleton
+          className="h-[18px] w-[59px] rounded"
+          isLoading={isLoading}
+        >
+          <p>{formatMessage(MSG[feeType])}</p>
+        </LoadingSkeleton>
         <div className="flex items-center gap-2">
-          <p className="font-semibold">{feeAmount} USDC</p>
+          <LoadingSkeleton
+            className="h-[18px] w-[59px] rounded"
+            isLoading={isLoading}
+          >
+            <p className="font-semibold">{feeAmount} USDC</p>
+          </LoadingSkeleton>
           {/* @TODO: This should have a tooltip */}
           <Info
             size={12}
             className={clsx('text-gray-400', {
-              'text-gray-300': isFormDisabled,
+              '!text-gray-300': isFormDisabled || isLoading,
             })}
           />
         </div>
@@ -89,16 +112,26 @@ const SummaryCard: FC<SummaryCardProps> = ({ isFormDisabled }) => {
       <div className="my-1 border-b" />
 
       <div className="flex justify-between">
-        <p className="font-semibold">{formatMessage(MSG.receive)}</p>
+        <LoadingSkeleton
+          className="h-[18px] w-[99px] rounded"
+          isLoading={isLoading}
+        >
+          <p className="font-semibold">{formatMessage(MSG.receive)}</p>
+        </LoadingSkeleton>
         <div className="flex items-center gap-2">
-          <p className="font-semibold">
-            {receiveAmount} {selectedCurrency}
-          </p>
+          <LoadingSkeleton
+            className="h-[18px] w-[59px] rounded"
+            isLoading={isLoading}
+          >
+            <p className="font-semibold">
+              {receiveAmount} {selectedCurrency}
+            </p>
+          </LoadingSkeleton>
           {/* @TODO: This should have a tooltip */}
           <Info
             size={12}
             className={clsx('text-gray-400', {
-              'text-gray-300': isFormDisabled,
+              '!text-gray-300': isFormDisabled || isLoading,
             })}
           />
         </div>

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/TransferForm.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/TransferForm.tsx
@@ -2,6 +2,7 @@ import { SpinnerGap } from '@phosphor-icons/react';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 
+import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
 import { formatText } from '~utils/intl.ts';
 import Button from '~v5/shared/Button/Button.tsx';
 import IconButton from '~v5/shared/Button/IconButton.tsx';
@@ -13,7 +14,13 @@ import WithdrawCard from './WithdrawCard.tsx';
 
 const displayName = 'common.Extensions.UserHub.partials.TransferForm';
 
-const TransferForm = ({ isFormDisabled }: { isFormDisabled: boolean }) => {
+const TransferForm = ({
+  isFormDisabled,
+  isKycStatusLoading,
+}: {
+  isFormDisabled: boolean;
+  isKycStatusLoading: boolean;
+}) => {
   const {
     formState: { isSubmitting, isLoading },
     setValue,
@@ -36,12 +43,17 @@ const TransferForm = ({ isFormDisabled }: { isFormDisabled: boolean }) => {
           isFormDisabled={isFormDisabled}
           balance={balance}
           handleSetMax={handleSetMax}
+          isLoading={isKycStatusLoading}
         />
         <ReceiveCard
           isFormDisabled={isFormDisabled}
           handleSetMax={handleSetMax}
+          isLoading={isKycStatusLoading}
         />
-        <SummaryCard isFormDisabled={isFormDisabled} />
+        <SummaryCard
+          isFormDisabled={isFormDisabled}
+          isLoading={isKycStatusLoading}
+        />
       </div>
       {isSubmitting || isLoading ? (
         <IconButton
@@ -55,14 +67,20 @@ const TransferForm = ({ isFormDisabled }: { isFormDisabled: boolean }) => {
           }
         />
       ) : (
-        <Button
-          mode="primarySolid"
-          type="submit"
-          text={formatText({ id: `button.transfer` })}
-          className="my-6"
-          isFullSize
-          disabled={isFormDisabled}
-        />
+        <div className="mb-6 mt-20 sm:mt-6">
+          <LoadingSkeleton
+            className="my-6 h-10 w-full rounded-lg"
+            isLoading={isKycStatusLoading}
+          >
+            <Button
+              mode="primarySolid"
+              type="submit"
+              text={formatText({ id: `button.transfer` })}
+              isFullSize
+              disabled={isFormDisabled}
+            />
+          </LoadingSkeleton>
+        </div>
       )}
     </>
   );

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/WithdrawCard.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/WithdrawCard.tsx
@@ -2,6 +2,7 @@ import React, { type ChangeEvent, type FC } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { defineMessages } from 'react-intl';
 
+import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
 import EthereumIcon from '~icons/EthereumIcon.tsx';
 import Numeral from '~shared/Numeral/index.ts';
 import { formatMessage } from '~utils/yup/tests/helpers.ts';
@@ -28,12 +29,14 @@ interface WithdrawCardProps {
   isFormDisabled: boolean;
   balance: number;
   handleSetMax: () => void;
+  isLoading: boolean;
 }
 
 const WithdrawCard: FC<WithdrawCardProps> = ({
   isFormDisabled,
   balance,
   handleSetMax,
+  isLoading,
 }) => {
   const name = 'amount';
 
@@ -55,17 +58,27 @@ const WithdrawCard: FC<WithdrawCardProps> = ({
 
   return (
     <>
-      <CardWrapper isFormDisabled={isFormDisabled} hasError={hasError}>
+      <CardWrapper
+        isFormDisabled={isFormDisabled}
+        hasError={hasError}
+        isLoading={isLoading}
+      >
         <CardHeader
           title={formatMessage(MSG.withdraw)}
           isFormDisabled={isFormDisabled}
           handleSetMax={handleSetMax}
+          isLoading={isLoading}
         >
-          <Numeral
-            prefix={formatMessage(MSG.balance)}
-            value={balance}
-            decimals={6}
-          />
+          <LoadingSkeleton
+            className="h-4 w-[70px] rounded"
+            isLoading={isLoading}
+          >
+            <Numeral
+              prefix={formatMessage(MSG.balance)}
+              value={balance}
+              decimals={6}
+            />
+          </LoadingSkeleton>
         </CardHeader>
         <CardInput
           isFormDisabled={isFormDisabled}
@@ -74,6 +87,7 @@ const WithdrawCard: FC<WithdrawCardProps> = ({
           onChange={handleChange}
           symbol="USDC"
           name={name}
+          isLoading={isLoading}
         />
       </CardWrapper>
       {hasError && <p className="text-sm text-negative-400">{error.message}</p>}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -247,7 +247,7 @@ module.exports = {
             right: '-1px',
             bottom: '-1px',
             'z-index': 1,
-            'background-color': theme('colors.gray.200'),
+            'background-color': theme('colors.gray.100'),
             'background-repeat': 'no-repeat',
             'min-height': '1em',
             'background-image':


### PR DESCRIPTION
## Description

If the KYC status is not approved or if there is no liquidation address.

| non-loading state | loading state |
| ---- | ---- |
| ![Screenshot 2024-08-16 at 15 18 35](https://github.com/user-attachments/assets/e2f7d7f4-6587-4f66-83d2-e3571dca648e) | ![c2f loader](https://github.com/user-attachments/assets/186b7269-ca35-42ee-b4e2-380caf1ed6e0) |

## Testing

> [!IMPORTANT]
> In the `bridgeXYZMutation/src/index.ts` file, make sure you update the `apiKey` with our sandbox api key.
> Connect a Dev Wallet that hasn't done a KYC check yet.

1. Visit a Colony
2. Open the UserHub
3. Go to the Crypto to fiat tab
4. Verify that you can see the KYC card and the form is disabled
![image](https://github.com/user-attachments/assets/193fcacb-e846-4efe-93e6-862a647d8631)
5. Click "Complete verification"
6. Verify you are taken to the Crypto to fiat page
7. Completed step 1 Verification and make sure you're approved
8. Go back to a Colony
9. Open the UserHub
10. Go to the Crypto to fiat tab
11. Verify that the KYC card is not present anymore and that the form is enabled

Resolves #2953