### PR TITLE
Always show chain native tokens in incoming funds table

### DIFF
--- a/amplify/backend/function/fetchColonyNativeFundsClaim/src/index.js
+++ b/amplify/backend/function/fetchColonyNativeFundsClaim/src/index.js
@@ -68,7 +68,7 @@ exports.handler = async ({ source: { id: colonyAddress } }) => {
     }
   }
 
-  // If the unclaimed balance is 0, or unclaimed balance is 0, still return a claim with amount zero.
+  // If the balance is 0, or unclaimed balance is 0, still return a claim with amount zero.
   // This is because we want to always show native chain tokens in the incoming funds table.
   return colonyFundsClaim;
 };

--- a/amplify/backend/function/fetchColonyNativeFundsClaim/src/index.js
+++ b/amplify/backend/function/fetchColonyNativeFundsClaim/src/index.js
@@ -1,4 +1,4 @@
-const { constants, providers, Contract } = require('ethers');
+const { constants, providers, Contract, BigNumber } = require('ethers');
 const basicColonyAbi = require('./basicColonyAbi.json');
 
 let rpcURL = 'http://network-contracts:8545'; // this needs to be extended to all supported networks
@@ -31,6 +31,15 @@ exports.handler = async ({ source: { id: colonyAddress } }) => {
     provider,
   );
 
+  const colonyFundsClaim = {
+    __typeName: 'ColonyFundsClaim',
+    amount: BigNumber.from(0).toString(),
+    id: `${chainId}_${constants.AddressZero}_0`,
+    createdAt: now,
+    updatedAt: now,
+    createdAtBlock: block,
+  };
+
   const balance = await provider.getBalance(colonyAddress);
 
   /*
@@ -53,14 +62,13 @@ exports.handler = async ({ source: { id: colonyAddress } }) => {
 
     if (unclaimedBalance.gt(0)) {
       return {
-        __typeName: 'ColonyFundsClaim',
+        ...colonyFundsClaim,
         amount: unclaimedBalance.toString(),
-        id: `${chainId}_${constants.AddressZero}_0`,
-        createdAt: now,
-        updatedAt: now,
-        createdAtBlock: block,
       };
     }
   }
-  return null;
+
+  // If the unclaimed balance is 0, or unclaimed balance is 0, still return a claim with amount zero.
+  // This is because we want to always show native chain tokens in the incoming funds table.
+  return colonyFundsClaim;
 };

--- a/src/components/frame/v5/pages/FundsPage/partials/FundsTable/hooks.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/FundsTable/hooks.tsx
@@ -3,6 +3,7 @@ import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { isEqual } from 'lodash';
 import React, { useMemo, useState } from 'react';
 
+import { ADDRESS_ZERO } from '~constants';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useColonyFundsClaims from '~hooks/useColonyFundsClaims.ts';
 import { notNull } from '~utils/arrays/index.ts';
@@ -53,6 +54,11 @@ export const useFundsTable = (): UseFundsTableProps => {
       colony.tokens?.items.filter(notNull).sort((a, b) => {
         if (!a.token || !b.token) return 0;
 
+        // Native chain tokens should always be last
+        if (a.token.tokenAddress === ADDRESS_ZERO) {
+          return 1;
+        }
+
         return a.token.name
           .toLowerCase()
           .localeCompare(b.token.name.toLowerCase());
@@ -82,6 +88,11 @@ export const useFundsTable = (): UseFundsTableProps => {
     })
     .sort((a, b) => {
       if (!a.token || !b.token) return 0;
+
+      // Native chain tokens should always be last
+      if (a.token.tokenAddress === ADDRESS_ZERO) {
+        return 1;
+      }
 
       return a.token.name
         .toLowerCase()

--- a/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
@@ -1,9 +1,11 @@
-import { CaretDown } from '@phosphor-icons/react';
+import { CaretDown, WarningCircle } from '@phosphor-icons/react';
 import { getSortedRowModel } from '@tanstack/react-table';
 import clsx from 'clsx';
 import { BigNumber } from 'ethers';
 import React, { type FC } from 'react';
+import { defineMessages } from 'react-intl';
 
+import { ADDRESS_ZERO } from '~constants';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useMobile } from '~hooks/index.ts';
 import useColonyFundsClaims from '~hooks/useColonyFundsClaims.ts';
@@ -24,6 +26,14 @@ import { useTokenTableColumns } from './hooks.tsx';
 import { type TokenTableProps } from './types.ts';
 
 const displayName = 'v5.pages.FundsPage.partials.TokenTable';
+
+const MSG = defineMessages({
+  nativeChainTokenWarning: {
+    id: `${displayName}.nativeChainTokenWarning`,
+    defaultMessage:
+      'Previously accepted incoming funds are not able to be displayed for this token',
+  },
+});
 
 const TokenTable: FC<TokenTableProps> = ({ token }) => {
   const isMobile = useMobile();
@@ -60,6 +70,7 @@ const TokenTable: FC<TokenTableProps> = ({ token }) => {
   });
 
   const isTokenNative = token?.tokenAddress === nativeToken.tokenAddress;
+  const isTokenNativeChainToken = token?.tokenAddress === ADDRESS_ZERO;
 
   const handleToggleToken = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -142,6 +153,14 @@ const TokenTable: FC<TokenTableProps> = ({ token }) => {
           // In other words, it's always sorting by all columns.
           isMultiSortEvent={() => true}
         />
+        {isTokenNativeChainToken && (
+          <div className="flex items-center gap-1 border-t border-gray-100 px-[1.125rem] py-4">
+            <WarningCircle size={14} />
+            <p className="text-sm font-normal">
+              {formatText(MSG.nativeChainTokenWarning)}
+            </p>
+          </div>
+        )}
       </AccordionItem>
       {isMobile ? (
         <Modal

--- a/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
@@ -154,8 +154,10 @@ const TokenTable: FC<TokenTableProps> = ({ token }) => {
           isMultiSortEvent={() => true}
         />
         {isTokenNativeChainToken && (
-          <div className="flex items-center gap-1 border-t border-gray-100 px-[1.125rem] py-4">
-            <WarningCircle size={14} />
+          <div className="flex items-center border-t border-gray-100 px-[1.125rem] py-4">
+            <div className="mr-1">
+              <WarningCircle size={14} />
+            </div>
             <p className="text-sm font-normal">
               {formatText(MSG.nativeChainTokenWarning)}
             </p>


### PR DESCRIPTION
## Description

There was an [issue raised](https://github.com/JoinColony/colonyCDapp/issues/2787) where the chain's native token was disappearing from the Incoming Funds table after you claimed the funds. With the other tokens, the claim remains in a 'claimed' state. The problem is that the way chain native tokens are handled is very different - see the comments in the issue for more details on that.

This is a solution which will ensure there is no confusion when the chain native token is claimed and disappears from the list. In the future when financial reporting is worked on then this behaviour can be changed properly.

Here's a description of what this PR will do:

- Ensure that the chain's native token item will always be visible at the bottom of the Incoming Funds table.

Collapsed view:
- It will show a value of 0 if there is nothing to claim.
- If there are incoming funds, then it will show the value of funds to claim.

Expanded view:
- There will be an info row that always appears at the bottom of the expanded table for this token, regardless if there are funds to claim or not.
- Claimable incoming funds will appear above the notice and work as expected, allowing claiming with the claimed funds rows disappearing, keeping the note in place.

## Testing

You'll need to test that when you send ethereum to a colony, it shows up as expected. That includes before sending, after sending, and after claiming.

* Step 1. On a clean environment, go to the incoming funds page. You should see Ether at the bottom of the table with 0 Eth incoming. There should also be a warning message when you expand this row informing you that a history of claims won't be saved:

<img width="1428" alt="Screenshot 2024-08-21 at 12 07 30" src="https://github.com/user-attachments/assets/26a8e84b-45ae-43da-a708-23be99e6645c">

* Step 2. Get the colony address. I like to do this just by going to the balances page and clicking on the `Add funds to the colony` button in the top right:

<img width="1435" alt="Screenshot 2024-08-21 at 12 05 31" src="https://github.com/user-attachments/assets/8bcfe8b7-a3b3-4c77-9a5c-31630761da52">

* Step 3. Open a dev wallet in metamask, and send some ethereum to the colony. Ensure that you're on the correct network (Ganache Local) and that you're on the right account (dev wallet). If you need help setting up the network or importing a dev wallet let me know and I can help you do so. Also if this transaction fails, you may need to reset your nonces, again, just let me know and I can help you.

<img width="362" alt="Screenshot 2024-08-21 at 12 09 09" src="https://github.com/user-attachments/assets/51792306-e45a-4203-8fbb-0afacc637119">

* Step 4. Go back to the incoming funds page and refresh. You should now see some Eth available to be claimed.

<img width="1328" alt="Screenshot 2024-08-21 at 12 11 08" src="https://github.com/user-attachments/assets/f733a9fa-1d69-4cc9-8203-fcb5ccedf674">

* Step 5. Accept the Eth, and you should see it be accepted (the button will disable while this is in progress) and then go back to zero. The row should _not_ disappear from the table.

<img width="1310" alt="Screenshot 2024-08-21 at 12 12 37" src="https://github.com/user-attachments/assets/1d68072e-706d-4469-be9b-8ca37a5a86ab">

## Diffs

**Changes** 🏗

* Always return a claim from the `fetchColonyNativeFundsClaim` lambda, even if the amount is zero.
* Always show Eth at the bottom of the incoming funds table.
* Add a warning message to the incoming funds table.

Resolves #2787
