### PR TITLE
Maintenance: Replace uses of `ethereum.selectedAddress` as it is deprecated

### DIFF
--- a/src/context/AppContext/AppContextProvider.tsx
+++ b/src/context/AppContext/AppContextProvider.tsx
@@ -126,9 +126,12 @@ const AppContextProvider = ({ children }: { children: ReactNode }) => {
    * When the user switches account in Metamask, re-initiate the wallet connect flow
    * so as to update their wallet details in the app's memory.
    */
-  const handleAccountChange = useCallback(() => {
+  const handleAccountChange = useCallback(async () => {
     // @ts-ignore
-    const loggedInAccount = window.ethereum?.selectedAddress;
+    const accounts = await window.ethereum.request({
+      method: 'eth_accounts',
+    });
+    const loggedInAccount = accounts[0];
     if (loggedInAccount) {
       connectWallet();
     }

--- a/src/redux/sagas/setupUserContext.ts
+++ b/src/redux/sagas/setupUserContext.ts
@@ -32,14 +32,15 @@ import getOnboard from './wallet/onboard.ts';
 
 const ONBOARD_METAMASK_WALLET_LABEL = 'MetaMask';
 
-const getMetamaskAddress = () => {
+const getMetamaskAddress = async () => {
   // try/catch just in case createAddress errors
   try {
     if (window.ethereum) {
-      return createAddress(
-        // @ts-ignore
-        window.ethereum.selectedAddress,
-      );
+      // @ts-ignore
+      const accounts = await window.ethereum.request({
+        method: 'eth_accounts',
+      });
+      return createAddress(accounts[0]);
     }
   } catch {
     // silent
@@ -100,7 +101,7 @@ export default function* setupUserContext() {
     try {
       wallet = getContext(ContextModule.Wallet);
 
-      const selectedMetamaskAddress = getMetamaskAddress();
+      const selectedMetamaskAddress = yield getMetamaskAddress();
       /*
        * If the wallet we've pulled from context does not have the same address as the selected account
        * in Metamask, it's because the user just switched their account in metamask.


### PR DESCRIPTION
## Description

`ethereum.selectedAddress` is deprecated and may be removed in the future.

This PR replaces uses of it with `window.ethereum.request({method: 'eth_accounts'})` so that we don't get caught out in the future!

More information can be found here: [https://github.com/MetaMask/metamask-improvement-proposals/discussions/23](https://github.com/MetaMask/metamask-improvement-proposals/discussions/23) and here: [https://docs.metamask.io/wallet/reference/eth_accounts/](https://docs.metamask.io/wallet/reference/eth_accounts/)

<img width="338" alt="Screenshot 2024-08-21 at 11 08 51" src="https://github.com/user-attachments/assets/c22f60e8-898f-494d-9ebe-8871c9009e5e">

## Testing

Test switching between two different metamask wallets.

https://github.com/user-attachments/assets/bdea21cd-0b41-4b98-8f63-2d2b6d4ce82b

Compared to master where you will get a console warning:

https://github.com/user-attachments/assets/e40e5d9c-1cd8-4ba6-9f02-9ac12d7225d3

## Diffs

**Changes** 🏗

* Uses of `ethereum.selectedAddress`  replaced with `window.ethereum.request({method: 'eth_accounts'})`
