### PR TITLE
fix: show header when cancel modal is visible

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/CancelModal/CancelModal.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/CancelModal/CancelModal.tsx
@@ -70,7 +70,13 @@ const CancelModal: FC<CancelModalProps> = ({
     expenditure.lockingActions.items.length > 0;
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} icon={Prohibit} {...rest}>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      icon={Prohibit}
+      shouldShowHeader
+      {...rest}
+    >
       <h5 className="mb-2 heading-5">
         {formatText({
           id: isExpenditureLocked


### PR DESCRIPTION
## Description

You should be able to interact with the header in order to view and managed your transactions while in the modal.

## Testing

* Create a new Adv. Payment action.
* Cancel the new action.
* The cancel modal will open.
* Check if header is accesible

## Diffs

**New stuff** ✨

* 

**Changes** 🏗

* `shouldShowHeader` set to true in `CancelModal` component

**Deletions** ⚰️

* 

## TODO

- 

Resolves https://github.com/JoinColony/colonyCDapp/issues/2863