### PR TITLE
fix: extensions list order and copy update

### DIFF
--- a/src/components/frame/Extensions/pages/Extensions/ExtensionDetailsPage/partials/StakedExpenditureSettings.tsx
+++ b/src/components/frame/Extensions/pages/Extensions/ExtensionDetailsPage/partials/StakedExpenditureSettings.tsx
@@ -3,6 +3,7 @@ import { useFormContext } from 'react-hook-form';
 import { FormattedMessage, defineMessages } from 'react-intl';
 
 import ContentTypeText from '~shared/Extensions/Accordion/partials/ContentTypeText.tsx';
+import SpecialHourInput from '~shared/Extensions/ConnectForm/partials/SpecialHourInput.tsx';
 import SpecialPercentageInput from '~shared/Extensions/ConnectForm/partials/SpecialPercentageInput.tsx';
 import { type InstalledExtensionData } from '~types/extensions.ts';
 import { formatText } from '~utils/intl.ts';
@@ -59,15 +60,27 @@ const StakedExpenditureSettings: FC<
       </div>
       <h3 className="mb-6 text-gray-900 heading-5">{formatText(MSG.title)}</h3>
       {showForm ? (
-        <div className="flex justify-between text-gray-900">
-          <ContentTypeText
-            title="Required Stake"
-            subTitle="What percentage of the team’s reputation, in token terms, is required to create a Payment builder, Split or Staged payment action?"
-          />
-          <div className="ml-6 shrink-0">
-            <SpecialPercentageInput name="params.stakeFraction" />
-          </div>
-        </div>
+        <>
+          {extensionData.initializationParams?.length && (
+            <>
+              {extensionData.initializationParams.map(
+                ({ title, description, paramName, complementaryLabel }) => (
+                  <div className="flex justify-between text-gray-900">
+                    <ContentTypeText title={title} subTitle={description} />
+                    <div className="ml-6 shrink-0">
+                      {complementaryLabel === 'percent' && (
+                        <SpecialPercentageInput name={`params.${paramName}`} />
+                      )}
+                      {complementaryLabel === 'hours' && (
+                        <SpecialHourInput name={`params.${paramName}`} />
+                      )}
+                    </div>
+                  </div>
+                ),
+              )}
+            </>
+          )}
+        </>
       ) : (
         children
       )}

--- a/src/components/frame/Extensions/pages/Extensions/ExtensionsListingPage/ExtensionsListingPage.tsx
+++ b/src/components/frame/Extensions/pages/Extensions/ExtensionsListingPage/ExtensionsListingPage.tsx
@@ -1,12 +1,18 @@
-import React, { type FC, useMemo } from 'react';
+import React, { type FC } from 'react';
 import { defineMessages } from 'react-intl';
 
 import ExtensionItem from '~common/Extensions/ExtensionItem/index.ts';
+import {
+  decisionMethodSupportedExtensionsConfig,
+  paymentSupportedExtensionsConfig,
+} from '~constants';
 import { useSetPageHeadingTitle } from '~context/PageHeadingContext/PageHeadingContext.ts';
 import useExtensionsData from '~hooks/useExtensionsData.ts';
-import { type AnyExtensionData } from '~types/extensions.ts';
+import { sortExtensionByName } from '~utils/arrays/index.ts';
 import { isInstalledExtensionData } from '~utils/extensions.ts';
 import { formatText } from '~utils/intl.ts';
+
+import { getExtensionData } from './utils.ts';
 
 const displayName = 'frame.Extensions.pages.Extensions.ExtensionsListingPage';
 
@@ -19,34 +25,44 @@ const MSG = defineMessages({
     id: `${displayName}.availableExtensions`,
     defaultMessage: 'Available Extensions',
   },
+  decisionMethods: {
+    id: `${displayName}.decisionMethods`,
+    defaultMessage: 'Decision methods',
+  },
+  payments: {
+    id: `${displayName}.payments`,
+    defaultMessage: 'Payments',
+  },
 });
 
 const ExtensionsListingPage: FC = () => {
   const { availableExtensionsData, installedExtensionsData } =
     useExtensionsData();
-
   useSetPageHeadingTitle(formatText(MSG.title));
 
-  const allExtensions: AnyExtensionData[] = useMemo(
-    () => [...availableExtensionsData, ...installedExtensionsData],
-    [availableExtensionsData, installedExtensionsData],
-  );
-
-  const categorizedExtensions: Record<string, AnyExtensionData[]> =
-    allExtensions.reduce((acc, extension) => {
-      if (!acc[extension.category]) {
-        acc[extension.category] = [];
-      }
-
-      acc[extension.category].push(extension);
-
-      return acc;
-    }, {});
+  const categorizedExtensions = [
+    {
+      category: formatText(MSG.decisionMethods),
+      extensions: getExtensionData(
+        decisionMethodSupportedExtensionsConfig,
+        availableExtensionsData,
+        installedExtensionsData,
+      ).sort(sortExtensionByName),
+    },
+    {
+      category: formatText(MSG.payments),
+      extensions: getExtensionData(
+        paymentSupportedExtensionsConfig,
+        availableExtensionsData,
+        installedExtensionsData,
+      ).sort(sortExtensionByName),
+    },
+  ];
 
   return (
     <div>
       <h2 className="mb-6 heading-4">{formatText(MSG.availableExtensions)}</h2>
-      {Object.entries(categorizedExtensions).map(([category, extensions]) => (
+      {categorizedExtensions.map(({ category, extensions }) => (
         <div
           key={category}
           className="mb-6 border-b border-gray-100 last:mb-0 last:border-none"

--- a/src/components/frame/Extensions/pages/Extensions/ExtensionsListingPage/utils.ts
+++ b/src/components/frame/Extensions/pages/Extensions/ExtensionsListingPage/utils.ts
@@ -1,0 +1,33 @@
+import {
+  type InstallableExtensionData,
+  type AnyExtensionData,
+  type ExtensionConfig,
+  type InstalledExtensionData,
+} from '~types/extensions.ts';
+import { notMaybe } from '~utils/arrays/index.ts';
+
+export const getExtensionData = (
+  items: ExtensionConfig[],
+  availableExtensionsData: InstallableExtensionData[],
+  installedExtensionsData: InstalledExtensionData[],
+): AnyExtensionData[] =>
+  items
+    .map((item) => item?.extensionId)
+    .filter(notMaybe)
+    .reduce<AnyExtensionData[]>((acc, extensionId) => {
+      let extensionData = availableExtensionsData.find(
+        (extension) => extension.extensionId === extensionId,
+      );
+
+      if (!extensionData) {
+        extensionData = installedExtensionsData.find(
+          (extension) => extension.extensionId === extensionId,
+        );
+      }
+
+      if (extensionData) {
+        acc.push(extensionData);
+      }
+
+      return acc;
+    }, []);

--- a/src/constants/extensions.ts
+++ b/src/constants/extensions.ts
@@ -235,7 +235,7 @@ const stakedExpenditureMessages = {
   },
   stakedExpenditureStakeFractionDescription: {
     id: `${stakedExpenditureName}.param.stakeFraction.description`,
-    defaultMessage: `What percentage of the team's reputation, in token terms, should need to stake to create an expenditure?\n\n<span>e.g. if a team has 100 reputation points between them, and the Required Stake is 5%, then 5 tokens would need to be staked to create an expenditure.</span>`,
+    defaultMessage: `The percentage of a team's reputation, in token terms, that is required to stake in order to create Advanced payment, Split payment, and Staged payment actions.`,
   },
 };
 
@@ -315,23 +315,7 @@ const MSG = defineMessages({
   ...streamingPaymentsMessage,
 });
 
-export const supportedExtensionsConfig: ExtensionConfig[] = [
-  {
-    extensionId: Extension.OneTxPayment,
-    category: ExtensionCategory.Payments,
-    name: MSG.oneTxPaymentName,
-    descriptionShort: MSG.oneTxPaymentDescriptionShort,
-    descriptionLong: MSG.oneTxPaymentDescriptionLong,
-    icon: ExtensionOneTransactionPaymentIcon,
-    neededColonyPermissions: [
-      ColonyRole.Administration,
-      ColonyRole.Funding,
-      ColonyRole.Arbitration,
-    ],
-    imageURLs: [oneTransactionHero, oneTransactionInterface],
-    uninstallable: false,
-    createdAt: 1557698400000,
-  },
+export const decisionMethodSupportedExtensionsConfig: ExtensionConfig[] = [
   {
     extensionId: Extension.VotingReputation,
     category: ExtensionCategory.DecisionMethods,
@@ -494,6 +478,25 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
     uninstallable: true,
     createdAt: 1603915271852,
   },
+];
+
+export const paymentSupportedExtensionsConfig: ExtensionConfig[] = [
+  {
+    extensionId: Extension.OneTxPayment,
+    category: ExtensionCategory.Payments,
+    name: MSG.oneTxPaymentName,
+    descriptionShort: MSG.oneTxPaymentDescriptionShort,
+    descriptionLong: MSG.oneTxPaymentDescriptionLong,
+    icon: ExtensionOneTransactionPaymentIcon,
+    neededColonyPermissions: [
+      ColonyRole.Administration,
+      ColonyRole.Funding,
+      ColonyRole.Arbitration,
+    ],
+    imageURLs: [oneTransactionHero, oneTransactionInterface],
+    uninstallable: false,
+    createdAt: 1557698400000,
+  },
   // @BETA: Disabled for now
   {
     icon: ExtensionAdvancedPaymentsIcon,
@@ -555,4 +558,9 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
     uninstallable: true,
     createdAt: 1692048380000,
   },
+];
+
+export const supportedExtensionsConfig: ExtensionConfig[] = [
+  ...decisionMethodSupportedExtensionsConfig,
+  ...paymentSupportedExtensionsConfig,
 ];

--- a/src/utils/arrays/index.ts
+++ b/src/utils/arrays/index.ts
@@ -1,3 +1,6 @@
+import { type AnyExtensionData } from '~types/extensions.ts';
+import { formatText } from '~utils/intl.ts';
+
 /**
  * Sort an array of objects by multiple properties.
  */
@@ -183,3 +186,8 @@ export type UnionOfArraysToArrayOfUnions<T extends unknown[]> = ItemType<T>[];
 export const unionOfArraysToArrayOfUnions = <T extends unknown[]>(
   array: T,
 ): UnionOfArraysToArrayOfUnions<T> => array;
+
+export const sortExtensionByName = (
+  extensionA: AnyExtensionData,
+  extensionB: AnyExtensionData,
+) => formatText(extensionA.name).localeCompare(formatText(extensionB.name));


### PR DESCRIPTION
## Description

Extensions list order

## Testing

* Go to the Extensions page.
* Note the order and grouping of extensions.
* Install an extension.
* Note the order of extensions.

## Diffs

**New stuff** ✨

* 

**Changes** 🏗

* `supportedExtensionsConfig` split into `paymentSupportedExtensionsConfig` and `decisionMethodSupportedExtensionsConfig`
* `StakedExpenditureSettings` component updated to use `initializationParams` array of the extension

**Deletions** ⚰️

* 

## TODO

- [ ] Add TODOs

Resolves https://github.com/JoinColony/colonyCDapp/issues/2928
