### PR TITLE
fix: draft agreement description flashing

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/Description/Description.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Description/Description.tsx
@@ -1,6 +1,5 @@
 import { Pencil } from '@phosphor-icons/react';
 import React, { type FC } from 'react';
-import { useFormContext } from 'react-hook-form';
 
 import { useAdditionalFormOptionsContext } from '~context/AdditionalFormOptionsContext/AdditionalFormOptionsContext.ts';
 import { formatText } from '~utils/intl.ts';
@@ -20,10 +19,8 @@ const Description: FC<DescriptionProps> = ({
 }) => {
   const hasNoDecisionMethods = useHasNoDecisionMethods();
   const { readonly } = useAdditionalFormOptionsContext();
-  const { watch } = useFormContext();
-  const descriptionValue = watch(DESCRIPTION_FIELD_NAME);
 
-  return !(readonly && !descriptionValue) ? (
+  return !readonly ? (
     <ActionFormRow
       icon={Pencil}
       fieldName={DESCRIPTION_FIELD_NAME}

--- a/src/components/v5/common/ActionSidebar/partials/RemoveDraftModal/RemoveDraftModal.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/RemoveDraftModal/RemoveDraftModal.tsx
@@ -35,7 +35,7 @@ const RemoveDraftModal: FC<RemoveDraftModalProps> = ({
   }
 
   return (
-    <ModalBase isOpen={isOpen} isFullOnMobile>
+    <ModalBase isOpen={isOpen} isFullOnMobile hasPadding>
       <span className="mb-4 flex h-[2.5rem] w-[2.5rem] flex-shrink-0 items-center justify-center rounded border border-gray-200 shadow-content">
         <WarningCircle size={24} />
       </span>

--- a/src/components/v5/shared/RichText/hooks.ts
+++ b/src/components/v5/shared/RichText/hooks.ts
@@ -105,14 +105,21 @@ export const useRichText = ({
       content: field.value,
       onUpdate: (props) => {
         const trimmedText = props.editor.getText().trim();
-        const isCreatingHeading = !!props.editor.getAttributes('heading');
-        const isCreatingList = !!props.editor.getAttributes('list');
+        const isCreatingHeading = !!Object.keys(
+          props.editor.getAttributes('heading'),
+        ).length;
+        const isCreatingList = !!Object.keys(props.editor.getAttributes('list'))
+          .length;
         const html =
           (props.editor.isEmpty || trimmedText.length === 0) &&
           !isCreatingHeading &&
           !isCreatingList
             ? ''
             : props.editor.getHTML();
+
+        if (!html) {
+          return;
+        }
 
         field.onChange(html);
       },


### PR DESCRIPTION
## Description

Fix for: The description field flashes and clicking to expand the description field does not show your draft content.

## Testing

* Create an Agreement action.
* Add some content and then save it as a draft.
* Close down the action sidebar.
* Navigate to the agreement page and click the "Create agreement" button, or create a new action.
* In the modal to asking to remove the draft, click the "View draft" button.
* Note if your draft shows up or not.

## Diffs

**New stuff** ✨

* 

**Changes** 🏗

* `onUpdate` - when `html` const is empty return without `field.onChange` and checking if `getAttributes` objects are empty, until now it returned true all the time

**Deletions** ⚰️

* 

## TODO

- 

Resolves https://github.com/JoinColony/colonyCDapp/issues/2790
