### PR TITLE
Feat/2952: Calculate receive amount in user hub tab

### DIFF
--- a/amplify/backend/api/colonycdapp/schema/bridge.graphql
+++ b/amplify/backend/api/colonycdapp/schema/bridge.graphql
@@ -15,6 +15,11 @@ type BridgeCheckKYCReturn {
   liquidationAddress: String
 }
 
+type BridgeGatewayFeeReturn {
+  transactionFeePercentage: Float
+  success: Boolean
+}
+
 type BridgeDrainReceipt {
   url: String!
 }

--- a/amplify/backend/api/colonycdapp/schema/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema/schema.graphql
@@ -944,6 +944,11 @@ type Query {
   """
   bridgeGetUserLiquidationAddress(userAddress: String!): String
     @function(name: "bridgeXYZMutation-${env}")
+  """
+  Get bridge gateway fee
+  """
+  bridgeGetGatewayFee: BridgeGatewayFeeReturn
+    @function(name: "bridgeXYZMutation-${env}")
 }
 
 """

--- a/amplify/backend/function/bridgeXYZMutation/src/handlers/getGatewayFee.js
+++ b/amplify/backend/function/bridgeXYZMutation/src/handlers/getGatewayFee.js
@@ -1,0 +1,31 @@
+const fetch = require('cross-fetch');
+const { v4: uuid } = require('uuid');
+
+const getGatewayFeeHandler = async (_, { apiKey, apiUrl }) => {
+  try {
+    const res = await fetch(`${apiUrl}/v0/developer/fees`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Api-Key': apiKey,
+      },
+    });
+
+    const data = await res.json();
+
+    if (!data.default_liquidation_address_fee_percent) {
+      throw new Error('No default_liquidation_address_fee_percent returned');
+    } else {
+      return {
+        transactionFeePercentage: parseFloat(data.default_liquidation_address_fee_percent),
+        success: true,
+      };
+    }
+  } catch (e) {
+    console.error(e);
+    return undefined;
+  }
+};
+
+module.exports = {
+    getGatewayFeeHandler,
+};

--- a/amplify/backend/function/bridgeXYZMutation/src/index.js
+++ b/amplify/backend/function/bridgeXYZMutation/src/index.js
@@ -7,6 +7,7 @@ const {
   updateExternalAccountHandler,
 } = require('./handlers/updateExternalAccount');
 const { getDrainsHistoryHandler } = require('./handlers/getDrainsHistory');
+const { getGatewayFeeHandler } = require('./handlers/getGatewayFee.js');
 const {
   getUserLiquidationAddressHandler,
 } = require('./handlers/getUserLiquidationAddress');
@@ -36,6 +37,7 @@ const BRIDGE_OPERATIONS = {
   GET_USER_LIQUIDATION_ADDRESS: 'bridgeGetUserLiquidationAddress',
   CREATE_EXTERNAL_ACCOUNT: 'bridgeCreateBankAccount',
   UPDATE_EXTERNAL_ACCOUNT: 'bridgeUpdateBankAccount',
+  GET_GATEWAY_FEE: 'bridgeGetGatewayFee',
 };
 
 exports.handler = async (event) => {
@@ -54,6 +56,7 @@ exports.handler = async (event) => {
     [BRIDGE_OPERATIONS.CHECK_KYC]: checkKYCHandler,
     [BRIDGE_OPERATIONS.GET_USER_LIQUIDATION_ADDRESS]:
       getUserLiquidationAddressHandler,
+    [BRIDGE_OPERATIONS.GET_GATEWAY_FEE]: getGatewayFeeHandler,
     'v0/kyc_links': kycLinksHandler,
     default: () => {
       console.log('Running default handler');

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/ReceiveCard.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/ReceiveCard.tsx
@@ -5,7 +5,6 @@ import { type Message, useFormContext, useWatch } from 'react-hook-form';
 import { defineMessages } from 'react-intl';
 
 import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
-import { useCurrencyContext } from '~context/CurrencyContext/CurrencyContext.ts';
 import Tooltip from '~shared/Extensions/Tooltip/Tooltip.tsx';
 import { formatMessage } from '~utils/yup/tests/helpers.ts';
 
@@ -17,7 +16,7 @@ import {
   getUnconvertedAmount,
   getUnformattedStringNumeral,
 } from './helpers.ts';
-import { TransferFields } from './hooks.ts';
+import { TransferFields, useBankAccountCurrency } from './hooks.ts';
 
 const displayName = 'common.Extensions.UserHub.partials.ReceiveCard';
 
@@ -38,6 +37,8 @@ const MSG = defineMessages({
 
 interface ReceiveCardProps {
   isFormDisabled: boolean;
+  conversionRate: number;
+  conversionDate: Date;
   handleSetMax: () => void;
   isLoading: boolean;
 }
@@ -46,6 +47,8 @@ const CONVERTED_AMOUNT_TRANSFER_FIELD_NAME = TransferFields.CONVERTED_AMOUNT;
 
 const ReceiveCard: FC<ReceiveCardProps> = ({
   isFormDisabled,
+  conversionRate,
+  conversionDate,
   handleSetMax,
   isLoading,
 }) => {
@@ -58,11 +61,8 @@ const ReceiveCard: FC<ReceiveCardProps> = ({
     | Message
     | undefined;
 
-  const { currency: selectedCurrency } = useCurrencyContext();
+  const selectedCurrency = useBankAccountCurrency();
 
-  // @TODO: Get actual conversion rate
-  const conversionRate = parseFloat('0.93');
-  const conversionDate = new Date();
   const formattedConversionDateTime = format(conversionDate, `LLL dd 'at' p`);
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -73,9 +73,7 @@ const ReceiveCard: FC<ReceiveCardProps> = ({
     const tokenAmount = Number.isNaN(numberValue)
       ? 0
       : getUnconvertedAmount(numberValue, conversionRate);
-    const formattedTokenAmount = getFormattedStringNumeral(
-      tokenAmount.toString(),
-    );
+    const formattedTokenAmount = getFormattedStringNumeral(tokenAmount);
 
     setValue(CONVERTED_AMOUNT_TRANSFER_FIELD_NAME, formattedValue, {
       shouldValidate: true,
@@ -115,7 +113,7 @@ const ReceiveCard: FC<ReceiveCardProps> = ({
               <p>
                 {formatMessage(MSG.oneUSDC)}
                 <span className="font-medium">
-                  {conversionRate} {selectedCurrency}
+                  {getFormattedStringNumeral(conversionRate)} {selectedCurrency}
                 </span>
               </p>
             </Tooltip>

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/SummaryAmountRow.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/SummaryAmountRow.tsx
@@ -14,7 +14,7 @@ const displayName = 'common.Extensions.UserHub.partials.SummaryAmmountRow';
 interface SummaryAmountRowProps {
   isHighlighted?: boolean;
   description: string;
-  amount: number;
+  amount: string;
   currency: ExtendedSupportedCurrencies | SupportedCurrencies;
   tooltipContent: string;
   isDisabled?: boolean;

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/SummaryCard.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/SummaryCard.tsx
@@ -2,24 +2,19 @@ import clsx from 'clsx';
 import React, { type FC } from 'react';
 import { defineMessages } from 'react-intl';
 
-import { useCurrencyContext } from '~context/CurrencyContext/CurrencyContext.ts';
 import { ExtendedSupportedCurrencies } from '~gql';
 import { formatMessage } from '~utils/yup/tests/helpers.ts';
 
+import { useTransferFees } from './hooks.ts';
 import SummaryAmountRow from './SummaryAmountRow.tsx';
+import { FeeType } from './types.ts';
 
 const displayName = 'common.Extensions.UserHub.partials.SummaryCard';
-
-enum FeeType {
-  Wire = 'Wire',
-  SEPA = 'SEPA',
-  ACH = 'ACH',
-}
 
 const MSG = defineMessages({
   gatewayFee: {
     id: `${displayName}.gatewayFee`,
-    defaultMessage: 'Gateway fee (1%)',
+    defaultMessage: 'Gateway fee ({percentage}%)',
   },
   gatewayFeeTooltip: {
     id: `${displayName}.gatewayFeeTooltip`,
@@ -58,15 +53,16 @@ interface SummaryCardProps {
 }
 
 const SummaryCard: FC<SummaryCardProps> = ({ isFormDisabled, isLoading }) => {
-  const { currency: selectedCurrency } = useCurrencyContext();
   const fromCurrency = ExtendedSupportedCurrencies.Usdc;
-  // @TODO: Calculate proper values
-  const gatewayAmount = 0;
 
-  const feeAmount = 0;
-  const feeType = FeeType.Wire;
-
-  const receiveAmount = 0;
+  const {
+    gatewayPercentage,
+    gatewayAmount,
+    feeType,
+    feeAmount,
+    receiveAmount,
+    selectedCurrency,
+  } = useTransferFees();
 
   return (
     <div
@@ -79,7 +75,9 @@ const SummaryCard: FC<SummaryCardProps> = ({ isFormDisabled, isLoading }) => {
       )}
     >
       <SummaryAmountRow
-        description={formatMessage(MSG.gatewayFee)}
+        description={formatMessage(MSG.gatewayFee, {
+          percentage: gatewayPercentage * 100,
+        })}
         amount={gatewayAmount}
         currency={fromCurrency}
         tooltipContent={formatMessage(MSG.gatewayFeeTooltip)}

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/WithdrawCard.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/WithdrawCard.tsx
@@ -34,6 +34,7 @@ const MSG = defineMessages({
 interface WithdrawCardProps {
   isFormDisabled: boolean;
   balance: number;
+  conversionRate: number;
   handleSetMax: () => void;
   isLoading: boolean;
 }
@@ -43,11 +44,10 @@ const AMOUNT_TRANSFER_FIELD_NAME = TransferFields.AMOUNT;
 const WithdrawCard: FC<WithdrawCardProps> = ({
   isFormDisabled,
   balance,
+  conversionRate,
   handleSetMax,
   isLoading,
 }) => {
-  // @TODO: Get actual conversion rate
-  const conversionRate = parseFloat('0.93');
 
   const {
     setValue,
@@ -67,9 +67,7 @@ const WithdrawCard: FC<WithdrawCardProps> = ({
       ? 0
       : getConvertedAmount(numberValue, conversionRate);
 
-    const formattedConvertedAmount = getFormattedStringNumeral(
-      convertedAmount.toString(),
-    );
+    const formattedConvertedAmount = getFormattedStringNumeral(convertedAmount);
 
     setValue(AMOUNT_TRANSFER_FIELD_NAME, formattedValue, {
       shouldValidate: true,

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/helpers.ts
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/helpers.ts
@@ -1,6 +1,12 @@
-import { formatNumeral, unformatNumeral } from 'cleave-zen';
+import {
+  formatNumeral,
+  unformatNumeral,
+  type FormatNumeralOptions,
+} from 'cleave-zen';
 
 import { mapPayload, pipe } from '~utils/actions.ts';
+
+import { FeeType } from './types.ts';
 
 export const getTransferTransformFn = ({
   userAddress,
@@ -29,11 +35,33 @@ export const getUnconvertedAmount = (
   return amount / conversionRate;
 };
 
-export const getUnformattedStringNumeral = (value) => unformatNumeral(value);
-export const getFormattedStringNumeral = (value) =>
-  formatNumeral(value, {
+export const getUnformattedStringNumeral = (value: string | number) =>
+  unformatNumeral(typeof value === 'number' ? value.toString() : value);
+export const getFormattedStringNumeral = (
+  value: string | number,
+  options: FormatNumeralOptions = {},
+) =>
+  formatNumeral(typeof value === 'number' ? value.toString() : value, {
     delimiter: ',',
     numeralPositiveOnly: true,
     numeralDecimalScale: 4,
     numeralDecimalMark: '.',
+    ...options,
   });
+
+export const getFeeAmountBasedOn = (type: FeeType) => {
+  switch (type) {
+    case FeeType.ACH: {
+      return 0.5;
+    }
+    case FeeType.SEPA: {
+      return 1;
+    }
+    case FeeType.Wire: {
+      return 20;
+    }
+    default: {
+      return 0;
+    }
+  }
+};

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/hooks.ts
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/hooks.ts
@@ -1,10 +1,25 @@
+import { useWatch } from 'react-hook-form';
 import { defineMessages } from 'react-intl';
 import { type ObjectSchema, object, number } from 'yup';
 
+import { useCryptoToFiatContext } from '~frame/v5/pages/UserCryptoToFiatPage/context/CryptoToFiatContext.ts';
+import {
+  ExtendedSupportedCurrencies,
+  SupportedCurrencies,
+  useGetGatewayFeeQuery,
+} from '~gql';
+import { useCurrencyConversionRate } from '~hooks/useCurrencyConversionRate.ts';
 import { pipe, mapPayload } from '~utils/actions.ts';
+import { type CoinGeckoSupportedCurrencies } from '~utils/currency/types.ts';
 import { formatText } from '~utils/intl.ts';
 
-import { type TransferFormValues } from './types.ts';
+import {
+  getConvertedAmount,
+  getFeeAmountBasedOn,
+  getFormattedStringNumeral,
+  getUnformattedStringNumeral,
+} from './helpers.ts';
+import { FeeType, type TransferFormValues } from './types.ts';
 
 const MSG = defineMessages({
   amountRequired: {
@@ -61,7 +76,7 @@ export const useTransferForm = () => {
   const transform = pipe(
     mapPayload(({ amount }) => {
       return {
-        amount,
+        amount: getNullableFloat(amount),
       };
     }),
   );
@@ -69,5 +84,67 @@ export const useTransferForm = () => {
   return {
     transform,
     validationSchema,
+  };
+};
+
+export const useBankAccountCurrency = () => {
+  const { bankAccountData } = useCryptoToFiatContext();
+
+  return (
+    (bankAccountData?.currency.toUpperCase() as CoinGeckoSupportedCurrencies) ??
+    SupportedCurrencies.Usd
+  );
+};
+
+export const useTransferFees = () => {
+  const selectedCurrency = useBankAccountCurrency();
+  const selectedCurrencyConversionRate = useCurrencyConversionRate({
+    tokenSymbol: ExtendedSupportedCurrencies.Usdc,
+    conversionDenomination: selectedCurrency,
+  });
+  const conversionRate = selectedCurrencyConversionRate?.conversionRate ?? 0;
+
+  /**
+   * Given the fee amount is expressed in dollars, the simplest way is to convert it to USDC
+   * so it doesn't depend on the selected currency
+   */
+  const usdCurrencyConversionRate = useCurrencyConversionRate({
+    tokenSymbol: ExtendedSupportedCurrencies.Usdc,
+    conversionDenomination: SupportedCurrencies.Usd,
+  });
+  const usdcConversionRate =
+    1 / (usdCurrencyConversionRate?.conversionRate ?? 1);
+  const feeType =
+    selectedCurrency === SupportedCurrencies.Usd ? FeeType.ACH : FeeType.SEPA;
+  const feeAmount = (getFeeAmountBasedOn(feeType) * 1) / usdcConversionRate;
+
+  const withdrawAmount = useWatch({ name: TransferFields.AMOUNT });
+  const withdrawAmountValue = parseFloat(
+    getUnformattedStringNumeral(withdrawAmount.toString()),
+  );
+
+  const { data: bridgeGatewayFeeData, loading: bridgeGatewayFeeLoading } =
+    useGetGatewayFeeQuery();
+  const gatewayPercentage = bridgeGatewayFeeLoading
+    ? 0
+    : bridgeGatewayFeeData?.bridgeGetGatewayFee?.transactionFeePercentage ?? 0;
+  const gatewayAmount = withdrawAmountValue * gatewayPercentage ?? 0;
+
+  const receiveAmountInBaseCurrency =
+    withdrawAmountValue - gatewayAmount - feeAmount;
+  const receiveAmount = getConvertedAmount(
+    receiveAmountInBaseCurrency,
+    conversionRate,
+  );
+
+  return {
+    gatewayAmount: getFormattedStringNumeral(gatewayAmount),
+    gatewayPercentage,
+    feeType,
+    feeAmount: getFormattedStringNumeral(feeAmount),
+    receiveAmount: getFormattedStringNumeral(receiveAmount, {
+      numeralPositiveOnly: false,
+    }),
+    selectedCurrency,
   };
 };

--- a/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/types.ts
+++ b/src/components/common/Extensions/UserHub/partials/CryptoToFiatTab/partials/types.ts
@@ -6,6 +6,12 @@ export interface TransferFormValues {
   convertedAmount: number;
 }
 
+export enum FeeType {
+  Wire = 'Wire',
+  SEPA = 'SEPA',
+  ACH = 'ACH',
+}
+
 // @TODO: Add this in when the saga is in
 // export type CryptoToFiatTransferActionPayload =
 //   Action<ActionTypes.CRYPTO_TO_FIAT_TRANSFER>['payload'];

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -92,6 +92,12 @@ export const POLYGON_TOKEN: TokenInfo = {
   decimals: 18,
 };
 
+export const USDC_TOKEN: TokenInfo = {
+  name: 'USD Coin',
+  symbol: 'USDC',
+  decimals: 0,
+};
+
 export const GNOSIS_NETWORK: NetworkInfo = {
   name: 'Gnosis Chain',
   chainId: '100',

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -110,6 +110,12 @@ export type BridgeDrainReceipt = {
   url: Scalars['String'];
 };
 
+export type BridgeGatewayFeeReturn = {
+  __typename?: 'BridgeGatewayFeeReturn';
+  success?: Maybe<Scalars['Boolean']>;
+  transactionFeePercentage?: Maybe<Scalars['Float']>;
+};
+
 export type BridgeIbanAccountInput = {
   account_number: Scalars['String'];
   bic: Scalars['String'];
@@ -5810,6 +5816,8 @@ export type Query = {
   bridgeCheckKYC?: Maybe<BridgeCheckKycReturn>;
   /** Get drains history for the current user */
   bridgeGetDrainsHistory?: Maybe<Array<BridgeDrain>>;
+  /** Get bridge gateway fee */
+  bridgeGetGatewayFee?: Maybe<BridgeGatewayFeeReturn>;
   /** Get liquidation address of a given user */
   bridgeGetUserLiquidationAddress?: Maybe<Scalars['String']>;
   getActionByExpenditureId?: Maybe<ModelColonyActionConnection>;
@@ -9426,6 +9434,11 @@ export type GetUserLiquidationAddressQueryVariables = Exact<{
 
 export type GetUserLiquidationAddressQuery = { __typename?: 'Query', bridgeGetUserLiquidationAddress?: string | null };
 
+export type GetGatewayFeeQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetGatewayFeeQuery = { __typename?: 'Query', bridgeGetGatewayFee?: { __typename?: 'BridgeGatewayFeeReturn', transactionFeePercentage?: number | null, success?: boolean | null } | null };
+
 export type GetFullColonyByAddressQueryVariables = Exact<{
   address: Scalars['ID'];
 }>;
@@ -12086,6 +12099,41 @@ export function useGetUserLiquidationAddressLazyQuery(baseOptions?: Apollo.LazyQ
 export type GetUserLiquidationAddressQueryHookResult = ReturnType<typeof useGetUserLiquidationAddressQuery>;
 export type GetUserLiquidationAddressLazyQueryHookResult = ReturnType<typeof useGetUserLiquidationAddressLazyQuery>;
 export type GetUserLiquidationAddressQueryResult = Apollo.QueryResult<GetUserLiquidationAddressQuery, GetUserLiquidationAddressQueryVariables>;
+export const GetGatewayFeeDocument = gql`
+    query GetGatewayFee {
+  bridgeGetGatewayFee {
+    transactionFeePercentage
+    success
+  }
+}
+    `;
+
+/**
+ * __useGetGatewayFeeQuery__
+ *
+ * To run a query within a React component, call `useGetGatewayFeeQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetGatewayFeeQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetGatewayFeeQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetGatewayFeeQuery(baseOptions?: Apollo.QueryHookOptions<GetGatewayFeeQuery, GetGatewayFeeQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetGatewayFeeQuery, GetGatewayFeeQueryVariables>(GetGatewayFeeDocument, options);
+      }
+export function useGetGatewayFeeLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetGatewayFeeQuery, GetGatewayFeeQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetGatewayFeeQuery, GetGatewayFeeQueryVariables>(GetGatewayFeeDocument, options);
+        }
+export type GetGatewayFeeQueryHookResult = ReturnType<typeof useGetGatewayFeeQuery>;
+export type GetGatewayFeeLazyQueryHookResult = ReturnType<typeof useGetGatewayFeeLazyQuery>;
+export type GetGatewayFeeQueryResult = Apollo.QueryResult<GetGatewayFeeQuery, GetGatewayFeeQueryVariables>;
 export const GetFullColonyByAddressDocument = gql`
     query GetFullColonyByAddress($address: ID!) {
   getColonyByAddress(id: $address) {

--- a/src/graphql/queries/bridgeXYZ.graphql
+++ b/src/graphql/queries/bridgeXYZ.graphql
@@ -18,3 +18,10 @@ query CheckKYCStatus {
 query GetUserLiquidationAddress($userAddress: String!) {
   bridgeGetUserLiquidationAddress(userAddress: $userAddress)
 }
+
+query GetGatewayFee {
+  bridgeGetGatewayFee {
+    transactionFeePercentage
+    success
+  }
+}

--- a/src/hooks/useCurrencyConversionRate.ts
+++ b/src/hooks/useCurrencyConversionRate.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+import {
+  type CoinGeckoSupportedCurrencies,
+  coinGeckoMappings,
+} from '~utils/currency/index.ts';
+import { fetchTokenPriceDataByName } from '~utils/currency/tokenPriceDataByName.ts';
+
+interface CurrencyConversionRateArgs {
+  tokenSymbol: string;
+  conversionDenomination: CoinGeckoSupportedCurrencies;
+}
+
+interface CurrencyConversionRate {
+  conversionRate?: number;
+  lastUpdatedAt?: Date;
+}
+
+export const useCurrencyConversionRate = ({
+  tokenSymbol,
+  conversionDenomination,
+}: CurrencyConversionRateArgs) => {
+  const [currencyConversionRate, setCurrencyConversionRate] =
+    useState<CurrencyConversionRate | null>();
+  const tokenName = coinGeckoMappings.networkTokens[tokenSymbol];
+
+  useEffect(() => {
+    const getPriceData = async () => {
+      const priceData = await fetchTokenPriceDataByName({
+        tokenName,
+        conversionDenomination,
+      });
+
+      setCurrencyConversionRate(priceData);
+    };
+
+    if (tokenName) {
+      getPriceData();
+    }
+  }, [tokenName, conversionDenomination]);
+
+  return currencyConversionRate;
+};

--- a/src/utils/currency/config.ts
+++ b/src/utils/currency/config.ts
@@ -1,4 +1,4 @@
-import { ETHER_TOKEN, XDAI_TOKEN } from '~constants';
+import { ETHER_TOKEN, USDC_TOKEN, XDAI_TOKEN } from '~constants';
 import { SupportedCurrencies } from '~gql';
 import { Network } from '~types/network.ts';
 
@@ -19,6 +19,7 @@ export const currencyApiConfig = {
         from: 'ids',
         to: 'vs_currencies',
         api: 'x_cg_demo_api_key',
+        includeLastUpdatedAt: 'include_last_updated_at',
       },
     },
   },
@@ -58,6 +59,7 @@ export const coinGeckoMappings = {
   networkTokens: {
     [ETHER_TOKEN.symbol]: 'ethereum',
     [XDAI_TOKEN.symbol]: 'xdai',
+    [USDC_TOKEN.symbol]: 'usd-coin',
   },
 };
 

--- a/src/utils/currency/tokenPriceDataByName.ts
+++ b/src/utils/currency/tokenPriceDataByName.ts
@@ -1,0 +1,108 @@
+import fromUnixTime from 'date-fns/fromUnixTime';
+
+import { SupportedCurrencies } from '~gql';
+
+import { currencyApiConfig, coinGeckoMappings } from './config.ts';
+import {
+  type CoinGeckoSupportedCurrencies,
+  type TokenNamePriceSuccessResponse,
+  type TokenNamePriceResponse,
+} from './types.ts';
+import { buildAPIEndpoint, fetchData, mapToAPIFormat } from './utils.ts';
+
+// The functions defined in this file assume something about the shape of the api response.
+// If that changes, or if we change the api, these functions will need to be updated.
+
+const fallbackResponseData = {
+  conversionRate: 0,
+  lastUpdatedAt: new Date(),
+};
+
+const { currencies } = coinGeckoMappings;
+const buildTokenNameCoinGeckoURL = (
+  tokenName: string,
+  conversionDenomination: CoinGeckoSupportedCurrencies = SupportedCurrencies.Usd,
+) => {
+  const denomination = mapToAPIFormat(currencies, conversionDenomination);
+  const { url, searchParams } = currencyApiConfig.endpoints.tokenPriceByName;
+
+  return buildAPIEndpoint(new URL(`${url}/`), {
+    [searchParams.from]: tokenName,
+    [searchParams.to]: denomination,
+    [searchParams.api]: process.env.COINGECKO_API_KEY ?? '',
+    [searchParams.includeLastUpdatedAt]: 'true',
+  });
+};
+
+const extractTokenPriceDataFromResponse = (
+  data: TokenNamePriceSuccessResponse,
+  tokenName: string,
+  conversionDenomination: CoinGeckoSupportedCurrencies,
+) => {
+  try {
+    const tokenData = data[tokenName.toLowerCase()];
+    const formattedConversionDenomination = mapToAPIFormat(
+      currencies,
+      conversionDenomination,
+    );
+
+    return {
+      conversionRate: tokenData[formattedConversionDenomination],
+      lastUpdatedAt: fromUnixTime(tokenData.last_updated_at),
+    };
+  } catch (e) {
+    console.error(
+      'Could not get token price from CoinGecko response. Response shape might have changed.',
+      e,
+    );
+    return fallbackResponseData;
+  }
+};
+
+const isTokenPriceSuccessResponse = (
+  data: TokenNamePriceResponse,
+): data is TokenNamePriceSuccessResponse => {
+  if (
+    typeof data === 'undefined' ||
+    data === null ||
+    (typeof data === 'object' && Object.keys(data).length === 0)
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
+export const fetchTokenPriceDataByName = async ({
+  tokenName,
+  conversionDenomination = SupportedCurrencies.Usd,
+}: {
+  tokenName: string;
+  conversionDenomination: CoinGeckoSupportedCurrencies;
+}) => {
+  const url = buildTokenNameCoinGeckoURL(tokenName, conversionDenomination);
+
+  const priceData = await fetchData<
+    TokenNamePriceResponse,
+    { conversionRate: number; lastUpdatedAt: Date }
+  >(
+    url,
+    (data) => {
+      if (isTokenPriceSuccessResponse(data)) {
+        return extractTokenPriceDataFromResponse(
+          data,
+          tokenName,
+          conversionDenomination,
+        );
+      }
+
+      console.error(
+        `Unable to get price for ${tokenName}. It probably doesn't have a listed exchange value.`,
+      );
+      return fallbackResponseData;
+    },
+    `Api called failed at ${url}.`,
+  );
+
+  return priceData;
+};


### PR DESCRIPTION
## Description

- This PR handles computing the proper receive amount value based on the withdraw value and associated fees

> [!IMPORTANT]
> The user USDC balance is still hard coded

## Testing

TODO: High level overview of what reviewers are testing with your pr. 

TODO: Followed by step-by-step instructions for testing your branch so reviewers can easily jump straight in and start testing. 

* Step 1. Please update the `apiKey` value in `colonyCDapp/amplify/backend/function/bridgeXYZMutation/src/index.js`
* Step 2. Please update the `COINGECKO_API_KEY` and `COINGECKO_API_URL` env vars and run `npm run prepare`
* Step 3. Now that we are all set, go to the `planex` colony
* Step 4. Open the user hub > Crypto to fiat tab
* Step 5.1. Check the conversion rate updates based on the call to Coin Gecko
* Step 5.2. Check the gateway fee percentage is set to 1% of the entered value
* Step 5.3. Check the other fee has a fixed USD value that gets converted to USDC
* Step 5.4. Check the receive amount updates based on the value entered in the withdraw/receive field and the other fees 

![Screenshot 2024-08-22 at 16 54 34](https://github.com/user-attachments/assets/8566afa9-51ad-4289-8c76-b9633180df1a)
![Screenshot 2024-08-22 at 16 57 27](https://github.com/user-attachments/assets/57fb3878-3f7e-45e4-8f9b-6c0098297b84)


**Further testing**

**Testcase 1**
- Given you have used the fallback currency `USD`, you can now change it `SupportedCurrencies.Eur` in the `useBankAccountCurrency` hook
- Check the conversion rate, fee type and receive amount is properly updating for this currency

![Screenshot 2024-08-22 at 17 12 15](https://github.com/user-attachments/assets/3eb80518-b287-4244-bbd8-e8cc689fd2e0)


**Testcase 2**
- Now you can go to the user profile and properly update the KYC details `http://localhost:9091/account/crypto-to-fiat`
- Go back to the `planex` colony
- Open the user hub > Crypto to fiat tab
- Check the currency saved in the bank account details gets used for the receive amount and conversion rates

## Diffs

**New stuff** ✨

* `useGetGatewayFeeQuery` GraphQL query
* `useCurrencyConversionRate` hook

Resolves [#2952](https://github.com/JoinColony/colonyCDapp/issues/2952)
