### PR TITLE
Fix: Intermittent "not ready to send" transaction errors

### DIFF
--- a/src/redux/sagas/expenditures/fundExpenditure.ts
+++ b/src/redux/sagas/expenditures/fundExpenditure.ts
@@ -1,7 +1,6 @@
 import { ClientType } from '@colony/colony-js';
 import { fork, put, takeEvery } from 'redux-saga/effects';
 
-import { transactionPending } from '~redux/actionCreators/index.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
@@ -117,8 +116,6 @@ function* fundExpenditure({
         ActionTypes.TRANSACTION_CREATED,
       );
     }
-
-    yield put(transactionPending(fundMulticall.id));
 
     yield initiateTransaction(fundMulticall.id);
 


### PR DESCRIPTION
## Description

Occasionally the fundingExpenditure saga would fail with a "not ready to send" transaction error.

This was occurring because the transaction status was set to `pending` rather than `ready`.

The incorrect transaction status was being caused by `yield put(transactionPending(fundMulticall.id))` which sets the transaction status to pending, **however** it doesn't wait for the mutation to complete before proceeding. This meant on some occasions the `pending` mutation would complete **after** the `ready` mutation even though it was called first.

This PR removes `yield put(transactionPending(fundMulticall.id))` as it was being set to `ready` straight away after anyway, so setting it to `pending` first was unnecessary.

I have opened a separate PR on master (#2994) to make `yield put(transactionPending(transactionId))` actually wait for the mutation to complete before proceeding which will address any potential edge cases on other sagas where it is used.

## Testing

Step 1: Create an advanced payment action (I found the bug was happening more consistency with a larger number of payments, so feel free to import this CSV: https://drive.google.com/file/d/1h70lE_I_6Aa3L0cDRG1f9mjlzrvkBJfd/view?usp=sharing)
Step 2: Proceed through the rest of the flow to the funding stage. Fund using the permissions decision method.

The transaction should complete without issue - there is no need to complete the rest of the flow.

Whereas, on `feat/advanced-payments-ui` the funding step will fail on occassion:

<img width="1481" alt="Screenshot 2024-08-23 at 12 42 36" src="https://github.com/user-attachments/assets/d39f70c7-2282-4eaa-b178-1b2fd31841d2">

## Diffs

**Deletions** ⚰️

* `yield put(transactionPending(fundMulticall.id))` removed from fundingExpenditure saga

Resolves #2957
