### PR TITLE
Feat: Transaction pending mutation should be blocking

### DIFF
--- a/src/redux/actionCreators/transactions.ts
+++ b/src/redux/actionCreators/transactions.ts
@@ -128,11 +128,6 @@ export const transactionSucceeded = (
   meta: { id },
 });
 
-export const transactionPending = (id: string): AllActions => ({
-  type: ActionTypes.TRANSACTION_PENDING,
-  meta: { id },
-});
-
 export const transactionEstimateGas = (id: string): AllActions => ({
   type: ActionTypes.TRANSACTION_ESTIMATE_GAS,
   meta: { id },

--- a/src/redux/sagas/actions/createDomain.ts
+++ b/src/redux/sagas/actions/createDomain.ts
@@ -16,9 +16,11 @@ import {
   type CreateDomainMetadataMutation,
   type CreateDomainMetadataMutationVariables,
 } from '~gql';
-import { transactionPending } from '~redux/actionCreators/index.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
-import { transactionSetParams } from '~state/transactionState.ts';
+import {
+  transactionSetParams,
+  transactionSetPending,
+} from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { getDomainDatabaseId } from '~utils/databaseId.ts';
 import { toNumber } from '~utils/numbers.ts';
@@ -111,7 +113,7 @@ function* createDomainAction({
       );
     }
 
-    yield put(transactionPending(createDomain.id));
+    yield transactionSetPending(createDomain.id);
 
     const colonyClient = yield colonyManager.getClient(
       ClientType.ColonyClient,

--- a/src/redux/sagas/actions/editColony.ts
+++ b/src/redux/sagas/actions/editColony.ts
@@ -8,9 +8,11 @@ import {
   type UpdateColonyMetadataMutation,
   type UpdateColonyMetadataMutationVariables,
 } from '~gql';
-import { transactionPending } from '~redux/actionCreators/index.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
-import { transactionSetParams } from '~state/transactionState.ts';
+import {
+  transactionSetParams,
+  transactionSetPending,
+} from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { isEqual } from '~utils/lodash.ts';
 
@@ -97,7 +99,7 @@ function* editColonyAction({
       );
     }
 
-    yield put(transactionPending(editColony.id));
+    yield transactionSetPending(editColony.id);
 
     // /*
     //  * Upload colony metadata to IPFS

--- a/src/redux/sagas/actions/editDomain.ts
+++ b/src/redux/sagas/actions/editDomain.ts
@@ -12,9 +12,11 @@ import {
   type UpdateDomainMetadataMutation,
   type UpdateDomainMetadataMutationVariables,
 } from '~gql';
-import { transactionPending } from '~redux/actionCreators/index.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
-import { transactionSetParams } from '~state/transactionState.ts';
+import {
+  transactionSetParams,
+  transactionSetPending,
+} from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { getDomainDatabaseId } from '~utils/databaseId.ts';
 
@@ -105,7 +107,7 @@ function* editDomainAction({
       );
     }
 
-    yield put(transactionPending(editDomain.id));
+    yield transactionSetPending(editDomain.id);
 
     const colonyClient = yield colonyManager.getClient(
       ClientType.ColonyClient,

--- a/src/redux/sagas/actions/manageExistingSafes.ts
+++ b/src/redux/sagas/actions/manageExistingSafes.ts
@@ -8,9 +8,11 @@ import {
   type UpdateColonyMetadataMutation,
   type UpdateColonyMetadataMutationVariables,
 } from '~gql';
-import { transactionPending } from '~redux/actionCreators/index.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
-import { transactionSetReady } from '~state/transactionState.ts';
+import {
+  transactionSetPending,
+  transactionSetReady,
+} from '~state/transactionState.ts';
 import { type Safe } from '~types/graphql.ts';
 import { notNull } from '~utils/arrays/index.ts';
 import { excludeTypenameKey } from '~utils/objects/index.ts';
@@ -96,7 +98,7 @@ function* manageExistingSafesAction({
       );
     }
 
-    yield put(transactionPending(manageExistingSafes.id));
+    yield transactionSetPending(manageExistingSafes.id);
 
     let updatedColonySafes: Safe[];
 

--- a/src/redux/sagas/actions/managePermissions.ts
+++ b/src/redux/sagas/actions/managePermissions.ts
@@ -5,11 +5,11 @@ import { PERMISSIONS_NEEDED_FOR_ACTION } from '~constants/actions.ts';
 import { type ColonyManager } from '~context/index.ts';
 import { ActionTypes } from '~redux/actionTypes.ts';
 import { type AllActions, type Action } from '~redux/types/actions/index.ts';
-import { Authority } from '~types/authority.ts';
 import {
   transactionSetParams,
   transactionSetPending,
 } from '~state/transactionState.ts';
+import { Authority } from '~types/authority.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { clearContributorsAndRolesCache } from '~utils/members.ts';
 import { intArrayToBytes32 } from '~utils/web3/index.ts';

--- a/src/redux/sagas/actions/managePermissions.ts
+++ b/src/redux/sagas/actions/managePermissions.ts
@@ -3,11 +3,13 @@ import { call, put, takeEvery } from 'redux-saga/effects';
 
 import { PERMISSIONS_NEEDED_FOR_ACTION } from '~constants/actions.ts';
 import { type ColonyManager } from '~context/index.ts';
-import { transactionPending } from '~redux/actionCreators/index.ts';
 import { ActionTypes } from '~redux/actionTypes.ts';
 import { type AllActions, type Action } from '~redux/types/actions/index.ts';
-import { transactionSetParams } from '~state/transactionState.ts';
 import { Authority } from '~types/authority.ts';
+import {
+  transactionSetParams,
+  transactionSetPending,
+} from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { clearContributorsAndRolesCache } from '~utils/members.ts';
 import { intArrayToBytes32 } from '~utils/web3/index.ts';
@@ -137,7 +139,7 @@ function* managePermissionsAction({
       );
     }
 
-    yield put(transactionPending(setUserRoles.id));
+    yield transactionSetPending(setUserRoles.id);
 
     const colonyClient = yield colonyManager.getClient(
       ClientType.ColonyClient,

--- a/src/redux/sagas/actions/manageReputation.ts
+++ b/src/redux/sagas/actions/manageReputation.ts
@@ -2,9 +2,11 @@ import { ClientType, getPermissionProofs, ColonyRole } from '@colony/colony-js';
 import { call, put, takeEvery } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context/index.ts';
-import { transactionPending } from '~redux/actionCreators/index.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
-import { transactionSetParams } from '~state/transactionState.ts';
+import {
+  transactionSetParams,
+  transactionSetPending,
+} from '~state/transactionState.ts';
 
 import {
   createGroupTransaction,
@@ -105,7 +107,7 @@ function* manageReputationAction({
       );
     }
 
-    yield put(transactionPending(manageReputation.id));
+    yield transactionSetPending(manageReputation.id);
 
     if (isSmitingReputation) {
       const colonyClient = yield colonyManager.getClient(

--- a/src/redux/sagas/actions/moveFunds.ts
+++ b/src/redux/sagas/actions/moveFunds.ts
@@ -1,9 +1,11 @@
 import { ClientType } from '@colony/colony-js';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
-import { transactionPending } from '~redux/actionCreators/index.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
-import { transactionSetParams } from '~state/transactionState.ts';
+import {
+  transactionSetParams,
+  transactionSetPending,
+} from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
 import {
@@ -112,7 +114,7 @@ function* createMoveFundsAction({
       );
     }
 
-    yield put(transactionPending(moveFunds.id));
+    yield transactionSetPending(moveFunds.id);
 
     const [permissionDomainId, fromChildSkillIndex, toChildSkillIndex] =
       yield getMoveFundsPermissionProofs(colonyAddress, fromPot, toPot);

--- a/src/redux/sagas/actions/payment.ts
+++ b/src/redux/sagas/actions/payment.ts
@@ -3,10 +3,12 @@ import { BigNumber } from 'ethers';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context/index.ts';
-import { transactionPending } from '~redux/actionCreators/index.ts';
 import { ActionTypes, type Action, type AllActions } from '~redux/index.ts';
 import { type OneTxPaymentPayload } from '~redux/types/actions/colonyActions.ts';
-import { transactionSetParams } from '~state/transactionState.ts';
+import {
+  transactionSetParams,
+  transactionSetPending,
+} from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
 import {
@@ -125,7 +127,7 @@ function* createPaymentAction({
       );
     }
 
-    yield put(transactionPending(paymentAction.id));
+    yield transactionSetPending(paymentAction.id);
 
     const oneTxPaymentClient = yield colonyManager.getClient(
       ClientType.OneTxPaymentClient,

--- a/src/redux/sagas/colony/colonyCreate.ts
+++ b/src/redux/sagas/colony/colonyCreate.ts
@@ -33,11 +33,11 @@ import {
   type GetFullColonyByNameQuery,
   type GetFullColonyByNameQueryVariables,
 } from '~gql';
-import { transactionPending } from '~redux/actionCreators/index.ts';
 import { ActionTypes, type Action, type AllActions } from '~redux/index.ts';
 import {
   transactionSetIdentifier,
   transactionSetParams,
+  transactionSetPending,
   updateTransaction,
 } from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
@@ -422,7 +422,7 @@ function* deployExtensions(
   /*
    * Install OneTxPayment and StakedExpenditure extensions using multicall
    */
-  yield put(transactionPending(installExtensions.id));
+  yield transactionSetPending(installExtensions.id);
 
   const oneTxHash = getExtensionHash(Extension.OneTxPayment);
   const oneTxVersion = yield call(getExtensionVersion, Extension.OneTxPayment);
@@ -495,7 +495,7 @@ function* deployExtensions(
   /*
    * Set permissions for the newly deployed extensions
    */
-  yield put(transactionPending(setExtensionsRoles.id));
+  yield transactionSetPending(setExtensionsRoles.id);
 
   const setRolesMulticallData: string[] = [];
 
@@ -540,7 +540,7 @@ function* deployExtensions(
   /**
    * Enable Staked Expenditure
    */
-  // yield put(transactionPending(enableStakedExpenditure.id));
+  // yield transactionSetPending(enableStakedExpenditure.id);
 
   // yield put(
   //   transactionAddParams(enableStakedExpenditure.id, [DEFAULT_STAKE_FRACTION]),

--- a/src/redux/sagas/expenditures/fundExpenditure.ts
+++ b/src/redux/sagas/expenditures/fundExpenditure.ts
@@ -1,7 +1,6 @@
 import { ClientType } from '@colony/colony-js';
 import { fork, put, takeEvery } from 'redux-saga/effects';
 
-import { transactionPending } from '~redux/actionCreators/index.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
@@ -117,8 +116,6 @@ function* fundExpenditure({
         ActionTypes.TRANSACTION_CREATED,
       );
     }
-
-    yield put(transactionPending(fundMulticall.id));
 
     yield initiateTransaction(fundMulticall.id);
 

--- a/src/redux/sagas/expenditures/lockExpenditure.ts
+++ b/src/redux/sagas/expenditures/lockExpenditure.ts
@@ -1,7 +1,6 @@
 import { ClientType } from '@colony/colony-js';
 import { fork, put, takeEvery } from 'redux-saga/effects';
 
-import { transactionPending } from '~redux/actionCreators/transactions.ts';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { takeFrom } from '~utils/saga/effects.ts';
@@ -69,8 +68,6 @@ function* lockExpenditureAction({
         ActionTypes.TRANSACTION_CREATED,
       );
     }
-
-    yield put(transactionPending(lockExpenditure.id));
 
     yield initiateTransaction(lockExpenditure.id);
 

--- a/src/redux/sagas/motions/createDecisionMotion.ts
+++ b/src/redux/sagas/motions/createDecisionMotion.ts
@@ -152,7 +152,7 @@ function* createDecisionMotion({
       },
     });
 
-    // yield put(transactionPending(annotateMotion.id));
+    // yield transactionSetPending(annotateMotion.id);
 
     // yield put(
     //   transactionAddParams(annotateMotion.id, [

--- a/src/redux/sagas/motions/escalateMotion.ts
+++ b/src/redux/sagas/motions/escalateMotion.ts
@@ -8,10 +8,12 @@ import { BigNumber } from 'ethers';
 import { call, put, takeEvery } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context/index.ts';
-import { transactionPending } from '~redux/actionCreators/index.ts';
 import { ActionTypes } from '~redux/actionTypes.ts';
 import { type AllActions, type Action } from '~redux/types/actions/index.ts';
-import { transactionSetParams } from '~state/transactionState.ts';
+import {
+  transactionSetParams,
+  transactionSetPending,
+} from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
 import {
@@ -76,7 +78,7 @@ function* escalateMotion({
       ActionTypes.TRANSACTION_CREATED,
     );
 
-    yield put(transactionPending(escalateMotionTransaction.id));
+    yield transactionSetPending(escalateMotionTransaction.id);
 
     const { domainId, rootHash } = yield call(
       [votingReputationClient, votingReputationClient.getMotion],

--- a/src/redux/sagas/motions/stakeMotion.ts
+++ b/src/redux/sagas/motions/stakeMotion.ts
@@ -8,10 +8,12 @@ import {
 import { call, put, takeEvery } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context/index.ts';
-import { transactionPending } from '~redux/actionCreators/index.ts';
 import { ActionTypes } from '~redux/actionTypes.ts';
 import { type AllActions, type Action } from '~redux/types/actions/index.ts';
-import { transactionSetParams } from '~state/transactionState.ts';
+import {
+  transactionSetParams,
+  transactionSetPending,
+} from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 
 import {
@@ -178,7 +180,7 @@ function* stakeMotion({
       yield waitForTxResult(deposit.channel);
     }
 
-    yield put(transactionPending(approveStake.id));
+    yield transactionSetPending(approveStake.id);
 
     const { domainId, rootHash } = yield call(
       [votingReputationClient, votingReputationClient.getMotion],
@@ -195,7 +197,7 @@ function* stakeMotion({
 
     yield waitForTxResult(approveStake.channel);
 
-    yield put(transactionPending(stakeMotionTransaction.id));
+    yield transactionSetPending(stakeMotionTransaction.id);
 
     const [permissionDomainId, childSkillIndex] = yield getPermissionProofs(
       colonyClient.networkClient,

--- a/src/redux/sagas/transactions/transactionsToDb.ts
+++ b/src/redux/sagas/transactions/transactionsToDb.ts
@@ -36,7 +36,7 @@ const handleBeforeUnload = (e) => {
   return e.returnValue;
 };
 
-const onTransactionPending = (id: string) => {
+export const onTransactionPending = (id: string) => {
   pendingTransactions.add(id);
   // the first pending transaction, set up listener. I.e, we only need one
   if (pendingTransactions.size === 1) {
@@ -62,16 +62,6 @@ function* updateTransactionInDb({
 
   try {
     switch (type) {
-      case ActionTypes.TRANSACTION_PENDING: {
-        onTransactionPending(id);
-        yield updateTransaction({
-          id,
-          status: TransactionStatus.Pending,
-        });
-
-        break;
-      }
-
       case ActionTypes.TRANSACTION_LOAD_RELATED: {
         const { loading } = payload as TransactionLoadRelatedPayload;
         yield updateTransaction({
@@ -216,7 +206,7 @@ function* updateTransactionInDb({
 export default function* setupTransactionsSaga() {
   yield takeEvery(
     [
-      // TRANSACTION_READY, TRANSACTION_ADD_IDENTIFIER, TRANSACTION_ADD_PARAMS are handled separately
+      // TRANSACTION_READY, TRANSACTION_PENDING, TRANSACTION_ADD_IDENTIFIER, TRANSACTION_ADD_PARAMS are handled separately
       ActionTypes.TRANSACTION_SEND,
       ActionTypes.TRANSACTION_SENT,
       ActionTypes.TRANSACTION_RECEIPT_RECEIVED,
@@ -225,7 +215,6 @@ export default function* setupTransactionsSaga() {
       ActionTypes.TRANSACTION_CANCEL,
       ActionTypes.TRANSACTION_LOAD_RELATED,
       ActionTypes.TRANSACTION_HASH_RECEIVED,
-      ActionTypes.TRANSACTION_PENDING,
       ActionTypes.TRANSACTION_GAS_UPDATE,
     ],
     updateTransactionInDb,

--- a/src/redux/sagas/utils/annotations.ts
+++ b/src/redux/sagas/utils/annotations.ts
@@ -1,4 +1,4 @@
-import { call, put } from 'redux-saga/effects';
+import { call } from 'redux-saga/effects';
 
 import { ContextModule, getContext } from '~context/index.ts';
 import {
@@ -6,8 +6,10 @@ import {
   type CreateAnnotationMutation,
   type CreateAnnotationMutationVariables,
 } from '~gql';
-import { transactionPending } from '~redux/actionCreators/index.ts';
-import { transactionSetParams } from '~state/transactionState.ts';
+import {
+  transactionSetParams,
+  transactionSetPending,
+} from '~state/transactionState.ts';
 
 import {
   waitForTxResult,
@@ -57,7 +59,7 @@ export function* uploadAnnotation({
   txHash: string;
   actionId?: string;
 }) {
-  yield put(transactionPending(txChannel.id));
+  yield transactionSetPending(txChannel.id);
 
   /*
    * Upload annotation metadata to IPFS

--- a/src/state/transactionState.ts
+++ b/src/state/transactionState.ts
@@ -31,6 +31,7 @@ import {
   type CreateTransactionInput,
 } from '~gql';
 import { type TransactionType } from '~redux/immutable/index.ts';
+import { onTransactionPending } from '~redux/sagas/transactions/transactionsToDb.ts';
 import { type TransactionCreatedPayload } from '~redux/types/actions/transaction.ts';
 import { type AddressOrENSName } from '~types';
 import { type Transaction } from '~types/graphql.ts';
@@ -459,6 +460,19 @@ export const deleteTransaction = async (id: string) => {
       );
     },
   });
+};
+
+// Update the transaction status to pending in the database
+export const transactionSetPending = async (id: string) => {
+  onTransactionPending(id);
+  const wallet = getContext(ContextModule.Wallet);
+  const walletAddress = utils.getAddress(wallet.address);
+  const input = {
+    id,
+    from: walletAddress,
+    status: TransactionStatus.Pending,
+  };
+  return updateTransaction(input, input);
 };
 
 // Update the transaction status to ready in the database (important before sending it!)


### PR DESCRIPTION
## Description

Whilst working on #2992 I uncovered an issue with how `yield put(transactionPending(transactionId))` is being used.

The intention is to update the transaction status in the database to `pending`. This is usually followed by setting transaction parameters, before setting the status to `ready`. However, the pending mutation is done asynchronously leading to some edge cases where the `ready` mutation can complete before the `pending` mutation which can cause the `sendTransaction` function to fail.

This PR replaces `yield put(transactionPending(transactionId))` with a new `yield transactionSetPending(transactionId)` function which waits for the mutation to complete before proceeding.

## Testing

Test that none of the sagas have been broken, create a few actions and motions.

## Diffs

**New stuff** ✨

* `transactionSetPending` function

**Changes** 🏗

* All uses of `yield put(transactionPending(transactionId))` replaced with `yield transactionSetPending(transactionId)`
