### PR TITLE
fix: real time updating of verified member flags

### DIFF
--- a/src/utils/members.ts
+++ b/src/utils/members.ts
@@ -2,9 +2,9 @@ import { apolloClient } from '~apollo';
 import {
   GetColonyContributorDocument,
   type GetColonyContributorQuery,
-  GetColonyContributorsDocument,
-  type GetColonyContributorsQuery,
   type Profile,
+  SearchColonyContributorsDocument,
+  type SearchColonyContributorsQuery,
 } from '~gql';
 import { type ColonyContributor } from '~types/graphql.ts';
 import { merge } from '~utils/lodash.ts';
@@ -44,19 +44,19 @@ const updateContributorQueries = (
 ) => {
   apolloClient.cache.updateQuery(
     {
-      query: GetColonyContributorsDocument,
+      query: SearchColonyContributorsDocument,
       variables: {
         colonyAddress,
       },
     },
     (
-      data: GetColonyContributorsQuery | null,
-    ): GetColonyContributorsQuery | null => {
-      if (!data?.getContributorsByColony) {
+      data: SearchColonyContributorsQuery | null,
+    ): SearchColonyContributorsQuery | null => {
+      if (!data?.searchColonyContributors) {
         return null;
       }
 
-      const modifiedContributors = data.getContributorsByColony.items.map(
+      const modifiedContributors = data.searchColonyContributors.items.map(
         (contributor) => {
           if (!contributor) {
             return contributor;
@@ -77,8 +77,8 @@ const updateContributorQueries = (
 
       return {
         ...data,
-        getContributorsByColony: {
-          ...data.getContributorsByColony,
+        searchColonyContributors: {
+          ...data.searchColonyContributors,
           items: modifiedContributors,
         },
       };


### PR DESCRIPTION
## Description

Ez fix, just the query for getting colony contributors got switched in between.

## Testing

1. Go to the members page as `leela`
![image](https://github.com/user-attachments/assets/01fc735b-7ff9-4038-9b8b-b1fde45c022a)
2. Remove verified status from `amy` and `fry` by creating a `Manage verified members` action using `Permissions`
![image](https://github.com/user-attachments/assets/256705aa-01fb-4fdd-895b-76eebbb00dfe)
3. After the action passes, their verified checkmarks should disappear from both the members page and in the completed action view
![image](https://github.com/user-attachments/assets/6e1532ef-ad55-45c8-b80c-c8dd39a55c2e)
4. Now add them back as verified members
![image](https://github.com/user-attachments/assets/dc881044-b5ea-43f1-80a1-e9f03bd872ea)

Next up, we need to check if motions still work as intended :eyes: 

1. Install the voting reputation extension, then go back to the members page
2. Create a motion to remove `amy` and `fry` as verified members
![image](https://github.com/user-attachments/assets/f074493a-4959-4f5a-af1e-b268a048dde0)
3. Fully support it as `leela` and then run `npm run forward-time 1` in the terminal so the motion becomes finalizable (refresh the page). Assure that the verified flags are always present on `fry` and `amy` until we finalize the motion
![image](https://github.com/user-attachments/assets/a2181ea7-8f12-419a-b853-c88f7f65cf98)
![image](https://github.com/user-attachments/assets/e4a921d9-a2f9-412c-8fbe-a279b746956e)
4. Finalize the motion and observe how the checkmarks disappear from the members page and the completed action view
![image](https://github.com/user-attachments/assets/8e7b7c0e-cedc-48a0-9197-9203c6e3ea1c)
5. Now the other way around! Create a motion to verify `amy` and `fry`, fully support it as `leela`, observe that they don't have the verified checkmarks in the action view
![image](https://github.com/user-attachments/assets/e5ec9867-e5d2-4845-a1ae-6cd0d852b26a)
![image](https://github.com/user-attachments/assets/62273a0e-125f-425a-bc2c-0de4bfca2ea7)
6. Run `npm run forward-time 1` in a terminal and refresh the page. After finalizing the motion, the checkmarks should appear!
![image](https://github.com/user-attachments/assets/b6908e1a-e407-4ea4-88c3-116a1f34fedf)


## Diffs


**Changes** 🏗

* use `SearchColonyContributorsQuery` instead of `GetColonyContributorsQuery` for optimistic updates in the utils

Resolves  #2842
