### PR TITLE
[New Nav] Account Page Sidebar & Tab updates

### DIFF
--- a/src/components/frame/v5/pages/UserProfilePage/UserProfilePage.tsx
+++ b/src/components/frame/v5/pages/UserProfilePage/UserProfilePage.tsx
@@ -7,6 +7,7 @@ import {
   usePageHeadingContext,
   useSetPageHeadingTitle,
 } from '~context/PageHeadingContext/PageHeadingContext.ts';
+import { useTablet } from '~hooks';
 import {
   USER_CRYPTO_TO_FIAT_ROUTE,
   USER_ADVANCED_ROUTE,
@@ -57,6 +58,7 @@ const UserProfilePage: FC = () => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const featureFlags = useFeatureFlagsContext();
+  const isTablet = useTablet();
 
   const { setBreadcrumbs } = usePageHeadingContext();
 
@@ -91,11 +93,12 @@ const UserProfilePage: FC = () => {
   return (
     <Tabs
       activeTab={activeTab}
-      className="pt-6"
+      className="pt-6 md:pt-4"
       onTabClick={(_, id) =>
         navigate(tabRoutes.find((route) => route.id === id)?.route ?? '')
       }
       items={allowedTabRoutes}
+      showTabs={isTablet}
     />
   );
 };

--- a/src/components/shared/Extensions/Tabs/Tabs.tsx
+++ b/src/components/shared/Extensions/Tabs/Tabs.tsx
@@ -17,37 +17,40 @@ const Tabs: FC<PropsWithChildren<TabsProps>> = ({
   className,
   upperContainerClassName,
   children,
+  showTabs = true,
 }) => (
   <>
-    <ReactTabs
-      activeTab={activeTab}
-      onTabClick={onTabClick}
-      tabsUpperContainerClassName={clsx(
-        'before:content-[" "] relative flex w-full items-center p-0 font-semibold before:absolute before:bottom-0 before:left-0 before:block before:h-px before:w-full before:bg-gray-200',
-        upperContainerClassName,
-      )}
-      leftNavBtnClassName="absolute top-[50%] translate-y-[-50%] left-0 z-base"
-      rightNavBtnClassName="z-base"
-      // @ts-ignore - react-tabs-scrollable has invalid type for this prop
-      leftBtnIcon={<CaretLeft size={12} />}
-      // @ts-ignore - react-tabs-scrollable has invalid type for this prop
-      rightBtnIcon={<CaretRight size={12} />}
-      navBtnClassName="transition-colors duration-normal border-none bg-gray-200 w-[1.375rem] h-[1.375rem] rounded flex items-center justify-center shrink-0 sm:hover:bg-gray-300 [&_i]:w-[0.625em] [&_i]:h-[0.625em]"
-      hideNavBtnsOnMobile={false}
-    >
-      {items.map(({ id, title, notificationNumber }) => (
-        <Tab
-          key={id}
-          className={clsx('!bg-transparent', {
-            '!font-semibold': id === activeTab,
-            'text-gray-700': id !== activeTab,
-          })}
-        >
-          {formatText({ id: `tabs.${id}`, defaultMessage: `${title}` })}
-          {!!notificationNumber && <CountBox count={notificationNumber} />}
-        </Tab>
-      ))}
-    </ReactTabs>
+    {showTabs && (
+      <ReactTabs
+        activeTab={activeTab}
+        onTabClick={onTabClick}
+        tabsUpperContainerClassName={clsx(
+          'before:content-[" "] relative flex w-full items-center p-0 font-semibold before:absolute before:bottom-0 before:left-0 before:block before:h-px before:w-full before:bg-gray-200',
+          upperContainerClassName,
+        )}
+        leftNavBtnClassName="absolute top-[50%] translate-y-[-50%] left-0 z-base"
+        rightNavBtnClassName="z-base"
+        // @ts-ignore - react-tabs-scrollable has invalid type for this prop
+        leftBtnIcon={<CaretLeft size={12} />}
+        // @ts-ignore - react-tabs-scrollable has invalid type for this prop
+        rightBtnIcon={<CaretRight size={12} />}
+        navBtnClassName="transition-colors duration-normal border-none bg-gray-200 w-[1.375rem] h-[1.375rem] rounded flex items-center justify-center shrink-0 sm:hover:bg-gray-300 [&_i]:w-[0.625em] [&_i]:h-[0.625em]"
+        hideNavBtnsOnMobile={false}
+      >
+        {items.map(({ id, title, notificationNumber }) => (
+          <Tab
+            key={id}
+            className={clsx('!bg-transparent', {
+              '!font-semibold': id === activeTab,
+              'text-gray-700': id !== activeTab,
+            })}
+          >
+            {formatText({ id: `tabs.${id}`, defaultMessage: `${title}` })}
+            {!!notificationNumber && <CountBox count={notificationNumber} />}
+          </Tab>
+        ))}
+      </ReactTabs>
+    )}
     {items.map(({ id, content }) => (
       <TabScreen
         className={clsx(className)}

--- a/src/components/shared/Extensions/Tabs/types.ts
+++ b/src/components/shared/Extensions/Tabs/types.ts
@@ -15,4 +15,5 @@ export interface TabsProps {
   onTabClick: (_: React.BaseSyntheticEvent, id: number) => void;
   className?: string;
   upperContainerClassName?: string;
+  showTabs?: boolean;
 }

--- a/src/components/v5/shared/Navigation/ColonySwitcher/ColonySwitcher.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/ColonySwitcher.tsx
@@ -1,9 +1,11 @@
 import { CaretUpDown } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React from 'react';
+import { defineMessages } from 'react-intl';
 import { usePopperTooltip } from 'react-popper-tooltip';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { formatText } from '~utils/intl.ts';
 import { capitalizeFirstLetter } from '~utils/strings.ts';
 import Button from '~v5/shared/Button/index.ts';
 
@@ -15,11 +17,19 @@ import { type ColonySwitcherProps } from './types.ts';
 
 const displayName = 'v5.common.Navigation.ColonySwitcher';
 
+const MSG = defineMessages({
+  selectColony: {
+    id: `${displayName}.selectColony`,
+    defaultMessage: 'Select colony',
+  },
+});
+
 const ColonySwitcher: React.FC<ColonySwitcherProps> = ({
   isLogoButton,
   offset,
   className,
   enableMobileAndDesktopLayoutBreakpoints,
+  showColonySwitcherText = false,
 }) => {
   const colonyContext = useColonyContext({ nullableContext: true });
 
@@ -52,9 +62,11 @@ const ColonySwitcher: React.FC<ColonySwitcherProps> = ({
               enableMobileAndDesktopLayoutBreakpoints
             }
           />
-          {colonyName && (
+          {showColonySwitcherText && (
             <p className="truncate text-md font-semibold text-base-white">
-              {capitalizeFirstLetter(colonyName)}
+              {colonyName
+                ? capitalizeFirstLetter(colonyName)
+                : formatText(MSG.selectColony)}
             </p>
           )}
         </section>

--- a/src/components/v5/shared/Navigation/ColonySwitcher/types.ts
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/types.ts
@@ -5,4 +5,5 @@ export interface ColonySwitcherProps {
   offset?: PopperConfig['offset'];
   className?: string;
   enableMobileAndDesktopLayoutBreakpoints?: boolean;
+  showColonySwitcherText?: boolean;
 }

--- a/src/components/v5/shared/Navigation/Sidebar/Sidebar.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/Sidebar.tsx
@@ -30,7 +30,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
         ref={ref}
         className={clsx(
           'modal-blur top-[calc(var(--header-nav-section-height)+var(--top-content-height))]',
-          'z-sidebar hidden h-full w-fit flex-col items-start rounded-lg bg-gray-900 px-2 pb-4.5 pt-[13.5px] md:flex',
+          'pb-4.5 z-sidebar hidden h-full w-fit flex-col items-start rounded-lg bg-gray-900 px-2 pt-[13.5px] md:flex',
           className,
         )}
       >

--- a/src/components/v5/shared/Navigation/Sidebar/partials/SidebarRouteItem/types.ts
+++ b/src/components/v5/shared/Navigation/Sidebar/partials/SidebarRouteItem/types.ts
@@ -3,11 +3,10 @@ import { type Icon } from '@phosphor-icons/react';
 import { type TypedMessageDescriptor } from '~types';
 
 export interface SidebarRouteItemProps {
-  id: string;
   icon?: Icon;
-  routeType?: 'colony' | 'account';
   translation: TypedMessageDescriptor;
   path: string;
   subItems?: SidebarRouteItemProps[];
   onClick?: () => void;
+  isColonyRoute?: boolean;
 }

--- a/src/components/v5/shared/Navigation/Sidebar/sidebars/AccountPageSidebar/AccountPageSidebar.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/sidebars/AccountPageSidebar/AccountPageSidebar.tsx
@@ -1,0 +1,51 @@
+import {
+  CreditCard,
+  Faders,
+  UserCircleGear,
+  Wrench,
+} from '@phosphor-icons/react';
+import React from 'react';
+
+import {
+  USER_ADVANCED_ROUTE,
+  USER_CRYPTO_TO_FIAT_ROUTE,
+  USER_EDIT_PROFILE_ROUTE,
+  USER_HOME_ROUTE,
+  USER_PREFERENCES_ROUTE,
+} from '~routes';
+import SidebarRouteItem from '~v5/shared/Navigation/Sidebar/partials/SidebarRouteItem/index.ts';
+import Sidebar from '~v5/shared/Navigation/Sidebar/Sidebar.tsx';
+
+export const AccountPageSidebar = () => {
+  return (
+    <Sidebar
+      className="!w-[216px]"
+      headerClassName="mb-[27px]"
+      colonySwitcherProps={{ showColonySwitcherText: true }}
+    >
+      <section className="flex flex-col gap-0.5">
+        <SidebarRouteItem
+          path={`${USER_HOME_ROUTE}/${USER_EDIT_PROFILE_ROUTE}`}
+          translation={{ id: 'userProfileTab.title' }}
+          icon={UserCircleGear}
+        />
+        <SidebarRouteItem
+          path={`${USER_HOME_ROUTE}/${USER_PREFERENCES_ROUTE}`}
+          translation={{ id: 'userPreferencesPage.title' }}
+          icon={Faders}
+        />
+        <SidebarRouteItem
+          path={`${USER_HOME_ROUTE}/${USER_ADVANCED_ROUTE}`}
+          translation={{ id: 'advancedSettings.title' }}
+          icon={Wrench}
+        />
+      </section>
+      <div className="mx-3 my-[15px] border-b border-gray-200 md:mx-2 md:border-gray-700" />
+      <SidebarRouteItem
+        path={`${USER_HOME_ROUTE}/${USER_CRYPTO_TO_FIAT_ROUTE}`}
+        translation={{ id: 'userCryptoToFiatPage.title' }}
+        icon={CreditCard}
+      />
+    </Sidebar>
+  );
+};

--- a/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/ColonyPageSidebar.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/ColonyPageSidebar.tsx
@@ -84,6 +84,7 @@ const ColonyPageSidebar = () => {
       showColonySwitcher={!isTablet}
       headerClassName="mb-[27px]"
       footerClassName="!items-start !gap-2"
+      colonySwitcherProps={{ showColonySwitcherText: true }}
     >
       <ColonyPageSidebarContent />
     </Sidebar>

--- a/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/consts.ts
+++ b/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/consts.ts
@@ -24,87 +24,75 @@ import { type SidebarRouteItemProps } from '~v5/shared/Navigation/Sidebar/partia
 
 export const sidebarNavigationScheme: SidebarRouteItemProps[] = [
   {
-    id: 'dashboard',
     icon: Layout,
     translation: { id: 'navigation.dashboard' },
     path: '',
-    routeType: 'colony',
+    isColonyRoute: true,
   },
   {
-    id: 'activity',
     icon: ClockCountdown,
     translation: { id: 'teamsPage.links.activity' },
     path: COLONY_ACTIVITY_ROUTE,
-    routeType: 'colony',
+    isColonyRoute: true,
   },
   {
-    id: 'finances',
     icon: PresentationChart,
     translation: { id: 'navigation.finances' },
-    routeType: 'colony',
     path: COLONY_BALANCES_ROUTE,
+    isColonyRoute: true,
     subItems: [
       {
-        id: 'balances',
         translation: { id: 'navigation.finances.balances' },
         path: COLONY_BALANCES_ROUTE,
-        routeType: 'colony',
+        isColonyRoute: true,
       },
       {
-        id: 'incoming',
         translation: { id: 'navigation.finances.incoming' },
         path: COLONY_INCOMING_ROUTE,
-        routeType: 'colony',
+        isColonyRoute: true,
       },
       // @TODO: Uncomment once these pages are available
       // {
       //   id: 'streaming',
       //   translation: { id: 'navigation.finances.streaming' },
       //   path: COLONY_STREAMING_ROUTE,
-      //   routeType: 'colony',
       // },
       // {
       //   id: 'crypto-to-fiat',
       //   translation: { id: 'userCryptoToFiatPage.title' },
       //   path: `account/${USER_CRYPTO_TO_FIAT_ROUTE}`,
-      //   routeType: 'account',
       // },
     ],
   },
   {
-    id: 'teams',
     icon: UsersThree,
     translation: { id: 'navigation.members.teams' },
     path: COLONY_TEAMS_ROUTE,
-    routeType: 'colony',
+    isColonyRoute: true,
   },
   {
-    id: 'agreements',
     icon: FileText,
     translation: { id: 'navigation.agreements' },
     path: COLONY_AGREEMENTS_ROUTE,
-    routeType: 'colony',
+    isColonyRoute: true,
   },
   {
-    id: 'members',
     icon: AddressBook,
     translation: { id: 'navigation.members' },
     path: COLONY_MEMBERS_ROUTE,
-    routeType: 'colony',
+    isColonyRoute: true,
   },
   {
-    id: 'permissions',
     icon: UserSwitch,
     translation: { id: 'navigation.members.permissions' },
     path: COLONY_PERMISSIONS_ROUTE,
-    routeType: 'colony',
+    isColonyRoute: true,
   },
   {
-    id: 'extensions',
     icon: GearSix,
     translation: { id: 'navigation.admin.extensions' },
     path: COLONY_EXTENSIONS_ROUTE,
-    routeType: 'colony',
+    isColonyRoute: true,
   },
 ];
 

--- a/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/partials/SidebarRoutesSection.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/partials/SidebarRoutesSection.tsx
@@ -4,10 +4,12 @@ import SidebarRouteItem from '~v5/shared/Navigation/Sidebar/partials/SidebarRout
 
 import { sidebarNavigationScheme } from '../consts.ts';
 
-export const SidebarRoutesSection = () => (
-  <section className="flex w-full flex-col gap-0 md:gap-0.5">
-    {sidebarNavigationScheme.map((scheme) => (
-      <SidebarRouteItem key={scheme.id} {...scheme} />
-    ))}
-  </section>
-);
+export const SidebarRoutesSection = () => {
+  return (
+    <section className="flex w-full flex-col gap-0 md:gap-0.5">
+      {sidebarNavigationScheme.map((scheme) => (
+        <SidebarRouteItem key={scheme.translation.id} {...scheme} />
+      ))}
+    </section>
+  );
+};

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -776,6 +776,7 @@
     "teamsPage.description": "Teams of the Colony",
     "teamsPage.createNewTeam": "Create new team",
     "teamsPage.allTeams": "All teams",
+    "userProfileTab.title": "Profile",
     "userProfile.title": "Account",
     "userProfilePage.title": "User account",
     "userProfilePage.description": "Edit and update your account information",

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -71,6 +71,7 @@ import {
   // UNWRAP_TOKEN_ROUTE,
   // CLAIM_TOKEN_ROUTE,
 } from './routeConstants.ts';
+import UserRoute from './UserRoute.tsx';
 
 // import { ClaimTokensPage, UnwrapTokensPage } from '~dashboard/Vesting';
 
@@ -90,9 +91,11 @@ const Routes = () => {
         <Route element={<MainRoute />}>
           <Route path={USER_INVITE_ROUTE} element={<ColonyPreviewPage />} />
           <Route path={COLONY_SPLASH_ROUTE} element={<ColonyPreviewPage />} />
+        </Route>
 
-          {/* User routes */}
-          <Route path={USER_HOME_ROUTE} element={<UserProfilePage />}>
+        {/* User routes */}
+        <Route path={USER_HOME_ROUTE} element={<UserRoute />}>
+          <Route element={<UserProfilePage />}>
             <Route
               path={USER_EDIT_PROFILE_ROUTE}
               element={<UserAccountPage />}

--- a/src/routes/UserRoute.tsx
+++ b/src/routes/UserRoute.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 
-const UserRoute = () => <Outlet />;
+import { MainLayout } from '~frame/Extensions/layouts/index.ts';
+import { AccountPageSidebar } from '~v5/shared/Navigation/Sidebar/sidebars/AccountPageSidebar/AccountPageSidebar.tsx';
+
+const UserRoute = () => (
+  <MainLayout sidebar={<AccountPageSidebar />}>
+    <Outlet />
+  </MainLayout>
+);
 
 export default UserRoute;


### PR DESCRIPTION
## Description

This PR updates the Account Page so that it uses the new Sidebar design.

![account-page-tabs](https://github.com/user-attachments/assets/9c452c68-02d2-4b77-8be1-d0fca2d0b702)

## Testing

> [!NOTE]
> The dark theme issue with Sidebar-related components will be dealt with separately

1. Visit the Account page
2. Set the browser width to 1025px
3. Verify that the Sidebar matches the Figma designs
4. Verify that on tablet view and above, the in-page tabs are not present and that they take you to the correct tab
5. Set the browser width to 1024px
6. Verify that the sidebar is not present
7. Verify that the in-page tabs are present

Resolves #2874 