### PR TITLE
[Dashboard] feat: redesign the native token pill

### DIFF
--- a/src/components/frame/Extensions/pages/ColonyDetailsPage/ColonyDetailsPage.tsx
+++ b/src/components/frame/Extensions/pages/ColonyDetailsPage/ColonyDetailsPage.tsx
@@ -83,7 +83,6 @@ const ColonyDetailsPage: FC = () => {
               <h2 className="heading-2">{colonyDisplayName}</h2>
               {nativeToken && (
                 <NativeTokenPill
-                  variant="secondary"
                   token={nativeToken}
                   isLocked={isNativeTokenLocked}
                 />

--- a/src/components/v5/common/NativeTokenPill/NativeTokenPill.tsx
+++ b/src/components/v5/common/NativeTokenPill/NativeTokenPill.tsx
@@ -1,5 +1,4 @@
 import { LockKey } from '@phosphor-icons/react';
-import clsx from 'clsx';
 import React from 'react';
 
 import { useMobile } from '~hooks';
@@ -15,55 +14,40 @@ import Modal from '~v5/shared/Modal/index.ts';
 import Portal from '~v5/shared/Portal/index.ts';
 
 interface NativeTokenPillProps {
-  variant?: 'primary' | 'secondary';
   token: Token;
   isLocked?: boolean;
 }
 
 const displayName = 'v5.shared.NativeTokenPill';
 
-const NativeTokenPill = ({
-  variant = 'primary',
-  token,
-  isLocked = false,
-}: NativeTokenPillProps) => {
+const NativeTokenPill = ({ token, isLocked = false }: NativeTokenPillProps) => {
   const isMobile = useMobile();
 
   const [
-    isTokenModalOpened,
-    { toggleOff: toggleTokenModalOff, toggleOn: toggleTokenModalOn },
+    isTokenModalVisible,
+    {
+      toggle: toggleTokenModal,
+      toggleOff: toggleTokenModalOff,
+      registerContainerRef,
+    },
   ] = useToggle();
-  const [isTokenVisible, { toggle: toggleToken, registerContainerRef }] =
-    useToggle();
 
   const { portalElementRef, relativeElementRef } = useRelativePortalElement<
     HTMLButtonElement,
     HTMLDivElement
-  >([isTokenVisible], {
+  >([isTokenModalVisible], {
     top: 8,
   });
-  const isTokenInfoShown = isTokenModalOpened || isTokenVisible;
 
   return (
     <>
       <button
         type="button"
         ref={relativeElementRef}
-        className={clsx(
-          'group flex h-[1.875rem] cursor-pointer flex-row items-center rounded-lg px-1.5 text-gray-900',
-          {
-            'bg-base-bg': variant === 'primary',
-            'border border-gray-200 bg-base-white': variant === 'secondary',
-          },
-        )}
-        onClick={isMobile ? toggleTokenModalOn : toggleToken}
+        className="flex h-[1.75rem] cursor-pointer flex-row items-center rounded-[32px] bg-blue-100 px-2.5 text-gray-900"
+        onClick={toggleTokenModal}
       >
-        <span
-          className={clsx('text-sm font-medium', {
-            'text-gray-900 group-hover:text-blue-400': !isTokenInfoShown,
-            'text-blue-400': isTokenInfoShown,
-          })}
-        >
+        <span className="text-sm font-medium text-blue-400">
           {multiLineTextEllipsis(token.symbol, 5)}
         </span>
         {isLocked && (
@@ -72,7 +56,7 @@ const NativeTokenPill = ({
               <span>{formatText({ id: 'tooltip.lockedToken' })}</span>
             }
           >
-            <LockKey size={11} className="ml-0.5" />
+            <LockKey size={11} className="ml-0.5 text-blue-400" />
           </Tooltip>
         )}
       </button>
@@ -80,12 +64,12 @@ const NativeTokenPill = ({
         <Modal
           isFullOnMobile={false}
           onClose={toggleTokenModalOff}
-          isOpen={isTokenModalOpened}
+          isOpen={isTokenModalVisible}
         >
           <TokenInfo className="w-full !p-0" token={token} isTokenNative />
         </Modal>
       ) : (
-        isTokenVisible && (
+        isTokenModalVisible && (
           <Portal>
             <MenuContainer
               className="absolute z-sidebar min-w-80 !p-0"

--- a/src/components/v5/frame/ColonyHome/partials/DashboardHeader/DashboardHeader.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/DashboardHeader/DashboardHeader.tsx
@@ -23,7 +23,7 @@ const DashboardHeader = () => {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-end gap-3">
+      <div className="flex items-center gap-4">
         <h1 className="truncate capitalize text-gray-900 heading-2">
           {colonyName}
         </h1>


### PR DESCRIPTION
## Description

The one on the details page changed too, but we don't need to do anything as that page will be retired soon enough.
[Figma link](https://www.figma.com/design/gac6xVgGNCAge5Bia933dp/Dashboard?node-id=5072-23432&t=WWUSxHubtxhNqeaI-4)

## Testing

1. Open up the colony home page and check the native token pill
![image](https://github.com/user-attachments/assets/ae0f5c3a-edff-4976-8705-89d408c13c19)
2. Inspect it and make sure it looks like it should (I've aligned the padding to 10px on each side, in the designs it's 11 left and 9 right, probably not intentional?)
3. Open up the native token modal and verify it opens
![image](https://github.com/user-attachments/assets/da7d02a8-40be-41e2-947d-70e41c390d5a)
4. verify that the tooltip shows upon hovering over the lock icon
![image](https://github.com/user-attachments/assets/7479d2c5-31d9-4942-b58e-44d504fb257c)
5. verify that the modal works on mobile
![image](https://github.com/user-attachments/assets/5dd87056-8241-40ff-a8b3-084f3e549dff)


## Diffs

**Changes** 🏗

* Reworked the native token pill to have just one source for opening and closing it and ofc restyled it


Resolves #2848 
