### PR TITLE
[Dashboard] Feat: Adjust social icons for colony header redesign

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/ColonyLinks.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/ColonyLinks.tsx
@@ -54,6 +54,7 @@ const ColonyLinks = () => {
   const { colonyAddress, metadata } = colony || {};
   const { dropdownMenuProps } = useHeaderLinks();
   const { pathname } = useLocation();
+  const isMobile = useMobile();
   const {
     handleClipboardCopy: handleShareUrlCopy,
     isCopied: isShareUrlCopied,
@@ -69,7 +70,7 @@ const ColonyLinks = () => {
     : [];
 
   return (
-    <ul className="flex items-center gap-4">
+    <ul className="flex items-center gap-2.5">
       {topLinks.map(({ link, name }) => {
         const { label, LinkIcon } = COLONY_LINK_CONFIG[name];
 
@@ -85,7 +86,7 @@ const ColonyLinks = () => {
               })}
             >
               <ExternalLink href={link}>
-                <LinkIcon size={16} />
+                <LinkIcon size={isMobile ? 14 : 16} />
               </ExternalLink>
             </ColonyLinkWrapper>
           </li>

--- a/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useHeaderLinks.ts
+++ b/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useHeaderLinks.ts
@@ -1,7 +1,7 @@
 import {
   CopySimple,
   Door,
-  Rocket,
+  // Rocket,
   ShareNetwork,
   Smiley,
 } from '@phosphor-icons/react';
@@ -12,7 +12,7 @@ import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useColonyDashboardContext } from '~context/ColonyDashboardContext/ColonyDashboardContext.ts';
 import { useMobile } from '~hooks/index.ts';
 import useCopyToClipboard from '~hooks/useCopyToClipboard.ts';
-import { COLONY_DETAILS_ROUTE } from '~routes/index.ts';
+// import { COLONY_DETAILS_ROUTE } from '~routes/index.ts';
 import { formatText } from '~utils/intl.ts';
 import {
   type DropdownMenuProps,
@@ -51,14 +51,15 @@ export const useHeaderLinks = (): { dropdownMenuProps: DropdownMenuProps } => {
     {
       key: 'headerDropdown.section1',
       items: [
-        {
-          key: 'headerDropdown.section1.about',
-          label: formatText({
-            id: 'dashboard.burgerMenu.item.aboutColony',
-          }),
-          icon: Rocket,
-          to: `/${colony?.name}/${COLONY_DETAILS_ROUTE}`,
-        },
+        // @TODO: Temporarily disabled
+        // {
+        //   key: 'headerDropdown.section1.about',
+        //   label: formatText({
+        //     id: 'dashboard.burgerMenu.item.aboutColony',
+        //   }),
+        //   icon: Rocket,
+        //   to: `/${colony?.name}/${COLONY_DETAILS_ROUTE}`,
+        // },
         {
           key: 'colonyData.section1.copyAddress',
           label: formatText({ id: 'dashboard.burgerMenu.item.colonyAddress' }),

--- a/src/components/v5/shared/SocialLinks/colonyLinks.ts
+++ b/src/components/v5/shared/SocialLinks/colonyLinks.ts
@@ -72,10 +72,10 @@ export const COLONY_LINK_CONFIG: Record<ExternalLinks, ColonyLink> = {
     LinkIcon: Scroll,
     label: formatText(MSG[ExternalLinks.Whitepaper]),
   },
-  [ExternalLinks.Youtube]: {
-    id: ExternalLinks.Youtube,
-    LinkIcon: YoutubeLogo,
-    label: formatText(MSG[ExternalLinks.Youtube]),
+  [ExternalLinks.Github]: {
+    id: ExternalLinks.Github,
+    LinkIcon: GithubLogo,
+    label: formatText(MSG[ExternalLinks.Github]),
   },
   [ExternalLinks.Discord]: {
     id: ExternalLinks.Discord,
@@ -92,10 +92,10 @@ export const COLONY_LINK_CONFIG: Record<ExternalLinks, ColonyLink> = {
     LinkIcon: TelegramLogo,
     label: formatText(MSG[ExternalLinks.Telegram]),
   },
-  [ExternalLinks.Github]: {
-    id: ExternalLinks.Github,
-    LinkIcon: GithubLogo,
-    label: formatText(MSG[ExternalLinks.Github]),
+  [ExternalLinks.Youtube]: {
+    id: ExternalLinks.Youtube,
+    LinkIcon: YoutubeLogo,
+    label: formatText(MSG[ExternalLinks.Youtube]),
   },
   [ExternalLinks.Facebook]: {
     id: ExternalLinks.Facebook,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1521,7 +1521,7 @@
     "colony.tooltip.contractAddress.copy": "Copy contract address",
     "dashboard.burgerMenu.item.aboutColony": "About this colony",
     "dashboard.burgerMenu.item.share": "Share",
-    "dashboard.burgerMenu.item.colonyAddress": "Copy Colony address",
+    "dashboard.burgerMenu.item.colonyAddress": "Copy colony address",
     "dashboard.burgerMenu.item.notifications": "Notifications",
     "dashboard.burgerMenu.item.leaveColony": "Leave this colony",
     "dashboard.burgerMenu.item.externalLinks": "External links",


### PR DESCRIPTION
## Description

As part of the dashboard redesign, the social icons require some small changes.

This PR makes some styling tweaks to the social icons, and re-orders the priority order.

[Check the original issue for the full requirements](https://github.com/JoinColony/colonyCDapp/issues/2846)

## Testing

* Step 1: Navigate to the dashboard. Check the social icons match the [figma file](https://www.figma.com/design/gac6xVgGNCAge5Bia933dp/Dashboard?node-id=4859-36367&t=3YmH0OCdhMXflaYC-0) on all screen widths.

<img width="319" alt="Screenshot 2024-08-30 at 09 11 53" src="https://github.com/user-attachments/assets/07426e45-acec-4d07-8b6f-8e4945730998">

<img width="544" alt="Screenshot 2024-08-30 at 09 12 20" src="https://github.com/user-attachments/assets/4ce9a181-2922-43ee-9ca7-94481813013e">

* Step 2: Create an 'edit colony' action and remove the custom link and whitepaper link (and any other links you'd like)

<img width="669" alt="Screenshot 2024-08-30 at 09 14 16" src="https://github.com/user-attachments/assets/eec3c408-988c-4b0c-98d7-66adae1cc16f">

* Step 3: Check the icon order respects the expected priority order (as detailed in the original issue).

<img width="462" alt="Screenshot 2024-08-30 at 09 14 30" src="https://github.com/user-attachments/assets/f6b02273-80d6-43a9-9e5d-bc5e57e1a7e1">


## Diffs

**Changes** 🏗

* Social icon styling tweaks
* Social icon priority order changes
* `Copy Colony address` is now `Copy colony address`

Resolves #2846
