### PR TITLE
fix: split payment table ui

### DIFF
--- a/src/components/shared/Numeral/Numeral.tsx
+++ b/src/components/shared/Numeral/Numeral.tsx
@@ -13,11 +13,11 @@ import type Decimal from 'decimal.js';
 
 import styles from './Numeral.module.css';
 
+const displayName = 'Numeral';
+
 // needed for capitalized abbreviations
 numbro.registerLanguage(numbroLanguage);
 numbro.setLanguage('en-GB');
-
-const displayName = 'Numeral';
 
 export type NumeralValue = string | number | BigNumber | Decimal;
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentPayoutsTotal/SplitPaymentPayoutsTotal.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentPayoutsTotal/SplitPaymentPayoutsTotal.tsx
@@ -13,6 +13,7 @@ const SplitPaymentPayoutsTotal: FC<SplitPaymentPayoutsTotalProps> = ({
   token,
   convertToWEI,
   className,
+  value,
 }) => {
   const summedAmount =
     useMemo(() => {
@@ -44,7 +45,7 @@ const SplitPaymentPayoutsTotal: FC<SplitPaymentPayoutsTotalProps> = ({
         'flex items-center gap-3 text-gray-900 text-1',
       )}
     >
-      <Numeral value={summedAmount} decimals={token.decimals} />
+      <Numeral value={value || summedAmount} decimals={token.decimals} />
       <div className="flex items-center gap-1">
         <TokenAvatar
           tokenAddress={token.tokenAddress}

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentPayoutsTotal/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentPayoutsTotal/types.ts
@@ -7,4 +7,5 @@ export interface SplitPaymentPayoutsTotalProps {
   token: Token;
   convertToWEI?: boolean;
   className?: string;
+  value?: string;
 }

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentPercentField/SplitPaymentPercentField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentPercentField/SplitPaymentPercentField.tsx
@@ -26,7 +26,8 @@ const SplitPaymentPercentField: FC<SplitPaymentPercentFieldProps> = ({
         }
       }}
       wrapperClassName="flex-row flex text-md"
-      type="number"
+      type="text"
+      shouldAllowOnlyNumbers
       mode="secondary"
       placeholder={formatText({ id: 'actionSidebar.enterValue' })}
       suffix="%"

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/SplitPaymentRecipientsField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/SplitPaymentRecipientsField.tsx
@@ -45,6 +45,7 @@ const SplitPaymentRecipientsField: FC<SplitPaymentRecipientsFieldProps> = ({
     amount,
     fieldArrayMethods,
     disabled,
+    distributionMethod,
   });
   const isTablet = useTablet();
   const getMenuProps = ({ index }) => ({

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/hooks.tsx
@@ -1,5 +1,6 @@
 import { createColumnHelper, type ColumnDef } from '@tanstack/react-table';
 import Decimal from 'decimal.js';
+import moveDecimal from 'move-decimal-point';
 import React, { useMemo, useCallback, useEffect } from 'react';
 import { type FieldValues, type UseFieldArrayReturn } from 'react-hook-form';
 
@@ -31,6 +32,7 @@ export const useRecipientsFieldTableColumns = ({
   amount,
   fieldArrayMethods: { update },
   disabled,
+  distributionMethod,
 }: {
   name: string;
   token: Token;
@@ -38,6 +40,7 @@ export const useRecipientsFieldTableColumns = ({
   amount: string | undefined;
   fieldArrayMethods: UseFieldArrayReturn<FieldValues, string, 'id'>;
   disabled?: boolean;
+  distributionMethod?: SplitPaymentDistributionType;
 }): ColumnDef<SplitPaymentRecipientsTableModel, string>[] => {
   const isTablet = useTablet();
   const columnHelper = useMemo(
@@ -106,6 +109,10 @@ export const useRecipientsFieldTableColumns = ({
               <SplitPaymentPayoutsTotal
                 data={dataRef.current || []}
                 token={token}
+                value={
+                  distributionMethod === SplitPaymentDistributionType.Equal &&
+                  (amount ? moveDecimal(amount, token.decimals) : 0)
+                }
                 convertToWEI
               />
               {isTablet && (
@@ -113,7 +120,8 @@ export const useRecipientsFieldTableColumns = ({
                   {parseFloat(
                     (
                       dataRef.current?.reduce(
-                        (acc, _, index) => acc + getPercentValue(index),
+                        (acc, _, index) =>
+                          Number(acc) + Number(getPercentValue(index)),
                         0,
                       ) || 0
                     ).toFixed(4),
@@ -161,24 +169,28 @@ export const useRecipientsFieldTableColumns = ({
             />
           ),
           footer: !isTablet
-            ? () => (
-                <span className="text-md font-medium text-gray-900">
-                  {parseFloat(
-                    (
-                      dataRef.current?.reduce(
-                        (acc, _, index) => acc + getPercentValue(index),
-                        0,
-                      ) || 0
-                    ).toFixed(4),
-                  )}
-                  %
-                </span>
-              )
+            ? () => {
+                return (
+                  <span className="text-md font-medium text-gray-900">
+                    {distributionMethod === SplitPaymentDistributionType.Equal
+                      ? '100%'
+                      : `${Number(
+                          dataRef.current
+                            ?.reduce(
+                              (acc, _, index) =>
+                                Number(acc) + Number(getPercentValue(index)),
+                              0,
+                            )
+                            .toFixed(4) || 0,
+                        )}%`}
+                  </span>
+                );
+              }
             : undefined,
         }),
       ],
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [amount, columnHelper, name, token, disabled],
+      [amount, columnHelper, name, token, disabled, distributionMethod],
     );
 
   return columns;
@@ -210,8 +222,7 @@ export const useDistributionMethodUpdate = ({
               percent: Number(percentPerRecipient.toFixed(4)),
               amount: amount
                 ? new Decimal(amount)
-                    .mul(percentPerRecipient)
-                    .div(100)
+                    .div(data.length || 1)
                     .toDecimalPlaces(
                       getSelectedToken(colony, data[index].tokenAddress || '')
                         ?.decimals || DEFAULT_TOKEN_DECIMALS,

--- a/src/components/v5/common/CompletedAction/partials/SplitPayment/SplitPayment.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SplitPayment/SplitPayment.tsx
@@ -63,7 +63,6 @@ import {
   DescriptionRow,
   TeamFromRow,
 } from '../rows/index.ts';
-import { getFormattedTokenAmount } from '../utils.ts';
 
 import SplitPaymentTable from './partials/SplitPaymentTable/SplitPaymentTable.tsx';
 
@@ -168,10 +167,7 @@ const SplitPayment = ({ action }: SplitPaymentProps) => {
             [ACTION_TYPE_FIELD_NAME]: Action.SplitPayment,
             distributionMethod: distributionType,
             [TEAM_FIELD_NAME]: fundFromDomainNativeId,
-            [AMOUNT_FIELD_NAME]: getFormattedTokenAmount(
-              amount,
-              splitToken?.decimals,
-            ),
+            [AMOUNT_FIELD_NAME]: formattedAmount,
             payments: slots.map((slot) => {
               const currentAmount = moveDecimal(
                 slot.payouts?.[0].amount,

--- a/src/components/v5/common/Fields/InputBase/FormInputBase.tsx
+++ b/src/components/v5/common/Fields/InputBase/FormInputBase.tsx
@@ -17,6 +17,7 @@ const FormInputBase: FC<FormInputBaseProps> = ({
   onBlur: onBlurProp,
   readOnly,
   onChange: onChangeProp,
+  shouldAllowOnlyNumbers,
   ...rest
 }) => {
   const {
@@ -47,7 +48,14 @@ const FormInputBase: FC<FormInputBaseProps> = ({
         if (type === 'number') {
           onChange(Number.isNaN(valueAsNumber) ? 0 : valueAsNumber);
         } else {
-          onChange(inputValue);
+          onChange(
+            shouldAllowOnlyNumbers
+              ? inputValue
+                  .replace(/[^0-9.]/g, '')
+                  .replace(/(\..*?)\..*/g, '$1')
+                  .replace(/^0[^.]/, '0')
+              : inputValue,
+          );
         }
       }}
       state={invalid ? FieldState.Error : undefined}

--- a/src/components/v5/common/Fields/InputBase/types.ts
+++ b/src/components/v5/common/Fields/InputBase/types.ts
@@ -23,6 +23,7 @@ export interface FormInputBaseProps
   extends Omit<InputBaseProps, 'onChange' | 'state' | 'value'> {
   name: string;
   onChange?: () => void;
+  shouldAllowOnlyNumbers?: boolean;
 }
 
 export interface FormattedInputProps extends Omit<InputBaseProps, 'prefix'> {


### PR DESCRIPTION
## Description

- Equal distribution method now uses fractions to calculate amount instead of percentages
- Changed decimals to dots everywhere in payment table
- Total amounts is not higher then the originally intended value
<img width="658" alt="image" src="https://github.com/user-attachments/assets/68bcaf75-2c8c-4ce8-8b42-e1fbf7e668b7">


## Testing

* Create a split payment and play with it

(Resolves | Contributes to) https://github.com/JoinColony/colonyCDapp/issues/3012
