### PR TITLE
Fix: Advanced payments UI not updating after successful motion stake

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/RevealStep/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/RevealStep/hooks.ts
@@ -78,11 +78,15 @@ export const useRevealStep = ({
 
   const { vote, hasUserVoted, userVoteRevealed, setUserVoteRevealed } =
     useRevealWidgetUpdate(voterRecord || [], stopPollingAction);
-  const transform = mapPayload(() => ({
-    colonyAddress,
-    userAddress: user?.walletAddress ?? '',
-    motionId: BigNumber.from(motionId),
-  }));
+  const transform = useMemo(
+    () =>
+      mapPayload(() => ({
+        colonyAddress,
+        userAddress: user?.walletAddress ?? '',
+        motionId: BigNumber.from(motionId),
+      })),
+    [colonyAddress, user?.walletAddress, motionId],
+  );
 
   const handleSuccess: OnSuccess<Record<string, number>> = (_, { reset }) => {
     reset();

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/StakingForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/StakingForm.tsx
@@ -132,7 +132,7 @@ const StakingForm: FC<StakingFormProps> = ({
                             checked && !disabled && isDarkMode,
                         }),
                       icon: ThumbsDown,
-                      disabled: isFullyObjected || isRefetching,
+                      disabled: isSubmitting || isFullyObjected || isRefetching,
                     },
                     {
                       label: formatText({ id: 'motion.support' }),
@@ -150,7 +150,8 @@ const StakingForm: FC<StakingFormProps> = ({
                             checked && !disabled && isDarkMode,
                         }),
                       icon: ThumbsUp,
-                      disabled: isFullySupported || isRefetching,
+                      disabled:
+                        isSubmitting || isFullySupported || isRefetching,
                     },
                   ]}
                   disabled={disableForm}

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/StakingStep/partials/StakingForm/hooks.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from 'ethers';
 import moveDecimal from 'move-decimal-point';
+import { useMemo } from 'react';
 import { defineMessages } from 'react-intl';
 import { number, object, type ObjectSchema, string } from 'yup';
 
@@ -110,14 +111,25 @@ export const useStakingForm = () => {
     })
     .defined();
 
-  const transform = getStakingTransformFn({
-    userAddress: user?.walletAddress ?? '',
-    colonyAddress: colony?.colonyAddress ?? '',
-    motionId,
-    nativeTokenDecimals: tokenDecimals,
-    tokenAddress,
-    activeAmount: tokenBalanceData?.activeBalance ?? '0',
-  });
+  const transform = useMemo(
+    () =>
+      getStakingTransformFn({
+        userAddress: user?.walletAddress ?? '',
+        colonyAddress: colony?.colonyAddress ?? '',
+        motionId,
+        nativeTokenDecimals: tokenDecimals,
+        tokenAddress,
+        activeAmount: tokenBalanceData?.activeBalance ?? '0',
+      }),
+    [
+      user?.walletAddress,
+      colony?.colonyAddress,
+      motionId,
+      tokenDecimals,
+      tokenAddress,
+      tokenBalanceData?.activeBalance,
+    ],
+  );
 
   const handleSuccess = getHandleStakeSuccessFn(
     setIsRefetching,

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/VotingStep/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/VotingStep/hooks.tsx
@@ -1,6 +1,6 @@
 import { Extension } from '@colony/colony-js';
 import { BigNumber } from 'ethers';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { number, object } from 'yup';
 
 import MemberReputation from '~common/Extensions/UserNavigation/partials/MemberReputation/index.ts';
@@ -118,14 +118,18 @@ export const useVotingStep = ({
 
   const currentUserVote = getLocalStorageVoteValue(transactionId);
 
-  const transform = mapPayload(
-    ({ vote }) =>
-      ({
-        colonyAddress,
-        userAddress: user?.walletAddress,
-        vote: Number(vote),
-        motionId: BigNumber.from(motionId),
-      }) as MotionVotePayload,
+  const transform = useMemo(
+    () =>
+      mapPayload(
+        ({ vote }) =>
+          ({
+            colonyAddress,
+            userAddress: user?.walletAddress,
+            vote: Number(vote),
+            motionId: BigNumber.from(motionId),
+          }) as MotionVotePayload,
+      ),
+    [colonyAddress, user?.walletAddress, motionId],
   );
 
   const handleSuccess: OnSuccess<VotingFormValues> = (vote, { reset }) => {


### PR DESCRIPTION
## Description

This PR fixes an issue with the funding motion for an advanced payment getting stuck on the staking step.

<img width="327" alt="Screenshot 2024-09-03 at 13 29 03" src="https://github.com/user-attachments/assets/3a5e375a-ad9e-4a43-93f8-72e64d93f14a">

The issue was occurring because the PaymentBuilderWidget would re-render whilst polling for motion updates, which would cause the `transform` function to change resulting in the `useAyncFunction` promiseListener to get unsubscribed.

This PR memoizes the `transform` function to prevent it changing on these re-renders unless the actual values change.

Whilst working on this I also noticed similar behaviour on the voting and reveal steps so have memoized those `transform` functions too.

This PR also disables the "Oppose" and "Support" buttons whilst the form is submitting.

## Testing

Follow these steps on `feat/advanced-payments-ui-next` if you'd like to replicate the original issue - it is also easier to replicate using the metamask wallet rather than a developer wallet.

Step 1 - Install and enable the reputation weighted voting extension
Step 2 - Create an advanced payment action using permissions
Step 3 - Confirm details for the advanced payment
Step 4 - Fund using the reputation decision method
Step 5 - Support the motion and click "Stake" - if you are on `feat/advanced-payments-ui-next` this is where the bug should occur whilst confirming the transactions (it doesn't always occur so may take a few attempts to replicate - vote to oppose the motion to make it easier to repeat).
Step 6 - Whilst the stake saga is processing, the "Oppose" and "Support" buttons should be disabled.

<img width="322" alt="Screenshot 2024-09-03 at 13 25 58" src="https://github.com/user-attachments/assets/8232a8d6-67b1-470a-9351-7757fe367a2e">

Step 7 - Follow through the rest of the motion to confirm the vote and reveal steps work as expected.

## Diffs

**Changes** 🏗

* Memoized `transform` functions for staking, voting and revealing
* Disabled "Oppose" and "Support" buttons whilst form is submitting

Resolves #2882
