### PR TITLE
[Notifications] Feat: Add empty notifications list to UserHub

### DIFF
--- a/src/components/common/Extensions/UserHub/UserHub.tsx
+++ b/src/components/common/Extensions/UserHub/UserHub.tsx
@@ -10,6 +10,7 @@ import TitleLabel from '~v5/shared/TitleLabel/index.ts';
 
 import { tabList } from './consts.ts';
 import CryptoToFiatTab from './partials/CryptoToFiatTab/CryptoToFiatTab.tsx';
+import NotificationsTab from './partials/NotificationsTab/NotificationsTab.tsx';
 import ReputationTab from './partials/ReputationTab/index.ts';
 import StakesTab from './partials/StakesTab/index.ts';
 import TransactionsTab from './partials/TransactionsTab/index.ts';
@@ -42,12 +43,21 @@ const UserHub: FC<Props> = ({ initialOpenTab = UserHubTab.Balance }) => {
   const featureFlags = useContext(FeatureFlagsContext);
   const [selectedTab, setSelectedTab] = useState(initialOpenTab);
 
-  const filteredTabList = tabList.filter(
-    (tabItem) =>
+  // @TODO: get from notifications context
+  const notificationsServiceIsEnabled = true;
+
+  const filteredTabList = tabList.filter((tabItem) => {
+    const isFeatureFlagEnabled =
       !tabItem.featureFlag ||
       (!featureFlags[tabItem.featureFlag]?.isLoading &&
-        featureFlags[tabItem.featureFlag]?.isEnabled),
-  );
+        featureFlags[tabItem.featureFlag]?.isEnabled);
+
+    if (tabItem.id !== UserHubTab.Notifications) {
+      return isFeatureFlagEnabled;
+    }
+
+    return isFeatureFlagEnabled && notificationsServiceIsEnabled;
+  });
 
   const handleTabChange = (newTab: UserHubTab) => {
     setSelectedTab(newTab);
@@ -129,10 +139,11 @@ const UserHub: FC<Props> = ({ initialOpenTab = UserHubTab.Balance }) => {
         {selectedTab === UserHubTab.Balance && (
           <ReputationTab onTabChange={handleTabChange} />
         )}
-        {selectedTab === UserHubTab.Stakes && <StakesTab />}
+        {selectedTab === UserHubTab.Notifications && <NotificationsTab />}
         {selectedTab === UserHubTab.Transactions && (
           <TransactionsTab appearance={{ interactive: true }} />
         )}
+        {selectedTab === UserHubTab.Stakes && <StakesTab />}
         {selectedTab === UserHubTab.CryptoToFiat && <CryptoToFiatTab />}
       </div>
       {/* @BETA: Disabled for now */}

--- a/src/components/common/Extensions/UserHub/consts.ts
+++ b/src/components/common/Extensions/UserHub/consts.ts
@@ -3,6 +3,7 @@ import {
   Receipt,
   Invoice,
   CreditCard,
+  Bell,
 } from '@phosphor-icons/react';
 import { defineMessages } from 'react-intl';
 
@@ -16,13 +17,17 @@ export const menuMessages = defineMessages({
     id: 'UserSubmenu.balance',
     defaultMessage: 'Balance',
   },
-  stakes: {
-    id: 'UserSubmenu.stakes',
-    defaultMessage: 'Stakes',
+  notifications: {
+    id: 'UserSubmenu.notifications',
+    defaultMessage: 'Notifications',
   },
   transactions: {
     id: 'UserSubmenu.transactions',
     defaultMessage: 'Transactions',
+  },
+  stakes: {
+    id: 'UserSubmenu.stakes',
+    defaultMessage: 'Stakes',
   },
   cryptoToFiat: {
     id: 'UserSubmenu.cryptoToFiat',
@@ -38,16 +43,22 @@ export const tabList: UserHubTabList = [
     icon: Invoice,
   },
   {
-    id: UserHubTab.Stakes,
-    label: formatText(menuMessages.stakes),
-    value: UserHubTab.Stakes,
-    icon: CoinVertical,
+    id: UserHubTab.Notifications,
+    label: formatText(menuMessages.notifications),
+    value: UserHubTab.Notifications,
+    icon: Bell,
   },
   {
     id: UserHubTab.Transactions,
     label: formatText(menuMessages.transactions),
     value: UserHubTab.Transactions,
     icon: Receipt,
+  },
+  {
+    id: UserHubTab.Stakes,
+    label: formatText(menuMessages.stakes),
+    value: UserHubTab.Stakes,
+    icon: CoinVertical,
   },
   {
     id: UserHubTab.CryptoToFiat,

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
@@ -1,0 +1,42 @@
+import { Binoculars } from '@phosphor-icons/react';
+import React from 'react';
+import { defineMessages } from 'react-intl';
+
+import { formatText } from '~utils/intl.ts';
+import EmptyContent from '~v5/common/EmptyContent/EmptyContent.tsx';
+
+const displayName = 'common.Extensions.UserHub.partials.NotificationsTab';
+
+const MSG = defineMessages({
+  notifications: {
+    id: `${displayName}.notifications`,
+    defaultMessage: 'Notifications',
+  },
+});
+
+const NotificationsTab = () => {
+  const isEmpty = true;
+
+  return (
+    <div className="h-full px-6 pb-6 pt-6 sm:pb-2">
+      <p className="heading-5">{formatText(MSG.notifications)}</p>
+      <div className="flex h-full flex-col justify-center pt-4 sm:h-auto sm:justify-normal">
+        {isEmpty && (
+          <>
+            <EmptyContent
+              title={{ id: 'empty.content.title.notifications' }}
+              description={{ id: 'empty.content.subtitle.notifications' }}
+              icon={Binoculars}
+              className="sm:pt-[100px]"
+            />
+            <div className="h-[25%] sm:h-0" />
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+NotificationsTab.displayName = displayName;
+
+export default NotificationsTab;

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
@@ -12,6 +12,14 @@ const MSG = defineMessages({
     id: `${displayName}.notifications`,
     defaultMessage: 'Notifications',
   },
+  emptyTitle: {
+    id: `${displayName}.emptyTitle`,
+    defaultMessage: 'No notifications yet',
+  },
+  emptyDescription: {
+    id: `${displayName}.emptyDescription`,
+    defaultMessage: 'Your notifications will appear here.',
+  },
 });
 
 const NotificationsTab = () => {
@@ -24,8 +32,8 @@ const NotificationsTab = () => {
         {isEmpty && (
           <>
             <EmptyContent
-              title={{ id: 'empty.content.title.notifications' }}
-              description={{ id: 'empty.content.subtitle.notifications' }}
+              title={formatText(MSG.emptyTitle)}
+              description={formatText(MSG.emptyDescription)}
               icon={Binoculars}
               className="sm:pt-[100px]"
             />

--- a/src/components/common/Extensions/UserHub/types.ts
+++ b/src/components/common/Extensions/UserHub/types.ts
@@ -12,7 +12,8 @@ export type UserHubTabList = {
 
 export enum UserHubTab {
   Balance = 0,
-  Stakes = 1,
+  Notifications = 1,
   Transactions = 2,
-  CryptoToFiat = 3,
+  Stakes = 3,
+  CryptoToFiat = 4,
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -768,8 +768,6 @@
     "empty.content.subtitle.stakes": "New stakes will appear here",
     "empty.content.title.transactions": "There are no transactions yet",
     "empty.content.subtitle.transactions": "New transactions will appear here",
-    "empty.content.title.notifications": "No notifications yet",
-    "empty.content.subtitle.notifications": "Your notifications will appear here.",
     "handle.unselect.transaction": "handle unselect transaction",
     "missing.colonies": "You don't have created colonies",
     "user.typing": "The user is actively typing....",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -768,6 +768,8 @@
     "empty.content.subtitle.stakes": "New stakes will appear here",
     "empty.content.title.transactions": "There are no transactions yet",
     "empty.content.subtitle.transactions": "New transactions will appear here",
+    "empty.content.title.notifications": "No notifications yet",
+    "empty.content.subtitle.notifications": "Your notifications will appear here.",
     "handle.unselect.transaction": "handle unselect transaction",
     "missing.colonies": "You don't have created colonies",
     "user.typing": "The user is actively typing....",


### PR DESCRIPTION
## Description

This PR adds the notifications tab to UserHub with the empty notifications list state.

[Figma link](https://www.figma.com/design/0Fi3AaDlr3LAXBfsOXBGyk/User-Account?node-id=6754-9623&t=DbRYLaxphOdTpK4N-4)

<img width="758" alt="Screenshot 2024-09-03 at 17 30 27" src="https://github.com/user-attachments/assets/e609d6fe-c6a9-4cdb-852d-6ad456405897">

<img width="549" alt="Screenshot 2024-09-03 at 17 30 19" src="https://github.com/user-attachments/assets/348e9582-2f5e-4875-ae9a-bb7d6d7a084b">


## Testing

Simply load up a colony and open the UserHub. The notifications tab should be visible and show the empty state. Test on all screen widths.

The tab should also not be visible when the notifications service is disabled by the user. This has not yet been implemented, but to test it change this line in `src/components/common/Extensions/UserHub/UserHub.tsx`

```
const notificationsServiceIsEnabled = true; // change to false
```

## Diffs

**New stuff** ✨

* Added notifications tab to userhub

**Changes** 🏗

* Re-ordered tabs to match figma

Resolves #3006 
