### PR TITLE
[Notifications] Feat: Show unread notifications alert

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,6 @@ POSTHOG_HOST=
 # Needed for crypto-to-fiat
 USDC_LOCAL_ADDRESS=
 PERSONA_ENVIRONMENT_ID=
+
+# Needed for magicbell notifications
+MAGICBELL_API_KEY=

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@colony/redux-promise-listener": "^1.2.0",
         "@colony/unicode-confusables-noascii": "^0.1.2",
         "@hookform/resolvers": "^2.9.10",
+        "@magicbell/react-headless": "^5.0.1",
         "@phosphor-icons/react": "^2.1.5",
         "@popperjs/core": "^2.3.3",
         "@tanstack/react-table": "^8.10.0",
@@ -7092,6 +7093,42 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@magicbell/react-headless": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@magicbell/react-headless/-/react-headless-5.0.1.tgz",
+      "integrity": "sha512-di+M37PZsNjuQ03omx4LiZmZG3fCoxTjY9I8QY/6+E2jy1TMV7r8rXaaS+enPjpGBGIU7GDMecynXz8dfO7PAg==",
+      "dependencies": {
+        "dayjs": "^1.11.10",
+        "humps": "^2.0.1",
+        "immer": "^9.0.21",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "magicbell": "4.0.0",
+        "mitt": "^3.0.1",
+        "ramda": "^0.28.0",
+        "tiny-invariant": "^1.3.1",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.6.2",
+        "zustand": "^4.5.2"
+      },
+      "peerDependencies": {
+        "react": ">= 18.3.1"
+      }
+    },
+    "node_modules/@magicbell/react-headless/node_modules/ramda": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
+      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
+    },
+    "node_modules/@magicbell/react-headless/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/@mdx-js/react": {
       "version": "3.0.1",
@@ -20647,9 +20684,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.5",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debounce": {
       "version": "1.2.1",
@@ -20662,7 +20699,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -24818,6 +24854,17 @@
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fetch-addons": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-addons/-/fetch-addons-1.2.0.tgz",
+      "integrity": "sha512-e1xtLHBS8eXTkTkkBsZZbjppd+3bzRKJ7+a9AE2vLH8eDU5FjHa8JCrUhd4JL9cgRlo3qmBs6JYq2J3UBabMDw==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/smeijer/fetch-addons?sponsor=1"
       }
     },
     "node_modules/fetch-retry": {
@@ -38397,6 +38444,11 @@
         "node": ">=8.12.0"
       }
     },
+    "node_modules/humps": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
+      "integrity": "sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g=="
+    },
     "node_modules/husky": {
       "version": "4.3.8",
       "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
@@ -38545,6 +38597,15 @@
       "integrity": "sha512-RrGCXRm/fRVqMIhqXrGEX9rRADavPiDFSoMb/k64i9XMk8uH4r/Omi5Ctierj6XzNecwDbO4WuFbDD1zmpl3Tg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/immer": {
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
     },
     "node_modules/immutable": {
       "version": "4.1.0",
@@ -44803,6 +44864,18 @@
       "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.0.tgz",
+      "integrity": "sha512-UeVN/ery4/JeXI8h4rM8yZPxsH+KqPi/84qFxHfTGHZnWnK9D0UU9ZGYO+6XAaJLqCWMiks+ARuFOKAiSxJCHA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -45159,6 +45232,15 @@
       "integrity": "sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ky": {
+      "name": "@smeijer/ky",
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/@smeijer/ky/-/ky-0.33.3.tgz",
+      "integrity": "sha512-qK1UT8hXAsFVc6wbE5RqEF4kvngiehoEGEEKJAle3C1/3X9lZytsgcxTSbglU8uWql4QpWUrRVAZKJvAQ5aRGw==",
+      "funding": {
+        "url": "https://github.com/smeijer/ky?sponsor=1"
+      }
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",
@@ -47096,6 +47178,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/magicbell": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/magicbell/-/magicbell-4.0.0.tgz",
+      "integrity": "sha512-EuOK95rsJQ8t7EvkhRWHZjAZ/ag4JinU6QqytaczRn6nCKaR2lnpHCWbRda2tQghgRucxBqQJ+LVhscGCCGUEg==",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "fetch-addons": "^1.2.0",
+        "json-schema-to-ts": "3.1.0",
+        "ky": "npm:@smeijer/ky@^0.33.3",
+        "url-join": "^4.0.1"
+      }
+    },
     "node_modules/make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -47852,6 +47946,11 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
+    },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -47930,7 +48029,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/multiaddr": {
@@ -51975,8 +52073,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "license": "MIT",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -56856,7 +56955,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tiny-secp256k1": {
@@ -56883,6 +56981,11 @@
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tinyspy": {
       "version": "2.2.1",
@@ -57131,6 +57234,11 @@
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
     },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
@@ -58317,6 +58425,11 @@
         "querystring": "0.2.0"
       }
     },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+    },
     "node_modules/url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -58383,8 +58496,9 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "license": "MIT",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
@@ -59677,6 +59791,33 @@
       "license": "MIT",
       "dependencies": {
         "zen-observable": "0.8.15"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.5.tgz",
+      "integrity": "sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "@colony/redux-promise-listener": "^1.2.0",
     "@colony/unicode-confusables-noascii": "^0.1.2",
     "@hookform/resolvers": "^2.9.10",
+    "@magicbell/react-headless": "^5.0.1",
     "@phosphor-icons/react": "^2.1.5",
     "@popperjs/core": "^2.3.3",
     "@tanstack/react-table": "^8.10.0",

--- a/src/components/common/Extensions/UserHub/UserHub.tsx
+++ b/src/components/common/Extensions/UserHub/UserHub.tsx
@@ -9,6 +9,7 @@ import Select from '~v5/common/Fields/Select/index.ts';
 import TitleLabel from '~v5/shared/TitleLabel/index.ts';
 
 import { tabList } from './consts.ts';
+import CountBadge from './partials/CountBadge.tsx';
 import CryptoToFiatTab from './partials/CryptoToFiatTab/CryptoToFiatTab.tsx';
 import NotificationsTab from './partials/NotificationsTab/NotificationsTab.tsx';
 import ReputationTab from './partials/ReputationTab/index.ts';
@@ -45,6 +46,8 @@ const UserHub: FC<Props> = ({ initialOpenTab = UserHubTab.Balance }) => {
 
   // @TODO: get from notifications context
   const notificationsServiceIsEnabled = true;
+  // @TODO: Get from context
+  const unreadCount = 1;
 
   const filteredTabList = tabList.filter((tabItem) => {
     const isFeatureFlagEnabled =
@@ -120,7 +123,10 @@ const UserHub: FC<Props> = ({ initialOpenTab = UserHubTab.Balance }) => {
                           'font-medium': selectedTab === id,
                         })}
                       >
-                        <span className="mr-2 flex shrink-0">
+                        <span className="relative mr-2 flex shrink-0">
+                          {id === UserHubTab.Notifications && (
+                            <CountBadge count={unreadCount} />
+                          )}
                           <Icon size={14} />
                         </span>
                         {formatText(label)}

--- a/src/components/common/Extensions/UserHub/UserHub.tsx
+++ b/src/components/common/Extensions/UserHub/UserHub.tsx
@@ -1,3 +1,4 @@
+import { useBell } from '@magicbell/react-headless';
 import clsx from 'clsx';
 import React, { type FC, useState, useContext } from 'react';
 import { defineMessages } from 'react-intl';
@@ -46,8 +47,8 @@ const UserHub: FC<Props> = ({ initialOpenTab = UserHubTab.Balance }) => {
 
   // @TODO: get from notifications context
   const notificationsServiceIsEnabled = true;
-  // @TODO: Get from context
-  const unreadCount = 1;
+
+  const { unreadCount } = useBell() || {};
 
   const filteredTabList = tabList.filter((tabItem) => {
     const isFeatureFlagEnabled =

--- a/src/components/common/Extensions/UserHub/UserHub.tsx
+++ b/src/components/common/Extensions/UserHub/UserHub.tsx
@@ -126,7 +126,7 @@ const UserHub: FC<Props> = ({ initialOpenTab = UserHubTab.Balance }) => {
                       >
                         <span className="relative mr-2 flex shrink-0">
                           {id === UserHubTab.Notifications && (
-                            <CountBadge count={unreadCount} />
+                            <CountBadge count={unreadCount} maximum={99} />
                           )}
                           <Icon size={14} />
                         </span>

--- a/src/components/common/Extensions/UserHub/partials/CountBadge.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CountBadge.tsx
@@ -2,18 +2,26 @@ import React, { type FC } from 'react';
 
 interface Props {
   count?: number;
+  maximum?: number;
 }
 
 const displayName = 'common.Extensions.UserHub.partials.CountBadge';
 
-const CountBadge: FC<Props> = ({ count }) => {
+const CountBadge: FC<Props> = ({ count, maximum }) => {
   if (!count || count < 1) {
     return null;
   }
+
+  let cappedCount: string | number = count;
+
+  if (maximum && count > maximum) {
+    cappedCount = `${maximum}+`;
+  }
+
   return (
     <div className="absolute -right-1.5 -top-1 flex min-h-[11px] min-w-[11px] items-center justify-center rounded-full border border-base-white bg-blue-400">
       <p className="mx-[3px] my-[2.5px] h-1.5 min-w-[5px] text-[8px] font-medium leading-[0.8] text-base-white">
-        {count}
+        {cappedCount}
       </p>
     </div>
   );

--- a/src/components/common/Extensions/UserHub/partials/CountBadge.tsx
+++ b/src/components/common/Extensions/UserHub/partials/CountBadge.tsx
@@ -1,0 +1,24 @@
+import React, { type FC } from 'react';
+
+interface Props {
+  count?: number;
+}
+
+const displayName = 'common.Extensions.UserHub.partials.CountBadge';
+
+const CountBadge: FC<Props> = ({ count }) => {
+  if (!count || count < 1) {
+    return null;
+  }
+  return (
+    <div className="absolute -right-1.5 -top-1 flex min-h-[11px] min-w-[11px] items-center justify-center rounded-full border border-base-white bg-blue-400">
+      <p className="mx-[3px] my-[2.5px] h-1.5 min-w-[5px] text-[8px] font-medium leading-[0.8] text-base-white">
+        {count}
+      </p>
+    </div>
+  );
+};
+
+CountBadge.displayName = displayName;
+
+export default CountBadge;

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
@@ -1,3 +1,4 @@
+import { useBell } from '@magicbell/react-headless';
 import { Binoculars } from '@phosphor-icons/react';
 import React from 'react';
 import { defineMessages } from 'react-intl';
@@ -20,14 +21,27 @@ const MSG = defineMessages({
     id: `${displayName}.emptyDescription`,
     defaultMessage: 'Your notifications will appear here.',
   },
+  new: {
+    id: `${displayName}.new`,
+    defaultMessage: 'new',
+  },
 });
 
 const NotificationsTab = () => {
   const isEmpty = true;
 
+  const { unreadCount } = useBell() || {};
+
   return (
     <div className="h-full px-6 pb-6 pt-6 sm:pb-2">
-      <p className="heading-5">{formatText(MSG.notifications)}</p>
+      <div className="flex items-center">
+        <p className="heading-5">{formatText(MSG.notifications)}</p>
+        {!!unreadCount && unreadCount > 0 && (
+          <p className="ml-2 h-fit rounded-sm bg-blue-100 px-[3px] py-[2.5px] text-[8px] font-bold text-blue-400">
+            {unreadCount} {formatText(MSG.new)}
+          </p>
+        )}
+      </div>
       <div className="flex h-full flex-col justify-center pt-4 sm:h-auto sm:justify-normal">
         {isEmpty && (
           <>

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
@@ -32,13 +32,20 @@ const NotificationsTab = () => {
 
   const { unreadCount } = useBell() || {};
 
+  let cappedCount: string | number = unreadCount ?? 0;
+  const maximum = 99;
+
+  if (!!unreadCount && unreadCount > maximum) {
+    cappedCount = `${maximum}+`;
+  }
+
   return (
     <div className="h-full px-6 pb-6 pt-6 sm:pb-2">
       <div className="flex items-center">
         <p className="heading-5">{formatText(MSG.notifications)}</p>
         {!!unreadCount && unreadCount > 0 && (
           <p className="ml-2 h-fit rounded-sm bg-blue-100 px-[3px] py-[2.5px] text-[8px] font-bold text-blue-400">
-            {unreadCount} {formatText(MSG.new)}
+            {cappedCount} {formatText(MSG.new)}
           </p>
         )}
       </div>

--- a/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
+++ b/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
@@ -158,6 +158,9 @@ const UserHubButton: FC<Props> = ({ openTab, onOpen }) => {
     user?.profile?.displayName ??
     splitWalletAddress(walletAddress ?? ADDRESS_ZERO);
 
+  // @TODO: Get from context
+  const unreadCount = 1;
+
   return (
     <div className="flex-shrink-0">
       <Button
@@ -172,6 +175,7 @@ const UserHubButton: FC<Props> = ({ openTab, onOpen }) => {
           'min-w-[3rem] md:hover:!border-blue-400',
         )}
         onClick={handleButtonClick}
+        showNotificationDot={unreadCount > 0}
       >
         <div className="flex flex-shrink-0 items-center">
           {/* If there's a user, there's a wallet */}

--- a/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
+++ b/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
@@ -161,6 +161,8 @@ const UserHubButton: FC<Props> = ({ openTab, onOpen }) => {
     user?.profile?.displayName ??
     splitWalletAddress(walletAddress ?? ADDRESS_ZERO);
 
+  const showNotificationDot = !!unreadCount && unreadCount > 0;
+
   return (
     <div className="flex-shrink-0">
       <Button
@@ -175,7 +177,6 @@ const UserHubButton: FC<Props> = ({ openTab, onOpen }) => {
           'min-w-[3rem] md:hover:!border-blue-400',
         )}
         onClick={handleButtonClick}
-        showNotificationDot={!!unreadCount && unreadCount > 0}
       >
         <div className="flex flex-shrink-0 items-center">
           {/* If there's a user, there's a wallet */}
@@ -205,6 +206,9 @@ const UserHubButton: FC<Props> = ({ openTab, onOpen }) => {
             </>
           ) : null}
         </div>
+        {showNotificationDot && (
+          <div className="absolute right-[-1.26px] top-[2.28px] h-2.5 w-2.5 rounded-full border border-base-white bg-blue-400" />
+        )}
       </Button>
       {visible && (
         <PopoverBase

--- a/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
+++ b/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
@@ -1,3 +1,4 @@
+import { useBell } from '@magicbell/react-headless';
 import clsx from 'clsx';
 import React, { type FC, useState, useEffect, useCallback } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
@@ -49,6 +50,8 @@ const UserHubButton: FC<Props> = ({ openTab, onOpen }) => {
   const [searchParams] = useSearchParams();
   const transactionId = searchParams?.get(TX_SEARCH_PARAM);
   const previousTransactionId = usePrevious(transactionId);
+
+  const { unreadCount } = useBell() || {};
 
   const { trackEvent } = useAnalyticsContext();
   const walletAddress = wallet?.address;
@@ -158,9 +161,6 @@ const UserHubButton: FC<Props> = ({ openTab, onOpen }) => {
     user?.profile?.displayName ??
     splitWalletAddress(walletAddress ?? ADDRESS_ZERO);
 
-  // @TODO: Get from context
-  const unreadCount = 1;
-
   return (
     <div className="flex-shrink-0">
       <Button
@@ -175,7 +175,7 @@ const UserHubButton: FC<Props> = ({ openTab, onOpen }) => {
           'min-w-[3rem] md:hover:!border-blue-400',
         )}
         onClick={handleButtonClick}
-        showNotificationDot={unreadCount > 0}
+        showNotificationDot={!!unreadCount && unreadCount > 0}
       >
         <div className="flex flex-shrink-0 items-center">
           {/* If there's a user, there's a wallet */}

--- a/src/components/v5/shared/Button/Button.tsx
+++ b/src/components/v5/shared/Button/Button.tsx
@@ -30,7 +30,6 @@ const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProps>>(
       icon,
       iconSize = 18,
       isIconRight,
-      showNotificationDot = false,
       ...rest
     },
     ref,
@@ -113,9 +112,6 @@ const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProps>>(
             >
               {children}
             </ButtonContent>
-            {showNotificationDot && (
-              <div className="absolute right-[-1.26px] top-[2.28px] h-2.5 w-2.5 rounded-full border border-base-white bg-blue-400" />
-            )}
           </button>
         )}
       </>

--- a/src/components/v5/shared/Button/Button.tsx
+++ b/src/components/v5/shared/Button/Button.tsx
@@ -30,6 +30,7 @@ const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProps>>(
       icon,
       iconSize = 18,
       isIconRight,
+      showNotificationDot = false,
       ...rest
     },
     ref,
@@ -49,7 +50,7 @@ const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProps>>(
         ) : (
           <button
             className={clsx(
-              'flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-all duration-normal',
+              'relative flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-all duration-normal',
               `${isFullRounded ? 'rounded-full' : 'rounded-lg'}`,
               {
                 'min-h-[2.5rem] px-4 py-2 text-md': size === 'default',
@@ -112,6 +113,9 @@ const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProps>>(
             >
               {children}
             </ButtonContent>
+            {showNotificationDot && (
+              <div className="absolute right-[-1.26px] top-[2.28px] h-2.5 w-2.5 rounded-full border border-base-white bg-blue-400" />
+            )}
           </button>
         )}
       </>

--- a/src/components/v5/shared/Button/types.ts
+++ b/src/components/v5/shared/Button/types.ts
@@ -63,6 +63,7 @@ export interface ButtonAppearanceCommonProps extends ButtonContentProps {
   isFullSize?: boolean;
   isFullRounded?: boolean;
   className?: string;
+  showNotificationDot?: boolean;
 }
 
 export type ButtonProps = Omit<CommonButtonProps, 'setTriggerRef'> &

--- a/src/components/v5/shared/Button/types.ts
+++ b/src/components/v5/shared/Button/types.ts
@@ -63,7 +63,6 @@ export interface ButtonAppearanceCommonProps extends ButtonContentProps {
   isFullSize?: boolean;
   isFullRounded?: boolean;
   className?: string;
-  showNotificationDot?: boolean;
 }
 
 export type ButtonProps = Omit<CommonButtonProps, 'setTriggerRef'> &

--- a/src/context/NotificationsContext/NotificationsContextProvider.tsx
+++ b/src/context/NotificationsContext/NotificationsContextProvider.tsx
@@ -1,3 +1,4 @@
+import { MagicBellProvider } from '@magicbell/react-headless';
 import React, { type ReactNode, useEffect, useMemo } from 'react';
 
 import { useCreateUserNotificationsDataMutation } from '~gql';
@@ -30,10 +31,27 @@ const NotificationsContextProvider = ({
 
   const value = useMemo(() => ({}), []);
 
+  if (!user) {
+    return <>{children}</>;
+  }
+
+  if (!user?.notificationsData?.magicbellUserId) {
+    return (
+      <NotificationsContext.Provider value={value}>
+        {children}
+      </NotificationsContext.Provider>
+    );
+  }
+
   return (
-    <NotificationsContext.Provider value={value}>
-      {children}
-    </NotificationsContext.Provider>
+    <MagicBellProvider
+      apiKey={import.meta.env.MAGICBELL_API_KEY}
+      userExternalId={user.walletAddress}
+    >
+      <NotificationsContext.Provider value={value}>
+        {children}
+      </NotificationsContext.Provider>
+    </MagicBellProvider>
   );
 };
 


### PR DESCRIPTION
## Description

Note: It probably makes sense to test #3066 straight after this one as it is such a tiny additional change.

This PR adds unread notifications alerts to the UserHub button and UserHub notifications tab. It also adds the MagicBell provider to get easy access to the unread notifications count.

## Testing

Add `MAGICBELL_API_KEY="<API_KEY>"` to your `.env.local.secrets` file.

Add `MAGICBELL_API_KEY="<API_KEY>"` and `MAGICBELL_API_SECRET="<API_SECRET>"` to `amplify/backend/function/createUserNotificationsData/.env` if you don't already have it.

Log with a dev wallet where the user has unread notifications (at the time of writing this is true for Leela - dev wallet 1)
Check the unread notification alert appears on the UserHub when closed, then on the notifications tab. (If there are no notifications, you can create a notification via the UI [https://app.magicbell.com/projects/8931/compose](https://app.magicbell.com/projects/8931/compose) - set the user's wallet address as the recipient).

<img width="756" alt="Screenshot 2024-09-09 at 11 22 28" src="https://github.com/user-attachments/assets/ac166695-bdd8-4d80-8273-1898fe516495">

<img width="402" alt="Screenshot 2024-09-09 at 11 22 37" src="https://github.com/user-attachments/assets/f9e6f445-65c7-4789-a147-93a1b8568f67">


## Diffs

**New stuff** ✨

* MagicBell provider added

**Changes** 🏗

* UserHub now shows unread notifications alert

Resolves #3008
