### PR TITLE
[Dashboard] Feat: Update recent activity table

### DIFF
--- a/src/components/common/ColonyActionsTable/RecentActivityTable.tsx
+++ b/src/components/common/ColonyActionsTable/RecentActivityTable.tsx
@@ -1,0 +1,46 @@
+import React, { type FC } from 'react';
+
+import useActionsCount from '~hooks/useActionsCount.ts';
+import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
+import { type ColonyAction } from '~types/graphql.ts';
+import Table from '~v5/common/Table/index.ts';
+
+import { useActionsTableProps } from './hooks/useActionsTableProps.tsx';
+import { type ColonyActionsTableProps } from './types.ts';
+
+const displayName = 'common.RecentActivityTable';
+
+const RecentActivityTable: FC<ColonyActionsTableProps> = ({ ...props }) => {
+  const selectedDomain = useGetSelectedDomainFilter();
+  const nativeDomainId = selectedDomain?.nativeId;
+
+  const { actionsCount: totalActions, loading: loadingActionsCount } =
+    useActionsCount({
+      domainId: nativeDomainId,
+    });
+
+  const pageCount = Math.ceil(totalActions / (props.pageSize ?? 10));
+
+  const { tableProps, renderSubComponent } = useActionsTableProps({
+    ...props,
+    showUserAvatar: false,
+    hasHorizontalPadding: false,
+    showTotalPagesNumber: !loadingActionsCount,
+    isRecentActivityVariant: true,
+  });
+
+  return (
+    <Table<ColonyAction>
+      {...tableProps}
+      showTableHead={false}
+      showBorder={false}
+      hasHorizontalPadding={false}
+      renderSubComponent={renderSubComponent}
+      pageCount={pageCount}
+    />
+  );
+};
+
+RecentActivityTable.displayName = displayName;
+
+export default RecentActivityTable;

--- a/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
@@ -42,6 +42,10 @@ export const useActionsTableProps = (
     className,
     pageSize = 10,
     additionalPaginationButtonsContent,
+    showTotalPagesNumber,
+    showUserAvatar,
+    hasHorizontalPadding,
+    isRecentActivityVariant,
     ...rest
   } = props;
 
@@ -60,11 +64,14 @@ export const useActionsTableProps = (
     refetchMotionStates,
     pageNumber,
   } = useActionsTableData(pageSize);
-  const columns = useColonyActionsTableColumns(
+
+  const columns = useColonyActionsTableColumns({
     loading,
     loadingMotionStates,
     refetchMotionStates,
-  );
+    showUserAvatar,
+    hasHorizontalPadding,
+  });
   const {
     actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
   } = useActionSidebarContext();
@@ -123,7 +130,7 @@ export const useActionsTableProps = (
     ],
   });
   const isMobile = useMobile();
-  const renderRowLink = useRenderRowLink(loading);
+  const renderRowLink = useRenderRowLink(loading, isRecentActivityVariant);
   const renderSubComponent = useRenderSubComponent({
     loadingMotionStates,
     loading,
@@ -134,8 +141,12 @@ export const useActionsTableProps = (
     {
       className: clsx(
         className,
-        'sm:[&_td:first-child]:pl-[1.125rem] sm:[&_td]:h-[70px] sm:[&_td]:pr-[1.125rem] sm:[&_th:first-child]:pl-[1.125rem] sm:[&_th:not(:first-child)]:pl-0 sm:[&_th]:pr-[1.125rem]',
+        'sm:[&_td]:h-[70px] sm:[&_td]:pr-[1.125rem] sm:[&_th:not(:first-child)]:pl-0 sm:[&_th]:pr-[1.125rem]',
         {
+          'sm:[&_td:first-child]:pl-[1.125rem] sm:[&_th:first-child]:pl-[1.125rem]':
+            hasHorizontalPadding,
+          'sm:[&_td:first-child]:pl-0 [&_td:first-child_div]:pl-0 sm:[&_td:last-child]:pr-0 [&_td:last-child_div]:pr-0 sm:[&_th:first-child]:pl-0 sm:[&_th:last-child]:pr-0 [&_th:last-child_div]:pr-0':
+            !hasHorizontalPadding,
           'sm:[&_tr:hover]:bg-gray-25': data.length > 0 && !loading,
         },
       ),
@@ -164,14 +175,14 @@ export const useActionsTableProps = (
         : additionalPaginationButtonsContent,
       onSortingChange: setSorting,
       getRowId: (row) => row.transactionHash,
-      meatBallMenuStaticSize: '3rem',
+      meatBallMenuStaticSize: isRecentActivityVariant ? '2rem' : '3rem',
       getMenuProps,
       columns,
       data,
       manualPagination: true,
       canNextPage: hasNextPage || loading,
       canPreviousPage: hasPrevPage,
-      showTotalPagesNumber: false,
+      showTotalPagesNumber,
       nextPage: goToNextPage,
       previousPage: goToPreviousPage,
       paginationDisabled: loading,

--- a/src/components/common/ColonyActionsTable/hooks/useColonyActionsTableColumns.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useColonyActionsTableColumns.tsx
@@ -6,7 +6,6 @@ import { defineMessages } from 'react-intl';
 
 import { useMobile } from '~hooks';
 import { type ActivityFeedColonyAction } from '~hooks/useActivityFeed/types.ts';
-import { type RefetchMotionStates } from '~hooks/useNetworkMotionStates.ts';
 import { getFormattedDateFrom } from '~utils/getFormattedDateFrom.ts';
 import { formatText } from '~utils/intl.ts';
 import TeamBadge from '~v5/common/Pills/TeamBadge/index.ts';
@@ -23,11 +22,13 @@ const MSG = defineMessages({
   },
 });
 
-const useColonyActionsTableColumns = (
-  loading: boolean,
-  loadingMotionStates: boolean,
-  refetchMotionStates: RefetchMotionStates,
-) => {
+const useColonyActionsTableColumns = ({
+  loading,
+  loadingMotionStates,
+  refetchMotionStates,
+  showUserAvatar = true,
+  hasHorizontalPadding = true,
+}) => {
   const isMobile = useMobile();
 
   return useMemo(() => {
@@ -45,6 +46,7 @@ const useColonyActionsTableColumns = (
             loading={loading}
             refetchMotionStates={refetchMotionStates}
             hideDetails={getIsExpanded()}
+            showUserAvatar={showUserAvatar}
           />
         ),
         colSpan: (isExpanded) => (isExpanded ? 2 : undefined),
@@ -100,7 +102,12 @@ const useColonyActionsTableColumns = (
         },
       }),
       helper.accessor('motionState', {
-        staticSize: isMobile ? '7.4375rem' : '6.25rem',
+        staticSize: (() => {
+          if (isMobile) {
+            return hasHorizontalPadding ? '7.4375rem' : '7rem';
+          }
+          return '6.25rem';
+        })(),
         header: formatText({
           id: 'activityFeedTable.table.header.status',
         }),
@@ -124,7 +131,7 @@ const useColonyActionsTableColumns = (
       }),
       helper.display({
         id: 'expander',
-        staticSize: '2.25rem',
+        staticSize: hasHorizontalPadding ? '2.25rem' : '1rem',
         header: () => null,
         enableSorting: false,
         cell: ({ row: { getIsExpanded, toggleExpanded } }) => {
@@ -142,7 +149,14 @@ const useColonyActionsTableColumns = (
         cellContentWrapperClassName: 'pl-0',
       }),
     ];
-  }, [isMobile, loading, loadingMotionStates, refetchMotionStates]);
+  }, [
+    isMobile,
+    loading,
+    loadingMotionStates,
+    refetchMotionStates,
+    hasHorizontalPadding,
+    showUserAvatar,
+  ]);
 };
 
 export default useColonyActionsTableColumns;

--- a/src/components/common/ColonyActionsTable/hooks/useRenderRowLink.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useRenderRowLink.tsx
@@ -11,6 +11,7 @@ import Link from '~v5/shared/Link/index.ts';
 
 const useRenderRowLink = (
   loading: boolean,
+  isRecentActivityVariant: boolean = false,
 ): RenderCellWrapper<ActivityFeedColonyAction> => {
   const cellClassName = tw(
     'flex h-full flex-col justify-center py-1 text-md text-gray-500',
@@ -27,7 +28,10 @@ const useRenderRowLink = (
       </div>
     ) : (
       <Link
-        className={clsx(cellClassName, 'items-start')}
+        className={clsx(cellClassName, {
+          'items-end': isRecentActivityVariant,
+          'items-start': !isRecentActivityVariant,
+        })}
         to={setQueryParamOnUrl(
           window.location.search,
           TX_SEARCH_PARAM,

--- a/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
@@ -20,6 +20,7 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
   loading,
   refetchMotionStates,
   hideDetails,
+  showUserAvatar = true,
 }) => {
   const isMobile = useMobile();
   const {
@@ -78,18 +79,22 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
 
   return (
     <div className="flex w-full items-center gap-2 sm:gap-4">
-      {loading ? (
-        <div className="aspect-square h-[26px] w-auto rounded-full skeleton before:rounded-full" />
-      ) : (
-        <UserAvatar
-          size={26}
-          userAddress={walletAddress}
-          userName={user?.profile?.displayName ?? undefined}
-          userAvatarSrc={
-            user?.profile?.thumbnail ?? user?.profile?.avatar ?? undefined
-          }
-          className="flex-shrink-0 flex-grow-0"
-        />
+      {showUserAvatar && (
+        <>
+          {loading ? (
+            <div className="aspect-square h-[26px] w-auto rounded-full skeleton before:rounded-full" />
+          ) : (
+            <UserAvatar
+              size={26}
+              userAddress={walletAddress}
+              userName={user?.profile?.displayName ?? undefined}
+              userAvatarSrc={
+                user?.profile?.thumbnail ?? user?.profile?.avatar ?? undefined
+              }
+              className="flex-shrink-0 flex-grow-0"
+            />
+          )}
+        </>
       )}
       <div className="flex flex-grow flex-col-reverse gap-0.5 md:flex-row md:items-center md:justify-between md:gap-4">
         <div>

--- a/src/components/common/ColonyActionsTable/partials/ActionDescription/types.ts
+++ b/src/components/common/ColonyActionsTable/partials/ActionDescription/types.ts
@@ -6,4 +6,5 @@ export interface ActionDescriptionProps {
   refetchMotionStates: RefetchMotionStates;
   loading: boolean;
   hideDetails?: boolean;
+  showUserAvatar?: boolean;
 }

--- a/src/components/common/ColonyActionsTable/types.ts
+++ b/src/components/common/ColonyActionsTable/types.ts
@@ -5,4 +5,7 @@ export interface ColonyActionsTableProps
   extends Partial<TableProps<ActivityFeedColonyAction>> {
   pageSize?: number;
   withHeader?: boolean;
+  showUserAvatar?: boolean;
+  hasHorizontalPadding?: boolean;
+  isRecentActivityVariant?: boolean;
 }

--- a/src/components/frame/v5/pages/ActivityPage/ActivityPage.tsx
+++ b/src/components/frame/v5/pages/ActivityPage/ActivityPage.tsx
@@ -27,7 +27,11 @@ const ActivityPage: FC = () => {
       <WidgetBoxList items={widgets} />
       <div>
         <FiltersContextProvider>
-          <ColonyActionsTable className="[&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none" />
+          <ColonyActionsTable
+            className="[&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none"
+            showTotalPagesNumber={false}
+            hasHorizontalPadding
+          />
         </FiltersContextProvider>
       </div>
     </div>

--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -47,6 +47,9 @@ const Table = <T,>({
   virtualizedProps,
   tableClassName,
   tableBodyRowKeyProp,
+  showTableHead = true,
+  showBorder = true,
+  hasHorizontalPadding = true,
   ...rest
 }: TableProps<T>) => {
   const helper = useMemo(() => createColumnHelper<T>(), []);
@@ -109,16 +112,11 @@ const Table = <T,>({
     <div className={className}>
       <table
         className={clsx(
-          `
-          h-px
-          w-full
-          table-fixed
-          border-separate
-          border-spacing-0
-          rounded-lg
-          border
-          border-gray-200
-        `,
+          'h-px w-full table-fixed',
+          {
+            'border-separate border-spacing-0 rounded-lg border border-gray-200':
+              showBorder,
+          },
           tableClassName,
         )}
         cellPadding="0"
@@ -229,64 +227,66 @@ const Table = <T,>({
           })
         ) : (
           <>
-            <thead>
-              {headerGroups.map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => (
-                    <th
-                      key={header.id}
-                      className={clsx(
-                        header.column.columnDef.headCellClassName,
-                        'border-b border-b-gray-200 bg-gray-50 px-[1.125rem] py-2.5 text-left text-sm font-normal text-gray-600 first:rounded-tl-lg last:rounded-tr-lg empty:p-0',
-                        {
-                          'cursor-pointer':
-                            header.column.getCanSort() &&
-                            !shouldShowEmptyContent,
-                        },
-                      )}
-                      onClick={
-                        shouldShowEmptyContent
-                          ? undefined
-                          : header.column.getToggleSortingHandler()
-                      }
-                      style={{
-                        width:
-                          header.column.columnDef.staticSize ||
-                          (header.getSize() !== 150
-                            ? `${header.column.getSize()}${sizeUnit}`
-                            : undefined),
-                      }}
-                    >
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
-                      {header.column.getCanSort() ? (
-                        <ArrowDown
-                          size={12}
-                          className={clsx(
-                            'mb-0.5 ml-1 inline-block align-middle transition-[transform,opacity]',
-                            {
-                              'rotate-180':
-                                header.column.getIsSorted() === 'asc' &&
-                                !shouldShowEmptyContent,
-                              'rotate-0':
-                                header.column.getIsSorted() === 'desc' &&
-                                !shouldShowEmptyContent,
-                              hidden:
-                                header.column.getIsSorted() === false ||
-                                shouldShowEmptyContent,
-                            },
-                          )}
-                        />
-                      ) : null}
-                    </th>
-                  ))}
-                </tr>
-              ))}
-            </thead>
+            {showTableHead && (
+              <thead>
+                {headerGroups.map((headerGroup) => (
+                  <tr key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => (
+                      <th
+                        key={header.id}
+                        className={clsx(
+                          header.column.columnDef.headCellClassName,
+                          'border-b border-b-gray-200 bg-gray-50 px-[1.125rem] py-2.5 text-left text-sm font-normal text-gray-600 first:rounded-tl-lg last:rounded-tr-lg empty:p-0',
+                          {
+                            'cursor-pointer':
+                              header.column.getCanSort() &&
+                              !shouldShowEmptyContent,
+                          },
+                        )}
+                        onClick={
+                          shouldShowEmptyContent
+                            ? undefined
+                            : header.column.getToggleSortingHandler()
+                        }
+                        style={{
+                          width:
+                            header.column.columnDef.staticSize ||
+                            (header.getSize() !== 150
+                              ? `${header.column.getSize()}${sizeUnit}`
+                              : undefined),
+                        }}
+                      >
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )}
+                        {header.column.getCanSort() ? (
+                          <ArrowDown
+                            size={12}
+                            className={clsx(
+                              'mb-0.5 ml-1 inline-block align-middle transition-[transform,opacity]',
+                              {
+                                'rotate-180':
+                                  header.column.getIsSorted() === 'asc' &&
+                                  !shouldShowEmptyContent,
+                                'rotate-0':
+                                  header.column.getIsSorted() === 'desc' &&
+                                  !shouldShowEmptyContent,
+                                hidden:
+                                  header.column.getIsSorted() === false ||
+                                  shouldShowEmptyContent,
+                              },
+                            )}
+                          />
+                        ) : null}
+                      </th>
+                    ))}
+                  </tr>
+                ))}
+              </thead>
+            )}
             <tbody className="w-full">
               {shouldShowEmptyContent ? (
                 <tr className="[&:not(:last-child)>td]:border-b [&:not(:last-child)>td]:border-gray-100">
@@ -324,7 +324,7 @@ const Table = <T,>({
                           'expanded-below': showExpandableContent,
                         })}
                       >
-                        {row.getVisibleCells().map((cell) => {
+                        {row.getVisibleCells().map((cell, index) => {
                           const renderCellWrapperCommonArgs = [
                             clsx(
                               'flex h-full flex-col items-start justify-center p-[1.1rem] text-md',
@@ -356,6 +356,21 @@ const Table = <T,>({
                                 hidden: hideCell,
                               })}
                               colSpan={colSpan}
+                              style={
+                                // If !showTableHead then apply the column sizing from the first headerGroup
+                                !showTableHead
+                                  ? {
+                                      width:
+                                        headerGroups[0].headers[index].column
+                                          .columnDef.staticSize ||
+                                        (headerGroups[0].headers[
+                                          index
+                                        ].getSize() !== 150
+                                          ? `${headerGroups[0].headers[index].column.getSize()}${sizeUnit}`
+                                          : undefined),
+                                    }
+                                  : undefined
+                              }
                             >
                               {renderCellWrapper(
                                 ...renderCellWrapperCommonArgs,
@@ -432,6 +447,7 @@ const Table = <T,>({
               },
             )}
             disabled={paginationDisabled}
+            hasHorizontalPadding={hasHorizontalPadding}
           >
             {additionalPaginationButtonsContent}
           </TablePagination>

--- a/src/components/v5/common/Table/partials/TablePagination/TablePagination.tsx
+++ b/src/components/v5/common/Table/partials/TablePagination/TablePagination.tsx
@@ -14,6 +14,7 @@ const TablePagination: FC<PropsWithChildren<TablePaginationProps>> = ({
   canGoToNextPage,
   canGoToPreviousPage,
   disabled,
+  hasHorizontalPadding = true,
   children,
 }) => {
   const isMobile = useMobile();
@@ -24,8 +25,9 @@ const TablePagination: FC<PropsWithChildren<TablePaginationProps>> = ({
   return (
     <div
       className={clsx(
-        'grid grid-cols-[1fr_auto_1fr] items-center gap-2 px-[1.125rem] pb-[1.4375rem] pt-2',
+        'grid grid-cols-[1fr_auto_1fr] items-center gap-2 pb-[1.4375rem] pt-2',
         {
+          'px-[1.125rem]': hasHorizontalPadding,
           'sm:grid-cols-[1fr_auto_auto]': canGoNextOrAdditionalContentOnMobile,
           'sm:grid-cols-[1fr_auto]': !canGoNextOrAdditionalContentOnMobile,
         },

--- a/src/components/v5/common/Table/partials/TablePagination/types.ts
+++ b/src/components/v5/common/Table/partials/TablePagination/types.ts
@@ -5,4 +5,5 @@ export interface TablePaginationProps {
   canGoToPreviousPage?: boolean;
   canGoToNextPage?: boolean;
   disabled?: boolean;
+  hasHorizontalPadding?: boolean;
 }

--- a/src/components/v5/common/Table/types.ts
+++ b/src/components/v5/common/Table/types.ts
@@ -43,4 +43,7 @@ export interface TableProps<T>
   };
   tableClassName?: string;
   tableBodyRowKeyProp?: Extract<keyof T, React.Key>;
+  showTableHead?: boolean;
+  showBorder?: boolean;
+  hasHorizontalPadding?: boolean;
 }

--- a/src/components/v5/frame/ColonyHome/ColonyHome.tsx
+++ b/src/components/v5/frame/ColonyHome/ColonyHome.tsx
@@ -40,46 +40,50 @@ const ColonyHome = () => {
         </div>
       </div>
       <FundsCards />
-      <div className="flex h-fit w-full flex-col gap-6 lg:grid lg:grid-cols-[39%_1fr]">
-        <div className="flex w-full flex-1 flex-col gap-6 sm:grid sm:grid-cols-2 sm:gap-[1.125rem] lg:flex lg:flex-col lg:gap-[1.125rem]">
+      <div className="flex h-fit w-full flex-col gap-6 lg:grid lg:grid-cols-3">
+        {/* @TODO: Replace this with the actual TotalInOutBalance component once #3044 is merged (or as part of a rebase, whichever comes first) */}
+        <div className="col-span-2">
+          TotalInOutBalance component placeholder
+        </div>
+        <div className="block sm:hidden lg:block">
           <ReputationChart />
         </div>
-        <div className="w-full">
-          <FiltersContextProvider>
-            <ColonyActionsTable
-              className="w-full [&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none [&_tr:last-child_td>*:not(.expandable)]:!py-[.9375rem] [&_tr:not(last-child)_td>*:not(.expandable)]:!pb-[.875rem] [&_tr:not(last-child)_td>*:not(.expandable)]:!pt-[.9375rem]"
-              pageSize={7}
-              withHeader={false}
-              state={{
-                columnVisibility: isMobile
-                  ? {
-                      description: true,
-                      motionState: true,
-                      team: false,
-                      createdAt: false,
-                    }
-                  : {
-                      description: true,
-                      motionState: true,
-                      team: false,
-                      createdAt: true,
-                    },
-              }}
-              additionalPaginationButtonsContent={
-                <Link
-                  className="text-sm text-gray-700 underline"
-                  to={setQueryParamOnUrl(
-                    COLONY_ACTIVITY_ROUTE,
-                    TEAM_SEARCH_PARAM,
-                    selectedDomain?.nativeId.toString(),
-                  )}
-                >
-                  {formatText({ id: 'view.all' })}
-                </Link>
-              }
-            />
-          </FiltersContextProvider>
-        </div>
+      </div>
+      <div className="w-full">
+        <FiltersContextProvider>
+          <ColonyActionsTable
+            className="w-full [&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none [&_tr:last-child_td>*:not(.expandable)]:!py-[.9375rem] [&_tr:not(last-child)_td>*:not(.expandable)]:!pb-[.875rem] [&_tr:not(last-child)_td>*:not(.expandable)]:!pt-[.9375rem]"
+            pageSize={7}
+            withHeader={false}
+            state={{
+              columnVisibility: isMobile
+                ? {
+                    description: true,
+                    motionState: true,
+                    team: false,
+                    createdAt: false,
+                  }
+                : {
+                    description: true,
+                    motionState: true,
+                    team: false,
+                    createdAt: true,
+                  },
+            }}
+            additionalPaginationButtonsContent={
+              <Link
+                className="text-sm text-gray-700 underline"
+                to={setQueryParamOnUrl(
+                  COLONY_ACTIVITY_ROUTE,
+                  TEAM_SEARCH_PARAM,
+                  selectedDomain?.nativeId.toString(),
+                )}
+              >
+                {formatText({ id: 'view.all' })}
+              </Link>
+            }
+          />
+        </FiltersContextProvider>
       </div>
       <LeaveColonyModal />
     </div>

--- a/src/components/v5/frame/ColonyHome/ColonyHome.tsx
+++ b/src/components/v5/frame/ColonyHome/ColonyHome.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import FiltersContextProvider from '~common/ColonyActionsTable/FiltersContext/FiltersContextProvider.tsx';
-import ColonyActionsTable from '~common/ColonyActionsTable/index.ts';
+import RecentActivityTable from '~common/ColonyActionsTable/RecentActivityTable.tsx';
 import { useSetPageBreadcrumbs } from '~context/PageHeadingContext/PageHeadingContext.ts';
 import { useMobile } from '~hooks/index.ts';
 import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
@@ -49,12 +49,26 @@ const ColonyHome = () => {
           <ReputationChart />
         </div>
       </div>
-      <div className="w-full">
+      <div className="rounded-lg border border-gray-200 px-5">
+        <div className="flex justify-between py-6">
+          <h3 className="heading-5">
+            {formatText({ id: 'dashboard.recentActivity' })}
+          </h3>
+          <Link
+            className="text-sm font-medium text-gray-400 md:hover:text-gray-900"
+            to={setQueryParamOnUrl(
+              COLONY_ACTIVITY_ROUTE,
+              TEAM_SEARCH_PARAM,
+              selectedDomain?.nativeId.toString(),
+            )}
+          >
+            {formatText({ id: 'view.all' })}
+          </Link>
+        </div>
         <FiltersContextProvider>
-          <ColonyActionsTable
+          <RecentActivityTable
             className="w-full [&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none [&_tr:last-child_td>*:not(.expandable)]:!py-[.9375rem] [&_tr:not(last-child)_td>*:not(.expandable)]:!pb-[.875rem] [&_tr:not(last-child)_td>*:not(.expandable)]:!pt-[.9375rem]"
             pageSize={7}
-            withHeader={false}
             state={{
               columnVisibility: isMobile
                 ? {
@@ -70,18 +84,6 @@ const ColonyHome = () => {
                     createdAt: true,
                   },
             }}
-            additionalPaginationButtonsContent={
-              <Link
-                className="text-sm text-gray-700 underline"
-                to={setQueryParamOnUrl(
-                  COLONY_ACTIVITY_ROUTE,
-                  TEAM_SEARCH_PARAM,
-                  selectedDomain?.nativeId.toString(),
-                )}
-              >
-                {formatText({ id: 'view.all' })}
-              </Link>
-            }
           />
         </FiltersContextProvider>
       </div>

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/FundsCards.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/FundsCards.tsx
@@ -26,7 +26,7 @@ export const FundsCards = () => {
   return (
     <WidgetCards.List>
       {teams.map((item) => {
-        return <WidgetCards.Item title={item?.metadata?.name} />;
+        return <WidgetCards.Item key={item?.id} title={item?.metadata?.name} />;
       })}
       {/* Teams always will have at least 1 team by default - it is general */}
       {teams.length < 2 && (

--- a/src/components/v5/shared/KebapMenu/KebapMenu.tsx
+++ b/src/components/v5/shared/KebapMenu/KebapMenu.tsx
@@ -19,7 +19,7 @@ const KebapMenu: FC<KebapMenuProps> = ({
       type="button"
       className={clsx(
         className,
-        'flex cursor-pointer items-center justify-center p-[0.1875rem] text-gray-400 transition-all duration-normal md:hover:text-blue-400',
+        'flex cursor-pointer items-center justify-center p-[0.1875rem] text-gray-600 transition-all duration-normal md:hover:text-blue-400',
       )}
       aria-label={formatMessage({ id: 'ariaLabel.openMenu' })}
       ref={setTriggerRef}

--- a/src/components/v5/shared/MeatBallMenu/MeatBallMenu.tsx
+++ b/src/components/v5/shared/MeatBallMenu/MeatBallMenu.tsx
@@ -54,7 +54,7 @@ const MeatBallMenu: FC<MeatBallMenuProps> = ({
           {
             'cursor-pointer md:hover:text-blue-400': !disabled,
             'cursor-default': disabled,
-            'text-gray-400': !isMenuOpen,
+            'text-gray-600': !isMenuOpen,
             'text-blue-400': isMenuOpen,
           },
         )}

--- a/src/components/v5/shared/UserAvatars/UserAvatars.tsx
+++ b/src/components/v5/shared/UserAvatars/UserAvatars.tsx
@@ -23,8 +23,10 @@ const UserAvatars: FC<UserAvatarsProps> = ({
   if (isLoading) {
     return (
       <div className="flex flex-shrink-0">
-        {Array.from({ length: maxAvatarsToShow }).map(() => (
+        {Array.from({ length: maxAvatarsToShow }).map((_, index) => (
           <div
+            // eslint-disable-next-line react/no-array-index-key
+            key={index}
             className={clsx(
               'z-base -ml-2 overflow-hidden rounded-full border border-base-white',
               {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1455,6 +1455,7 @@
     "balanceModal.modal.addFundsToWallet.label": "Enter amount",
     "breadcrumbs.teams": "Teams",
     "breadcrumbs.allTeams": "All teams",
+    "dashboard.recentActivity": "Recent activity",
     "dashboard.objective.widget.title": "Current colony objective",
     "dashboard.objective.widget.noData": "There are no current objectives in the Colony to display.",
     "dashboard.objective.widget.createObjective": "Create a new objective",


### PR DESCRIPTION
## Description

This PR makes changes to the activity table on the dashboard to reflect the new figma designs.

[Figma link](https://www.figma.com/design/gac6xVgGNCAge5Bia933dp/Dashboard?node-id=4859-36367&t=3YmH0OCdhMXflaYC-0)

<img width="1071" alt="Screenshot 2024-09-10 at 10 22 12" src="https://github.com/user-attachments/assets/73546624-678b-4d42-8910-40ea0676dae6">

<img width="453" alt="Screenshot 2024-09-10 at 10 22 23" src="https://github.com/user-attachments/assets/8bf291c1-f15a-4287-9372-d42a3b4d9c92">

It was very tempting to separate out the dashboard activity feed from the main activity feed (and I did actually start to do this before realising how much work it would be), but I instead opted to add a few new props to the `useActionsTableProps` hook and the `Table` component. This probably isn't ideal but both the hook and the table component are in need of a refactor at some point and this didn't feel like the right place to do it.

The newly added props are used to remove the horizontal padding, remove the table header and border, hide the user avatar.

Note: The empty state for the table is not included in this PR and is covered by a separate issue.

## Testing

Spin up the environment and run the create-data script.

Check the activity feed on the dashboard matches the figma design on all screen widths.

Check the main activity feed on the activity page is unaltered.

## Diffs

**Changes** 🏗

* Dashboard activity feed changed to match new figma designs
* New props added to `useActionsTableProps` hook and the `Table` component
* KebabMenu and MeatBallMenu now use `text-gray-600`

Resolves #2850
