### PR TITLE
[Notifications] Feat: Mark all as read

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
@@ -25,12 +25,18 @@ const MSG = defineMessages({
     id: `${displayName}.new`,
     defaultMessage: 'new',
   },
+  markAllAsRead: {
+    id: `${displayName}.markAllAsRead`,
+    defaultMessage: 'Mark all as read',
+  },
 });
 
 const NotificationsTab = () => {
   const isEmpty = true;
 
-  const { unreadCount } = useBell() || {};
+  const { unreadCount, markAllAsRead } = useBell() || {};
+
+  const hasUnreadNotifications = !!unreadCount && unreadCount > 0;
 
   let cappedCount: string | number = unreadCount ?? 0;
   const maximum = 99;
@@ -41,12 +47,23 @@ const NotificationsTab = () => {
 
   return (
     <div className="h-full px-6 pb-6 pt-6 sm:pb-2">
-      <div className="flex items-center">
-        <p className="heading-5">{formatText(MSG.notifications)}</p>
-        {!!unreadCount && unreadCount > 0 && (
-          <p className="ml-2 h-fit rounded-sm bg-blue-100 px-[3px] py-[2.5px] text-[8px] font-bold text-blue-400">
-            {cappedCount} {formatText(MSG.new)}
-          </p>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center">
+          <p className="heading-5">{formatText(MSG.notifications)}</p>
+          {hasUnreadNotifications && (
+            <p className="ml-2 h-fit rounded-sm bg-blue-100 px-[3px] py-[2.5px] text-[8px] font-bold text-blue-400">
+              {cappedCount} {formatText(MSG.new)}
+            </p>
+          )}
+        </div>
+        {hasUnreadNotifications && markAllAsRead && (
+          <button
+            onClick={() => markAllAsRead()}
+            className="text-xs font-medium text-blue-400"
+            type="button"
+          >
+            {formatText(MSG.markAllAsRead)}
+          </button>
         )}
       </div>
       <div className="flex h-full flex-col justify-center pt-4 sm:h-auto sm:justify-normal">


### PR DESCRIPTION
## Description

Builds on the work done on #3063 - probably makes sense to review that one first then this one straight after as this is such a small addition.

This PR adds the "Mark all as read" button the notifications tab of the UserHub.

## Testing

Log in as Amy (dev wallet 2)

If there are no unread notifications, create one (or many) via the UI [https://app.magicbell.com/projects/8931/compose](https://app.magicbell.com/projects/8931/compose) - set the user's wallet address as the recipient.

Click the "Mark all as read" button in the notifications tab - the notification alert should disappear.

<img width="759" alt="Screenshot 2024-09-09 at 11 37 35" src="https://github.com/user-attachments/assets/e0fda98b-7be0-4440-99fe-ae77bf7b999a">

## Diffs

**New stuff** ✨

* Added "Mark all as read" button to UserHub notifications tab

Contributes to #3009 
