### PR TITLE
[Dashboard] feat: add new team filter component

### DIFF
--- a/src/components/v5/common/ArrowScroller/ArrowScroller.module.css
+++ b/src/components/v5/common/ArrowScroller/ArrowScroller.module.css
@@ -1,0 +1,17 @@
+.scrollContainer {
+  scroll-snap-type: x mandatory;
+}
+
+/* The scrollbar itself */
+.scrollContainer::-webkit-scrollbar {
+  display: none;
+}
+
+.scrollContainer::-webkit-scrollbar-track {
+  display: none;
+}
+
+/* The actual scrollbar handle */
+.scrollContainer::-webkit-scrollbar-thumb {
+  display: none;
+}

--- a/src/components/v5/common/ArrowScroller/ArrowScroller.tsx
+++ b/src/components/v5/common/ArrowScroller/ArrowScroller.tsx
@@ -1,0 +1,111 @@
+import clsx from 'clsx';
+import React, {
+  useRef,
+  useState,
+  useEffect,
+  type PropsWithChildren,
+  type FC,
+} from 'react';
+
+import styles from './ArrowScroller.module.css';
+
+interface ArrowScrollerProps extends PropsWithChildren {
+  className?: string;
+  buttonLeftContent: JSX.Element;
+  buttonRightContent: JSX.Element;
+}
+
+const SCROLL_OFFSET = 10;
+
+const ArrowScroller: FC<ArrowScrollerProps> = ({
+  buttonLeftContent,
+  buttonRightContent,
+  children,
+  className,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (!containerRef.current) {
+        return;
+      }
+      const { scrollLeft, scrollWidth, clientWidth } = containerRef.current;
+      const isAtStart = scrollLeft < 0 + SCROLL_OFFSET;
+      const isAtEnd =
+        Math.ceil(scrollLeft + clientWidth) > scrollWidth - SCROLL_OFFSET;
+
+      setCanScrollLeft(!isAtStart);
+      setCanScrollRight(!isAtEnd);
+    };
+
+    const { current } = containerRef;
+    current?.addEventListener('scroll', handleScroll);
+    handleScroll(); // Initial check
+
+    return () => {
+      current?.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  const scrollLeft = () => {
+    if (!containerRef.current) {
+      return;
+    }
+
+    const { clientWidth } = containerRef.current;
+    containerRef?.current.scrollBy({
+      left: -clientWidth * 0.75,
+      behavior: 'smooth',
+    });
+  };
+
+  const scrollRight = () => {
+    if (!containerRef.current) {
+      return;
+    }
+
+    const { clientWidth } = containerRef.current;
+    containerRef?.current.scrollBy({
+      left: clientWidth * 0.5,
+      behavior: 'smooth',
+    });
+  };
+
+  return (
+    <div className="relative max-w-full overflow-hidden">
+      {canScrollLeft && (
+        <button
+          type="button"
+          className="absolute left-0 top-0 h-full"
+          onClick={scrollLeft}
+        >
+          {buttonLeftContent}
+        </button>
+      )}
+      <div
+        ref={containerRef}
+        className={clsx(
+          styles.scrollContainer,
+          'scrollbar-hide max-w-full overflow-x-auto',
+          className,
+        )}
+      >
+        {children}
+      </div>
+      {canScrollRight && (
+        <button
+          type="button"
+          className="absolute right-0 top-0 h-full"
+          onClick={scrollRight}
+        >
+          {buttonRightContent}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ArrowScroller;

--- a/src/components/v5/frame/ColonyHome/ColonyHome.tsx
+++ b/src/components/v5/frame/ColonyHome/ColonyHome.tsx
@@ -15,6 +15,7 @@ import {
 import { formatText } from '~utils/intl.ts';
 import { setQueryParamOnUrl } from '~utils/urls.ts';
 import Link from '~v5/shared/Link/index.ts';
+import TeamFilter from '~v5/shared/TeamFilter/TeamFilter.tsx';
 
 import Agreements from './partials/Agreements/index.ts';
 import DashboardHeader from './partials/DashboardHeader/index.ts';
@@ -38,6 +39,7 @@ const ColonyHome = () => {
     <div className="flex flex-col gap-6 lg:gap-10">
       <div className="flex flex-col gap-9 sm:gap-10">
         <DashboardHeader />
+        <TeamFilter />
         <div className="flex w-full flex-col items-center gap-[1.125rem] sm:flex-row">
           <TotalActions />
           <TokenBalance />

--- a/src/components/v5/shared/TeamFilter/TeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/TeamFilter.tsx
@@ -1,46 +1,20 @@
 import React from 'react';
 
-import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
-import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
-import { notMaybe } from '~utils/arrays/index.ts';
-import ArrowScroller from '~v5/common/ArrowScroller/ArrowScroller.tsx';
+import { useMobile } from '~hooks';
 
-import AllTeamsItem from './partials/AllTeamsItem.tsx';
-import CreateNewTeamItem from './partials/CreateNewTeamItem.tsx';
-import { LeftButton } from './partials/LeftButton.tsx';
-import { RightButton } from './partials/RightButton.tsx';
-import TeamItem from './partials/TeamItem.tsx';
+import DesktopTeamFilter from './partials/DesktopTeamFilter/DesktopTeamFilter.tsx';
+import MobileTeamFilter from './partials/MobileTeamFilter.tsx';
 
 const displayName = 'v5.shared.TeamFilter';
 
 const TeamFilter = () => {
-  const {
-    colony: { domains },
-  } = useColonyContext();
-  const selectedDomain = useGetSelectedDomainFilter();
+  const isMobile = useMobile();
 
-  const allDomains = domains?.items.filter(notMaybe) || [];
+  if (isMobile) {
+    return <MobileTeamFilter />;
+  }
 
-  const leftButton = <LeftButton />;
-  const rightButton = <RightButton />;
-
-  return (
-    <ArrowScroller
-      className="flex w-fit whitespace-nowrap rounded-lg border border-solid border-gray-200"
-      buttonLeftContent={leftButton}
-      buttonRightContent={rightButton}
-    >
-      <AllTeamsItem selected={selectedDomain === undefined} />
-      {allDomains.map((domain) => (
-        <TeamItem
-          key={`teamFilter.${domain.id}`}
-          selected={selectedDomain?.nativeId === domain.nativeId}
-          domain={domain}
-        />
-      ))}
-      <CreateNewTeamItem />
-    </ArrowScroller>
-  );
+  return <DesktopTeamFilter />;
 };
 
 TeamFilter.displayName = displayName;

--- a/src/components/v5/shared/TeamFilter/TeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/TeamFilter.tsx
@@ -3,12 +3,13 @@ import React from 'react';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
 import { notMaybe } from '~utils/arrays/index.ts';
+import ArrowScroller from '~v5/common/ArrowScroller/ArrowScroller.tsx';
 
 import AllTeamsItem from './partials/AllTeamsItem.tsx';
 import CreateNewTeamItem from './partials/CreateNewTeamItem.tsx';
+import { LeftButton } from './partials/LeftButton.tsx';
+import { RightButton } from './partials/RightButton.tsx';
 import TeamItem from './partials/TeamItem.tsx';
-
-const MAX_TEAM_LIMIT = 10;
 
 const displayName = 'v5.shared.TeamFilter';
 
@@ -20,13 +21,17 @@ const TeamFilter = () => {
 
   const allDomains = domains?.items.filter(notMaybe) || [];
 
-  const domainsForMenu = allDomains.slice(0, MAX_TEAM_LIMIT);
-  // const domainsForDropdown = allDomains.slice(MAX_TEAM_LIMIT);
+  const leftButton = <LeftButton />;
+  const rightButton = <RightButton />;
 
   return (
-    <div className="flex w-fit max-w-full overflow-hidden rounded-lg border border-solid  border-gray-200">
+    <ArrowScroller
+      className="flex w-fit whitespace-nowrap rounded-lg border border-solid border-gray-200"
+      buttonLeftContent={leftButton}
+      buttonRightContent={rightButton}
+    >
       <AllTeamsItem selected={selectedDomain === undefined} />
-      {domainsForMenu.map((domain) => (
+      {allDomains.map((domain) => (
         <TeamItem
           key={`teamFilter.${domain.id}`}
           selected={selectedDomain?.nativeId === domain.nativeId}
@@ -34,7 +39,7 @@ const TeamFilter = () => {
         />
       ))}
       <CreateNewTeamItem />
-    </div>
+    </ArrowScroller>
   );
 };
 

--- a/src/components/v5/shared/TeamFilter/TeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/TeamFilter.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
+import { notMaybe } from '~utils/arrays/index.ts';
+
+import AllTeamsItem from './partials/AllTeamsItem.tsx';
+import CreateNewTeamItem from './partials/CreateNewTeamItem.tsx';
+import TeamItem from './partials/TeamItem.tsx';
+
+const MAX_TEAM_LIMIT = 10;
+
+const displayName = 'v5.shared.TeamFilter';
+
+const TeamFilter = () => {
+  const {
+    colony: { domains },
+  } = useColonyContext();
+  const selectedDomain = useGetSelectedDomainFilter();
+
+  const allDomains = domains?.items.filter(notMaybe) || [];
+
+  const domainsForMenu = allDomains.slice(0, MAX_TEAM_LIMIT);
+  // const domainsForDropdown = allDomains.slice(MAX_TEAM_LIMIT);
+
+  return (
+    <div className="flex w-fit max-w-full overflow-hidden rounded-lg border border-solid  border-gray-200">
+      <AllTeamsItem selected={selectedDomain === undefined} />
+      {domainsForMenu.map((domain) => (
+        <TeamItem
+          key={`teamFilter.${domain.id}`}
+          selected={selectedDomain?.nativeId === domain.nativeId}
+          domain={domain}
+        />
+      ))}
+      <CreateNewTeamItem />
+    </div>
+  );
+};
+
+TeamFilter.displayName = displayName;
+export default TeamFilter;

--- a/src/components/v5/shared/TeamFilter/partials/AllTeamsItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/AllTeamsItem.tsx
@@ -1,0 +1,48 @@
+import clsx from 'clsx';
+import React, { type FC } from 'react';
+import { defineMessages } from 'react-intl';
+import { useSearchParams } from 'react-router-dom';
+
+import { TEAM_SEARCH_PARAM } from '~routes/index.ts';
+import { formatText } from '~utils/intl.ts';
+
+const displayName = 'v5.shared.TeamFilter.partials.AllTeamsItem';
+
+const MSG = defineMessages({
+  allTeams: {
+    id: `${displayName}.allTeams`,
+    defaultMessage: 'All teams',
+  },
+});
+
+interface AllTeamsItemProps {
+  selected: boolean;
+}
+
+const AllTeamsItem: FC<AllTeamsItemProps> = ({ selected }) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const handleClick = () => {
+    searchParams.delete(TEAM_SEARCH_PARAM);
+    setSearchParams(searchParams);
+  };
+
+  return (
+    <button
+      type="button"
+      className={clsx(
+        'border-r border-solid border-gray-200 px-4 py-2 text-3',
+        {
+          'bg-base-white font-medium text-gray-700': !selected,
+          'bg-gray-50 font-semibold text-gray-900': selected,
+        },
+      )}
+      onClick={handleClick}
+    >
+      {formatText(MSG.allTeams)}
+    </button>
+  );
+};
+
+AllTeamsItem.displayName = displayName;
+export default AllTeamsItem;

--- a/src/components/v5/shared/TeamFilter/partials/AllTeamsItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/AllTeamsItem.tsx
@@ -31,7 +31,7 @@ const AllTeamsItem: FC<AllTeamsItemProps> = ({ selected }) => {
     <button
       type="button"
       className={clsx(
-        'border-r border-solid border-gray-200 px-4 py-2 text-3',
+        'border-r border-solid border-gray-200 px-4 py-2 text-sm',
         {
           'bg-base-white font-medium text-gray-700': !selected,
           'bg-gray-50 font-semibold text-gray-900': selected,

--- a/src/components/v5/shared/TeamFilter/partials/CreateNewTeamItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/CreateNewTeamItem.tsx
@@ -21,7 +21,7 @@ const CreateNewTeamItem = () => {
   return (
     <button
       type="button"
-      className="bg-base-white px-4 py-2 font-medium text-gray-400 text-3 hover:bg-gray-50 hover:text-gray-900"
+      className="border-gray-200 bg-base-white px-4 py-2 font-medium text-gray-400 text-3 hover:bg-gray-50 hover:text-gray-900"
       onClick={handleClick}
     >
       <Plus size={16} />

--- a/src/components/v5/shared/TeamFilter/partials/CreateNewTeamItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/CreateNewTeamItem.tsx
@@ -1,0 +1,33 @@
+import { Plus } from '@phosphor-icons/react';
+import React from 'react';
+
+import { Action } from '~constants/actions.ts';
+import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
+import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
+
+const displayName = 'v5.shared.TeamFilter.partials.CreateNewTeamItem';
+
+const CreateNewTeamItem = () => {
+  const {
+    actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
+  } = useActionSidebarContext();
+
+  const handleClick = () => {
+    toggleActionSidebarOn({
+      [ACTION_TYPE_FIELD_NAME]: Action.CreateNewTeam,
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      className="bg-base-white px-4 py-2 font-medium text-gray-400 text-3 hover:bg-gray-50 hover:text-gray-900"
+      onClick={handleClick}
+    >
+      <Plus size={16} />
+    </button>
+  );
+};
+
+CreateNewTeamItem.displayName = displayName;
+export default CreateNewTeamItem;

--- a/src/components/v5/shared/TeamFilter/partials/CreateNewTeamItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/CreateNewTeamItem.tsx
@@ -21,10 +21,10 @@ const CreateNewTeamItem = () => {
   return (
     <button
       type="button"
-      className="border-gray-200 bg-base-white px-4 py-2 font-medium text-gray-400 text-3 hover:bg-gray-50 hover:text-gray-900"
+      className="border-gray-200 bg-base-white px-4 py-2 text-sm font-medium text-gray-400 hover:bg-gray-50 hover:text-gray-900"
       onClick={handleClick}
     >
-      <Plus size={16} />
+      <Plus size={18} />
     </button>
   );
 };

--- a/src/components/v5/shared/TeamFilter/partials/DesktopTeamFilter/DesktopTeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/DesktopTeamFilter/DesktopTeamFilter.tsx
@@ -25,7 +25,9 @@ const DesktopTeamFilter = () => {
   const {
     colony: { domains },
   } = useColonyContext();
+
   const selectedDomain = useGetSelectedDomainFilter();
+  const isAllTeamsFilterActive = selectedDomain === undefined;
 
   // this is in memo due to being a dependency for the other memo
   const allDomains = useMemo(() => {
@@ -94,7 +96,7 @@ const DesktopTeamFilter = () => {
 
   return (
     <div className="flex h-[34px] w-fit overflow-hidden whitespace-nowrap rounded-lg border border-solid border-gray-200">
-      <AllTeamsItem selected={selectedDomain === undefined} />
+      <AllTeamsItem selected={isAllTeamsFilterActive} />
       <div className="flex flex-wrap overflow-hidden" ref={containerRef}>
         {displayDomains.map((domain, index) => (
           <div

--- a/src/components/v5/shared/TeamFilter/partials/DesktopTeamFilter/DesktopTeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/DesktopTeamFilter/DesktopTeamFilter.tsx
@@ -1,0 +1,128 @@
+import clsx from 'clsx';
+import { throttle } from 'lodash';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
+import { notMaybe } from '~utils/arrays/index.ts';
+
+import AllTeamsItem from '../AllTeamsItem.tsx';
+import CreateNewTeamItem from '../CreateNewTeamItem.tsx';
+import TeamItem from '../TeamItem.tsx';
+import TeamsDropdown from '../TeamsDropdown/TeamsDropdown.tsx';
+
+import { getOrderedDomains } from './helpers.ts';
+
+const displayName = 'v5.shared.TeamFilter.DesktopTeamFilter';
+
+const DesktopTeamFilter = () => {
+  const [teamsWidth, setTeamsWidth] = useState(0);
+  const [overflowingItemIndex, setOverFlowingItemIndex] = useState(-1);
+
+  const teamItemsRef = useRef<HTMLDivElement[]>([]);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const {
+    colony: { domains },
+  } = useColonyContext();
+  const selectedDomain = useGetSelectedDomainFilter();
+
+  // this is in memo due to being a dependency for the other memo
+  const allDomains = useMemo(() => {
+    return domains?.items.filter(notMaybe) || [];
+  }, [domains?.items]);
+
+  useEffect(() => {
+    const { current: teamsElement } = containerRef;
+
+    const handleResize = throttle((entries) => {
+      const newWidth = entries[0].contentRect.width;
+
+      setTeamsWidth(newWidth);
+    }, 200);
+
+    const observer = new ResizeObserver(handleResize);
+
+    if (teamsElement) {
+      observer.observe(teamsElement);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (containerRef.current && teamItemsRef.current.length) {
+      let overflowingIndex = -1;
+
+      for (let i = 0; i < teamItemsRef.current.length; i += 1) {
+        const item = teamItemsRef.current[i];
+
+        if (item) {
+          if (item.offsetTop > containerRef.current.offsetTop) {
+            overflowingIndex = i;
+            break;
+          }
+        }
+      }
+
+      setOverFlowingItemIndex((prevIndex) => {
+        if (prevIndex !== overflowingIndex) {
+          return overflowingIndex; // Only update state if there's an actual change
+        }
+        return prevIndex;
+      });
+    }
+  }, [teamsWidth, selectedDomain]);
+
+  const displayDomains = useMemo(() => {
+    if (overflowingItemIndex === -1) {
+      return allDomains;
+    }
+    /*
+     * @NOTE if maxDomains confuses you, if the 4th element is overflowing, it's index is 3
+     * that means that we can show 3 domains and everything from the 4th one onwards is in a domainsForDropdown
+     * so it checks out :)
+     */
+    return getOrderedDomains({
+      maxDomains: overflowingItemIndex,
+      domains: allDomains,
+      selectedDomain,
+    });
+  }, [allDomains, overflowingItemIndex, selectedDomain]);
+
+  return (
+    <div className="flex h-[34px] w-fit overflow-hidden whitespace-nowrap rounded-lg border border-solid border-gray-200">
+      <AllTeamsItem selected={selectedDomain === undefined} />
+      <div className="flex flex-wrap overflow-hidden" ref={containerRef}>
+        {displayDomains.map((domain, index) => (
+          <div
+            ref={(el) => {
+              if (el) {
+                teamItemsRef.current[index] = el;
+              }
+            }}
+            key={`teamFilter.${domain.id}`}
+            className={clsx('flex-1 flex-shrink-0', {
+              'pointer-events-none opacity-0':
+                overflowingItemIndex > -1 && index >= overflowingItemIndex,
+            })}
+          >
+            <TeamItem
+              selected={selectedDomain?.nativeId === domain.nativeId}
+              domain={domain}
+            />
+          </div>
+        ))}
+      </div>
+      {overflowingItemIndex > -1 && (
+        <TeamsDropdown domains={displayDomains.slice(overflowingItemIndex)} />
+      )}
+      <CreateNewTeamItem />
+    </div>
+  );
+};
+
+DesktopTeamFilter.displayName = displayName;
+export default DesktopTeamFilter;

--- a/src/components/v5/shared/TeamFilter/partials/DesktopTeamFilter/helpers.ts
+++ b/src/components/v5/shared/TeamFilter/partials/DesktopTeamFilter/helpers.ts
@@ -1,0 +1,40 @@
+import { type Domain } from '~types/graphql.ts';
+
+interface GetDomainsForMenuParams {
+  domains: Domain[];
+  selectedDomain?: Domain;
+  maxDomains: number;
+}
+
+// this function will return all the domains + the selected one in the last place available to display
+export const getOrderedDomains = ({
+  domains,
+  selectedDomain,
+  maxDomains,
+}: GetDomainsForMenuParams): Domain[] => {
+  if (!selectedDomain) {
+    return domains;
+  }
+
+  const selectedDomainIndex = domains.findIndex(
+    (domain) => domain.nativeId === selectedDomain.nativeId,
+  );
+  // if selected domain is not in the dropdown, just return the same
+  if (selectedDomainIndex < maxDomains) {
+    return domains;
+  }
+
+  // Remove the selected domain from its current position
+  const domainsWithoutSelected = domains.filter(
+    (domain) => domain.nativeId !== selectedDomain.nativeId,
+  );
+
+  // Insert the selected domain at the last position before maxDomains
+  const orderedDomains = [
+    ...domainsWithoutSelected.slice(0, maxDomains - 1),
+    selectedDomain,
+    ...domainsWithoutSelected.slice(maxDomains - 1),
+  ];
+
+  return orderedDomains;
+};

--- a/src/components/v5/shared/TeamFilter/partials/LeftButton.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/LeftButton.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 export const LeftButton = () => {
   return (
     <div className="flex h-full items-center rounded-l-lg border border-gray-200 bg-base-bg px-4 py-2 text-gray-400">
-      <CaretLeft size={14} />
+      <CaretLeft size={18} />
     </div>
   );
 };

--- a/src/components/v5/shared/TeamFilter/partials/LeftButton.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/LeftButton.tsx
@@ -1,0 +1,10 @@
+import { CaretLeft } from '@phosphor-icons/react';
+import React from 'react';
+
+export const LeftButton = () => {
+  return (
+    <div className="flex h-full items-center rounded-l-lg border border-gray-200 bg-base-bg px-4 py-2 text-gray-400">
+      <CaretLeft size={14} />
+    </div>
+  );
+};

--- a/src/components/v5/shared/TeamFilter/partials/MobileTeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/MobileTeamFilter.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
+import { notMaybe } from '~utils/arrays/index.ts';
+import ArrowScroller from '~v5/common/ArrowScroller/ArrowScroller.tsx';
+
+import AllTeamsItem from './AllTeamsItem.tsx';
+import CreateNewTeamItem from './CreateNewTeamItem.tsx';
+import { LeftButton } from './LeftButton.tsx';
+import { RightButton } from './RightButton.tsx';
+import TeamItem from './TeamItem.tsx';
+
+const displayName = 'v5.shared.TeamFilter.MobileTeamFilter';
+
+const MobileTeamFilter = () => {
+  const {
+    colony: { domains },
+  } = useColonyContext();
+  const selectedDomain = useGetSelectedDomainFilter();
+
+  const allDomains = domains?.items.filter(notMaybe) || [];
+
+  const leftButton = <LeftButton />;
+  const rightButton = <RightButton />;
+
+  return (
+    <ArrowScroller
+      className="flex w-fit whitespace-nowrap rounded-lg border border-solid border-gray-200"
+      buttonLeftContent={leftButton}
+      buttonRightContent={rightButton}
+    >
+      <AllTeamsItem selected={selectedDomain === undefined} />
+      {allDomains.map((domain) => (
+        <TeamItem
+          key={`teamFilter.${domain.id}`}
+          selected={selectedDomain?.nativeId === domain.nativeId}
+          domain={domain}
+        />
+      ))}
+      <CreateNewTeamItem />
+    </ArrowScroller>
+  );
+};
+
+MobileTeamFilter.displayName = displayName;
+export default MobileTeamFilter;

--- a/src/components/v5/shared/TeamFilter/partials/RightButton.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/RightButton.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 export const RightButton = () => {
   return (
     <div className="flex h-full items-center rounded-r-lg border border-gray-200 bg-base-bg px-4 py-2 text-gray-400">
-      <CaretRight size={14} />
+      <CaretRight size={18} />
     </div>
   );
 };

--- a/src/components/v5/shared/TeamFilter/partials/RightButton.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/RightButton.tsx
@@ -1,0 +1,10 @@
+import { CaretRight } from '@phosphor-icons/react';
+import React from 'react';
+
+export const RightButton = () => {
+  return (
+    <div className="flex h-full items-center rounded-r-lg border border-gray-200 bg-base-bg px-4 py-2 text-gray-400">
+      <CaretRight size={14} />
+    </div>
+  );
+};

--- a/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
@@ -1,7 +1,9 @@
 import clsx from 'clsx';
-import React, { type FC } from 'react';
+import React, { useEffect, type FC } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
+import { useMobile } from '~hooks/index.ts';
+import { useScrollIntoView } from '~hooks/useScrollIntoView.ts';
 import { TEAM_SEARCH_PARAM } from '~routes/index.ts';
 import { type Domain } from '~types/graphql.ts';
 import { getTeamColor } from '~utils/teams.ts';
@@ -15,8 +17,20 @@ interface TeamItemProps {
 
 const TeamItem: FC<TeamItemProps> = ({ domain, selected }) => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { ref: teamItemRef, scroll } = useScrollIntoView<HTMLButtonElement>();
+  const isMobile = useMobile();
 
   const teamColor = getTeamColor(domain.metadata?.color);
+
+  useEffect(() => {
+    if (selected && isMobile) {
+      scroll({
+        block: 'end',
+        inline: 'center',
+        behavior: 'smooth',
+      });
+    }
+  }, [selected, isMobile, scroll]);
 
   const handleClick = () => {
     if (selected) {
@@ -30,9 +44,10 @@ const TeamItem: FC<TeamItemProps> = ({ domain, selected }) => {
 
   return (
     <button
+      ref={teamItemRef}
       type="button"
       className={clsx(
-        'w-full bg-base-white px-4 py-2 text-3',
+        'w-full bg-base-white px-4 py-2 text-sm',
         selected ? teamColor : null,
         {
           'border-r border-solid border-gray-200 font-medium text-gray-700':

--- a/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
@@ -1,0 +1,51 @@
+import clsx from 'clsx';
+import React, { type FC } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import { TEAM_SEARCH_PARAM } from '~routes/index.ts';
+import { type Domain } from '~types/graphql.ts';
+import { getTeamColor } from '~utils/teams.ts';
+
+const displayName = 'v5.shared.TeamFilter.partials.TeamItem';
+
+interface TeamItemProps {
+  selected: boolean;
+  domain: Domain;
+}
+
+const TeamItem: FC<TeamItemProps> = ({ domain, selected }) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const teamColor = getTeamColor(domain.metadata?.color);
+
+  const handleClick = () => {
+    if (selected) {
+      searchParams.delete(TEAM_SEARCH_PARAM);
+      setSearchParams(searchParams);
+    } else {
+      searchParams.set(TEAM_SEARCH_PARAM, domain.nativeId.toString());
+      setSearchParams(searchParams);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className={clsx(
+        ' bg-base-white px-4 py-2 text-3',
+        selected ? teamColor : null,
+        {
+          'border-r border-solid border-gray-200 font-medium text-gray-700':
+            !selected,
+          'border-0 font-semibold text-base-white': selected,
+        },
+      )}
+      onClick={handleClick}
+    >
+      {domain.metadata?.name ?? domain.id}
+    </button>
+  );
+};
+
+TeamItem.displayName = displayName;
+export default TeamItem;

--- a/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
@@ -32,7 +32,7 @@ const TeamItem: FC<TeamItemProps> = ({ domain, selected }) => {
     <button
       type="button"
       className={clsx(
-        ' bg-base-white px-4 py-2 text-3',
+        'w-full bg-base-white px-4 py-2 text-3',
         selected ? teamColor : null,
         {
           'border-r border-solid border-gray-200 font-medium text-gray-700':

--- a/src/components/v5/shared/TeamFilter/partials/TeamsDropdown/TeamsDropdown.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamsDropdown/TeamsDropdown.tsx
@@ -56,7 +56,7 @@ const TeamsDropdown: FC<TeamsDropdownProps> = ({ domains }) => {
               type="button"
               key={`TeamsDropdown.${domain.nativeId}`}
               onClick={() => handleClick(domain)}
-              className="w-full text-sm font-medium text-gray-700 hover:font-semibold hover:text-gray-900"
+              className="w-full text-start text-sm font-medium text-gray-700 hover:font-semibold hover:text-gray-900"
             >
               {domain.metadata?.name}
             </button>

--- a/src/components/v5/shared/TeamFilter/partials/TeamsDropdown/TeamsDropdown.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamsDropdown/TeamsDropdown.tsx
@@ -1,0 +1,71 @@
+import { DotsThree } from '@phosphor-icons/react';
+import clsx from 'clsx';
+import React, { type FC } from 'react';
+import { usePopperTooltip } from 'react-popper-tooltip';
+import { useSearchParams } from 'react-router-dom';
+
+import { TEAM_SEARCH_PARAM } from '~routes';
+import { type Domain } from '~types/graphql.ts';
+
+const displayName = 'v5.shared.TeamFilter.TeamsDropdown';
+
+interface TeamsDropdownProps {
+  domains: Domain[];
+}
+
+// no need to handle deselection since as soon as it's selected, it will go to the other menu
+const TeamsDropdown: FC<TeamsDropdownProps> = ({ domains }) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const { getTooltipProps, setTooltipRef, setTriggerRef, visible, triggerRef } =
+    usePopperTooltip({
+      placement: 'bottom-end',
+      trigger: ['click'],
+      interactive: true,
+      closeOnOutsideClick: true,
+      offset: [0, 1],
+    });
+
+  const handleClick = (domain: Domain) => {
+    searchParams.set(TEAM_SEARCH_PARAM, domain.nativeId.toString());
+    setSearchParams(searchParams);
+
+    triggerRef?.click();
+  };
+
+  return (
+    <div>
+      <button
+        type="button"
+        ref={setTriggerRef}
+        className={clsx(
+          'h-full border-r border-gray-200 bg-base-white px-4 py-2 text-gray-700 hover:bg-gray-50',
+          { 'bg-gray-50': visible },
+        )}
+      >
+        <DotsThree size={16} className="mt-1" />
+      </button>
+      {visible && (
+        <div
+          ref={setTooltipRef}
+          {...getTooltipProps()}
+          className="flex flex-col gap-2 rounded-b-lg border-b border-l border-r border-gray-200 bg-base-white px-4 py-2"
+        >
+          {domains.map((domain) => (
+            <button
+              type="button"
+              key={`TeamsDropdown.${domain.nativeId}`}
+              onClick={() => handleClick(domain)}
+              className="w-full text-sm font-medium text-gray-700 hover:font-semibold hover:text-gray-900"
+            >
+              {domain.metadata?.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+TeamsDropdown.displayName = displayName;
+export default TeamsDropdown;

--- a/src/hooks/useScrollIntoView.ts
+++ b/src/hooks/useScrollIntoView.ts
@@ -1,13 +1,13 @@
-import { useRef } from 'react';
+import { useCallback, useRef } from 'react';
 
 export const useScrollIntoView = <T extends HTMLElement>() => {
   const ref = useRef<T>(null);
 
-  const scroll = (options: ScrollIntoViewOptions) => {
+  const scroll = useCallback((options: ScrollIntoViewOptions) => {
     if (ref.current) {
       ref.current.scrollIntoView({ ...options });
     }
-  };
+  }, []);
 
   return { ref, scroll };
 };


### PR DESCRIPTION
## Description

Changing the solution from the dropdown to use the newly designed tabs.
Removing the current dropdown should be done as part of #2860.

[Figma link](https://www.figma.com/design/gac6xVgGNCAge5Bia933dp/Dashboard?node-id=4887-20952&t=XheoZNvOyt62DJXq-4)
![image](https://github.com/user-attachments/assets/832042ea-7fc6-4d8a-b551-457f998531f3)

## Testing

Needs to be tested functionality wise and UI wise.

### Functionality
1. Make sure that when you click a team, it shows up in the search params and everything starts getting filtered
![image](https://github.com/user-attachments/assets/84810844-9236-4b0a-86a1-001d2bfa01af)
2. Clicking on another one should immediately change the filter:
![image](https://github.com/user-attachments/assets/ba0ba674-7234-49ed-954d-9c4076e54c4d)
3. Clicking on the same one should disable it and highlight `All teams`:
![image](https://github.com/user-attachments/assets/9ac1f015-d2c3-41c7-b30e-020745cd96ae)
4. Clicking on `All teams` when a domain is selected, should disable the filter
5. Clicking on the `+` button should open up the sidebar with the "Create new team" action
![image](https://github.com/user-attachments/assets/7d1b7d45-8629-424f-8017-fe370e59260a)


### Mobile UI
1. Set the screen to a mobile size and verify that you see the arrows:
![image](https://github.com/user-attachments/assets/8a9bd36d-b15b-41c0-b23d-95690c05c94e)
2. Clicking on the right arrow should scroll a bit forward and the left arrow should appear
![image](https://github.com/user-attachments/assets/0adca3b0-b66f-4bdd-b2e9-ed1553774947)
3. Verify that you can click on the right button until you get to the end and see the new team button
![image](https://github.com/user-attachments/assets/fd4cc765-dbaf-4498-8710-02b6e27f2aa6)
4. Verify that you can also scroll left with the left button
5. Additionally, you should be able to drag this on mobile

### Desktop UI
1. Open up the dev tools and start resizing! When the teams would take up too much space, a dropdown should appear, displaying the overflowing teams inside it (NOTE: if you go to less than 850px, the mobile view will appear)
![image](https://github.com/user-attachments/assets/c8e91cee-9cac-4bd2-82b8-bdb71255a527)
2. On hover the text should be bold
![image](https://github.com/user-attachments/assets/4f5baef9-bd72-4ca4-8a0d-1ac46f1c928a)
3. When you select a team from the dropdown, it should display on the last spot, pushing the previously last domain into the dropdown
![image](https://github.com/user-attachments/assets/bdd6d743-9c6c-4d25-99f3-3e56be132084)
4. Choose `azizazizazizazizaziz` and try to expand and shrink the viewport, you should be able to see how items pop out and into the dropdown

Then just try to break it :D 

## Diffs

**New stuff** ✨

* Fully composable `ArrowScroller` component
* New `TeamFilter` component which has mobile and desktop variants separated
* `DesktopTeamFilter` which has the magic disappearing component with the dropdown
* `MobileTeamFilter` which uses the `ArrowScroller`


Resolves  #2849 
