### PR TITLE
[Navigation] Fix: UI Page header adjustments

### DIFF
--- a/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
+++ b/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
@@ -178,7 +178,7 @@ const UserHubButton: FC<Props> = ({ openTab, onOpen }) => {
           {
             '!border-blue-400': visible,
           },
-          'min-w-[3rem] md:hover:!border-blue-400',
+          '!min-h-[2.375rem] min-w-[2.875rem] !px-3 !py-0 md:hover:!border-blue-400',
         )}
         onClick={handleButtonClick}
       >
@@ -198,7 +198,7 @@ const UserHubButton: FC<Props> = ({ openTab, onOpen }) => {
                   <p className="ml-1 truncate text-sm font-medium">
                     {userName}
                   </p>
-                  <div className="ml-2">
+                  <div className="md:ml-2">
                     <MemberReputation
                       colonyAddress={colonyAddress}
                       hideOnMobile

--- a/src/components/common/Extensions/UserNavigation/partials/NetworkName/NetworkName.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/NetworkName/NetworkName.tsx
@@ -27,7 +27,7 @@ const NetworkName: FC<NetworkNameProps> = ({
     >
       <div
         className={clsx(
-          'flex min-h-[2.5rem] min-w-[2.625rem] items-center justify-center gap-1 rounded-full border border-gray-200 bg-base-white px-[0.875rem] py-[0.625rem]',
+          'flex min-h-[2.375rem] min-w-[2.875rem] items-center justify-center gap-1 rounded-full border border-gray-200 bg-base-white px-3 py-0 sm:min-w-[2.75rem]',
           {
             'border-warning-400': error,
             'cursor-pointer': error,

--- a/src/components/v5/frame/PageLayout/partials/PageHeader/PageHeader.tsx
+++ b/src/components/v5/frame/PageLayout/partials/PageHeader/PageHeader.tsx
@@ -62,7 +62,7 @@ const PageHeader: FC<PageHeaderProps> = ({ pageHeadingProps }) => {
               </section>
             )}
             {isTablet && (
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-6">
                 <MobileColonySwitcherToggle />
                 {colonyContext && (
                   <MobileColonyPageSidebarToggle

--- a/src/components/v5/shared/Button/Hamburger.tsx
+++ b/src/components/v5/shared/Button/Hamburger.tsx
@@ -38,7 +38,7 @@ const Hamburger: FC<HamburgerProps> = ({
       ) : (
         <button
           className={clsx(
-            'relative flex min-h-[2.5rem] min-w-12 items-center justify-center rounded-full border bg-base-white p-2.5 text-gray-700 transition-all duration-normal text-1 disabled:text-gray-300',
+            'relative flex min-h-[2.375rem] min-w-[2.875rem] items-center justify-center rounded-full border bg-base-white text-gray-700 transition-all duration-normal text-1 disabled:text-gray-300 sm:min-w-[2.75rem]',
             {
               'pointer-events-none': disabled,
               'border-blue-400': isOpened,

--- a/src/components/v5/shared/Button/Hamburger.tsx
+++ b/src/components/v5/shared/Button/Hamburger.tsx
@@ -38,7 +38,7 @@ const Hamburger: FC<HamburgerProps> = ({
       ) : (
         <button
           className={clsx(
-            'relative flex min-h-[2.5rem] min-w-[2.625rem] items-center justify-center rounded-full border bg-base-white p-2.5 text-gray-700 transition-all duration-normal text-1 disabled:text-gray-300',
+            'relative flex min-h-[2.5rem] min-w-12 items-center justify-center rounded-full border bg-base-white p-2.5 text-gray-700 transition-all duration-normal text-1 disabled:text-gray-300',
             {
               'pointer-events-none': disabled,
               'border-blue-400': isOpened,


### PR DESCRIPTION
## Description

This PR makes two small fixes to the page header on mobile. The space between the colony logo and the menu icon has been increased. The width of the settings button has been increased to match the other icon buttons ~~(note: this does not match the figma design which has the borders on the inside of the component rather than the outside, so I have instead opted to make this consistent with the other two buttons as this would be a bigger change that needs a bit more thought)~~ I did a bit of digging found this was only an issue with these buttons, so have gone ahead and made the changes.

Before:
<img width="473" alt="Screenshot 2024-09-11 at 09 51 03" src="https://github.com/user-attachments/assets/adcdf890-d4c6-4c6d-b588-73143f15ecf9">


After:

<img width="519" alt="Screenshot 2024-09-12 at 14 30 15" src="https://github.com/user-attachments/assets/e1197d9c-efd3-41f4-8552-2df43166d800">

<img width="780" alt="Screenshot 2024-09-12 at 14 50 34" src="https://github.com/user-attachments/assets/5eabfdb8-2c87-4c13-9f45-b295aeb1754e">

<img width="1096" alt="Screenshot 2024-09-12 at 14 30 30" src="https://github.com/user-attachments/assets/98d09981-e6e4-4a11-9694-b996a443cf10">


## Testing

Does the spacing match the figma design.
Does the settings button match the other buttons.

## Diffs

**Changes** 🏗

* Increased spacing
* Increased width

Resolves #3047 
