### PR TITLE
[Navigation] Fix: Colony switcher UI adjustments

### DIFF
--- a/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColonyItem/JoinedColonyItem.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColonyItem/JoinedColonyItem.tsx
@@ -23,7 +23,7 @@ const JoinedColonyItem = ({
     <button
       type="button"
       className={clsx(
-        'group flex h-[50px] w-full flex-row items-center justify-start gap-3 rounded px-6 py-8 hover:bg-gray-50 md:px-2 md:py-0',
+        'group flex h-[50px] w-full flex-row items-center justify-start gap-2.5 rounded px-6 py-[2.625rem] md:px-2 md:py-0 md:hover:bg-gray-50',
         {
           'sm:px-2 sm:py-0': enableMobileAndDesktopLayoutBreakpoints,
         },
@@ -46,7 +46,7 @@ const JoinedColonyItem = ({
         <p className="truncate text-md font-semibold text-gray-900">
           {capitalizeFirstLetter(name)}
         </p>
-        <p className="truncate text-sm font-normal uppercase text-gray-700">
+        <p className="truncate text-sm font-normal uppercase text-gray-600">
           {tokenSymbol}
         </p>
       </div>


### PR DESCRIPTION
## Description

This PR resolves the 3 UI issues described in the original issue.

* Increases the height of the switcher item on mobile
* Changes the token text colour to text-gray-600
* Reduces the gap between the token logo and name to 10px

It also removes the colony switcher hover state on mobile / tablet as discussed with Mel.

## Testing

Open the colony switcher on mobile and check it matches the issue / figma design. (The height changes are more apparent if you create a third colony.

<img width="410" alt="Screenshot 2024-09-12 at 12 06 53" src="https://github.com/user-attachments/assets/5b390094-9530-43c5-b952-0cea445e48d0">


## Diffs

**Changes** 🏗

* Increases the height of the switcher item on mobile
* Changes the token text colour to text-gray-600
* Reduces the gap between the token logo and name to 10px


Resolves #3046 
