### PR TITLE
[Dashboard] feat: reputation chart dropdown menu

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/ReputationChart.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/ReputationChart.tsx
@@ -9,6 +9,7 @@ import { formatText } from '~utils/intl.ts';
 
 import { useContributorsByDomain } from './hooks/useContributorsByDomain.tsx';
 import { Chart } from './partials/Chart.tsx';
+import TeamActionsMenu from './partials/TeamActionsMenu.tsx';
 import {
   getContributorReputationChartData,
   getTeamReputationChartData,
@@ -66,6 +67,7 @@ const ReputationChart = () => {
         <h5 className="text-gray-900 heading-5">
           {formatText(reputationTitle)}
         </h5>
+        <TeamActionsMenu />
       </div>
       <Chart data={chartData} />
     </div>

--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/TeamActionsMenu.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/TeamActionsMenu.tsx
@@ -1,0 +1,118 @@
+import { DotsThreeVertical, Eye, LockKey, Pencil } from '@phosphor-icons/react';
+import clsx from 'clsx';
+import React from 'react';
+import { defineMessages } from 'react-intl';
+import { usePopperTooltip } from 'react-popper-tooltip';
+import { Link } from 'react-router-dom';
+
+import { Action } from '~constants/actions.ts';
+import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { tw } from '~utils/css/index.ts';
+import { formatText } from '~utils/intl.ts';
+import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
+
+const displayName =
+  'v5.frame.ColonyHome.ReputationChart.partials.TeamActionsMenu';
+
+const MSG = defineMessages({
+  viewAllTeams: {
+    id: `${displayName}.viewAllTeams`,
+    defaultMessage: 'View all teams',
+  },
+  createTeam: {
+    id: `${displayName}.createTeam`,
+    defaultMessage: 'Create new team',
+  },
+  editTeam: {
+    id: `${displayName}.editTeam`,
+    defaultMessage: 'Edit team',
+  },
+});
+
+// @TODO maybe decouple some of this into a dropdown menu component?
+// eslint-disable-next-line max-len
+const dropdownItemClassName = tw`flex w-full items-center gap-2 rounded-s px-3 py-2 text-md text-gray-900 hover:font-medium md:hover:bg-gray-50`;
+
+const TeamActionsMenu = () => {
+  const {
+    colony: { name: colonyName },
+  } = useColonyContext();
+  const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
+  const { getTooltipProps, setTooltipRef, setTriggerRef, visible } =
+    usePopperTooltip({
+      placement: 'bottom-end',
+      trigger: ['click'],
+      visible: isDropdownOpen,
+      onVisibleChange: setIsDropdownOpen,
+      interactive: true,
+      closeOnOutsideClick: true,
+      offset: [0, 0],
+    });
+
+  const {
+    actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
+  } = useActionSidebarContext();
+
+  const handleCreateTeamClick = () => {
+    toggleActionSidebarOn({
+      [ACTION_TYPE_FIELD_NAME]: Action.CreateNewTeam,
+    });
+    setIsDropdownOpen(false);
+  };
+
+  const handleEditTeamClick = () => {
+    toggleActionSidebarOn({
+      [ACTION_TYPE_FIELD_NAME]: Action.EditExistingTeam,
+    });
+    setIsDropdownOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        ref={setTriggerRef}
+        className={clsx('hover:text-blue-400', {
+          'text-gray-400': !visible,
+          'text-blue-400': visible,
+        })}
+      >
+        <DotsThreeVertical size={18} />
+      </button>
+      {visible && (
+        <div
+          ref={setTooltipRef}
+          {...getTooltipProps()}
+          className="z-dropdown w-full px-6 sm:w-auto sm:px-0"
+        >
+          <div className="flex w-full flex-col rounded-lg border border-gray-200 bg-base-white px-3 py-4 shadow-default sm:w-[14.25rem]">
+            <Link to={`/${colonyName}/teams`} className={dropdownItemClassName}>
+              <Eye size={18} />
+              <span>{formatText(MSG.viewAllTeams)}</span>
+            </Link>
+            <button
+              type="button"
+              className={dropdownItemClassName}
+              onClick={handleCreateTeamClick}
+            >
+              <LockKey size={18} />
+              <span>{formatText(MSG.createTeam)}</span>
+            </button>
+            <button
+              type="button"
+              className={dropdownItemClassName}
+              onClick={handleEditTeamClick}
+            >
+              <Pencil size={18} />
+              <span>{formatText(MSG.editTeam)}</span>
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+TeamActionsMenu.displayName = displayName;
+export default TeamActionsMenu;


### PR DESCRIPTION
## Description

Implement dropdown chart with team actions for the reputation donut chart.
I didn't use our existing `DropdownMenu` component, because it's way too cumbersome and I've instead opted for a simple solution using `popper` and a `div`. 
I think we will be able to decouple this in due time, but I didn't start on it right now.

[Figma link](https://www.figma.com/design/gac6xVgGNCAge5Bia933dp/Dashboard?node-id=4878-88566&t=ZEsiLeswZqxoEGLv-4)
![image](https://github.com/user-attachments/assets/9a40e7f4-07fd-4d5b-b925-fc94f5b7d5d6)

## Testing

### Functionality

1. Verify that the dropdown opens showing all 3 items
![image](https://github.com/user-attachments/assets/7aa5e754-6e77-4a42-b8ce-ab83382d8336)
2. Clicking on `View all teams` goes to the teams page
3. Clicking on `Create new team` opens the sidebar with the `Create new team` option preselected
4. Clicking on `Edit new team` opens the sidebar with the `Edit new team` option preselected

### UI

I couldn't find any designs for the hover state so I just tried to replicate what we have on our current dropdowns :shrug:

1. Verify that the three dots turn blue when the menu is active and on hover
![image](https://github.com/user-attachments/assets/80c1440a-e4bc-4894-a995-c20bf3893cc7)
2. Verify that the items turn bold on hover and have a rounded gray background 
![image](https://github.com/user-attachments/assets/de50136c-1418-418b-ba47-802c52883541)
3. Verify that on mobile the dropdown is full width and has padding left and right
![image](https://github.com/user-attachments/assets/88827c2e-c7fc-463a-8214-5950f2acce41)


## Diffs

**New stuff** ✨

* `TeamActionsMenu` component

Resolves #3060
