### PR TITLE
[New Nav] Fix: Update Route Accordion Item behaviour on non-desktop view

### DIFF
--- a/src/components/v5/shared/Navigation/Sidebar/partials/SidebarRouteItem/SidebarRouteItem.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/partials/SidebarRouteItem/SidebarRouteItem.tsx
@@ -51,18 +51,20 @@ const SidebarRouteItem: React.FC<SidebarRouteItemProps> = ({
   const handleClick = () => {
     onClick?.();
 
-    if (isTablet) {
-      toggleTabletSidebar();
-    }
-
     const pathPrefix = routeType === 'colony' ? `/${colony.name}` : '';
 
     const derivedPath = `${pathPrefix}/${path}`;
 
-    navigate(derivedPath);
-
     if (isAccordion) {
+      if (!isTablet) {
+        navigate(derivedPath);
+      }
+
       setIsAccordionExpanded(true);
+    } else {
+      toggleTabletSidebar();
+
+      navigate(derivedPath);
     }
   };
 


### PR DESCRIPTION
## Description

![mobile-accordion](https://github.com/user-attachments/assets/399201ba-b634-401b-9d87-a0b977bc7ebf)

## Testing

1. Click Finances
2. Verify that
 - the Sidebar is not dismissed
 - the Accordion items are revealed
3. Click Balances
4. Verify that
 - the Sidebar is dismissed
 - you are taken to the Balances page
 
Resolves #3098 