### PR TITLE
[New Nav] Fix: Colony Sidebar UI adjustments

### DIFF
--- a/src/components/v5/shared/Navigation/ColonySwitcher/ColonySwitcher.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/ColonySwitcher.tsx
@@ -36,9 +36,11 @@ const ColonySwitcher: React.FC<ColonySwitcherProps> = ({
       <Button
         ref={setTriggerRef}
         type="button"
-        className={clsx(sidebarButtonClass, className, '!py-[6px]', {
+        className={clsx(sidebarButtonClass, className, 'group !py-[4.5px]', {
           '!justify-center': isLogoButton,
           '!justify-between': !isLogoButton,
+          '!bg-gray-800': visible,
+          '!p-2 hover:!bg-gray-800': enableMobileAndDesktopLayoutBreakpoints,
         })}
       >
         <section className="flex flex-row items-center gap-3 overflow-hidden">
@@ -55,7 +57,15 @@ const ColonySwitcher: React.FC<ColonySwitcherProps> = ({
         </section>
         {!isLogoButton && (
           <section>
-            <CaretUpDown className="h-3 w-auto flex-shrink-0 text-gray-400" />
+            <CaretUpDown
+              size={12}
+              className={clsx(
+                'w-auto flex-shrink-0 text-gray-400 transition-colors group-hover:text-base-white',
+                {
+                  '!text-base-white': visible,
+                },
+              )}
+            />
           </section>
         )}
       </Button>

--- a/src/components/v5/shared/Navigation/ColonySwitcher/partials/ColonySwitcherAvatar.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/partials/ColonySwitcherAvatar.tsx
@@ -37,7 +37,12 @@ export const ColonySwitcherAvatar = ({
           src={colonyAvatarSrc}
         />
       ) : (
-        <ColonyIcon size={36} className="text-gray-900 md:text-base-white" />
+        <ColonyIcon
+          size={36}
+          className={clsx('text-gray-900 md:text-base-white', {
+            '!text-base-white': enableMobileAndDesktopLayoutBreakpoints,
+          })}
+        />
       )}
     </div>
   );

--- a/src/components/v5/shared/Navigation/Sidebar/Sidebar.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/Sidebar.tsx
@@ -30,7 +30,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
         ref={ref}
         className={clsx(
           'top-[calc(var(--header-nav-section-height)+var(--top-content-height))]',
-          'z-sidebar hidden h-full w-fit flex-col items-start rounded-lg bg-gray-900 px-2 pb-4 pt-2 md:flex',
+          'z-sidebar hidden h-full w-fit flex-col items-start rounded-lg bg-gray-900 px-2 pb-4.5 pt-[13.5px] md:flex',
           className,
         )}
       >

--- a/src/components/v5/shared/Navigation/Sidebar/partials/SidebarRouteItem/SidebarRouteItem.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/partials/SidebarRouteItem/SidebarRouteItem.tsx
@@ -96,13 +96,13 @@ const SidebarRouteItem: React.FC<SidebarRouteItemProps> = ({
           <p className={sidebarButtonTextClass}>{formatText(translation)}</p>
         </div>
         {isAccordion && (
-          <div className="flex w-full justify-end pr-1.5 md:pr-0">
+          <div className="flex w-full justify-end pr-1.5 md:pr-[1px]">
             <div
               onClick={onToggleAccordion}
               onKeyDown={noop}
               tabIndex={0}
               role="button"
-              className="flex aspect-square h-[22px] items-center justify-center rounded-[4px] transition-colors hover:bg-base-white md:hover:bg-gray-900"
+              className="flex aspect-square items-center justify-center rounded p-1 transition-colors hover:bg-base-white md:hover:bg-gray-900"
             >
               <CaretDown
                 className={clsx(

--- a/src/components/v5/shared/Navigation/Sidebar/sidebar.styles.ts
+++ b/src/components/v5/shared/Navigation/Sidebar/sidebar.styles.ts
@@ -1,6 +1,6 @@
 import { tw } from '~utils/css/index.ts';
 
-export const sidebarButtonClass = tw`flex min-h-[38px] w-full items-center !justify-start !gap-3 rounded-lg !border-none bg-base-white !px-3 !py-3 hover:bg-gray-100 md:bg-gray-900 md:!px-2 md:!py-2 md:hover:bg-gray-800`;
+export const sidebarButtonClass = tw`flex min-h-[38px] w-full items-center !justify-start !gap-3 rounded-lg !border-none bg-base-white px-3 py-3 hover:bg-gray-100 md:bg-gray-900 md:px-2 md:py-2 md:hover:bg-gray-800`;
 
 export const sidebarButtonIconClass = tw`aspect-auto h-5 w-auto flex-shrink-0 text-gray-900 md:text-base-white`;
 

--- a/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/ColonyPageSidebar.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/ColonyPageSidebar.tsx
@@ -82,7 +82,7 @@ const ColonyPageSidebar = () => {
     <Sidebar
       className={colonyPageSidebarDesktopClass}
       showColonySwitcher={!isTablet}
-      headerClassName="mb-6"
+      headerClassName="mb-[27px]"
       footerClassName="!items-start !gap-2"
     >
       <ColonyPageSidebarContent />

--- a/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/consts.ts
+++ b/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/consts.ts
@@ -20,8 +20,7 @@ import {
   COLONY_PERMISSIONS_ROUTE,
   COLONY_TEAMS_ROUTE,
 } from '~routes';
-
-import { type SidebarRouteItemProps } from '../../partials/SidebarRouteItem/types.ts';
+import { type SidebarRouteItemProps } from '~v5/shared/Navigation/Sidebar/partials/SidebarRouteItem/types.ts';
 
 export const sidebarNavigationScheme: SidebarRouteItemProps[] = [
   {
@@ -34,7 +33,7 @@ export const sidebarNavigationScheme: SidebarRouteItemProps[] = [
   {
     id: 'activity',
     icon: ClockCountdown,
-    translation: { id: 'navigation.dashboard.activityFeed' },
+    translation: { id: 'teamsPage.links.activity' },
     path: COLONY_ACTIVITY_ROUTE,
     routeType: 'colony',
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -152,6 +152,9 @@ module.exports = {
         userNav: '11',
         userNavModal: '1001',
       },
+      spacing: {
+        4.5: '1.125rem',
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
## Description

![colony sidebar adjustments](https://github.com/user-attachments/assets/134426f5-64fe-4a96-8637-103e64138fd6)

## Testing

1. Connect Dev Wallet 1
2. Visit the planex colony
3. Observe the Colony Sidebar and verify that Activity Feed is now called Activity
4. Click the Colony Switcher component and verify that it maintains its hover state when the colony switcher popover is present

Resolves #3092 