### PR TITLE
Fix/3048 stake form

### DIFF
--- a/src/components/v5/shared/Stepper/Stepper.tsx
+++ b/src/components/v5/shared/Stepper/Stepper.tsx
@@ -101,9 +101,12 @@ function Stepper<TKey extends React.Key>({
           </button>
         )}
         <ul
-          className={clsx('relative flex w-full flex-row justify-start gap-0', {
-            'overflow-auto no-scrollbar': withArrowsOnMobile,
-          })}
+          className={clsx(
+            'relative flex w-full justify-between gap-3 sm:flex-col sm:justify-start sm:gap-0',
+            {
+              'overflow-auto no-scrollbar': withArrowsOnMobile,
+            },
+          )}
           ref={listRef}
         >
           {items.map(
@@ -169,6 +172,7 @@ function Stepper<TKey extends React.Key>({
                   <InView
                     as="div"
                     onChange={(inView) => handleChange(key, inView)}
+                    className="z-base flex flex-col items-start gap-[.375rem] sm:flex-row sm:items-center"
                   >
                     <StepperButton
                       stage={


### PR DESCRIPTION
## Description
![image](https://github.com/user-attachments/assets/4056be3f-1b31-42b0-9829-5df7028f3b5a)

These changes are actually a revert for the Stepper component from this PR - https://github.com/JoinColony/colonyCDapp/pull/2931 
So we need to ensure that the bug is fixed and nothing from that PR is broken

## Testing
* Step 1. Create motion stake (enable reputation widget, create mint token motion with reputation permission method)
* Step 2. Check if the motion stake UI looks good:

<img width="901" alt="image" src="https://github.com/user-attachments/assets/9933cab7-f102-41ca-8639-d95e1ecc09b9">
* Step 3. Navigate to create colony screen (node scripts/create-colony)
* Step 4. Check that the mobile stepper is working as expected:

<img width="367" alt="image" src="https://github.com/user-attachments/assets/09f78244-df11-48a9-b936-a9c7feef056d">


Resolves #3048 
