### PR TITLE
build: update network image hash to latest multi-sig commit

### DIFF
--- a/docker/colony-cdapp-dev-env-network
+++ b/docker/colony-cdapp-dev-env-network
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV NETWORK_HASH=b4332968786428e1c8af7dc68f5485a2a465a4f7
+ENV NETWORK_HASH=1c45d3aa82b6a86f817bd7d0d88e50490916aadf
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]


### PR DESCRIPTION
## Description

Just realign the network hash so Multi-Sig shows up as expected :)

## Testing
1. Open up the app and go to the extensions list, Multi-Sig should show up
![image](https://github.com/user-attachments/assets/de8720d5-87a0-45e0-b500-c67578becbc3)
