### PR TITLE
Fix: Motion change vote

### DIFF
--- a/src/components/frame/Extensions/pages/partials/InstallButton.tsx
+++ b/src/components/frame/Extensions/pages/partials/InstallButton.tsx
@@ -20,6 +20,7 @@ import Toast from '~shared/Extensions/Toast/Toast.tsx';
 import { type AnyExtensionData } from '~types/extensions.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionButton from '~v5/shared/Button/ActionButton.tsx';
+import { LoadingBehavior } from '~v5/shared/Button/types.ts';
 
 import {
   ExtensionTabId,
@@ -94,7 +95,7 @@ const InstallButton = ({
 
   return (
     <ActionButton
-      useTxLoader
+      loadingBehavior={LoadingBehavior.TxLoader}
       actionType={ActionTypes.EXTENSION_INSTALL}
       isLoading={isPolling}
       values={{ colonyAddress, extensionData }}

--- a/src/components/frame/Extensions/pages/partials/SaveSettingsButton.tsx
+++ b/src/components/frame/Extensions/pages/partials/SaveSettingsButton.tsx
@@ -3,6 +3,7 @@ import React, { useContext } from 'react';
 import { ExtensionSaveSettingsContext } from '~context/ExtensionSaveSettingsContext/ExtensionSaveSettingsContext.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionButton from '~v5/shared/Button/ActionButton.tsx';
+import { LoadingBehavior } from '~v5/shared/Button/types.ts';
 
 const displayName = 'pages.ExtensionDetailsPage.SaveSettingsButton';
 
@@ -12,7 +13,7 @@ const SaveSettingsButton = () => {
 
   return isVisible && !!actionType ? (
     <ActionButton
-      useTxLoader
+      loadingBehavior={LoadingBehavior.TxLoader}
       actionType={actionType}
       values={handleGetValues}
       onSuccess={handleOnSuccess}

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/RevealStep/RevealStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/RevealStep/RevealStep.tsx
@@ -117,7 +117,7 @@ const RevealStep: FC<RevealStepProps> = ({
               transform={transform}
               onSuccess={handleSuccess}
             >
-              {hasUserVoted ? (
+              {hasUserVoted && !!userVote ? (
                 <div className="mb-1.5">
                   <div className={clsx({ 'mb-6': !userVoteRevealed })}>
                     <div className="mb-2 flex items-center justify-between gap-2">

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/VotingStep/VotingStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/VotingStep/VotingStep.tsx
@@ -1,23 +1,29 @@
+import { ThumbsDown, ThumbsUp } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { type FC } from 'react';
 import { defineMessages } from 'react-intl';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
+import { usePageThemeContext } from '~context/PageThemeContext/PageThemeContext.ts';
 import { ActionTypes } from '~redux/index.ts';
 import { ActionForm } from '~shared/Fields/index.ts';
 import { MotionVote } from '~utils/colonyMotions.ts';
 import { formatText } from '~utils/intl.ts';
 import FormButtonRadioButtons from '~v5/common/Fields/RadioButtons/ButtonRadioButtons/FormButtonRadioButtons.tsx';
 import MotionVoteBadge from '~v5/common/Pills/MotionVoteBadge/index.ts';
-import Button from '~v5/shared/Button/index.ts';
+import Button, { ActionButton } from '~v5/shared/Button/index.ts';
+import { LoadingBehavior } from '~v5/shared/Button/types.ts';
 import MenuWithStatusText from '~v5/shared/MenuWithStatusText/index.ts';
 import ProgressBar from '~v5/shared/ProgressBar/index.ts';
 import { StatusTypes } from '~v5/shared/StatusText/consts.ts';
 
 import { useVotingStep } from './hooks.tsx';
 import DescriptionList from './partials/DescriptionList/index.ts';
-import { type VotingStepProps, VotingStepSections } from './types.ts';
-import { useRenderVoteRadioButtons } from './utils.tsx';
+import {
+  type VotingStepProps,
+  VotingStepSections,
+  type VotingFormValues,
+} from './types.ts';
 
 const displayName =
   'v5.common.ActionSidebar.partials.motions.MotionSimplePayment.steps.VotingStep';
@@ -48,6 +54,8 @@ const VotingStep: FC<VotingStepProps> = ({
     thresholdPercent,
     validationSchema,
     transform,
+    handleChangeVoteSuccess,
+    getChangeVotePayload,
   } = useVotingStep({
     actionData,
     startPollingAction,
@@ -55,16 +63,14 @@ const VotingStep: FC<VotingStepProps> = ({
     transactionId,
   });
 
+  const { isDarkMode } = usePageThemeContext();
+
   const { wallet, user } = useAppContext();
   const isRevealPhase = actionData.motionData.motionStateHistory.inRevealPhase;
   const canVote = !!wallet && !!user && !isRevealPhase;
 
   const isSupportVote = currentUserVote === MotionVote.Yay;
   const isOpposeVote = currentUserVote === MotionVote.Nay;
-  const votingItems = useRenderVoteRadioButtons(
-    hasUserVoted,
-    currentUserVote || 0,
-  );
 
   return (
     <MenuWithStatusText
@@ -107,67 +113,126 @@ const VotingStep: FC<VotingStepProps> = ({
         {
           key: VotingStepSections.Vote,
           content: (
-            <ActionForm
-              actionType={ActionTypes.MOTION_VOTE}
-              transform={transform}
-              onSuccess={handleSuccess}
-              validationSchema={validationSchema}
-              defaultValues={{ vote: undefined }}
-            >
-              <div>
-                {hasUserVoted && (isSupportVote || isOpposeVote) && (
-                  <div className="w-full">
-                    <div className="flex items-center justify-between gap-2">
-                      <h4 className="text-2">
-                        {formatText({ id: 'motion.votingStep.voted' })}
-                      </h4>
-                      <MotionVoteBadge vote={currentUserVote} />
-                    </div>
-                    {!isRevealPhase && (
-                      <div className="mt-4 w-full">
-                        <h4 className="mb-1 text-2">
-                          {formatText({ id: 'motion.votingStep.changeVote' })}
-                        </h4>
-                        <p className="text-sm text-gray-600">
-                          {formatText({
-                            id: 'motion.votingStep.changeVoteDescription',
+            <>
+              <ActionForm<VotingFormValues>
+                actionType={ActionTypes.MOTION_VOTE}
+                transform={transform}
+                onSuccess={handleSuccess}
+                validationSchema={validationSchema}
+                defaultValues={{ vote: undefined }}
+              >
+                {({ formState: { isSubmitting } }) => (
+                  <>
+                    <div>
+                      {hasUserVoted && (isSupportVote || isOpposeVote) && (
+                        <div className="w-full">
+                          <div className="flex items-center justify-between gap-2">
+                            <h4 className="text-2">
+                              {formatText({ id: 'motion.votingStep.voted' })}
+                            </h4>
+                            <MotionVoteBadge vote={currentUserVote} />
+                          </div>
+                          {!isRevealPhase && (
+                            <div className="mt-4 w-full">
+                              <h4 className="mb-1 text-2">
+                                {formatText({
+                                  id: 'motion.votingStep.changeVote',
+                                })}
+                              </h4>
+                              <p className="text-sm text-gray-600">
+                                {formatText({
+                                  id: 'motion.votingStep.changeVoteDescription',
+                                })}
+                              </p>
+                            </div>
+                          )}
+                        </div>
+                      )}
+                      {canVote && !hasUserVoted && (
+                        <div
+                          className={clsx('w-full', {
+                            'mt-4': hasUserVoted,
                           })}
-                        </p>
-                      </div>
+                        >
+                          <h4 className="mb-3 text-center text-1">
+                            {formatText({ id: 'motion.votingStep.title' })}
+                          </h4>
+                          <FormButtonRadioButtons
+                            disabled={isSubmitting}
+                            items={[
+                              {
+                                label: formatText({ id: 'motion.oppose' }),
+                                id: 'oppose',
+                                value: MotionVote.Nay,
+                                className: (checked, disabled) =>
+                                  clsx({
+                                    'border-negative-300 text-gray-900 [&_.icon]:text-negative-400':
+                                      !checked && !disabled,
+                                    'border-gray-300 text-gray-300 [&_.icon]:text-gray-300':
+                                      disabled,
+                                    'border-negative-400 bg-negative-400 text-base-white':
+                                      checked && !disabled && !isDarkMode,
+                                    'border-negative-400 bg-negative-400 text-gray-900':
+                                      checked && !disabled && isDarkMode,
+                                  }),
+                                icon: ThumbsDown,
+                                disabled: isSubmitting,
+                              },
+                              {
+                                label: formatText({ id: 'motion.support' }),
+                                id: 'support',
+                                value: MotionVote.Yay,
+                                className: (checked, disabled) =>
+                                  clsx({
+                                    'border-purple-200 text-gray-900 [&_.icon]:text-purple-400':
+                                      !checked && !disabled,
+                                    'border-gray-300 text-gray-300 [&_.icon]:text-gray-300':
+                                      disabled,
+                                    'border-purple-400 bg-purple-400 text-base-white':
+                                      checked && !disabled && !isDarkMode,
+                                    'border-purple-400 bg-purple-400 text-gray-900':
+                                      checked && !disabled && isDarkMode,
+                                  }),
+                                icon: ThumbsUp,
+                                disabled: isSubmitting,
+                              },
+                            ]}
+                            name="vote"
+                          />
+                        </div>
+                      )}
+                    </div>
+                    <DescriptionList
+                      items={items}
+                      className="mt-6 border-t border-gray-200 pt-6"
+                    />
+                    {canVote && !hasUserVoted && (
+                      <Button
+                        disabled={isSubmitting}
+                        mode="primarySolid"
+                        isFullSize
+                        type="submit"
+                        className="mt-6"
+                        text={formatText(MSG.submitVote)}
+                      />
                     )}
-                  </div>
+                  </>
                 )}
-                {canVote && (
-                  <div
-                    className={clsx('w-full', {
-                      'mt-4': hasUserVoted,
-                    })}
+              </ActionForm>
+              {canVote && hasUserVoted && (
+                <div className="mt-6">
+                  <ActionButton
+                    actionType={ActionTypes.MOTION_VOTE}
+                    loadingBehavior={LoadingBehavior.Disabled}
+                    isFullSize
+                    values={getChangeVotePayload}
+                    onSuccess={handleChangeVoteSuccess}
                   >
-                    {!hasUserVoted && (
-                      <h4 className="mb-3 text-center text-1">
-                        {formatText({ id: 'motion.votingStep.title' })}
-                      </h4>
-                    )}
-                    <FormButtonRadioButtons items={votingItems} name="vote" />
-                  </div>
-                )}
-              </div>
-              <DescriptionList
-                items={items}
-                className="mt-6 border-t border-gray-200 pt-6"
-              />
-              {canVote && (
-                <Button
-                  mode="primarySolid"
-                  isFullSize
-                  type="submit"
-                  className="mt-6"
-                  text={formatText(
-                    hasUserVoted ? MSG.changeVote : MSG.submitVote,
-                  )}
-                />
+                    {formatText(MSG.changeVote)}
+                  </ActionButton>
+                </div>
               )}
-            </ActionForm>
+            </>
           ),
         },
       ]}

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/VotingStep/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/VotingStep/utils.tsx
@@ -1,61 +1,9 @@
-import { ThumbsDown, ThumbsUp } from '@phosphor-icons/react';
-import clsx from 'clsx';
-
-import { usePageThemeContext } from '~context/PageThemeContext/PageThemeContext.ts';
-import { MotionVote } from '~utils/colonyMotions.ts';
-import { formatText } from '~utils/intl.ts';
-
-export const useRenderVoteRadioButtons = (
-  hasUserVoted: boolean,
-  userVote: number,
-) => {
-  const { isDarkMode } = usePageThemeContext();
-  const supportOption = {
-    label: formatText({ id: 'motion.support' }),
-    id: 'support',
-    value: MotionVote.Yay,
-    className: (checked, disabled) =>
-      clsx({
-        'border-purple-200 text-gray-900 [&_.icon]:text-purple-400':
-          !checked && !disabled,
-        'border-gray-300 text-gray-300 [&_.icon]:text-gray-300': disabled,
-        'border-purple-400 bg-purple-400 text-base-white':
-          checked && !disabled && !isDarkMode,
-        'border-purple-400 bg-purple-400 text-gray-900':
-          checked && !disabled && isDarkMode,
-      }),
-    icon: ThumbsUp,
-  };
-  const opposeOption = {
-    label: formatText({ id: 'motion.oppose' }),
-    id: 'oppose',
-    value: MotionVote.Nay,
-    className: (checked, disabled) =>
-      clsx({
-        'border-negative-300 text-gray-900 [&_.icon]:text-negative-400':
-          !checked && !disabled,
-        'border-gray-300 text-gray-300 [&_.icon]:text-gray-300': disabled,
-        'border-negative-400 bg-negative-400 text-base-white':
-          checked && !disabled && !isDarkMode,
-        'border-negative-400 bg-negative-400 text-gray-900':
-          checked && !disabled && isDarkMode,
-      }),
-    icon: ThumbsDown,
-  };
-
-  if (!hasUserVoted) {
-    return [opposeOption, supportOption];
-  }
-
-  if (userVote === MotionVote.Nay) {
-    return [supportOption];
-  }
-
-  return [opposeOption];
-};
+import { type MotionVote } from '~utils/colonyMotions.ts';
 
 export const setLocalStorageVoteValue = (transactionId: string, vote: number) =>
   localStorage.setItem(`${transactionId}-vote`, `${vote}`);
 
-export const getLocalStorageVoteValue = (transactionId: string) =>
+export const getLocalStorageVoteValue = (
+  transactionId: string,
+): MotionVote | null =>
   JSON.parse(localStorage.getItem(`${transactionId}-vote`) || 'null');

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/CancelButton/CancelButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/CancelButton/CancelButton.tsx
@@ -6,7 +6,7 @@ import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { ActionTypes } from '~redux/actionTypes.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionButton from '~v5/shared/Button/ActionButton.tsx';
-import { type ButtonProps } from '~v5/shared/Button/types.ts';
+import { LoadingBehavior, type ButtonProps } from '~v5/shared/Button/types.ts';
 
 const displayName =
   'v5.common.ActionSidebar.partials.MultiSig.partials.CancelButton';
@@ -45,7 +45,7 @@ const CancelButton: FC<CancelButtonProps> = ({
   return (
     <ActionButton
       isFullSize
-      useTxLoader
+      loadingBehavior={LoadingBehavior.TxLoader}
       isLoading={isLoading}
       actionType={ActionTypes.MULTISIG_CANCEL}
       values={getCancelPayload}

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/RemoveVoteButton/RemoveVoteButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/RemoveVoteButton/RemoveVoteButton.tsx
@@ -10,6 +10,7 @@ import { extractColonyRoles } from '~utils/colonyRoles.ts';
 import { extractColonyDomains } from '~utils/domains.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionButton from '~v5/shared/Button/ActionButton.tsx';
+import { LoadingBehavior } from '~v5/shared/Button/types.ts';
 
 const displayName =
   'v5.common.ActionSidebar.partials.MultiSig.partials.RemoveVoteButton';
@@ -54,7 +55,7 @@ const RemoveVoteButton: FC<RemoveVoteButtonProps> = ({
 
   return (
     <ActionButton
-      useTxLoader
+      loadingBehavior={LoadingBehavior.TxLoader}
       isFullSize
       actionType={ActionTypes.MULTISIG_VOTE}
       isLoading={isLoading}

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/VoteButton/VoteButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/VoteButton/VoteButton.tsx
@@ -10,7 +10,7 @@ import { extractColonyRoles } from '~utils/colonyRoles.ts';
 import { extractColonyDomains } from '~utils/domains.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionButton from '~v5/shared/Button/ActionButton.tsx';
-import { type ButtonProps } from '~v5/shared/Button/types.ts';
+import { LoadingBehavior, type ButtonProps } from '~v5/shared/Button/types.ts';
 
 const displayName =
   'v5.common.ActionSidebar.partials.MultiSig.partials.VoteButton';
@@ -69,7 +69,7 @@ const VoteButton: FC<VoteButtonProps> = ({
   return (
     <ActionButton
       isFullSize
-      useTxLoader
+      loadingBehavior={LoadingBehavior.TxLoader}
       actionType={ActionTypes.MULTISIG_VOTE}
       isLoading={isLoading}
       onError={() => {

--- a/src/components/v5/shared/Button/ActionButton.tsx
+++ b/src/components/v5/shared/Button/ActionButton.tsx
@@ -8,7 +8,7 @@ import { getFormAction } from '~utils/actions.ts';
 
 import Button from './Button.tsx';
 import IconButton from './IconButton.tsx';
-import { type ActionButtonProps } from './types.ts';
+import { LoadingBehavior, type ActionButtonProps } from './types.ts';
 
 const ActionButton: FC<ActionButtonProps> = ({
   actionType,
@@ -20,7 +20,7 @@ const ActionButton: FC<ActionButtonProps> = ({
   transform,
   values,
   isLoading = false,
-  useTxLoader,
+  loadingBehavior,
   ...props
 }) => {
   const isMobile = useMobile();
@@ -47,12 +47,13 @@ const ActionButton: FC<ActionButtonProps> = ({
       if (isMountedRef.current) setLoading(false);
       if (typeof onSuccess == 'function') onSuccess(result);
     } catch (err) {
-      setLoading(false);
       onError?.(err);
+    } finally {
+      setLoading(false);
     }
   };
 
-  return useTxLoader && (isLoading || loading) ? (
+  if (loadingBehavior === LoadingBehavior.TxLoader && (isLoading || loading)) {
     <IconButton
       rounded="s"
       isFullSize={props.isFullSize || isMobile}
@@ -63,8 +64,14 @@ const ActionButton: FC<ActionButtonProps> = ({
         </span>
       }
       className="!px-4 !text-md"
-    />
-  ) : (
+    />;
+  }
+
+  if (loadingBehavior === LoadingBehavior.Disabled && (isLoading || loading)) {
+    return <Button onClick={handleClick} disabled {...props} />;
+  }
+
+  return (
     <Button onClick={handleClick} loading={loading || isLoading} {...props} />
   );
 };

--- a/src/components/v5/shared/Button/types.ts
+++ b/src/components/v5/shared/Button/types.ts
@@ -97,6 +97,11 @@ export interface CloseButtonProps extends CommonButtonProps {
   iconSize?: number;
 }
 
+export enum LoadingBehavior {
+  TxLoader = 'txLoader', // Tx loader
+  Disabled = 'disabled', // Disabled during load
+}
+
 export interface ActionButtonProps extends ButtonProps {
   actionType: ActionTypes;
   isLoading?: boolean;
@@ -108,7 +113,7 @@ export interface ActionButtonProps extends ButtonProps {
   text?: MessageDescriptor | string;
   transform?: ActionTransformFnType;
   values?: any;
-  useTxLoader?: boolean;
+  loadingBehavior?: LoadingBehavior;
 }
 
 export type ButtonLinkProps = Omit<


### PR DESCRIPTION
## Description

This PR addresses a few issues with the motion voting step.

On occasion, the UI would not update after a successful transaction to show the status of the vote. This PR resolves this by memoizing the transform function.

This PR also removes the single option after voting, and instead just handles the vote change when clicking the "Change vote" button.

The "Change vote" button uses the `ActionButton` component, which I have added a `loadingBehavior` prop to which allows for the button to be disabled when submitting to match how the "Submit vote" button works.

The "Oppose" and "Support" vote buttons are now disabled whilst the form is submitting.

(Note: The pending count issue described in the original issue will be handled in a separate PR.)

## Testing

* Step 1 - Install the reputation voting extension
* Step 2 - Create a motion and stake it
* Step 3 - Vote to either "Oppose" or "Suppose" the motion

The "Oppose" and "Support" buttons should be disabled whilst submitting. The UI should automatically update after the transaction.

* Step 4 - Click "Change vote" to change your vote (without needing to first select an option).

Notice the "Change vote" button will be disabled whilst submitting.

https://github.com/user-attachments/assets/4e5aba4d-bac9-4342-a41b-63676941bdf0

## Diffs

**Changes** 🏗

* Voting transform function is now memoized
* Voting options are no longer shown after initial vote
* "Change vote" button now uses `ActionButton` component to submit payload with changed vote
* "Oppose" and "Support" vote buttons are now disabled whilst the form is submitting.

Contributes to #2883 