### PR TITLE
Fix: Finalize button goes to pending state when isSubmitting

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
@@ -162,75 +162,88 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
           key: FinalizeStepSections.Finalize,
           content: (
             <ActionForm {...action} onSuccess={handleSuccess}>
-              {items.length > 0 && (
+              {({ formState: { isSubmitting } }) => (
                 <>
-                  <div className="mb-2">
-                    <h4 className="mb-3 flex items-center justify-between text-1">
-                      {formatText({ id: 'motion.finalizeStep.title' })}
-                      {isClaimed && (
-                        <PillsBase className="bg-teams-pink-100 text-teams-pink-500">
-                          {formatText({ id: 'motion.finalizeStep.claimed' })}
-                        </PillsBase>
-                      )}
-                    </h4>
-                  </div>
-                  <DescriptionList
-                    items={items}
-                    className={clsx({
-                      'mb-6':
-                        !isMotionFailedNotFinalizable &&
-                        (!isMotionFinalized || (!isClaimed && canClaimStakes)),
-                    })}
-                  />
-                </>
-              )}
-              {canInteract && (
-                <>
-                  {isPolling && (
-                    <IconButton
-                      className="w-full"
-                      rounded="s"
-                      text={{ id: 'button.pending' }}
-                      icon={
-                        <span className="ml-1.5 flex shrink-0">
-                          <SpinnerGap size={14} className="animate-spin" />
-                        </span>
-                      }
-                      title={{ id: 'button.pending' }}
-                      ariaLabel={{ id: 'button.pending' }}
-                    />
+                  {items.length > 0 && (
+                    <>
+                      <div className="mb-2">
+                        <h4 className="mb-3 flex items-center justify-between text-1">
+                          {formatText({ id: 'motion.finalizeStep.title' })}
+                          {isClaimed && (
+                            <PillsBase className="bg-teams-pink-100 text-teams-pink-500">
+                              {formatText({
+                                id: 'motion.finalizeStep.claimed',
+                              })}
+                            </PillsBase>
+                          )}
+                        </h4>
+                      </div>
+                      <DescriptionList
+                        items={items}
+                        className={clsx({
+                          'mb-6':
+                            !isMotionFailedNotFinalizable &&
+                            (!isMotionFinalized ||
+                              (!isClaimed && canClaimStakes)),
+                        })}
+                      />
+                    </>
                   )}
-                  {!isPolling &&
-                    !isMotionFailedNotFinalizable &&
-                    !isMotionFinalized &&
-                    !isMotionAgreement && (
-                      <Button
-                        mode="primarySolid"
-                        disabled={!isFinalizable || wrongMotionState}
-                        isFullSize
-                        text={formatText({
-                          id: 'motion.finalizeStep.submit',
-                        })}
-                        type="submit"
-                      />
-                    )}
-                  {!isPolling &&
-                    !isMotionFailedNotFinalizable &&
-                    isMotionClaimable &&
-                    !isClaimed &&
-                    canClaimStakes && (
-                      <Button
-                        mode="primarySolid"
-                        disabled={!canClaimStakes || wrongMotionState}
-                        isFullSize
-                        text={formatText({
-                          id: isMotionAgreement
-                            ? 'motion.finalizeStep.returnStakes'
-                            : buttonTextId,
-                        })}
-                        type="submit"
-                      />
-                    )}
+                  {canInteract && (
+                    <>
+                      {(isPolling || isSubmitting) && (
+                        <IconButton
+                          className="w-full"
+                          rounded="s"
+                          text={{ id: 'button.pending' }}
+                          icon={
+                            <span className="ml-1.5 flex shrink-0">
+                              <SpinnerGap size={14} className="animate-spin" />
+                            </span>
+                          }
+                          title={{ id: 'button.pending' }}
+                          ariaLabel={{ id: 'button.pending' }}
+                        />
+                      )}
+                      {!isPolling &&
+                        !isSubmitting &&
+                        !isMotionFailedNotFinalizable &&
+                        !isMotionFinalized &&
+                        !isMotionAgreement && (
+                          <Button
+                            mode="primarySolid"
+                            disabled={!isFinalizable || wrongMotionState}
+                            isFullSize
+                            text={formatText({
+                              id: 'motion.finalizeStep.submit',
+                            })}
+                            type="submit"
+                          />
+                        )}
+                      {!isPolling &&
+                        !isSubmitting &&
+                        !isMotionFailedNotFinalizable &&
+                        isMotionClaimable &&
+                        !isClaimed &&
+                        canClaimStakes && (
+                          <Button
+                            mode="primarySolid"
+                            disabled={
+                              !canClaimStakes ||
+                              wrongMotionState ||
+                              isSubmitting
+                            }
+                            isFullSize
+                            text={formatText({
+                              id: isMotionAgreement
+                                ? 'motion.finalizeStep.returnStakes'
+                                : buttonTextId,
+                            })}
+                            type="submit"
+                          />
+                        )}
+                    </>
+                  )}
                 </>
               )}
             </ActionForm>


### PR DESCRIPTION
## Description

This PR changes the "Finalize" button to a "Pending" button whilst the form is submitting. Previously the "Finalize" button was not disabled meaning it was possible to click the button multiple times opening up multiple transactions.

The same fix has been applied to the "Claim" button.

## Testing

* Step 1 - Install the reputation voting extension
* Step 2 - Create any motion
* Step 3 - Stake both sides, vote to support, reveal your vote to get to the finalize step
* Step 4 - Click the Finalize button - notice the "Pending" state whilst the transaction is submitting. (To make this even more apparent, switch to the metamask wallet. When you click "Finalize" the transaction should pop up, ignore it and try clicking the "Pending" button again. No new transactions should be opened.)

<img width="1087" alt="Screenshot 2024-09-18 at 12 15 08" src="https://github.com/user-attachments/assets/249a5925-2137-4308-93a8-bc161c2a8952">

## Diffs

**Changes** 🏗

* `FinalizeStep` shows a "Pending" button whilst the form is submitting

Resolves #2895
