### PR TITLE
[Dashboard] feat: breadcrumbs

### DIFF
--- a/src/Entry.tsx
+++ b/src/Entry.tsx
@@ -7,6 +7,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
 
 import AnalyticsContextProvider from '~context/AnalyticsContext/AnalyticsContextProvider.tsx';
+import BreadcrumbsContextProvider from '~context/BreadcrumbsContext/BreadcrumbsContextProvider.tsx';
 import { getContext, ContextModule } from '~context/index.ts';
 import RouteTracker from '~routes/RouteTracker.tsx';
 
@@ -55,8 +56,10 @@ const Entry = ({ store }: Props) => {
             <HelmetProvider>
               <AnalyticsContextProvider>
                 <Router>
-                  <RouteTracker />
-                  <Routes />
+                  <BreadcrumbsContextProvider>
+                    <RouteTracker />
+                    <Routes />
+                  </BreadcrumbsContextProvider>
                 </Router>
               </AnalyticsContextProvider>
             </HelmetProvider>

--- a/src/components/frame/Extensions/layouts/ColonyLayout.tsx
+++ b/src/components/frame/Extensions/layouts/ColonyLayout.tsx
@@ -19,7 +19,6 @@ import { UserHubTab } from '~common/Extensions/UserHub/types.ts';
 import UserHubButton from '~common/Extensions/UserHubButton/index.ts';
 import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
-import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useColonyCreatedModalContext } from '~context/ColonyCreateModalContext/ColonyCreatedModalContext.ts';
 import { useMemberModalContext } from '~context/MemberModalContext/MemberModalContext.ts';
 import { usePageHeadingContext } from '~context/PageHeadingContext/PageHeadingContext.ts';
@@ -54,8 +53,7 @@ const displayName = 'frame.Extensions.layouts.ColonyLayout';
 
 const ColonyLayout: FC<PropsWithChildren> = ({ children }) => {
   const { user } = useAppContext();
-  const { colony } = useColonyContext();
-  const { title: pageHeadingTitle, breadcrumbs = [] } = usePageHeadingContext();
+  const { title: pageHeadingTitle } = usePageHeadingContext();
   // @TODO: Eventually we want the action sidebar context to be better intergrated in the layout (maybe only used here and not in UserNavigation(Wrapper))
   const { actionSidebarToggle } = useActionSidebarContext();
   const [isActionSidebarOpen, { toggleOn: toggleActionSidebarOn }] =
@@ -157,18 +155,6 @@ const ColonyLayout: FC<PropsWithChildren> = ({ children }) => {
         headerProps={{
           pageHeadingProps: {
             title: pageHeadingTitle,
-            breadcrumbs: [
-              ...(colony.name
-                ? [
-                    {
-                      key: '1',
-                      href: `/${colony.name}`,
-                      label: colony.metadata?.displayName || '',
-                    },
-                  ]
-                : []),
-              ...breadcrumbs,
-            ],
           },
           /** @TODO: Move this inside the Header component */
           userNavigation: getUserNavigation(isActionSidebarOpen),

--- a/src/components/frame/Extensions/layouts/MainLayout.tsx
+++ b/src/components/frame/Extensions/layouts/MainLayout.tsx
@@ -15,19 +15,17 @@ const MainLayout: FC<PropsWithChildren<MainLayoutProps>> = ({
   sidebar,
   header,
 }) => {
-  const { title: pageHeadingTitle, breadcrumbs = [] } = usePageHeadingContext();
+  const { title: pageHeadingTitle } = usePageHeadingContext();
 
   return (
     <PageLayout
       // @TODO: Move page heading props logic inside the header component itself
       headerProps={{
-        pageHeadingProps:
-          pageHeadingTitle || breadcrumbs.length
-            ? {
-                title: pageHeadingTitle,
-                breadcrumbs,
-              }
-            : undefined,
+        pageHeadingProps: pageHeadingTitle
+          ? {
+              title: pageHeadingTitle,
+            }
+          : undefined,
         userNavigation: <UserNavigationWrapper />,
       }}
       sidebar={sidebar ?? <BasicPageSidebar />}

--- a/src/components/frame/LandingPage/LandingPage.tsx
+++ b/src/components/frame/LandingPage/LandingPage.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 
 import InvitationBlock from '~common/InvitationBlock/index.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
-import { usePageHeadingContext } from '~context/PageHeadingContext/PageHeadingContext.ts';
+import { useBreadcrumbsContext } from '~context/BreadcrumbsContext/BreadcrumbsContext.ts';
 import { MainLayout } from '~frame/Extensions/layouts/index.ts';
 import LoadingTemplate from '~frame/LoadingTemplate/index.ts';
 import ColonyIcon from '~icons/ColonyIcon.tsx';
@@ -100,16 +100,12 @@ const LandingPage = () => {
   const navigate = useNavigate();
   const { user, connectWallet, wallet, walletConnecting, userLoading } =
     useAppContext();
-  const { setBreadcrumbs } = usePageHeadingContext();
+  const { setShouldShowBreadcrumbs } = useBreadcrumbsContext();
 
   useEffect(() => {
-    setBreadcrumbs([
-      {
-        key: 'landing-page',
-        label: 'Colony App',
-      },
-    ]);
-  }, [setBreadcrumbs]);
+    setShouldShowBreadcrumbs(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (userLoading || walletConnecting) {
     return <LoadingTemplate />;

--- a/src/components/frame/v5/pages/UserProfilePage/UserProfilePage.tsx
+++ b/src/components/frame/v5/pages/UserProfilePage/UserProfilePage.tsx
@@ -1,12 +1,11 @@
 import React, { type FC, useEffect } from 'react';
+import { defineMessages } from 'react-intl';
 import { Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
 
+import { useBreadcrumbsContext } from '~context/BreadcrumbsContext/BreadcrumbsContext.ts';
 import { useFeatureFlagsContext } from '~context/FeatureFlagsContext/FeatureFlagsContext.ts';
 import { FeatureFlag } from '~context/FeatureFlagsContext/types.ts';
-import {
-  usePageHeadingContext,
-  useSetPageHeadingTitle,
-} from '~context/PageHeadingContext/PageHeadingContext.ts';
+import { useSetPageHeadingTitle } from '~context/PageHeadingContext/PageHeadingContext.ts';
 import {
   USER_CRYPTO_TO_FIAT_ROUTE,
   USER_ADVANCED_ROUTE,
@@ -19,6 +18,13 @@ import { formatText } from '~utils/intl.ts';
 import { TabId } from './types.ts';
 
 const displayName = 'v5.pages.UserProfilePage';
+
+const MSG = defineMessages({
+  homeBreadcrumbLabel: {
+    id: `${displayName}.homeBreadcrumbLabel`,
+    defaultMessage: 'Colony',
+  },
+});
 
 const tabRoutes = [
   {
@@ -58,7 +64,8 @@ const UserProfilePage: FC = () => {
   const { pathname } = useLocation();
   const featureFlags = useFeatureFlagsContext();
 
-  const { setBreadcrumbs } = usePageHeadingContext();
+  const { setRootBreadcrumbItem, setShouldShowBreadcrumbs, resetBreadcrumbs } =
+    useBreadcrumbsContext();
 
   const allowedTabRoutes = tabRoutes.filter((route) =>
     route.featureFlag
@@ -73,14 +80,17 @@ const UserProfilePage: FC = () => {
   )?.id;
 
   useEffect(() => {
-    setBreadcrumbs([
-      {
-        key: 'landing-page',
-        label: 'Colony App',
-        href: '/',
-      },
-    ]);
-  }, [setBreadcrumbs]);
+    setRootBreadcrumbItem({
+      link: '',
+      label: formatText(MSG.homeBreadcrumbLabel),
+    });
+    setShouldShowBreadcrumbs(true);
+
+    return () => {
+      resetBreadcrumbs();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useSetPageHeadingTitle(formatText({ id: 'userProfile.title' }));
 

--- a/src/components/v5/frame/PageLayout/partials/PageHeader/PageHeader.tsx
+++ b/src/components/v5/frame/PageLayout/partials/PageHeader/PageHeader.tsx
@@ -35,7 +35,6 @@ const PageHeader: FC<PageHeaderProps> = ({ pageHeadingProps }) => {
 
   const isTablet = useTablet();
 
-  const breadcrumbs = pageHeadingProps?.breadcrumbs;
   const title = pageHeadingProps?.title;
 
   useHeightResizeObserver(
@@ -53,9 +52,9 @@ const PageHeader: FC<PageHeaderProps> = ({ pageHeadingProps }) => {
           )}
         >
           <div>
-            {!isTablet && breadcrumbs && (
+            {!isTablet && (
               <section className="flex-shrink-0">
-                <PageHeading breadcrumbs={breadcrumbs} />
+                <PageHeading />
               </section>
             )}
             {isTablet && (
@@ -94,14 +93,10 @@ const PageHeader: FC<PageHeaderProps> = ({ pageHeadingProps }) => {
           />
         </div>
       </section>
-      <section
-        className={clsx('flex w-full flex-col md:p-0', {
-          'px-6 pb-2 pt-6': breadcrumbs,
-        })}
-      >
-        {isTablet && breadcrumbs && (
+      <section className="flex w-full flex-col md:p-0">
+        {isTablet && (
           <section className="flex-shrink-0">
-            <PageHeading breadcrumbs={breadcrumbs} />
+            <PageHeading />
           </section>
         )}
         {title && (

--- a/src/components/v5/frame/PageLayout/partials/PageHeading/PageHeading.tsx
+++ b/src/components/v5/frame/PageLayout/partials/PageHeading/PageHeading.tsx
@@ -7,13 +7,9 @@ import { type PageHeadingProps } from './types.ts';
 
 const displayName = 'v5.frame.PageLayout.partials.PageHeading';
 
-const PageHeading: FC<PageHeadingProps> = ({
-  breadcrumbs,
-  title,
-  className,
-}) => (
+const PageHeading: FC<PageHeadingProps> = ({ title, className }) => (
   <div className={clsx(className, 'modal-blur')}>
-    <Breadcrumbs className={clsx({ 'mb-2': title })} items={breadcrumbs} />
+    <Breadcrumbs className={clsx({ 'mb-2': title })} />
     {title && <h1 className="text-gray-900 heading-3">{title}</h1>}
   </div>
 );

--- a/src/components/v5/frame/PageLayout/partials/PageHeading/types.ts
+++ b/src/components/v5/frame/PageLayout/partials/PageHeading/types.ts
@@ -1,7 +1,4 @@
-import { type BreadcrumbsItem } from '~v5/shared/Breadcrumbs/types.ts';
-
 export interface PageHeadingProps {
   title?: string;
-  breadcrumbs: BreadcrumbsItem[];
   className?: string;
 }

--- a/src/components/v5/shared/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/v5/shared/Breadcrumbs/Breadcrumbs.tsx
@@ -1,42 +1,61 @@
+import { CaretRight } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { type FC } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { useBreadcrumbsContext } from '~context/BreadcrumbsContext/BreadcrumbsContext.ts';
 
 import Link from '../Link/index.ts';
 
-import { type BreadcrumbsItem, type BreadcrumbsProps } from './types.ts';
+import { type BreadcrumbsProps } from './types.ts';
+import { getBreadcrumbItemName } from './utils.ts';
 
 const displayName = 'v5.Breadcrumbs';
 
-const getBreadcrumbItem = (item: BreadcrumbsItem) => {
-  if ('href' in item && item.href) {
-    return (
-      <Link to={item.href} className="text-inherit">
-        {item.label}
-      </Link>
-    );
+const Breadcrumbs: FC<BreadcrumbsProps> = ({ className }) => {
+  const { rootBreadcrumbItem, shouldShowBreadcrumbs } = useBreadcrumbsContext();
+  const location = useLocation();
+
+  if (!shouldShowBreadcrumbs) {
+    return null;
   }
+  const pathSections = location.pathname.split('/');
+  const initialPath = pathSections.slice(0, 2).join('/');
+  const breadcrumbItems = pathSections.slice(2);
 
-  return <h5>{item.label}</h5>;
-};
+  const getBreadcrumbLink = (index: number) => {
+    return `${initialPath}/${breadcrumbItems.slice(0, index + 1).join('/')}`;
+  };
 
-const Breadcrumbs: FC<BreadcrumbsProps> = ({ items, className }) => {
-  return items.length ? (
+  return (
     <ul
       className={clsx(
         className,
-        'flex flex-wrap items-center uppercase tracking-[.075rem] text-gray-900 text-3',
+        'flex items-center gap-2 text-sm text-gray-700',
       )}
     >
-      {items.map((item) => (
-        <li
-          className='after:mx-2 after:content-["/"] last:after:hidden'
-          key={item.key}
-        >
-          {getBreadcrumbItem(item)}
+      {rootBreadcrumbItem ? (
+        <li>
+          <Link to={rootBreadcrumbItem?.link}>{rootBreadcrumbItem?.label}</Link>
         </li>
+      ) : null}
+      {breadcrumbItems.map((item, index) => (
+        <React.Fragment key={`breadcrumbItem.${item}`}>
+          <CaretRight size={10} />
+          <li>
+            <Link
+              className={clsx('capitalize', {
+                'font-semibold': index === breadcrumbItems.length - 1, // if it's the last one, it's active
+              })}
+              to={getBreadcrumbLink(index)}
+            >
+              {getBreadcrumbItemName(item)}
+            </Link>
+          </li>
+        </React.Fragment>
       ))}
     </ul>
-  ) : null;
+  );
 };
 
 Breadcrumbs.displayName = displayName;

--- a/src/components/v5/shared/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/v5/shared/Breadcrumbs/Breadcrumbs.tsx
@@ -8,9 +8,12 @@ import { useBreadcrumbsContext } from '~context/BreadcrumbsContext/BreadcrumbsCo
 import Link from '../Link/index.ts';
 
 import BreadcrumbItem from './partials/BreadcrumbItem.tsx';
-import { type BreadcrumbsProps } from './types.ts';
 
 const displayName = 'v5.Breadcrumbs';
+
+interface BreadcrumbsProps {
+  className?: string;
+}
 
 const Breadcrumbs: FC<BreadcrumbsProps> = ({ className }) => {
   const { rootBreadcrumbItem, shouldShowBreadcrumbs } = useBreadcrumbsContext();
@@ -21,8 +24,8 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({ className }) => {
   }
   const pathSections = location.pathname
     .split('/')
-    .filter((test) => test.length > 0);
-  const initialPath = `${pathSections[0]}/`;
+    .filter((section) => section.length > 0);
+  const initialPath = `/${pathSections[0]}`;
   const breadcrumbItems = pathSections.slice(1);
 
   const getBreadcrumbLink = (index: number) => {

--- a/src/components/v5/shared/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/v5/shared/Breadcrumbs/Breadcrumbs.tsx
@@ -7,8 +7,8 @@ import { useBreadcrumbsContext } from '~context/BreadcrumbsContext/BreadcrumbsCo
 
 import Link from '../Link/index.ts';
 
+import BreadcrumbItem from './partials/BreadcrumbItem.tsx';
 import { type BreadcrumbsProps } from './types.ts';
-import { getBreadcrumbItemName } from './utils.ts';
 
 const displayName = 'v5.Breadcrumbs';
 
@@ -19,9 +19,11 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({ className }) => {
   if (!shouldShowBreadcrumbs) {
     return null;
   }
-  const pathSections = location.pathname.split('/');
-  const initialPath = pathSections.slice(0, 2).join('/');
-  const breadcrumbItems = pathSections.slice(2);
+  const pathSections = location.pathname
+    .split('/')
+    .filter((test) => test.length > 0);
+  const initialPath = `${pathSections[0]}/`;
+  const breadcrumbItems = pathSections.slice(1);
 
   const getBreadcrumbLink = (index: number) => {
     return `${initialPath}/${breadcrumbItems.slice(0, index + 1).join('/')}`;
@@ -44,12 +46,12 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({ className }) => {
           <CaretRight size={10} />
           <li>
             <Link
-              className={clsx('capitalize', {
+              className={clsx({
                 'font-semibold': index === breadcrumbItems.length - 1, // if it's the last one, it's active
               })}
               to={getBreadcrumbLink(index)}
             >
-              {getBreadcrumbItemName(item)}
+              <BreadcrumbItem parameter={item} />
             </Link>
           </li>
         </React.Fragment>

--- a/src/components/v5/shared/Breadcrumbs/consts.ts
+++ b/src/components/v5/shared/Breadcrumbs/consts.ts
@@ -1,6 +1,23 @@
-import { type MessageDescriptor } from 'react-intl';
+import { defineMessages, type MessageDescriptor } from 'react-intl';
 
 import { supportedExtensionsConfig } from '~constants';
+import {
+  COLONY_PERMISSIONS_MULTISIG_SECTION,
+  USER_CRYPTO_TO_FIAT_ROUTE,
+} from '~routes/routeConstants.ts';
+
+const displayName = 'v5.Breadcrumbs.RouteNames';
+
+const MSG = defineMessages({
+  cryptoToFiat: {
+    id: `${displayName}.cryptoToFiat`,
+    defaultMessage: 'Crypto to fiat',
+  },
+  multiSig: {
+    id: `${displayName}.multisig`,
+    defaultMessage: 'Multi-sig',
+  },
+});
 
 const extensionsBreadcrumbNames = supportedExtensionsConfig.reduce(
   (names, extensionConfig) => {
@@ -12,6 +29,9 @@ const extensionsBreadcrumbNames = supportedExtensionsConfig.reduce(
   {},
 );
 
+// @TODO we probably want to do it for all possible routes and refrain from automatically just capitalizing the route part
 export const breadcrumbItemNames: Record<string, MessageDescriptor> = {
   ...extensionsBreadcrumbNames,
+  [USER_CRYPTO_TO_FIAT_ROUTE]: MSG.cryptoToFiat,
+  [COLONY_PERMISSIONS_MULTISIG_SECTION]: MSG.multiSig,
 };

--- a/src/components/v5/shared/Breadcrumbs/consts.ts
+++ b/src/components/v5/shared/Breadcrumbs/consts.ts
@@ -1,0 +1,17 @@
+import { type MessageDescriptor } from 'react-intl';
+
+import { supportedExtensionsConfig } from '~constants';
+
+const extensionsBreadcrumbNames = supportedExtensionsConfig.reduce(
+  (names, extensionConfig) => {
+    return {
+      ...names,
+      [extensionConfig.extensionId]: extensionConfig.name,
+    };
+  },
+  {},
+);
+
+export const breadcrumbItemNames: Record<string, MessageDescriptor> = {
+  ...extensionsBreadcrumbNames,
+};

--- a/src/components/v5/shared/Breadcrumbs/partials/BreadcrumbItem.tsx
+++ b/src/components/v5/shared/Breadcrumbs/partials/BreadcrumbItem.tsx
@@ -1,0 +1,24 @@
+import { type FC } from 'react';
+import React from 'react';
+
+import { formatText } from '~utils/intl.ts';
+
+import { breadcrumbItemNames } from '../consts.ts';
+
+const displayName = 'v5.Breadcrumbs.partials.BreadcrumbItem';
+
+interface BreadcrumbItemProps {
+  parameter: string;
+}
+const BreadcrumbItem: FC<BreadcrumbItemProps> = ({ parameter }) => {
+  const itemName = breadcrumbItemNames[parameter];
+
+  if (itemName) {
+    return <span>{formatText(itemName)}</span>;
+  }
+
+  return <span className="capitalize">{parameter}</span>;
+};
+
+BreadcrumbItem.displayName = displayName;
+export default BreadcrumbItem;

--- a/src/components/v5/shared/Breadcrumbs/types.ts
+++ b/src/components/v5/shared/Breadcrumbs/types.ts
@@ -1,8 +1,0 @@
-export type BreadcrumbsItem = { key: string } & {
-  label: string;
-  href?: string;
-};
-
-export interface BreadcrumbsProps {
-  className?: string;
-}

--- a/src/components/v5/shared/Breadcrumbs/types.ts
+++ b/src/components/v5/shared/Breadcrumbs/types.ts
@@ -4,6 +4,5 @@ export type BreadcrumbsItem = { key: string } & {
 };
 
 export interface BreadcrumbsProps {
-  items: BreadcrumbsItem[];
   className?: string;
 }

--- a/src/components/v5/shared/Breadcrumbs/utils.ts
+++ b/src/components/v5/shared/Breadcrumbs/utils.ts
@@ -1,9 +1,0 @@
-import { formatText } from '~utils/intl.ts';
-
-import { breadcrumbItemNames } from './consts.ts';
-
-export const getBreadcrumbItemName = (parameter: string): string => {
-  return breadcrumbItemNames[parameter]
-    ? formatText(breadcrumbItemNames[parameter])
-    : parameter;
-};

--- a/src/components/v5/shared/Breadcrumbs/utils.ts
+++ b/src/components/v5/shared/Breadcrumbs/utils.ts
@@ -1,0 +1,9 @@
+import { formatText } from '~utils/intl.ts';
+
+import { breadcrumbItemNames } from './consts.ts';
+
+export const getBreadcrumbItemName = (parameter: string): string => {
+  return breadcrumbItemNames[parameter]
+    ? formatText(breadcrumbItemNames[parameter])
+    : parameter;
+};

--- a/src/context/BreadcrumbsContext/BreadcrumbsContext.ts
+++ b/src/context/BreadcrumbsContext/BreadcrumbsContext.ts
@@ -1,0 +1,29 @@
+import { createContext, useContext } from 'react';
+
+export interface BreadcrumbItem {
+  label: string;
+  link: string;
+}
+export interface BreadcrumbsContextValue {
+  rootBreadcrumbItem: BreadcrumbItem | null;
+  shouldShowBreadcrumbs: boolean;
+  setShouldShowBreadcrumbs: (shouldShow: boolean) => void;
+  setRootBreadcrumbItem: (item: BreadcrumbItem | null) => void;
+  resetBreadcrumbs: () => void;
+}
+
+export const BreadcrumbsContext = createContext<
+  BreadcrumbsContextValue | undefined
+>(undefined);
+
+export const useBreadcrumbsContext = () => {
+  const context = useContext(BreadcrumbsContext);
+
+  if (!context) {
+    throw new Error(
+      'This hook must be used within the "BreadcrumbsContext" provider',
+    );
+  }
+
+  return context;
+};

--- a/src/context/BreadcrumbsContext/BreadcrumbsContextProvider.tsx
+++ b/src/context/BreadcrumbsContext/BreadcrumbsContextProvider.tsx
@@ -1,0 +1,43 @@
+import React, {
+  type FC,
+  type PropsWithChildren,
+  useMemo,
+  useState,
+} from 'react';
+
+import {
+  type BreadcrumbItem,
+  BreadcrumbsContext,
+  type BreadcrumbsContextValue,
+} from './BreadcrumbsContext.ts';
+
+// @TODO if we end up doing route matching shennanigans, we can remove rootBreadcrumbItem
+const BreadcrumbsContextProvider: FC<PropsWithChildren> = ({ children }) => {
+  const [rootBreadcrumbItem, setRootBreadcrumbItem] =
+    useState<BreadcrumbItem | null>(null);
+  const [shouldShowBreadcrumbs, setShouldShowBreadcrumbs] = useState(false);
+
+  const resetBreadcrumbs = () => {
+    setShouldShowBreadcrumbs(false);
+    setRootBreadcrumbItem(null);
+  };
+
+  const value: BreadcrumbsContextValue = useMemo(
+    () => ({
+      rootBreadcrumbItem,
+      shouldShowBreadcrumbs,
+      setShouldShowBreadcrumbs,
+      setRootBreadcrumbItem,
+      resetBreadcrumbs,
+    }),
+    [rootBreadcrumbItem, shouldShowBreadcrumbs],
+  );
+
+  return (
+    <BreadcrumbsContext.Provider value={value}>
+      {children}
+    </BreadcrumbsContext.Provider>
+  );
+};
+
+export default BreadcrumbsContextProvider;

--- a/src/context/PageHeadingContext/PageHeadingContext.ts
+++ b/src/context/PageHeadingContext/PageHeadingContext.ts
@@ -1,3 +1,4 @@
+// @TODO remove this entire thing and render titles on each page instead
 import { createContext, useContext, useEffect } from 'react';
 
 import { type PageHeadingProps } from '~v5/frame/PageLayout/partials/PageHeading/types.ts';

--- a/src/context/PageHeadingContext/PageHeadingContext.ts
+++ b/src/context/PageHeadingContext/PageHeadingContext.ts
@@ -1,20 +1,14 @@
 // @TODO remove this entire thing and render titles on each page instead
 import { createContext, useContext, useEffect } from 'react';
 
-import { type PageHeadingProps } from '~v5/frame/PageLayout/partials/PageHeading/types.ts';
-
 interface PageHeadingContextValue {
   title?: string;
   setTitle: (title: string | undefined) => void;
-  breadcrumbs?: PageHeadingProps['breadcrumbs'];
-  setBreadcrumbs: (breadcrumbs: PageHeadingProps['breadcrumbs']) => void;
 }
 
 export const PageHeadingContext = createContext<PageHeadingContextValue>({
   title: undefined,
   setTitle: () => {},
-  breadcrumbs: undefined,
-  setBreadcrumbs: () => {},
 });
 
 export const usePageHeadingContext = (): PageHeadingContextValue =>

--- a/src/context/PageHeadingContext/PageHeadingContextProvider.tsx
+++ b/src/context/PageHeadingContext/PageHeadingContextProvider.tsx
@@ -5,24 +5,17 @@ import React, {
   useState,
 } from 'react';
 
-import { type PageHeadingProps } from '~v5/frame/PageLayout/partials/PageHeading/types.ts';
-
 import { PageHeadingContext } from './PageHeadingContext.ts';
 
 const PageHeadingContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const [title, setTitle] = useState<string | undefined>(undefined);
-  const [breadcrumbs, setBreadcrumbs] = useState<
-    PageHeadingProps['breadcrumbs'] | undefined
-  >(undefined);
 
   const value = useMemo(
     () => ({
       title,
       setTitle,
-      breadcrumbs,
-      setBreadcrumbs,
     }),
-    [breadcrumbs, title],
+    [title],
   );
 
   return (

--- a/src/routes/ColonyRoute.tsx
+++ b/src/routes/ColonyRoute.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { defineMessages } from 'react-intl';
 import { Navigate, Outlet, useParams } from 'react-router-dom';
 
 import ActionSidebarContextProvider from '~context/ActionSidebarContext/ActionSidebarContextProvider.tsx';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
+import { useBreadcrumbsContext } from '~context/BreadcrumbsContext/BreadcrumbsContext.ts';
 import ColonyContextProvider from '~context/ColonyContext/ColonyContextProvider.tsx';
 import ColonyCreateModalProvider from '~context/ColonyCreateModalContext/ColonyCreateModalContextProvider.tsx';
 import ColonyDecisionProvider from '~context/ColonyDecisionContext/ColonyDecisionContextProvider.tsx';
@@ -15,6 +16,7 @@ import { ColonyLayout } from '~frame/Extensions/layouts/index.ts';
 import LoadingTemplate from '~frame/LoadingTemplate/index.ts';
 import { useGetFullColonyByNameQuery } from '~gql';
 import useIsContributor from '~hooks/useIsContributor.ts';
+import { formatText } from '~utils/intl.ts';
 
 import NotFoundRoute from './NotFoundRoute.tsx';
 
@@ -25,10 +27,16 @@ const MSG = defineMessages({
     id: `${displayName}.loadingText`,
     defaultMessage: 'Loading Colony',
   },
+  dashboardBreadcrumbLabel: {
+    id: `${displayName}.dashboardBreadcrumbLabel`,
+    defaultMessage: 'Dashboard',
+  },
 });
 
 const ColonyRoute = () => {
   const { colonyName = '' } = useParams();
+  const { setRootBreadcrumbItem, setShouldShowBreadcrumbs, resetBreadcrumbs } =
+    useBreadcrumbsContext();
   const {
     data,
     loading: isColonyLoading,
@@ -52,6 +60,18 @@ const ColonyRoute = () => {
     colonyAddress: colony?.colonyAddress,
     walletAddress: user?.walletAddress,
   });
+
+  useEffect(() => {
+    setRootBreadcrumbItem({
+      link: `/${colonyName}`,
+      label: formatText(MSG.dashboardBreadcrumbLabel),
+    });
+    setShouldShowBreadcrumbs(true);
+    return () => {
+      resetBreadcrumbs();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [colonyName]);
 
   if (
     walletConnecting ||

--- a/src/routes/routeConstants.ts
+++ b/src/routes/routeConstants.ts
@@ -12,8 +12,11 @@ export const COLONY_OLD_HOME_ROUTE = '/old/:colonyName/*';
 export const COLONY_HOME_ROUTE = ':colonyName/';
 export const COLONY_ADMIN_ROUTE = `admin`;
 export const COLONY_REPUTATION_ROUTE = `reputation`;
+
 export const COLONY_PERMISSIONS_ROUTE = `permissions`;
-export const COLONY_MULTISIG_ROUTE = `permissions/multisig`;
+export const COLONY_PERMISSIONS_MULTISIG_SECTION = 'multisig';
+export const COLONY_MULTISIG_ROUTE = `${COLONY_PERMISSIONS_ROUTE}/${COLONY_PERMISSIONS_MULTISIG_SECTION}`;
+
 export const COLONY_EXTENSIONS_ROUTE = `extensions`;
 export const COLONY_INTEGRATIONS_ROUTE = `integrations`;
 export const COLONY_INCORPORATION_ROUTE = `incorporation`;

--- a/src/stories/frame/PageLayout.stories.tsx
+++ b/src/stories/frame/PageLayout.stories.tsx
@@ -169,13 +169,6 @@ const pageLayoutMeta: Meta<typeof PageLayout> = {
     headerProps: {
       pageHeadingProps: {
         title: 'Members',
-        breadcrumbs: [
-          {
-            key: '1',
-            label: 'Metacolony',
-            href: '/',
-          },
-        ],
       },
       userNavigation: <p>user navigation</p>,
     },

--- a/src/stories/shared/Breadcrumbs.stories.tsx
+++ b/src/stories/shared/Breadcrumbs.stories.tsx
@@ -5,15 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 const breadcrumbsMeta: Meta<typeof Breadcrumbs> = {
   title: 'Shared/Breadcrumbs',
   component: Breadcrumbs,
-  args: {
-    items: [
-      {
-        key: '1',
-        label: 'Metacolony',
-        href: '/',
-      },
-    ],
-  },
+  args: {},
 };
 
 export default breadcrumbsMeta;


### PR DESCRIPTION
## Description

This PR introduces a new `BreadcrumbsContext` instead of reusing the `PageHeaderContext` which will be removed soon.
The context enables us to toggle showing of the breadcrumbs and what the first item should be (this is due to the colony route being just `/:colonyName` and it's hard to route match otherwise)

## Testing

Spin up the app and see how the breadcrumbs work.

1. Verify that under the colony routes, the first item is always `Dashboard`
![image](https://github.com/user-attachments/assets/e9a30bb8-b55a-4179-88e3-8504eabc608f)
2. All the other pages should display the URL they are on but in breadcrumb mode
![image](https://github.com/user-attachments/assets/79b147d4-8250-4c4e-acf0-153474715825)
3. Pages with more tabs also have the tab under the breadcrumbs
![image](https://github.com/user-attachments/assets/76e8bfc0-e7cd-4d07-8152-9b5027dec6eb)
4. Extension pages get the correct breadcrumbs
![image](https://github.com/user-attachments/assets/388795f8-d7ba-46a0-98ee-554ad150b5b2)
5. They don't appear on the colony creation page, landing page and the profile creation page
6. The user account page breadcrumbs link to the landing page and change according to which tab is selected
![image](https://github.com/user-attachments/assets/ec64b85f-da7e-48ac-a1af-5ee05bf7c27d)


## Diffs

**New stuff** ✨

* `BreadcrumbsContext` to easily control display of breadcrumbs

**Changes** 🏗

* The `Breadcrumbs` component is now leaner and URL aware, also has its own utils to override URL path segments into i18n strings

Resolves #3087
