### PR TITLE
fix: add bottom paddings for 'filter & sort' modal

### DIFF
--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/ActionsTableFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/ActionsTableFilters.tsx
@@ -82,6 +82,7 @@ const ActionsTableFilters: FC = () => {
             isFullOnMobile={false}
             onClose={() => setOpened(false)}
             isOpen={isOpened}
+            withPaddingBottom
           >
             {filtersContent}
           </Modal>
@@ -89,6 +90,7 @@ const ActionsTableFilters: FC = () => {
             isFullOnMobile={false}
             onClose={() => setIsSearchOpened(false)}
             isOpen={isSearchOpened}
+            withPaddingBottom
           >
             <p className="mb-4 uppercase text-gray-400 text-4">
               {formatText({ id: 'activityFeedTable.filters.searchModalTitle' })}

--- a/src/components/frame/Extensions/pages/PermissionsPage/partials/PermissionsPageFilter.tsx
+++ b/src/components/frame/Extensions/pages/PermissionsPage/partials/PermissionsPageFilter.tsx
@@ -90,6 +90,7 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
             isOpen={isModalOpen}
             onClose={toggleModalOff}
             isFullOnMobile={false}
+            withPaddingBottom
           >
             <h4 className="mb-6 capitalize text-gray-900 heading-5 sm:mb-0 sm:px-4">
               {formatText({ id: 'filterAndSort' })}
@@ -100,6 +101,7 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
             isFullOnMobile={false}
             onClose={() => setIsSearchOpened(false)}
             isOpen={isSearchOpened}
+            withPaddingBottom
           >
             <p className="mb-4 uppercase text-gray-400 text-4">
               {formatText({ id: 'permissionsPage.filter.search' })}

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/AgreementsPageFilters.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/AgreementsPageFilters.tsx
@@ -87,6 +87,7 @@ const AgreementsPageFilters: FC = () => {
             isFullOnMobile={false}
             onClose={() => setOpened(false)}
             isOpen={isOpened}
+            withPaddingBottom
           >
             {FiltersContent}
           </Modal>
@@ -94,6 +95,7 @@ const AgreementsPageFilters: FC = () => {
             isFullOnMobile={false}
             onClose={() => setIsSearchOpened(false)}
             isOpen={isSearchOpened}
+            withPaddingBottom
           >
             <p className="mb-4 uppercase text-gray-400 text-4">
               {formatText({ id: 'agreementsPage.filter.searchPlaceholder' })}

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/BalanceFilters/BalanceFilters.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/BalanceFilters/BalanceFilters.tsx
@@ -83,6 +83,7 @@ const BalanceFilters: FC = () => {
             isFullOnMobile={false}
             onClose={() => setOpened(false)}
             isOpen={isOpened}
+            withPaddingBottom
           >
             {filtersContent}
           </Modal>
@@ -90,6 +91,7 @@ const BalanceFilters: FC = () => {
             isFullOnMobile={false}
             onClose={() => setIsSearchOpened(false)}
             isOpen={isSearchOpened}
+            withPaddingBottom
           >
             <p className="mb-4 uppercase text-gray-400 text-4">
               {formatText({ id: 'balancePage.filter.searchModalTitle' })}

--- a/src/components/frame/v5/pages/FundsPage/partials/Filter/Filter.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/Filter/Filter.tsx
@@ -100,6 +100,7 @@ function Filter<TValue extends FilterValue>({
             isOpen={isModalOpen}
             onClose={toggleModalOff}
             isFullOnMobile={false}
+            withPaddingBottom
           >
             <>
               <Header title={{ id: 'filters' }} />
@@ -110,6 +111,7 @@ function Filter<TValue extends FilterValue>({
             isFullOnMobile={false}
             onClose={() => setIsSearchOpened(false)}
             isOpen={isSearchOpened}
+            withPaddingBottom
           >
             <p className="mb-4 uppercase text-gray-400 text-4">
               {searchInputLabel}

--- a/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/TeamsPageFilter.tsx
+++ b/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/TeamsPageFilter.tsx
@@ -91,6 +91,7 @@ const TeamsPageFilter: FC<TeamsPageFilterProps> = ({
             isOpen={isModalOpen}
             onClose={toggleModalOff}
             isFullOnMobile={false}
+            withPaddingBottom
           >
             <>
               <Header title={{ id: 'filters' }} />
@@ -101,6 +102,7 @@ const TeamsPageFilter: FC<TeamsPageFilterProps> = ({
             isFullOnMobile={false}
             onClose={() => setIsSearchOpened(false)}
             isOpen={isSearchOpened}
+            withPaddingBottom
           >
             <p className="mb-4 uppercase text-gray-400 text-4">
               {formatText({ id: 'teamsPage.filter.search' })}

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsModal/BankDetailsModal.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsModal/BankDetailsModal.tsx
@@ -1,9 +1,7 @@
 import React, { type FC } from 'react';
-import { useIntl } from 'react-intl';
 
 import { type BridgeBankAccount } from '~types/graphql.ts';
-import { CloseButton } from '~v5/shared/Button/index.ts';
-import ModalBase from '~v5/shared/Modal/ModalBase.tsx';
+import Modal from '~v5/shared/Modal/Modal.tsx';
 
 import BankDetailsForm from '../BankDetailsForm/index.ts';
 import ContactDetailsForm from '../ContactDetailsForm/index.ts';
@@ -23,8 +21,6 @@ const BankDetailsModal: FC<BankDetailsModalProps> = ({
   onClose,
   data,
 }) => {
-  const { formatMessage } = useIntl();
-
   const {
     isLoading,
     bankDetailsFields,
@@ -37,18 +33,13 @@ const BankDetailsModal: FC<BankDetailsModalProps> = ({
   });
 
   return (
-    <ModalBase
+    <Modal
       isFullOnMobile={false}
       isOpen={isOpened}
-      onRequestClose={onClose}
+      onClose={onClose}
+      withPaddingBottom
     >
-      <CloseButton
-        aria-label={formatMessage({ id: 'ariaLabel.closeModal' })}
-        title={formatMessage({ id: 'button.cancel' })}
-        onClick={onClose}
-        className="absolute right-4 top-4 text-gray-400 hover:text-gray-600"
-      />
-      <div className="px-6 pb-6 pt-16">
+      <div className="pt-10">
         {!showContactDetailsForm ? (
           <BankDetailsForm
             onSubmit={handleSubmitFirstStep}
@@ -64,7 +55,7 @@ const BankDetailsModal: FC<BankDetailsModalProps> = ({
           />
         )}
       </div>
-    </ModalBase>
+    </Modal>
   );
 };
 

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/Verification/VerificationModal.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/Verification/VerificationModal.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, type FC, useState } from 'react';
-import { defineMessages, useIntl } from 'react-intl';
+import { defineMessages } from 'react-intl';
 
 import { useCreateKycLinksMutation } from '~gql';
 import { formatText } from '~utils/intl.ts';
-import { CloseButton } from '~v5/shared/Button/index.ts';
-import ModalBase from '~v5/shared/Modal/ModalBase.tsx';
+import Modal from '~v5/shared/Modal/Modal.tsx';
 
 import ModalHeading from '../ModalHeading/ModalHeading.tsx';
 import PersonalDetailsForm from '../PersonalDetailsForm/index.ts';
@@ -55,8 +54,6 @@ const VerificationModal: FC<VerificationModalProps> = ({
   onClose,
   onTermsAcceptance,
 }) => {
-  const { formatMessage } = useIntl();
-
   const [activeTab, setActiveTab] = useState<TabId>(TabId.PersonalDetails);
 
   const [kycLink, setKycLink] = useState(existingKycLink);
@@ -77,18 +74,13 @@ const VerificationModal: FC<VerificationModalProps> = ({
   }, [kycLink, onTermsAcceptance]);
 
   return (
-    <ModalBase
+    <Modal
       isFullOnMobile={false}
       isOpen={isOpened}
-      onRequestClose={onClose}
+      onClose={onClose}
+      withPaddingBottom
     >
-      <CloseButton
-        aria-label={formatMessage({ id: 'ariaLabel.closeModal' })}
-        title={formatMessage({ id: 'button.cancel' })}
-        onClick={onClose}
-        className="absolute right-4 top-4 text-gray-400 hover:text-gray-600"
-      />
-      <div className="px-6 pb-6 pt-16">
+      <div className="pt-10">
         <Stepper
           activeStepKey={activeTab}
           items={[
@@ -159,7 +151,7 @@ const VerificationModal: FC<VerificationModalProps> = ({
           ]}
         />
       </div>
-    </ModalBase>
+    </Modal>
   );
 };
 

--- a/src/components/v5/common/Filter/Filter.tsx
+++ b/src/components/v5/common/Filter/Filter.tsx
@@ -68,6 +68,7 @@ const Filter: FC<FilterProps> = ({
             isFullOnMobile={false}
             onClose={() => setOpened(false)}
             isOpen={isOpened}
+            withPaddingBottom
           >
             <FilterOptions excludeFilterType={excludeFilterType} />
           </Modal>

--- a/src/components/v5/common/Filter/Filter.tsx
+++ b/src/components/v5/common/Filter/Filter.tsx
@@ -76,6 +76,7 @@ const Filter: FC<FilterProps> = ({
             isFullOnMobile={false}
             onClose={() => setIsSearchOpened(false)}
             isOpen={isSearchOpened}
+            withPaddingBottom
           >
             <p className="mb-4 text-gray-400 text-4">{searchInputLabel}</p>
             <div className="sm:mb-6 sm:px-3.5">

--- a/src/components/v5/shared/Modal/Modal.tsx
+++ b/src/components/v5/shared/Modal/Modal.tsx
@@ -95,6 +95,7 @@ const Modal: FC<PropsWithChildren<ModalProps>> = ({
               'flex w-full flex-grow flex-col [-webkit-overflow-scrolling:touch]',
               {
                 'pr-6': withPadding,
+                'pb-6': withPadding && !withPaddingBottom,
               },
             )}
           >

--- a/src/components/v5/shared/Modal/Modal.tsx
+++ b/src/components/v5/shared/Modal/Modal.tsx
@@ -94,7 +94,7 @@ const Modal: FC<PropsWithChildren<ModalProps>> = ({
             className={clsx(
               'flex w-full flex-grow flex-col [-webkit-overflow-scrolling:touch]',
               {
-                'pb-6 pr-6': withPadding,
+                'pr-6': withPadding,
               },
             )}
           >


### PR DESCRIPTION
## Description
| Before | After |
| ----- | ----- |
|  ![image](https://github.com/user-attachments/assets/6805c1b1-ce9d-43f1-8e8d-00e00c5e74ff) | <img alt="image" src="https://github.com/user-attachments/assets/0a01ca32-1064-42ba-968f-4148a304f013"> |

## Testing
Step 1. Set the screen size to mobile.
Step 2. Open Members or Contributors Page - http://localhost:9091/planex/members 
Step 3. Open filters modal
Step 4. Ensure that Modal has padding bottom
<img width="261" alt="image" src="https://github.com/user-attachments/assets/f33ee68e-0763-4d2f-9fb1-5abad97aad06">

## NEW pages to check:
- http://localhost:9091/planex/activity (filter, search modal)
- http://localhost:9091/planex/permissions (filter, search modal)
- http://localhost:9091/planex/teams (filter, search modal)
- http://localhost:9091/planex/agreements (filter, search modal)
- http://localhost:9091/planex/balances (filter, search modal)
- http://localhost:9091/planex/incoming (filter, search modal)
- http://localhost:9091/planex/members (filter, search modal)
- http://localhost:9091/account/crypto-to-fiat (Verification Modal, Bank details Modal)

Resolves  #2698
