### PR TITLE
Fix: Advanced payment briefly shows "Passed" pill on creation

### DIFF
--- a/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
@@ -288,14 +288,18 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
                   </button>
                   {getShareButton()}
                 </div>
-                {action && !isMotion && !expenditure && !isMultiSig && (
-                  <PillsBase
-                    className="bg-success-100 text-success-400"
-                    isCapitalized={false}
-                  >
-                    {formatText({ id: 'action.passed' })}
-                  </PillsBase>
-                )}
+                {action &&
+                  !isMotion &&
+                  !isMultiSig &&
+                  !expenditure &&
+                  !loadingExpenditure && (
+                    <PillsBase
+                      className="bg-success-100 text-success-400"
+                      isCapitalized={false}
+                    >
+                      {formatText({ id: 'action.passed' })}
+                    </PillsBase>
+                  )}
                 {!!expenditure && (
                   <ExpenditureActionStatusBadge
                     expenditure={expenditure}


### PR DESCRIPTION
## Description

This PR fixes an issue where the "Passed" pill briefly shows when an Advanced payment is created before correcting itself to "Review". This issue was caused by the "Passed" pill not checking if the expenditure is loading.

## Testing

* Step 1 - Create an action and select "Advanced payment"
* Step 2 - Fill out the action form
* Step 3 - After submitting, as the completed action screen is loading, the first pill to be shown should be "Review"

Compared to master (or see the original issue for a video) where "Passed" will briefly be shown.

https://github.com/user-attachments/assets/18d7ac34-50b9-4658-9322-1531429ecf25


## Diffs

**Changes** 🏗

* Added `!loadingExpenditure` check to the "Passed" pill

Resolves #2930
