### PR TITLE
fix: remove getSigner spread as it is no longer needed and getSigner already included in the RetryRpcProvider class

### DIFF
--- a/src/hooks/useNetworkMotionStates.ts
+++ b/src/hooks/useNetworkMotionStates.ts
@@ -5,6 +5,8 @@ import { useAppContext } from '~context/AppContext/AppContext.ts';
 
 import useEnabledExtensions from './useEnabledExtensions.ts';
 
+import type { Provider } from '@ethersproject/providers';
+
 export type MotionStatesMap = Map<string, MotionState | null>;
 
 export type RefetchMotionStates = (motionIdsToRefetch?: string[]) => void;
@@ -23,7 +25,7 @@ const useNetworkMotionStates = (nativeMotionIds: string[], skip?: boolean) => {
   );
 
   useEffect(() => {
-    const { ethersProvider, address } = wallet || {};
+    const { ethersProvider } = wallet || {};
     if (
       skip ||
       !nativeMotionIds.length ||
@@ -44,11 +46,11 @@ const useNetworkMotionStates = (nativeMotionIds: string[], skip?: boolean) => {
     }
 
     // Properly initialize the signer with the current wallet address
-    const signer = ethersProvider.getSigner(address);
-
     const votingRepClient = VotingReputationFactory.connect(
       votingReputationAddress,
-      signer,
+      // We need to cast this to a Provider since colonyJS methods expect a "standard" provider,
+      // while ours is a custom one (which extends the base, standard provider)
+      ethersProvider as unknown as Provider,
     );
 
     const fetchMotionStates = async () => {

--- a/src/redux/sagas/utils/safeHelpers.ts
+++ b/src/redux/sagas/utils/safeHelpers.ts
@@ -10,6 +10,7 @@ import {
   type NetworkInfo,
   SUPPORTED_SAFE_NETWORKS,
 } from '~constants/index.ts';
+import { ContextModule, getContext } from '~context/index.ts';
 import {
   type Safe,
   type SafeTransactionData,
@@ -20,7 +21,7 @@ import { type ModuleAddress } from '~types/safes.ts';
 import { fetchTokenFromDatabase } from '~utils/queries.ts';
 import { getArrayFromString } from '~utils/safes/index.ts';
 
-import RetryProvider from '../wallet/RetryProvider.ts';
+import retryProviderFactory from '../wallet/RetryProvider.ts';
 
 import { erc721, ForeignAMB, HomeAMB, ZodiacBridgeModule } from './abis.ts'; // Temporary
 
@@ -70,7 +71,11 @@ export const getSafeAddresses = async (): Promise<SafeAddresses> => {
   return SAFE_ADDRESSES as SafeAddresses;
 };
 
-export const getHomeProvider = () => new RetryProvider();
+export const getHomeProvider = () => {
+  const wallet = getContext(ContextModule.Wallet);
+  const RetryProvider = retryProviderFactory(wallet.label);
+  return new RetryProvider();
+};
 
 export const getForeignProvider = (safeChainId: string) => {
   const network = SUPPORTED_SAFE_NETWORKS.find(

--- a/src/redux/sagas/wallet/RetryProvider.ts
+++ b/src/redux/sagas/wallet/RetryProvider.ts
@@ -13,7 +13,7 @@ type RetryProviderOptions = {
   delay?: number; // in milliseconds
 };
 
-const classFactory = (walletType: 'MetaMask' | string) => {
+const classFactory = (walletType: 'MetaMask' | string = '') => {
   const devWallet = walletType !== 'MetaMask';
 
   const Extender = devWallet

--- a/src/redux/sagas/wallet/RetryProvider.ts
+++ b/src/redux/sagas/wallet/RetryProvider.ts
@@ -2,7 +2,7 @@ import { type Block } from '@ethersproject/providers';
 import { providers, utils } from 'ethers';
 import { backOff } from 'exponential-backoff';
 
-import { GANACHE_LOCAL_RPC_URL, isDev } from '~constants/index.ts';
+import { GANACHE_LOCAL_RPC_URL } from '~constants/index.ts';
 import {
   RetryProviderMethod,
   IColonyContractMethodSignature,
@@ -13,10 +13,14 @@ type RetryProviderOptions = {
   delay?: number; // in milliseconds
 };
 
-const classFactory = (
-  Extender = isDev ? providers.JsonRpcProvider : providers.Web3Provider,
-) =>
-  class RetryRpcProvider extends Extender {
+const classFactory = (walletType: 'MetaMask' | string) => {
+  const devWallet = walletType !== 'MetaMask';
+
+  const Extender = devWallet
+    ? providers.JsonRpcProvider
+    : providers.Web3Provider;
+
+  return class RetryRpcProvider extends Extender {
     attempts: number;
 
     delay: number;
@@ -24,7 +28,7 @@ const classFactory = (
     bypassedMethods: string[];
 
     constructor(options?: RetryProviderOptions) {
-      super(isDev ? GANACHE_LOCAL_RPC_URL : window.ethereum);
+      super(devWallet ? GANACHE_LOCAL_RPC_URL : window.ethereum);
       this.attempts = options?.attempts || 5;
       this.delay = options?.delay || 1000;
       this.bypassedMethods = [
@@ -79,5 +83,6 @@ const classFactory = (
       });
     }
   };
+};
 
-export default classFactory();
+export default classFactory;

--- a/src/redux/sagas/wallet/index.ts
+++ b/src/redux/sagas/wallet/index.ts
@@ -22,7 +22,7 @@ import {
   clearLastWallet,
 } from '~utils/autoLogin.ts';
 
-import RetryProvider from './RetryProvider.ts';
+import retryProviderFactory from './RetryProvider.ts';
 
 // import { createAddress } from '~utils/web3';
 // import { DEFAULT_NETWORK, NETWORK_DATA, TOKEN_DATA } from '~constants';
@@ -82,6 +82,7 @@ export const getWallet = async (lastWallet: LastWallet | null) => {
   const [account] = wallet.accounts;
   setLastWallet({ type: wallet.label, address: account.address });
 
+  const RetryProvider = retryProviderFactory(wallet.label);
   const provider = new RetryProvider();
 
   return {

--- a/src/redux/sagas/wallet/index.ts
+++ b/src/redux/sagas/wallet/index.ts
@@ -1,7 +1,5 @@
 // import { eventChannel } from 'redux-saga';
-import { type Network } from '@ethersproject/providers';
 import { type WalletState } from '@web3-onboard/core';
-import { providers } from 'ethers';
 
 // import ganacheModule from './ganacheModule';
 
@@ -16,15 +14,13 @@ import { providers } from 'ethers';
 // import { ActionTypes } from '../../actionTypes';
 // import { Action, AllActions } from '../../types/actions';
 
-import { isDev } from '~constants/index.ts';
 import { ContextModule, getContext } from '~context/index.ts';
-import { type BasicWallet, type FullWallet } from '~types/wallet.ts';
+import { type FullWallet } from '~types/wallet.ts';
 import {
   setLastWallet,
   type LastWallet,
   clearLastWallet,
 } from '~utils/autoLogin.ts';
-import { getChainIdAsHex } from '~utils/chainId.ts';
 
 import RetryProvider from './RetryProvider.ts';
 
@@ -60,24 +56,6 @@ const getConnectOptions = (lastWallet: LastWallet | null) => {
   return undefined;
 };
 
-export const getBasicWallet = async (lastWallet: LastWallet) => {
-  const provider = new RetryProvider();
-  const network: Network | undefined = await provider?.getNetwork();
-  if (network?.chainId) {
-    return {
-      address: lastWallet.address,
-      label: lastWallet.type,
-      chains: [
-        { id: getChainIdAsHex(String(network.chainId)), namespace: 'evm' },
-      ],
-      ethersProvider: provider,
-    } as BasicWallet;
-  }
-
-  // Could not connect to provider
-  return undefined;
-};
-
 export const connectWallet = async (
   lastWallet: LastWallet | null,
 ): Promise<WalletState | undefined> => {
@@ -106,17 +84,9 @@ export const getWallet = async (lastWallet: LastWallet | null) => {
 
   const provider = new RetryProvider();
 
-  const providerForDev = {
-    ...provider,
-    getSigner: (addressOrIndex?: string | number) => {
-      const web3providerWrapper = new providers.Web3Provider(wallet.provider);
-      return web3providerWrapper.getSigner(addressOrIndex);
-    },
-  };
-
   return {
     ...wallet,
     ...account,
-    ethersProvider: isDev ? providerForDev : provider,
+    ethersProvider: provider,
   } as FullWallet;
 };

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -2,12 +2,14 @@ import { type WalletState } from '@web3-onboard/core';
 import { type Account } from '@web3-onboard/core/dist/types';
 
 import { type CustomEIP1193Provider } from '~redux/sagas/wallet/ganacheModule.ts';
-import type RetryRpcProvider from '~redux/sagas/wallet/RetryProvider.ts';
+import retryRpcProviderFactory from '~redux/sagas/wallet/RetryProvider.ts';
 
 export type ColonyWallet = BasicWallet | FullWallet;
 
+const RetryProvider = retryRpcProviderFactory();
+
 export interface FullWallet extends WalletState, Account {
-  ethersProvider: InstanceType<typeof RetryRpcProvider>;
+  ethersProvider: InstanceType<typeof RetryProvider>;
   provider: CustomEIP1193Provider;
 }
 


### PR DESCRIPTION
## Description
I pair-programmed this with @jakubcolony, and we agreed on the solution with @rdig 🙌 Thank you guys for helping!

The issue was that we encountered an error when creating advanced payments:
![image](https://github.com/user-attachments/assets/2fb59aaa-732b-4c85-8dac-5b482f0c5aaf)

The history of this bug is quite long. It seems @rdig implemented the `getSigner` method 9 months ago to make the Provider work. However, 7 months ago, @chmanie added this method to the Provider class itself, and by using the spread operator, we unintentionally lost a couple of methods from the Provider prototype (such as `getBlock`).

In my PR for the Metamask refactor (https://github.com/JoinColony/colonyCDapp/pull/2908), I removed the usage of the getBasicWallet method. As a result, this error now appears every time, rather than just once when logging in (getFullWallet), which makes the issue more noticeable.

## Testing
* Step 1. Create Advanced payment
* Step 2. Check that there are no errors in the console
<img width="1220" alt="image" src="https://github.com/user-attachments/assets/5aac9d46-5c42-4c0e-8bb2-ace3546f2d70">

I would also really appreciate it if you could point out any other errors you spot, as this wallet/provider part is quite vital to our app. 🙏✨

Resolves #3113