### PR TITLE
Fix CoinGecko ENV key import

### DIFF
--- a/src/utils/currency/tokenPriceByAddress.ts
+++ b/src/utils/currency/tokenPriceByAddress.ts
@@ -27,7 +27,7 @@ const buildTokenAddressCoinGeckoURL = (
   return buildAPIEndpoint(new URL(`${url}/${chain}`), {
     [searchParams.from]: contractAddress,
     [searchParams.to]: denomination,
-    [searchParams.api]: process.env.COINGECKO_API_KEY ?? '',
+    [searchParams.api]: import.meta.env.COINGECKO_API_KEY ?? '',
   });
 };
 

--- a/src/utils/currency/tokenPriceByName.ts
+++ b/src/utils/currency/tokenPriceByName.ts
@@ -22,7 +22,7 @@ const buildTokenNameCoinGeckoURL = (
   return buildAPIEndpoint(new URL(`${url}/`), {
     [searchParams.from]: tokenName,
     [searchParams.to]: denomination,
-    [searchParams.api]: process.env.COINGECKO_API_KEY ?? '',
+    [searchParams.api]: import.meta.env.COINGECKO_API_KEY ?? '',
   });
 };
 

--- a/src/utils/currency/tokenPriceDataByName.ts
+++ b/src/utils/currency/tokenPriceDataByName.ts
@@ -29,7 +29,7 @@ const buildTokenNameCoinGeckoURL = (
   return buildAPIEndpoint(new URL(`${url}/`), {
     [searchParams.from]: tokenName,
     [searchParams.to]: denomination,
-    [searchParams.api]: process.env.COINGECKO_API_KEY ?? '',
+    [searchParams.api]: import.meta.env.COINGECKO_API_KEY ?? '',
     [searchParams.includeLastUpdatedAt]: 'true',
   });
 };


### PR DESCRIPTION
This is just a simple PR that "fixes" the old format of ENV variable imports of `process.env` to the new one used by `vite` which is `import.meta.env`.

This was an obvious oversight, but not in issue #1965 where these code blocks are moved around, but actually in the PR that introduced `vite` altogether #1748 which actually got merged after the former.

---
#1965 was merged on February 29th

![Screenshot from 2024-09-20 14-56-15](https://github.com/user-attachments/assets/d9e2ddcd-9405-4500-a09f-c0ed05a021fb)

While #1748 was merged only on the 18th of March

![Screenshot from 2024-09-20 14-56-04](https://github.com/user-attachments/assets/b3ab9775-2523-4e59-b669-7b87e9b0b21a)

---

### Testing

1. Run your environment: `npm run dev`

2. Run the create data script: `node scripts/create-data.js`

3. Add some value to your `COINGECKO_API_KEY` variable inside the `.env.local.secrets` file _(doesn't really have to be an actual API key, just a random string you can identify)_

![Screenshot from 2024-09-20 15-12-48](https://github.com/user-attachments/assets/a03aba86-76c8-4928-b510-39287e4ac331)

4. Prepare the env file: `npm run prepare`

5. Apply this patch: `git apply <filename>`

```diff
diff --git a/src/utils/currency/currency.ts b/src/utils/currency/currency.ts
index d242f1d58..1b5adb81e 100644
--- a/src/utils/currency/currency.ts
+++ b/src/utils/currency/currency.ts
@@ -67,7 +67,6 @@ export const fetchCurrentPrice = async ({
 }: FetchCurrentPriceArgs): Promise<number | null> => {
   // It is useful to have a mock price for tokens in our dev environments, this ensures every token price
   // is equal to 1 unit of your local currency when running the app locally, since calls to coinGecko won't work.
-  if (isDev) return 1;
 
   const savedPrice = getSavedPrice({
     contractAddress,

```

6. Run the frontend: `npm run frontend`

7. Open the cdapp: http://localhost:9091/

8. Open your browser's dev tools

![image](https://github.com/user-attachments/assets/c074c2bf-9494-4998-bf59-cc25993fb739)

9. Go to the `planex` colony

10. Ensure that the calls to `coingecko` contain the API key value that you've set previously in your environments file

![Screenshot from 2024-09-20 15-20-13](https://github.com/user-attachments/assets/f775a4ce-a606-42f5-a3aa-380dc21600b1)

![Screenshot from 2024-09-20 15-20-53](https://github.com/user-attachments/assets/ca9925d8-96c9-4d4f-bda5-44b2cf21e0ae)
