### PR TITLE
Fix: Fund expenditure should use proper funding pot

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/FundingModal.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/FundingModal.tsx
@@ -9,7 +9,8 @@ import useAsyncFunction from '~hooks/useAsyncFunction.ts';
 import { ActionTypes } from '~redux';
 import { type FundExpenditurePayload } from '~redux/sagas/expenditures/fundExpenditure.ts';
 import { Form } from '~shared/Fields/index.ts';
-import { findDomainByNativeId } from '~utils/domains.ts';
+import { extractColonyRoles } from '~utils/colonyRoles.ts';
+import { extractColonyDomains, findDomainByNativeId } from '~utils/domains.ts';
 import { formatText } from '~utils/intl.ts';
 import Button from '~v5/shared/Button/Button.tsx';
 import Modal from '~v5/shared/Modal/index.ts';
@@ -174,14 +175,16 @@ const FundingModal: FC<FundingModalProps> = ({
 
   const handleFundExpenditure = async () => {
     try {
-      if (!expenditure) {
+      if (!expenditure || !selectedTeam) {
         return;
       }
 
       const payload: FundExpenditurePayload = {
         colonyAddress: colony.colonyAddress,
         expenditure,
-        fromDomainFundingPotId: 1,
+        fromDomainFundingPotId: selectedTeam.nativeFundingPotId,
+        colonyRoles: extractColonyRoles(colony.roles),
+        colonyDomains: extractColonyDomains(colony.domains),
       };
 
       await fundExpenditure(payload);

--- a/src/components/v5/payments/TmpAdvancedPayments.tsx
+++ b/src/components/v5/payments/TmpAdvancedPayments.tsx
@@ -28,8 +28,9 @@ import {
   type ExpenditureFundMotionPayload,
   type ExpenditureCancelMotionPayload,
 } from '~redux/types/actions/motion.ts';
+import { extractColonyRoles } from '~utils/colonyRoles.ts';
 import { getExpenditureDatabaseId } from '~utils/databaseId.ts';
-import { findDomainByNativeId } from '~utils/domains.ts';
+import { extractColonyDomains, findDomainByNativeId } from '~utils/domains.ts';
 import { getClaimableExpenditurePayouts } from '~utils/expenditures.ts';
 import InputBase from '~v5/common/Fields/InputBase/InputBase.tsx';
 import Button from '~v5/shared/Button/Button.tsx';
@@ -215,6 +216,8 @@ const TmpAdvancedPayments = () => {
       colonyAddress: colony.colonyAddress,
       expenditure,
       fromDomainFundingPotId: 1,
+      colonyRoles: extractColonyRoles(colony.roles),
+      colonyDomains: extractColonyDomains(colony.domains),
     };
 
     await fundExpenditure(payload);
@@ -368,6 +371,8 @@ const TmpAdvancedPayments = () => {
       motionDomainId: Id.RootDomain,
       fromDomainFundingPotId: 1,
       fromDomainId: 1,
+      colonyRoles: extractColonyRoles(colony.roles),
+      colonyDomains: extractColonyDomains(colony.domains),
     };
 
     await fundExpenditureViaMotion(payload);

--- a/src/redux/sagas/actions/moveFunds.ts
+++ b/src/redux/sagas/actions/moveFunds.ts
@@ -31,6 +31,8 @@ function* createMoveFundsAction({
     toDomain,
     amount,
     tokenAddress,
+    colonyDomains,
+    colonyRoles,
     annotationMessage,
     customActionTitle,
   },
@@ -117,7 +119,13 @@ function* createMoveFundsAction({
     yield transactionSetPending(moveFunds.id);
 
     const [permissionDomainId, fromChildSkillIndex, toChildSkillIndex] =
-      yield getMoveFundsPermissionProofs(colonyAddress, fromPot, toPot);
+      yield getMoveFundsPermissionProofs({
+        colonyAddress,
+        fromPotId: fromPot,
+        toPotId: toPot,
+        colonyDomains,
+        colonyRoles,
+      });
 
     yield transactionSetParams(moveFunds.id, [
       permissionDomainId,

--- a/src/redux/sagas/expenditures/fundExpenditure.ts
+++ b/src/redux/sagas/expenditures/fundExpenditure.ts
@@ -1,4 +1,5 @@
-import { ClientType, ColonyRole, Id } from '@colony/colony-js';
+import { ClientType, ColonyRole, getPotDomain } from '@colony/colony-js';
+import { type BigNumberish } from 'ethers';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
@@ -14,7 +15,7 @@ import { getExpenditureBalancesByTokenAddress } from '../utils/expenditures.ts';
 import {
   getColonyManager,
   getMoveFundsPermissionProofs,
-  getPermissionProofsLocal,
+  getSinglePermissionProofsFromSourceDomain,
   initiateTransaction,
   putError,
   takeFrom,
@@ -62,19 +63,19 @@ function* fundExpenditure({
   try {
     const userAddress = yield colonyClient.signer.getAddress();
 
-    // Move funds action can only be performed by a user with permissions in a parent domain
-    // Once nested teams is introduced this will need to find the closest parent domain id
-    // but for now, we can assume this is the root domain
-    const parentDomainId = Id.RootDomain;
+    const fromDomainId: BigNumberish = yield getPotDomain(
+      colonyClient,
+      fromDomainFundingPotId,
+    );
 
     const [userPermissionDomainId, userChildSkillIndex] = yield call(
-      getPermissionProofsLocal,
+      getSinglePermissionProofsFromSourceDomain,
       {
         networkClient: colonyClient.networkClient,
         colonyRoles,
         colonyDomains,
-        requiredDomainId: parentDomainId,
-        requiredColonyRoles: ColonyRole.Funding,
+        requiredDomainId: Number(fromDomainId),
+        requiredColonyRole: ColonyRole.Funding,
         permissionAddress: userAddress,
       },
     );

--- a/src/redux/sagas/utils/proofs.ts
+++ b/src/redux/sagas/utils/proofs.ts
@@ -8,6 +8,7 @@ import {
   type ColonyNetworkClient,
 } from '@colony/colony-js';
 import { BigNumber, constants, type BigNumberish } from 'ethers';
+import { call } from 'redux-saga/effects';
 
 import { type ColonyManager } from '~context/index.ts';
 import { type ColonyRoleFragment } from '~gql';
@@ -382,46 +383,63 @@ export const getPermissionProofsLocal = async ({
   });
 };
 
-export function* getMoveFundsPermissionProofs(
-  colonyAddress: string,
-  fromtPotId: BigNumberish,
-  toPotId: BigNumberish,
-) {
+export function* getMoveFundsPermissionProofs({
+  colonyAddress,
+  fromPotId,
+  toPotId,
+  colonyDomains,
+  colonyRoles,
+}: {
+  colonyAddress: string;
+  fromPotId: BigNumberish;
+  toPotId: BigNumberish;
+  colonyDomains: Domain[];
+  colonyRoles: ColonyRoleFragment[];
+}) {
   const colonyManager: ColonyManager = yield getColonyManager();
-
-  const { signer } = colonyManager;
-  const walletAddress = yield signer.getAddress();
 
   const colonyClient = yield colonyManager.getClient(
     ClientType.ColonyClient,
     colonyAddress,
   );
 
-  const fromDomainId = yield getPotDomain(colonyClient, fromtPotId);
-  const toDomainId = yield getPotDomain(colonyClient, toPotId);
-  const [fromPermissionDomainId, fromChildSkillIndex] =
-    yield getPermissionProofs(
-      colonyClient.networkClient,
-      colonyClient,
-      fromDomainId,
-      ColonyRole.Funding,
-      walletAddress,
-    );
-  // @TODO: once getPermissionProofs is more expensive we can just check the domain here
-  // with userHasRole and then immediately get the permission proofs
-  const [toPermissionDomainId, toChildSkillIndex] = yield getPermissionProofs(
-    colonyClient.networkClient,
+  const userAddress = yield colonyClient.signer.getAddress();
+
+  const fromDomainId: BigNumberish = yield getPotDomain(
     colonyClient,
-    toDomainId,
-    ColonyRole.Funding,
-    walletAddress,
+    fromPotId,
+  );
+  const toDomainId: BigNumberish = yield getPotDomain(colonyClient, toPotId);
+
+  const [fromPermissionDomainId, fromChildSkillIndex] = yield call(
+    getPermissionProofsLocal,
+    {
+      networkClient: colonyClient.networkClient,
+      colonyRoles,
+      colonyDomains,
+      requiredDomainId: Number(fromDomainId),
+      requiredColonyRoles: ColonyRole.Funding,
+      permissionAddress: userAddress,
+    },
+  );
+
+  const [toPermissionDomainId, toChildSkillIndex] = yield call(
+    getPermissionProofsLocal,
+    {
+      networkClient: colonyClient.networkClient,
+      colonyRoles,
+      colonyDomains,
+      requiredDomainId: Number(toDomainId),
+      requiredColonyRoles: ColonyRole.Funding,
+      permissionAddress: userAddress,
+    },
   );
   // Here's a weird case. We have found permissions for these domains but they don't share
   // a parent domain with that permission. We can still find a common parent domain that
   // has the funding permission
   if (!fromPermissionDomainId.eq(toPermissionDomainId)) {
     const hasFundingInRoot = yield colonyClient.hasUserRole(
-      walletAddress,
+      userAddress,
       Id.RootDomain,
       ColonyRole.Funding,
     );

--- a/src/redux/types/actions/colonyActions.ts
+++ b/src/redux/types/actions/colonyActions.ts
@@ -121,6 +121,8 @@ export type ColonyActionsActionTypes =
         fromDomain: Domain;
         toDomain: Domain;
         amount: BigNumber;
+        colonyDomains: Domain[];
+        colonyRoles: ColonyRoleFragment[];
         annotationMessage?: string;
       },
       MetaWithSetter<object>

--- a/src/redux/types/actions/expenditures.ts
+++ b/src/redux/types/actions/expenditures.ts
@@ -1,4 +1,7 @@
-import { type StreamingPaymentEndCondition } from '~gql';
+import {
+  type ColonyRoleFragment,
+  type StreamingPaymentEndCondition,
+} from '~gql';
 import { type ActionTypes } from '~redux/actionTypes.ts';
 import {
   type ExpenditurePayoutWithSlotId,
@@ -18,6 +21,8 @@ export type ExpenditureFundPayload = {
   colonyAddress: Address;
   fromDomainFundingPotId: number;
   expenditure: Expenditure;
+  colonyDomains: Domain[];
+  colonyRoles: ColonyRoleFragment[];
   annotationMessage?: string;
 };
 


### PR DESCRIPTION
## Description

This PR addresses an issue with the funding modal where the payload was hardcoded to fund the expenditure from the root domain.

This PR properly passes the intended domain in the payload. It also fixes a permissions issue with the saga.

I also refactored the `getMoveFundsPermissionProofs` util to use `getPermissionProofsLocal` whilst I was at it.

The important changes are in the `fundExpenditure` saga and the `FundingModal` component.

## Testing

* Step 1 - Create an action and select advanced payment
* Step 2 - Select any team other than general
* Step 3 - Add however many payment rows you like and submit (the expenditure ID will be logged to the console, copy it for later)
* Step 4 - Confirm the review stage
* Step 5 - Confirm the funding stage, select permissions as the decision method in the modal.
* Step 6 - Run this query and confirm the `nativeDomainId` and `fromPotId` are the same. (If you lost your copy from the console, the first expenditure ID on a fresh dev environment will be COLONYADDRESS_33)

```
query MyQuery {
  getActionByExpenditureId(
    expenditureId: "<EXPENDITURE_ID>"
    filter: {type: {eq: MOVE_FUNDS}}
  ) {
    items {
      type
      expenditure {
        nativeDomainId
        nativeFundingPotId
      }
      fromDomainId
      fromPotId
      toDomainId
      toPotId
    }
  }
}
```

<img width="634" alt="thispr" src="https://github.com/user-attachments/assets/3242b6ec-3d42-4690-a338-b1597b0a800b">

Compared to master where every advanced payment is funded from general.

<img width="626" alt="master" src="https://github.com/user-attachments/assets/00906e56-6019-4fc7-8f2c-5940a2fee528">

**Further testing (after fix commit):**
* Assign payer permissions to another user in a sub-domain, then create an expenditure as that user in the sub-domain. It should be possible to fund the expenditure.
* As Leela, create an advanced payment in general and fund it.
* Check the normal transfer funds action is still working as intended.

## Diffs

**Changes** 🏗

* `selectedTeam.nativeFundingPotId` is now passed in the funding expenditure payload
* Fixed permissions issue in the funding expenditure saga
* Refactored the `getMoveFundsPermissionProofs` util to use `getPermissionProofsLocal`