### PR TITLE
[Multi-sig] build: update network hash and realign thresholds

### DIFF
--- a/docker/colony-cdapp-dev-env-network
+++ b/docker/colony-cdapp-dev-env-network
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV NETWORK_HASH=1c45d3aa82b6a86f817bd7d0d88e50490916aadf
+ENV NETWORK_HASH=5a31b24546bf05d3c163dae22d70e790268187a0
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/MultiSigMembersError/MultiSigMembersError.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/partials/MultiSigMembersError/MultiSigMembersError.tsx
@@ -49,11 +49,10 @@ export const MultiSigMembersError: FC<MultiSigMembersErrorProps> = ({
   }, [fromDomain, selectedAction, team]);
 
   const thresholdDomainId = useMemo(() => {
-    // manage permissions gets "created" in the domain you are managing permissions in
-    // so the threshold used is for that specific domain
-    // but users still need permissions in the parent domain
-    // :')
-    if (selectedAction === Action.TransferFunds) {
+    if (
+      selectedAction === Action.TransferFunds ||
+      selectedAction === Action.ManagePermissions
+    ) {
       return Id.RootDomain;
     }
 

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/MultiSigWidget.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/MultiSigWidget.tsx
@@ -14,7 +14,11 @@ import Stepper from '~v5/shared/Stepper/Stepper.tsx';
 import ApprovalStep from './partials/ApprovalStep/ApprovalStep.tsx';
 import FinalizeStep from './partials/FinalizeStep/FinalizeStep.tsx';
 import { MultiSigState } from './types.ts';
-import { getIsMultiSigExecutable, getSignaturesPerRole } from './utils.ts';
+import {
+  getDomainIdForActionType,
+  getIsMultiSigExecutable,
+  getSignaturesPerRole,
+} from './utils.ts';
 
 const displayName =
   'v5.common.ActionSidebar.partials.MultiSig.partials.MultiSigWidget';
@@ -52,7 +56,10 @@ const MultiSigWidget: FC<MultiSigWidgetProps> = ({ action }) => {
   }, [actionType, multiSigData.nativeMultiSigDomainId]);
 
   const { isLoading, thresholdPerRole } = useDomainThreshold({
-    domainId: Number(multiSigData.nativeMultiSigDomainId),
+    domainId: getDomainIdForActionType(
+      actionType,
+      multiSigData.nativeMultiSigDomainId,
+    ),
     requiredRoles,
   });
 


### PR DESCRIPTION
## Description

Basically the updated Multi-sig extension checks the threshold for managing roles in a subdomain in its parent domain, so I had to realign it a bit.

## Testing

Note I had to use `Wayne` because my dev env was bugging out with members in `planex`

1. As `leela` install the Multi-sig extension, enable it, set its global threshold to 1 and the threshold in `Advanced technologies` to 2
![image](https://github.com/user-attachments/assets/76812ee0-d551-4cb0-9798-9bb545a8b6ed)
2. Give `leela` Owner Multi-sig permissions
![image](https://github.com/user-attachments/assets/19fe28c0-2325-4987-8e8b-6964ebb3e4e0)
3. Now go and try to create a `Simple payment` Multi-sig motion from `Advanced technologies`. You should get the not enough members banner
![image](https://github.com/user-attachments/assets/6ca2a466-ffa4-4dac-9731-fe1085b1760d)
4. Try to create a `Manage permissions` Multi-sig motion for assigning any user permissions there, there should be no error and you should be able to create it
![image](https://github.com/user-attachments/assets/98e78239-b44d-4ec0-b297-c0796c13105e)
5. Since the threshold is 1, you can also immediately finalize it! Try to do it and see that it goes through
![image](https://github.com/user-attachments/assets/fab8c456-fca6-43e5-b235-af7836a8bf94)
![image](https://github.com/user-attachments/assets/8d177c10-867c-446f-a33b-fdf7e90fb43d)


## Diffs

**Changes** 🏗

* `MultisigMembersError` now uses the root domain for determining the threshold of managing permissions in a subdomain
* And so does the `MultisigWidget` component
