### PR TITLE
[Dashboard] Add legend item active state on non-empty chart hover

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/ChartCustomTooltip/ChartCustomTooltip.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ChartCustomTooltip/ChartCustomTooltip.tsx
@@ -1,34 +1,13 @@
 import { useTooltipState } from '@nivo/tooltip';
 import { AnimatePresence, motion } from 'framer-motion';
-import React, { type PropsWithChildren, type FC, useEffect } from 'react';
+import React, { type PropsWithChildren, type FC } from 'react';
 
-interface ChartCustomTooltipProps extends PropsWithChildren {
-  onVisible?: (isVisible?: boolean) => void;
-}
+interface ChartCustomTooltipProps extends PropsWithChildren {}
 
 export const ChartCustomTooltip: FC<ChartCustomTooltipProps> = ({
   children,
-  onVisible,
 }) => {
   const { isVisible } = useTooltipState();
-
-  useEffect(() => {
-    return () => {
-      if (onVisible) {
-        onVisible(false);
-      }
-    };
-    // We are not including any deps here as we want to run react only to mounting/unmounting state
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    if (isVisible && onVisible) {
-      onVisible(true);
-    }
-    // We are not including onVisible here as we really only want to react to changes of isVisible
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isVisible]);
 
   return (
     <AnimatePresence>

--- a/src/components/v5/frame/ColonyHome/partials/ChartCustomTooltip/ChartCustomTooltip.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ChartCustomTooltip/ChartCustomTooltip.tsx
@@ -1,13 +1,35 @@
 import { useTooltipState } from '@nivo/tooltip';
 import { AnimatePresence, motion } from 'framer-motion';
-import React, { type PropsWithChildren, type FC } from 'react';
+import React, { type PropsWithChildren, type FC, useEffect } from 'react';
 
-interface ChartCustomTooltipProps extends PropsWithChildren {}
+interface ChartCustomTooltipProps extends PropsWithChildren {
+  onVisible?: (isVisible?: boolean) => void;
+}
 
 export const ChartCustomTooltip: FC<ChartCustomTooltipProps> = ({
   children,
+  onVisible,
 }) => {
   const { isVisible } = useTooltipState();
+
+  useEffect(() => {
+    return () => {
+      if (onVisible) {
+        onVisible(false);
+      }
+    };
+    // We are not including any deps here as we want to run react only to mounting/unmounting state
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (isVisible && onVisible) {
+      onVisible(true);
+    }
+    // We are not including onVisible here as we really only want to react to changes of isVisible
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isVisible]);
+
   return (
     <AnimatePresence>
       {isVisible && (

--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/ReputationChart.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/ReputationChart.tsx
@@ -3,6 +3,7 @@ import { defineMessages } from 'react-intl';
 
 import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { ReputationChartContextProvider } from '~context/ReputationChartContext/ReputationChartContextProvider.tsx';
 import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
 import { type Domain } from '~types/graphql.ts';
 import { notNull } from '~utils/arrays/index.ts';
@@ -79,7 +80,9 @@ const ReputationChart = () => {
         </LoadingSkeleton>
         <TeamActionsMenu isDisabled={isDataLoading} />
       </div>
-      <Chart data={chartData} isLoading={isDataLoading} />
+      <ReputationChartContextProvider>
+        <Chart data={chartData} isLoading={isDataLoading} />
+      </ReputationChartContextProvider>
     </div>
   );
 };

--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/Chart.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/Chart.tsx
@@ -2,6 +2,7 @@ import { ResponsivePie } from '@nivo/pie';
 import React, { type FC } from 'react';
 import { defineMessages } from 'react-intl';
 
+import { useReputationChartContext } from '~context/ReputationChartContext/ReputationChartContext.ts';
 import { formatText } from '~utils/intl.ts';
 
 import { pieChartConfig } from '../consts.ts';
@@ -35,6 +36,7 @@ interface ChartProps {
 }
 
 export const Chart: FC<ChartProps> = ({ data, isLoading }) => {
+  const { setActiveLegendItem } = useReputationChartContext();
   return (
     <>
       <div className="relative mb-3 mt-5 flex h-[136px] w-full flex-shrink-0 items-center justify-center">
@@ -43,6 +45,7 @@ export const Chart: FC<ChartProps> = ({ data, isLoading }) => {
           {...pieChartConfig}
           data={data.length ? data : [EMPTY_CHART_ITEM]}
           isInteractive={!!data.length}
+          onActiveIdChange={setActiveLegendItem}
           tooltip={ChartTooltip}
         />
       </div>

--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/ChartTooltip.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/ChartTooltip.tsx
@@ -1,16 +1,28 @@
 import { type PieTooltipProps } from '@nivo/pie';
 import React, { type FC } from 'react';
 
+import { useReputationChartContext } from '~context/ReputationChartContext/ReputationChartContext.ts';
 import Numeral from '~shared/Numeral/Numeral.tsx';
 import { ChartCustomTooltip } from '~v5/frame/ColonyHome/partials/ChartCustomTooltip/ChartCustomTooltip.tsx';
 
 import { type ReputationChartDataItem } from '../types.ts';
 
 export const ChartTooltip: FC<PieTooltipProps<ReputationChartDataItem>> = ({
-  datum: { label, value },
+  datum: { id, label, value },
 }) => {
+  const { setActiveLegendItem, resetActiveLegendItem } =
+    useReputationChartContext();
+
+  const onVisibleHandler = (isVisible?: boolean) => {
+    if (isVisible && id) {
+      setActiveLegendItem(id.toString());
+    } else {
+      resetActiveLegendItem();
+    }
+  };
+
   return (
-    <ChartCustomTooltip>
+    <ChartCustomTooltip onVisible={onVisibleHandler}>
       {label}
       <Numeral value={value.toFixed(2)} suffix="%" className="ml-1" />
     </ChartCustomTooltip>

--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/ChartTooltip.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/ChartTooltip.tsx
@@ -1,28 +1,16 @@
 import { type PieTooltipProps } from '@nivo/pie';
 import React, { type FC } from 'react';
 
-import { useReputationChartContext } from '~context/ReputationChartContext/ReputationChartContext.ts';
 import Numeral from '~shared/Numeral/Numeral.tsx';
 import { ChartCustomTooltip } from '~v5/frame/ColonyHome/partials/ChartCustomTooltip/ChartCustomTooltip.tsx';
 
 import { type ReputationChartDataItem } from '../types.ts';
 
 export const ChartTooltip: FC<PieTooltipProps<ReputationChartDataItem>> = ({
-  datum: { id, label, value },
+  datum: { label, value },
 }) => {
-  const { setActiveLegendItem, resetActiveLegendItem } =
-    useReputationChartContext();
-
-  const onVisibleHandler = (isVisible?: boolean) => {
-    if (isVisible && id) {
-      setActiveLegendItem(id.toString());
-    } else {
-      resetActiveLegendItem();
-    }
-  };
-
   return (
-    <ChartCustomTooltip onVisible={onVisibleHandler}>
+    <ChartCustomTooltip>
       {label}
       <Numeral value={value.toFixed(2)} suffix="%" className="ml-1" />
     </ChartCustomTooltip>

--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/LegendItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/LegendItem.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import React, { type FC } from 'react';
 
+import { useReputationChartContext } from '~context/ReputationChartContext/ReputationChartContext.ts';
 import Tooltip from '~shared/Extensions/Tooltip/Tooltip.tsx';
 import Numeral from '~shared/Numeral/Numeral.tsx';
 import { multiLineTextEllipsis } from '~utils/strings.ts';
@@ -13,6 +14,7 @@ interface LegendItemProps {
   chartItem:
     | ReputationChartDataItem
     | {
+        id?: string;
         color: string;
         label: string;
         value: undefined;
@@ -23,10 +25,14 @@ interface LegendItemProps {
 const LEGEND_LABEL_LENGTH = 12;
 
 const LegendItem: FC<LegendItemProps> = ({
-  chartItem: { color, label, value, shouldTruncateLegendLabel = true },
+  chartItem: { id, color, label, value, shouldTruncateLegendLabel = true },
 }) => {
   const isTruncated =
     shouldTruncateLegendLabel && label.length > LEGEND_LABEL_LENGTH;
+
+  const { activeLegendItemId } = useReputationChartContext();
+  const isLegendItemActive = activeLegendItemId === id;
+
   return (
     <Tooltip tooltipContent={isTruncated ? label : null}>
       <div className="flex flex-row items-center gap-1">
@@ -36,7 +42,11 @@ const LegendItem: FC<LegendItemProps> = ({
             summaryLegendColor[color] || summaryLegendColor.default,
           )}
         />
-        <span className="text-xs font-normal text-gray-500">
+        <span
+          className={clsx('text-xs font-normal text-gray-500', {
+            'text-gray-900': isLegendItemActive,
+          })}
+        >
           {isTruncated
             ? multiLineTextEllipsis(label, LEGEND_LABEL_LENGTH)
             : label}

--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/LegendItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/LegendItem.tsx
@@ -45,6 +45,8 @@ const LegendItem: FC<LegendItemProps> = ({
         <span
           className={clsx('text-xs font-normal text-gray-500', {
             'text-gray-900': isLegendItemActive,
+            // @TODO here we'll need to add if the search param exists once another PR gets merged
+            'cursor-pointer hover:text-gray-900': !!value,
           })}
         >
           {isTruncated

--- a/src/context/ReputationChartContext/ReputationChartContext.ts
+++ b/src/context/ReputationChartContext/ReputationChartContext.ts
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react';
+
+export const ReputationChartContext = createContext<
+  | {
+      setActiveLegendItem: (id: string) => void;
+      resetActiveLegendItem: () => void;
+      activeLegendItemId: string | null;
+    }
+  | undefined
+>(undefined);
+
+export const useReputationChartContext = () => {
+  const context = useContext(ReputationChartContext);
+  if (context === undefined) {
+    throw new Error(
+      'useReputationChartContext must be used within the ReputationChartContext',
+    );
+  }
+  return context;
+};

--- a/src/context/ReputationChartContext/ReputationChartContextProvider.tsx
+++ b/src/context/ReputationChartContext/ReputationChartContextProvider.tsx
@@ -1,0 +1,29 @@
+import React, {
+  type FC,
+  type PropsWithChildren,
+  useState,
+  useMemo,
+} from 'react';
+
+import { ReputationChartContext } from './ReputationChartContext.ts';
+
+export const ReputationChartContextProvider: FC<PropsWithChildren> = ({
+  children,
+}) => {
+  const [activeLegendItem, setActiveLegendItem] = useState<string | null>(null);
+
+  const value = useMemo(
+    () => ({
+      setActiveLegendItem: (id: string) => setActiveLegendItem(id),
+      resetActiveLegendItem: () => setActiveLegendItem(null),
+      activeLegendItemId: activeLegendItem,
+    }),
+    [activeLegendItem, setActiveLegendItem],
+  );
+
+  return (
+    <ReputationChartContext.Provider value={value}>
+      {children}
+    </ReputationChartContext.Provider>
+  );
+};


### PR DESCRIPTION
Feat: Add legend item active state on non-empty chart hover

## Description

Hovering over a section of the chart:
- [x] It should show the hover state of the section. 
- [x] It should highlight the team in the list.

[Figma link](https://www.figma.com/design/gac6xVgGNCAge5Bia933dp/Dashboard?node-id=4878-89693&node-type=frame&t=3xGH3p1iB0FF8qa7-0)

## Testing

TODO: Check the hover state over a section of the chart matches Figma.

* Step 1. Make sure you have data to test against
* Step 2. Go to http://localhost:9091/planex
* Step 2. Either leave the `All teams` or `General` team
* Step 3. Hover over a section of the `Influence by team` chart
* Step 4. Check hover state for the legend item is matching Figma

![Screenshot 2024-09-23 at 19 14 24](https://github.com/user-attachments/assets/e829fe80-37f1-4e42-bc03-df812c70ce2b)

* Step 5. Select another team
* Step 3. Hover over a section of the `Top contributors` chart
* Step 4. Check hover state for the legend item is matching Figma

![Screenshot 2024-09-23 at 19 14 14](https://github.com/user-attachments/assets/065e13d8-8376-4271-92ae-ecd1e68b6f52)



## Diffs

**New stuff** ✨

* `ReputationChartContext` and provider
* `onVisible` optional property for the `ChartCustomTooltip`

Resolves [#3146](https://github.com/JoinColony/colonyCDapp/issues/3146)
