### PR TITLE
fix: adjust blur when modal is active

### DIFF
--- a/src/components/v5/frame/PageLayout/PageLayout.tsx
+++ b/src/components/v5/frame/PageLayout/PageLayout.tsx
@@ -59,7 +59,7 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
               {headerProps ? <PageHeader {...headerProps} /> : header}
             </section>
             <section
-              className={clsx('w-full overflow-auto px-6 md:p-8', {
+              className={clsx('modal-blur w-full overflow-auto px-6 md:p-8', {
                 'md:!pt-[1.125rem]': !headerProps?.pageHeadingProps?.title,
               })}
             >

--- a/src/components/v5/frame/PageLayout/partials/PageHeader/PageHeader.tsx
+++ b/src/components/v5/frame/PageLayout/partials/PageHeader/PageHeader.tsx
@@ -95,7 +95,7 @@ const PageHeader: FC<PageHeaderProps> = ({ pageHeadingProps }) => {
         </div>
       </section>
       <section
-        className={clsx('flex w-full flex-col md:p-0', {
+        className={clsx('modal-blur flex w-full flex-col md:p-0', {
           'px-6 pb-2 pt-6': breadcrumbs,
         })}
       >

--- a/src/components/v5/shared/Navigation/Sidebar/Sidebar.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/Sidebar.tsx
@@ -29,7 +29,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
       <nav
         ref={ref}
         className={clsx(
-          'top-[calc(var(--header-nav-section-height)+var(--top-content-height))]',
+          'modal-blur top-[calc(var(--header-nav-section-height)+var(--top-content-height))]',
           'z-sidebar hidden h-full w-fit flex-col items-start rounded-lg bg-gray-900 px-2 pb-4.5 pt-[13.5px] md:flex',
           className,
         )}


### PR DESCRIPTION
## Description

Adds a blur to page layout components when a modal is visible.

![blur](https://github.com/user-attachments/assets/aa248332-96b5-43f6-b80b-253886d93494)

## Testing

1. Visit http://localhost:9091/planex/balances
2. Click the "Add funds to the colony" button
3. Verify that the rest of the page is blurred

Resolves #3079 