### PR TITLE
[Dashboard] Top contributors numbers should add up to 100

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/utils.ts
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/utils.ts
@@ -63,7 +63,7 @@ export const getTeamReputationChartData = (
     0,
   );
 
-  const topTeams = domainsWithoutRoot
+  let topTeams = domainsWithoutRoot
     // Filter out the domains without reputation in order to not display blank spaces in the chart
     .filter((domain) => !!domain.reputationPercentage)
     .slice(0, WIDGET_TEAM_LIMIT)
@@ -78,6 +78,18 @@ export const getTeamReputationChartData = (
         color: getTeamHexColor(domain.metadata?.color),
       };
     });
+
+  if (topTeams.length <= WIDGET_TEAM_LIMIT) {
+    const adjustedValues = adjustPercentagesTo100(
+      topTeams.map((team) => team.value),
+      // getNormalisedDomainReputationPercentage rounds to two decimals
+      2,
+    );
+    topTeams = topTeams.map((team, idx) => ({
+      ...team,
+      value: adjustedValues[idx],
+    }));
+  }
 
   const topTeamsTotalReputation = topTeams.reduce(
     (reputation, team) => reputation + team.value,

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -21,3 +21,34 @@ export const convertEnotationToNumber = (value: string) => {
   const realExponent = Math.abs(exponent - (tail?.length || 0));
   return `0.${realInteger.padStart(realExponent, '0')}`;
 };
+
+/**
+ * Adjusts an array of percentages so that they sum up to exactly 100% after rounding to the specified number of decimal places.
+ * It does this by calculating the rounding difference and adding it to the largest percentage value.
+ *
+ * @param percentages - An array of percentage values.
+ * @param decimals - The number of decimal places to round to.
+ * @returns A new array of percentages adjusted to sum up to 100%.
+ */
+export const adjustPercentagesTo100 = (
+  percentages: number[],
+  decimals: number,
+) => {
+  const multiplier = 10 ** decimals;
+  // Total sum needed (e.g., 10000 for two decimals)
+  const total = 100 * multiplier;
+  // Convert percentages to integer representations based on the specified decimals
+  const scaledValues = percentages.map((value) => value * multiplier);
+  // Round each value to the nearest integer
+  const roundedValues = scaledValues.map((value) => Math.round(value));
+  // Sum the rounded values
+  const sumRounded = roundedValues.reduce((acc, val) => acc + val, 0);
+  // Calculate the difference to reach the total
+  const delta = total - sumRounded;
+  // Find the index of the largest value in the original array
+  const maxIndex = roundedValues.indexOf(Math.max(...roundedValues));
+  // Adjust the largest value by adding the delta
+  roundedValues[maxIndex] += delta;
+  // Convert back to percentages with the specified number of decimals
+  return roundedValues.map((value) => value / multiplier);
+};


### PR DESCRIPTION
## Description

This PR makes sure that percentages add up to 100 if there are fewer than 5 people with reputation in the colony.

Bonus: I also did that for the domains graph :1st_place_medal:

## Testing

Look at this graph within the dashboard

![image](https://github.com/user-attachments/assets/3c143532-95f6-4723-8f9d-eb2dd3f42e0f)

The percentages should add up to 100 if there are 4 or less contributors.

## Diffs

**New stuff** ✨

* Add a `adjustPercentagesTo100` function

**Changes** 🏗

* Apply that function to domains and top contributors

Resolves #3119 