### PR TITLE
[New Nav] Trigger the Intercom Widget using the Help & Feedback button

### DIFF
--- a/src/components/common/Onboarding/Wizard/DesktopWizardSidebar.tsx
+++ b/src/components/common/Onboarding/Wizard/DesktopWizardSidebar.tsx
@@ -27,6 +27,7 @@ const DesktopWizardSidebar = ({
         offset: [-20, 226],
         enableMobileAndDesktopLayoutBreakpoints,
       }}
+      feedbackButtonProps={{ widgetPlacement: { horizontalPadding: 304 } }}
     >
       <div className="px-3 pt-10">
         <Heading3

--- a/src/components/shared/FeedbackButton/FeedbackButton.tsx
+++ b/src/components/shared/FeedbackButton/FeedbackButton.tsx
@@ -1,7 +1,7 @@
 import { ChatsCircle } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import { noop } from 'lodash';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { LEARN_MORE_COLONY_HELP_GENERAL } from '~constants';
 import { usePageThemeContext } from '~context/PageThemeContext/PageThemeContext.ts';
@@ -32,7 +32,7 @@ const FeedbackButton: React.FC<FeedbackButtonProps> = ({
     typeof window.Intercom !== 'undefined',
   );
 
-  const isWidgetOpen = useRef(false);
+  const [isWidgetOpen, setIsWidgetOpen] = useState(false);
 
   const bootIntercom = useCallback(() => {
     if (typeof window.Intercom !== 'undefined') {
@@ -65,11 +65,11 @@ const FeedbackButton: React.FC<FeedbackButtonProps> = ({
     });
 
     window.Intercom('onShow', () => {
-      isWidgetOpen.current = true;
+      setIsWidgetOpen(true);
     });
 
     window.Intercom('onHide', () => {
-      isWidgetOpen.current = false;
+      setIsWidgetOpen(false);
     });
 
     const handleClickOutside = (event: MouseEvent) => {
@@ -99,22 +99,24 @@ const FeedbackButton: React.FC<FeedbackButtonProps> = ({
     }
 
     try {
-      window.Intercom(isWidgetOpen.current ? 'hide' : 'show');
+      window.Intercom(isWidgetOpen ? 'hide' : 'show');
     } catch (error) {
       window.open(LEARN_MORE_COLONY_HELP_GENERAL, '_blank');
     }
-  }, [bootIntercom, isIntercomBooted, onClick]);
+  }, [bootIntercom, isIntercomBooted, isWidgetOpen, onClick]);
 
   return (
     <Button
       id={FEEDBACK_BUTTON_ID}
       onClick={handleClick}
       className={clsx(
-        'w-full !justify-start !gap-3 !border-none bg-gray-900 !p-2 !text-base-white',
+        'w-full !justify-start !gap-3 !border-none bg-gray-900 !p-2',
         {
           '!w-fit !justify-center': isPopoverMode,
-          '!bg-gray-100 !text-gray-900 hover:!bg-gray-50': isDarkMode,
+          '!bg-gray-100 hover:!bg-gray-50': isDarkMode,
+          '!bg-gray-50': isDarkMode && isWidgetOpen,
           'hover:!bg-gray-800': !isDarkMode,
+          '!bg-gray-800': !isDarkMode && isWidgetOpen,
         },
       )}
       iconSize={20}

--- a/src/components/shared/FeedbackButton/FeedbackButton.tsx
+++ b/src/components/shared/FeedbackButton/FeedbackButton.tsx
@@ -60,6 +60,10 @@ const FeedbackButton: React.FC<FeedbackButtonProps> = ({
       return noop;
     }
 
+    const hideIntercom = () => {
+      window.Intercom('hide');
+    };
+
     window.Intercom('onUnreadCountChange', (unreadMessages: number) => {
       setShowBadge(unreadMessages > 0);
     });
@@ -80,13 +84,17 @@ const FeedbackButton: React.FC<FeedbackButtonProps> = ({
         !intercomFrame?.contains(event.target as Node) &&
         !feedbackButton?.contains(event.target as Node)
       ) {
-        window.Intercom('hide');
+        hideIntercom();
       }
     };
 
     document.addEventListener('mousedown', handleClickOutside);
 
+    window.addEventListener('beforeunload', hideIntercom);
+
     return () => {
+      window.removeEventListener('beforeunload', hideIntercom);
+
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [bootIntercom, isIntercomBooted]);
@@ -110,7 +118,7 @@ const FeedbackButton: React.FC<FeedbackButtonProps> = ({
       id={FEEDBACK_BUTTON_ID}
       onClick={handleClick}
       className={clsx(
-        'w-full !justify-start !gap-3 !border-none bg-gray-900 !p-2',
+        'relative w-full !justify-start !gap-3 !border-none bg-gray-900 !p-2',
         {
           '!w-fit !justify-center': isPopoverMode,
           '!bg-gray-100 hover:!bg-gray-50': isDarkMode,
@@ -123,7 +131,7 @@ const FeedbackButton: React.FC<FeedbackButtonProps> = ({
     >
       <ChatsCircle
         className={clsx(
-          'aspect-auto h-5 w-auto flex-shrink-0 text-base-white',
+          'relative aspect-auto h-5 w-auto flex-shrink-0 text-base-white',
           {
             '!text-gray-900': isDarkMode,
           },

--- a/src/components/shared/FeedbackButton/FeedbackButton.tsx
+++ b/src/components/shared/FeedbackButton/FeedbackButton.tsx
@@ -1,7 +1,9 @@
 import { ChatsCircle } from '@phosphor-icons/react';
 import clsx from 'clsx';
-import React from 'react';
+import { noop } from 'lodash';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
+import { LEARN_MORE_COLONY_HELP_GENERAL } from '~constants';
 import { usePageThemeContext } from '~context/PageThemeContext/PageThemeContext.ts';
 import { formatText } from '~utils/intl.ts';
 import Button from '~v5/shared/Button/index.ts';
@@ -15,16 +17,98 @@ const MSG = {
   },
 };
 
+const FEEDBACK_BUTTON_ID = 'sidebar-feedback-button';
+
 const FeedbackButton: React.FC<FeedbackButtonProps> = ({
   onClick,
   isPopoverMode,
+  widgetPlacement,
 }) => {
   const { isDarkMode } = usePageThemeContext();
 
+  const [showBadge, setShowBadge] = useState(false);
+
+  const [isIntercomBooted, setIsIntercomBooted] = useState(
+    typeof window.Intercom !== 'undefined',
+  );
+
+  const isWidgetOpen = useRef(false);
+
+  const bootIntercom = useCallback(() => {
+    if (typeof window.Intercom !== 'undefined') {
+      window.Intercom('boot', {
+        // eslint-disable-next-line camelcase
+        alignment: widgetPlacement?.alignment ?? 'left',
+        // eslint-disable-next-line camelcase
+        horizontal_padding: widgetPlacement?.horizontalPadding ?? 0,
+        // eslint-disable-next-line camelcase
+        vertical_padding: widgetPlacement?.verticalPadding ?? 48,
+      });
+
+      setIsIntercomBooted(true);
+    }
+  }, [
+    widgetPlacement?.alignment,
+    widgetPlacement?.horizontalPadding,
+    widgetPlacement?.verticalPadding,
+  ]);
+
+  useEffect(() => {
+    bootIntercom();
+
+    if (!isIntercomBooted) {
+      return noop;
+    }
+
+    window.Intercom('onUnreadCountChange', (unreadMessages: number) => {
+      setShowBadge(unreadMessages > 0);
+    });
+
+    window.Intercom('onShow', () => {
+      isWidgetOpen.current = true;
+    });
+
+    window.Intercom('onHide', () => {
+      isWidgetOpen.current = false;
+    });
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const intercomFrame = document.querySelector('.intercom-messenger-frame');
+      const feedbackButton = document.querySelector(`#${FEEDBACK_BUTTON_ID}`);
+
+      if (
+        !intercomFrame?.contains(event.target as Node) &&
+        !feedbackButton?.contains(event.target as Node)
+      ) {
+        window.Intercom('hide');
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [bootIntercom, isIntercomBooted]);
+
+  const handleClick = useCallback(() => {
+    onClick?.();
+
+    if (!isIntercomBooted) {
+      bootIntercom();
+    }
+
+    try {
+      window.Intercom(isWidgetOpen.current ? 'hide' : 'show');
+    } catch (error) {
+      window.open(LEARN_MORE_COLONY_HELP_GENERAL, '_blank');
+    }
+  }, [bootIntercom, isIntercomBooted, onClick]);
+
   return (
     <Button
-      onClick={onClick}
-      mode="primaryOutlineFull"
+      id={FEEDBACK_BUTTON_ID}
+      onClick={handleClick}
       className={clsx(
         'w-full !justify-start !gap-3 !border-none bg-gray-900 !p-2 !text-base-white',
         {
@@ -33,9 +117,16 @@ const FeedbackButton: React.FC<FeedbackButtonProps> = ({
           'hover:!bg-gray-800': !isDarkMode,
         },
       )}
-      icon={ChatsCircle}
       iconSize={20}
     >
+      <ChatsCircle
+        className={clsx(
+          'aspect-auto h-5 w-auto flex-shrink-0 text-base-white',
+          {
+            '!text-gray-900': isDarkMode,
+          },
+        )}
+      />
       {!isPopoverMode && (
         <p
           className={clsx('text-md font-medium text-base-white', {
@@ -44,6 +135,9 @@ const FeedbackButton: React.FC<FeedbackButtonProps> = ({
         >
           {formatText(MSG.label)}
         </p>
+      )}
+      {showBadge && (
+        <div className="absolute right-2 aspect-square h-2 animate-pulse rounded-full bg-blue-400" />
       )}
     </Button>
   );

--- a/src/components/shared/FeedbackButton/types.ts
+++ b/src/components/shared/FeedbackButton/types.ts
@@ -1,4 +1,9 @@
 export interface FeedbackButtonProps {
   onClick?: () => void;
   isPopoverMode?: boolean;
+  widgetPlacement?: {
+    alignment?: 'left' | 'right';
+    verticalPadding?: number;
+    horizontalPadding?: number;
+  };
 }

--- a/src/components/v5/shared/Navigation/Sidebar/sidebars/AccountPageSidebar/AccountPageSidebar.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/sidebars/AccountPageSidebar/AccountPageSidebar.tsx
@@ -19,9 +19,10 @@ import Sidebar from '~v5/shared/Navigation/Sidebar/Sidebar.tsx';
 export const AccountPageSidebar = () => {
   return (
     <Sidebar
-      className="!w-[216px]"
+      className="!w-[216px] overflow-y-auto"
       headerClassName="mb-[27px]"
       colonySwitcherProps={{ showColonySwitcherText: true }}
+      feedbackButtonProps={{ widgetPlacement: { horizontalPadding: 240 } }}
     >
       <section className="flex flex-col gap-0.5">
         <SidebarRouteItem

--- a/src/components/v5/shared/Navigation/Sidebar/sidebars/BasicPageSidebar.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/sidebars/BasicPageSidebar.tsx
@@ -5,7 +5,10 @@ import Sidebar from '../index.ts';
 export const BasicPageSidebar = () => (
   <Sidebar
     colonySwitcherProps={{ isLogoButton: true, offset: [-20, 22] }}
-    feedbackButtonProps={{ isPopoverMode: true }}
+    feedbackButtonProps={{
+      isPopoverMode: true,
+      widgetPlacement: { horizontalPadding: 104 },
+    }}
     className="!items-center"
     footerClassName="!items-center"
   />

--- a/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/ColonyPageSidebar.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/ColonyPageSidebar.tsx
@@ -98,6 +98,9 @@ const ColonyPageSidebar = () => {
       headerClassName="mb-[27px]"
       footerClassName="!items-start !gap-2"
       colonySwitcherProps={{ showColonySwitcherText: true }}
+      feedbackButtonProps={{
+        widgetPlacement: { horizontalPadding: 240 },
+      }}
     >
       <ColonyPageSidebarContent />
     </Sidebar>

--- a/src/constants/externalUrls.ts
+++ b/src/constants/externalUrls.ts
@@ -71,7 +71,7 @@ export const MULTI_SIG_HELP_URL =
 export const LEARN_MORE_PAYMENTS = `https://docs.colony.io/use/making-payments/payments`;
 export const LEARN_MORE_DECISIONS = `https://docs.colony.io/use/decisions`;
 export const LEARN_MORE_ADMIN = `https://docs.colony.io/use/admin`;
-export const LEARN_MORE_COLONY_HELP_GENERAL = `https://help.colony.io/en/`;
+export const LEARN_MORE_COLONY_HELP_GENERAL = `https://help.colony.io/`;
 /*
  * Safe Control
  */

--- a/src/typedefs/intercom/index.d.ts
+++ b/src/typedefs/intercom/index.d.ts
@@ -1,0 +1,103 @@
+declare namespace Intercom_ {
+  interface IntercomSettings {
+    // Messenger attributes
+    app_id?: string | undefined;
+    api_base?: string | undefined;
+    alignment?: string | undefined;
+    custom_launcher_selector?: string | undefined;
+    hide_default_launcher?: boolean | undefined;
+    horizontal_padding?: number | undefined;
+    session_duration?: number | undefined;
+    vertical_padding?: number | undefined;
+    action_color?: string | undefined;
+    background_color?: string | undefined;
+
+    // Data attributes
+    email?: string | undefined;
+    phone?: string | undefined;
+    created_at?: number | undefined;
+    name?: string | undefined;
+    user_id?: string | undefined;
+    user_hash?: string | undefined;
+    unsubscribed_from_emails?: boolean | undefined;
+    language_override?: string | undefined;
+    utm_campaign?: string | undefined;
+    utm_content?: string | undefined;
+    utm_medium?: string | undefined;
+    utm_source?: string | undefined;
+    utm_term?: string | undefined;
+    company?: IntercomCompany | undefined;
+    companies?: IntercomCompany[] | undefined;
+    avatar?: IntercomAvatar | undefined;
+
+    // Custom attributes
+    [custom_attribute: string]:
+      | IntercomCompany
+      | IntercomCompany[]
+      | IntercomAvatar
+      | IntercomCustomAttribute;
+  }
+
+  interface IntercomCommandSignature {
+    boot: (settings: IntercomSettings) => void;
+    shutdown: () => void;
+    update: (settings?: IntercomSettings) => void;
+    hide: () => void;
+    show: () => void;
+    showMessages: () => void;
+    showNewMessage: (prepopulateMessage?: string) => void;
+    onHide: (callback: () => void) => void;
+    onShow: (callback: () => void) => void;
+    onUnreadCountChange: (callback: (unreadCount: number) => void) => void;
+    onActivatorClick: (callback: () => void) => void;
+    trackEvent: (tag?: string, metadata?: any) => void;
+    getVisitorId: () => string;
+    startTour: (tourId: number) => void;
+    showArticle: (articleId: number) => void;
+    showConversation: (conversationId: number) => void;
+    startSurvey: (surveyId: number) => void;
+    reattach_activator: () => void;
+    showSpace: (space: string) => void;
+    startChecklist: (checklistId: number) => void;
+  }
+
+  type IntercomCommand = keyof IntercomCommandSignature;
+
+  interface IntercomStatic {
+    <Command extends IntercomCommand>(
+      command: Command,
+      ...params: Parameters<IntercomCommandSignature[Command]>
+    ): ReturnType<IntercomCommandSignature[Command]>;
+    booted: boolean;
+  }
+
+  interface IntercomCompany {
+    name: string;
+    id?: string | number | undefined;
+    company_id?: string | number | undefined;
+    created_at?: number | undefined;
+    remote_created_at?: number | undefined;
+    plan?: string | undefined;
+    monthly_spend?: number | undefined;
+    user_count?: number | undefined;
+    size?: number | undefined;
+    website?: string | undefined;
+    industry?: string | undefined;
+    [custom_attribute: string]: IntercomCustomAttribute;
+  }
+
+  interface IntercomAvatar {
+    type: 'avatar';
+    image_url: string;
+  }
+
+  type IntercomCustomAttribute = string | number | boolean | null | undefined;
+}
+
+declare let Intercom: Intercom_.IntercomStatic;
+declare let intercomSettings: Intercom_.IntercomSettings | undefined;
+
+interface Window {
+  Intercom: Intercom_.IntercomStatic;
+  intercomSettings?: Intercom_.IntercomSettings | undefined;
+}


### PR DESCRIPTION
## Description

This PR is not going to update any piece of logic that happens within the Intercom widget. This includes attempting to hide the Previews from an Operator when the Widget is hidden.

This PR simply aims to do the following:
- Control the visibility of the Intercom Widget via  custom triggers
- Control the page offset of the Intercom Widget via Intercom's javascript API
- Redirect the user to https://help.colony.io/ if Intercom is not accessible

> [!IMPORTANT]
> There might be a delay when you click the Help & Feedback button for the first time on page load. I have discussed this extensively with Arren including options of how to handle the delay with loaders perhaps etc. etc.. But TLDR: It's fine as it is because it's not our fault that their widget takes time to be initialised. Even their native floating button can take time to show up on the page because of this inherent delay. The important thing is that the Widget eventually loads if Intercom is available. Otherwise, it should take the user to the Colony Help page.
 
![intercom](https://github.com/user-attachments/assets/0a82b7be-4298-4b1f-8f71-8670572fbc3c)

## Testing

> [!IMPORTANT]
> 1. Please speak to me or Arren about the `GOOGLE_TAG_MANAGER_ID` env variable value
> 2. Update the `GOOGLE_TAG_MANAGER_ID` env variable in your `.env` file
> 3. Run `npm run prepare` to inject the env variables properly
> 3. Reload the page

### Integration enabled

1. Visit a Colony
2. Click the Help & Feedback button
3. Verify that the Intercom widget shows up
4. Click it again
5. Verify that the Intercom widget is dismissed
6. Click it again
7. Verify that the Intercom widget shows up
8. Click outside of it
9. Verify that the Intercom widget is dismissed
10. Click it again
11. Verify that you see this UI:

<img width="319" alt="image" src="https://github.com/user-attachments/assets/6a5f4e92-38c6-4632-96da-08e855ef1880">

12. Click Send us a message
13. Verify that you see this UI:

<img width="422" alt="image" src="https://github.com/user-attachments/assets/755396b3-954d-4e35-82dd-f2266aee1543">

## Integration disabled

> [!IMPORTANT]
> 1. Please remove the value for the `GOOGLE_TAG_MANAGER_ID` env variable
> 2. Reload the page

1. Click the Help & Feedback button
2. Verify that you are taken to https://help.colony.io/ on a new tab

Resolves #3148 