### PR TITLE
fix: handle duplicated release actions

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/StagedPaymentStep.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/StagedPaymentStep.tsx
@@ -132,14 +132,8 @@ const StagedPaymentStep: FC<StagedPaymentStepProps> = ({
         uniqueId: `${item.slotId}-0`,
         createdAt: createdAt || '',
       };
-    })
-    .filter((item) => {
-      const motion = releaseMilestoneMotions?.find((m) =>
-        m?.expenditureSlotIds?.includes(item.slotId),
-      );
-
-      return !motion?.motionStateHistory.hasPassed;
     });
+
   const releaseItems = [...motionMilestones, ...releasedMilestones].sort(
     (a, b) => {
       if (new Date(a.createdAt) > new Date(b.createdAt)) return -1;


### PR DESCRIPTION
## Description

- You should be able to see the history of all milestone payments in the action timeline.
- You should be able to see which decision method was used for each milestone payment made.

<img width="870" alt="image" src="https://github.com/user-attachments/assets/409fa0c3-fbf8-4abd-badc-c35ccb9d70da">
<img width="889" alt="image" src="https://github.com/user-attachments/assets/86aa25fc-4328-4ca5-a2e5-9ea1cf7affdc">


## Testing

* Create a new Staged payment.
* Pay one of the milestone payment using Reputation.
* Go through the motion process to Support, but don't finalize the motion.
* Create another payment for the same milestone using Permission.
* Now, return to the previous motion and finalize it.

Resolves https://github.com/JoinColony/colonyCDapp/issues/3144
