### PR TITLE
[Dashboard] Refactor bar chart css variables

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/consts.ts
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/consts.ts
@@ -65,3 +65,11 @@ export const CHART_CONFIG_VALUES = {
   X_AXIS_TOP_MARGIN: 14,
   X_AXIS_LABEL_RIGHT_MARGIN: 8,
 };
+
+export const cssVariables = {
+  gray100: 'var(--color-gray-100)',
+  gray200: 'var(--color-gray-200)',
+  gray400: 'var(--color-gray-400)',
+  baseBlack: 'var(--color-base-black)',
+  baseWhite: 'var(--color-base-white)',
+};

--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/hooks.ts
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/hooks.ts
@@ -1,6 +1,6 @@
 import { type WatchQueryFetchPolicy } from '@apollo/client/core';
 import { type ResponsiveBarSvgProps, type BarDatum } from '@nivo/bar';
-import { useState, useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useCurrencyContext } from '~context/CurrencyContext/CurrencyContext.ts';
@@ -222,65 +222,22 @@ export const useDomainColorVariables = () => {
   };
 };
 
-export const useCssProperties = () => {
-  const [cssProperties, setCssProperties] = useState<any>({});
-  const domainColorVariables = useDomainColorVariables();
-
-  useEffect(() => {
-    const updateChartStyle = () => {
-      const computedStyles = getComputedStyle(document.documentElement);
-      setCssProperties({
-        gray100: computedStyles.getPropertyValue('--color-gray-100'),
-        gray200: computedStyles.getPropertyValue('--color-gray-200'),
-        gray400: computedStyles.getPropertyValue('--color-gray-400'),
-        baseBlack: computedStyles.getPropertyValue('--color-base-black'),
-        baseWhite: computedStyles.getPropertyValue('--color-base-white'),
-        fontFamily: computedStyles.getPropertyValue(
-          '--onboard-font-family-normal',
-        ),
-        primary: computedStyles.getPropertyValue(
-          domainColorVariables.primaryColorVariableName,
-        ),
-        secondary: computedStyles.getPropertyValue(
-          domainColorVariables.secondaryColorVariableName,
-        ),
-      });
-    };
-    const observer = new MutationObserver(updateChartStyle);
-
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['style'],
-    });
-
-    updateChartStyle();
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [
-    domainColorVariables.primaryColorVariableName,
-    domainColorVariables.secondaryColorVariableName,
-  ]);
-
-  return cssProperties;
-};
-
 export const useBarChartLegend = () => {
-  const cssProperties = useCssProperties();
+  const { primaryColorVariableName, secondaryColorVariableName } =
+    useDomainColorVariables();
 
   return useMemo<any>(
     () => [
       {
-        color: cssProperties.secondary,
+        color: `var(${secondaryColorVariableName})`,
         label: formatText(MSG.paymentsLegendTitle),
       },
       {
-        color: cssProperties.primary,
+        color: `var(${primaryColorVariableName})`,
         label: formatText(MSG.incomeLegendTitle),
       },
     ],
-    [cssProperties.primary, cssProperties.secondary],
+    [primaryColorVariableName, secondaryColorVariableName],
   );
 };
 
@@ -322,7 +279,8 @@ export const useChartYSteps = () => {
 export const useBarChartConfig = <T extends BarDatum>(): Partial<
   ResponsiveBarSvgProps<T>
 > => {
-  const cssProperties = useCssProperties();
+  const { primaryColorVariableName, secondaryColorVariableName } =
+    useDomainColorVariables();
 
   const barChartConfig = useMemo(() => {
     return {
@@ -330,7 +288,7 @@ export const useBarChartConfig = <T extends BarDatum>(): Partial<
         background: 'transparent',
       },
       colors: ({ id }) =>
-        id === 'in' ? cssProperties.primary : cssProperties.secondary,
+        `var(${id === 'in' ? primaryColorVariableName : secondaryColorVariableName})`,
       keys: ['out', 'in'],
       indexBy: 'label',
       groupMode: 'grouped' as any,
@@ -351,7 +309,7 @@ export const useBarChartConfig = <T extends BarDatum>(): Partial<
       // needed to override the default bar component
       barComponent: () => null,
     };
-  }, [cssProperties.primary, cssProperties.secondary]);
+  }, [primaryColorVariableName, secondaryColorVariableName]);
 
   return barChartConfig;
 };

--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/BarChart.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/BarChart.tsx
@@ -1,12 +1,8 @@
 import { ResponsiveBar } from '@nivo/bar';
 import React, { type FC } from 'react';
 
-import {
-  useBarChartConfig,
-  useChartYSteps,
-  useCssProperties,
-  useData,
-} from '../hooks.ts';
+import { cssVariables } from '../consts.ts';
+import { useBarChartConfig, useChartYSteps, useData } from '../hooks.ts';
 import { type BarChartDataItem } from '../types.ts';
 import {
   getFallbackData,
@@ -23,13 +19,12 @@ import { ChartCustomYAxisLayer } from './ChartCustomYAxisLayer.tsx';
 interface BarChartProps {}
 
 const EnhancedChartCustomXAxisLayer = (props) => {
-  const cssProperties = useCssProperties();
   const { loading: isLoading } = useData();
 
   return (
     <ChartCustomXAxisLayer
       {...props}
-      textColor={cssProperties.gray400}
+      textColor={cssVariables.gray400}
       formatLabel={getMonthShortName}
       isLoading={isLoading}
     />
@@ -37,7 +32,6 @@ const EnhancedChartCustomXAxisLayer = (props) => {
 };
 
 const EnhancedChartCustomYAxisLayer = (props) => {
-  const cssProperties = useCssProperties();
   const { loading: isLoading } = useData();
   const steps = useChartYSteps();
 
@@ -45,8 +39,8 @@ const EnhancedChartCustomYAxisLayer = (props) => {
     <ChartCustomYAxisLayer
       {...props}
       steps={steps}
-      textColor={cssProperties.gray400}
-      lineColor={cssProperties.gray200}
+      textColor={cssVariables.gray400}
+      lineColor={cssVariables.gray200}
       formatLabel={getFormattedShortAmount}
       isLoading={isLoading}
     />
@@ -54,13 +48,12 @@ const EnhancedChartCustomYAxisLayer = (props) => {
 };
 
 const EnhancedChartCustomBarGroupLayer = (props) => {
-  const cssProperties = useCssProperties();
   const { loading: isLoading } = useData();
 
   return (
     <ChartCustomBarGroupLayer
       {...props}
-      hoveredColor={cssProperties.gray100}
+      hoveredColor={cssVariables.gray100}
       isLoading={isLoading}
     />
   );

--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/ChartCustomBottomAxisLayer.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/ChartCustomBottomAxisLayer.tsx
@@ -1,7 +1,6 @@
 import React, { type FC } from 'react';
 
-import { CHART_CONFIG_VALUES } from '../consts.ts';
-import { useCssProperties } from '../hooks.ts';
+import { CHART_CONFIG_VALUES, cssVariables } from '../consts.ts';
 
 interface ChartCustomBottomAxisLayerProps {
   innerWidth: number;
@@ -11,14 +10,13 @@ interface ChartCustomBottomAxisLayerProps {
 export const ChartCustomBottomAxisLayer: FC<
   ChartCustomBottomAxisLayerProps
 > = ({ innerWidth, innerHeight }) => {
-  const cssProperties = useCssProperties();
   return (
     <line
       x1={5}
       y1={innerHeight}
       x2={innerWidth}
       y2={innerHeight}
-      stroke={cssProperties.gray200} // Color of the border
+      stroke={cssVariables.gray200} // Color of the border
       strokeWidth={CHART_CONFIG_VALUES.GRID_LINE_WIDTH}
       strokeLinecap="round"
     />


### PR DESCRIPTION
## Description

- This PR replaces the use of the `useCssProperties` hook with a `cssVariables` const for the `Total in and out` chart

## Testing

TODO: Just check this change does not affect the `Total in and out` chart between light and dark mode

`General` or `All teams`
![Screenshot 2024-09-25 at 23 46 05](https://github.com/user-attachments/assets/6a989dad-7e61-4f0e-b642-9625156cab91)
![Screenshot 2024-09-25 at 23 46 32](https://github.com/user-attachments/assets/eac9b7f0-3cb4-4b3a-9eb2-e6867029fbe9)
`Andromeda`
![Screenshot 2024-09-25 at 23 46 10](https://github.com/user-attachments/assets/7a5845ea-6f83-4740-82f5-ff46c0cab60e)
![Screenshot 2024-09-25 at 23 46 29](https://github.com/user-attachments/assets/f01d6ced-6a80-4e4b-8605-3ea71848ab6d)
`Rocinate`
![Screenshot 2024-09-25 at 23 46 19](https://github.com/user-attachments/assets/e86d0ddf-c225-4521-9bac-8144056788ac)
![Screenshot 2024-09-25 at 23 46 24](https://github.com/user-attachments/assets/9589af7e-5397-4d36-a3eb-f9c7dcbe50f0)

## Diffs

**New stuff** ✨

* `cssVariables`

**Deletions** ⚰️

* `useCssProperties` hook

Resolves [#3172](https://github.com/JoinColony/colonyCDapp/issues/3172)
