### PR TITLE
[Dashboard] Pay opens Payment section with team pre-filled

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/GroupedAction/GroupedActionItem.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/GroupedAction/GroupedActionItem.tsx
@@ -58,11 +58,13 @@ export const GroupedActionItem: FC<GroupedActionItemProps> = ({
   isNew = false,
 }) => {
   const {
+    actionSidebarInitialValues,
     actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
   } = useActionSidebarContext();
 
   const onClick = () => {
     toggleActionSidebarOn({
+      ...actionSidebarInitialValues,
       [ACTION_TYPE_FIELD_NAME]: action,
     });
   };

--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/PaymentsSection.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/PaymentsSection.tsx
@@ -31,8 +31,8 @@ export const PaymentsSection = () => {
     setShowTabletSidebar(false);
 
     toggleActionSidebarOn({
-      [ACTION_TYPE_FIELD_NAME]: Action.SimplePayment,
-      [FROM_FIELD_NAME]: selectedDomain?.nativeId ?? 1,
+      [ACTION_TYPE_FIELD_NAME]: Action.PaymentGroup,
+      [FROM_FIELD_NAME]: selectedDomain?.nativeId ?? '',
     });
   };
 


### PR DESCRIPTION
## Description

- Clicking on `Pay` in the `Total in and out` card should open the `Payment section` side panel with the team-preselected

## Testing

TODO: Check clicking `Pay` in the `Total in and out` card opens the `Payment section`. Then select any action from the ones available (`Simple payment` or `Advanced payment`) and check the selected domain is pre-filled in the `From` field of the action form. Switch between domains and have fun 🎉 


https://github.com/user-attachments/assets/7e7c5c4d-b442-4684-9e9f-dfeb2bac3925


## Diffs

**Changes** 🏗

* Using `actionSidebarInitialValues` in the `GroupedActionItem`


Contributes to #3173 
