### PR TITLE
fix: update get user query to be 'cache-first' to solve reloading issue

### DIFF
--- a/src/hooks/useUserByAddress.ts
+++ b/src/hooks/useUserByAddress.ts
@@ -13,7 +13,7 @@ const useUserByAddress = (
     variables: {
       address,
     },
-    fetchPolicy: 'cache-and-network',
+    fetchPolicy: 'cache-first',
     skip: tryLiquidationAddress || !address,
   });
 
@@ -23,7 +23,7 @@ const useUserByAddress = (
         userOrLiquidationAddress: address,
         chainId: Number(getChainId()),
       },
-      fetchPolicy: 'cache-and-network',
+      fetchPolicy: 'cache-first',
       skip: !tryLiquidationAddress || !address,
     });
 


### PR DESCRIPTION
## Description
Pairprogrammed it with @bassgeta. Thank you for your help :) 

### Before 
![blick-before](https://github.com/user-attachments/assets/58ea5ee5-a8b7-434a-867d-0ae845a90485) 

-------------- 


### Now
![blick-now](https://github.com/user-attachments/assets/8510bd76-94ba-4c37-ba52-d35c867214fb) 

## Testing

1. Ensure you have past activity in our colony.
2. Ensure your screen is wide enough to see the activity feed and open the action panel.
3. Open and close the action panel.
4. Note the activity feed isn't blicking now.

Resolves #2806