### PR TITLE
Maintenance: Udpate main content max width to 1278px

### DIFF
--- a/src/components/v5/frame/PageLayout/PageLayout.tsx
+++ b/src/components/v5/frame/PageLayout/PageLayout.tsx
@@ -64,7 +64,7 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
               })}
             >
               <div
-                className={clsx('mx-auto max-w-[71.5rem] pt-6 md:pt-0', {
+                className={clsx('mx-auto max-w-[79.875rem] pt-6 md:pt-0', {
                   '!pt-0': enableMobileAndDesktopLayoutBreakpoints,
                 })}
               >


### PR DESCRIPTION
## Description

This simply sets the max width of the main container to 1278px:

<img width="1325" alt="Screenshot 2024-09-26 at 18 40 54" src="https://github.com/user-attachments/assets/a1205fa1-fed7-437b-80b0-f50f71e32fb2">

## Testing

1. Maximise the browser width
2. Verify that even if the browser width exceeds 1278px, the main content width can only ever be a maximum of 1278px

Resolves #3180 