### PR TITLE
fix: delete old bank account only _after_ creating a new one

### DIFF
--- a/amplify/backend/function/bridgeXYZMutation/src/handlers/checkKyc.js
+++ b/amplify/backend/function/bridgeXYZMutation/src/handlers/checkKyc.js
@@ -2,7 +2,7 @@ const fetch = require('cross-fetch');
 const { utils } = require('ethers');
 const { v4: uuid } = require('uuid');
 const { graphqlRequest } = require('../utils');
-const { getLiquidationAddresses } = require('./utils');
+const { getLiquidationAddresses, getExternalAccounts } = require('./utils');
 /*
  * @TODO This needs to be imported properly into the project (maybe?)
  * So that we can always ensure it follows the latest schema
@@ -102,19 +102,8 @@ const checkKYCHandler = async (
       return { kycStatus };
     }
 
-    const externalAccountRes = await fetch(
-      `${apiUrl}/v0/customers/${bridgeCustomerId}/external_accounts`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          'Api-Key': apiKey,
-        },
-      },
-    );
+    const externalAccounts = await getExternalAccounts(apiUrl, apiKey, bridgeCustomerId);
 
-    const response = await externalAccountRes.json();
-
-    const externalAccounts = response.data;
     const firstAccount = externalAccounts?.[0];
 
     if (!firstAccount) {

--- a/amplify/backend/function/bridgeXYZMutation/src/handlers/getUserLiquidationAddress.js
+++ b/amplify/backend/function/bridgeXYZMutation/src/handlers/getUserLiquidationAddress.js
@@ -1,6 +1,6 @@
 const fetch = require('cross-fetch');
 const { graphqlRequest } = require('../utils');
-const { getLiquidationAddresses } = require('./utils');
+const { getLiquidationAddresses, getExternalAccounts } = require('./utils');
 
 const { getUser } = require('../graphql');
 
@@ -25,19 +25,7 @@ const getUserLiquidationAddressHandler = async (
     return null;
   }
 
-  const externalAccountRes = await fetch(
-    `${apiUrl}/v0/customers/${bridgeCustomerId}/external_accounts`,
-    {
-      headers: {
-        'Content-Type': 'application/json',
-        'Api-Key': apiKey,
-      },
-    },
-  );
-
-  const response = await externalAccountRes.json();
-
-  const externalAccounts = response.data;
+  const externalAccounts = await getExternalAccounts(apiUrl, apiKey, bridgeCustomerId);
   const firstAccount = externalAccounts?.[0];
 
   if (!firstAccount) {

--- a/amplify/backend/function/bridgeXYZMutation/src/handlers/updateExternalAccount.js
+++ b/amplify/backend/function/bridgeXYZMutation/src/handlers/updateExternalAccount.js
@@ -1,6 +1,6 @@
 const fetch = require('cross-fetch');
 const { graphqlRequest } = require('../utils');
-const { createExternalAccount, getLiquidationAddresses, getExternalAccounts } = require('./utils');
+const { createExternalAccount, deleteExternalAccount, getLiquidationAddresses, getExternalAccounts } = require('./utils');
 
 const { getUser } = require('../graphql');
 
@@ -41,23 +41,8 @@ const updateExternalAccountHandler = async (
     account,
   );
 
-  const deletePromises = externalAccounts.map(async ({ id }) => {
-    const deleteAccountRes = await fetch(
-      `${apiUrl}/v0/customers/${bridgeCustomerId}/external_accounts/${input.id}`,
-      {
-        headers: {
-          'Api-Key': apiKey,
-        },
-        method: 'DELETE',
-      },
-    );
-
-    if (deleteAccountRes.status !== 200) {
-      console.log(
-        `Error deleting external account: ${await deleteAccountRes.text()}`,
-      );
-    }
-  });
+  const deletePromises = externalAccounts.map(async ({ id }) =>
+    deleteExternalAccount(apiUrl, apiKey, bridgeCustomerId, id));
 
   await Promise.all(deletePromises);
 

--- a/amplify/backend/function/bridgeXYZMutation/src/handlers/utils.js
+++ b/amplify/backend/function/bridgeXYZMutation/src/handlers/utils.js
@@ -64,7 +64,30 @@ const getLiquidationAddresses = async (apiUrl, apiKey, bridgeCustomerId) => {
   return liquidationAddressesJson.data;
 };
 
+const getExternalAccounts = async (apiUrl, apiKey, bridgeCustomerId) => {
+  const externalAccountsRes = await fetch(
+    `${apiUrl}/v0/customers/${bridgeCustomerId}/external_accounts`,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'Api-Key': apiKey,
+      },
+    },
+  );
+
+  if (externalAccountsRes.status !== 200) {
+    console.log(`Could not fetch external accounts for customer ${bridgeCustomerId}`);
+    return null;
+  }
+
+  const externalAccountsJson = await externalAccountsRes.json();
+
+  return externalAccountsJson.data;
+}
+
 module.exports = {
   createExternalAccount,
+  getExternalAccounts,
   getLiquidationAddresses,
 };
+

--- a/amplify/backend/function/bridgeXYZMutation/src/handlers/utils.js
+++ b/amplify/backend/function/bridgeXYZMutation/src/handlers/utils.js
@@ -83,10 +83,29 @@ const getExternalAccounts = async (apiUrl, apiKey, bridgeCustomerId) => {
   const externalAccountsJson = await externalAccountsRes.json();
 
   return externalAccountsJson.data;
-}
+};
+
+const deleteExternalAccount = async (apiUrl, apiKey, bridgeCustomerId, id) => {
+  const deleteAccountRes = await fetch(
+    `${apiUrl}/v0/customers/${bridgeCustomerId}/external_accounts/${id}`,
+    {
+      headers: {
+        'Api-Key': apiKey,
+      },
+      method: 'DELETE',
+    },
+  );
+
+  if (deleteAccountRes.status !== 200) {
+    console.log(
+      `Error deleting external account: ${await deleteAccountRes.text()}`,
+    );
+  }
+};
 
 module.exports = {
   createExternalAccount,
+  deleteExternalAccount,
   getExternalAccounts,
   getLiquidationAddresses,
 };

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetails/BankDetails.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetails/BankDetails.tsx
@@ -12,7 +12,7 @@ import {
   getCTAScheme,
   HEADING_MSG,
 } from './consts.ts';
-import BankDetailsDescriptionComponent from './partials/BankDetailsDescription/BankDetailsDescription.tsx';
+import BankDetailsDescription from './partials/BankDetailsDescription/BankDetailsDescription.tsx';
 import { BankDetailsStatus } from './types.ts';
 
 const BankDetails = () => {
@@ -42,7 +42,7 @@ const BankDetails = () => {
       />
       <RowItem.Body
         descriptionComponent={
-          <BankDetailsDescriptionComponent
+          <BankDetailsDescription
             bankAccount={bankAccountData}
             isDataLoading={isKycStatusDataLoading}
           />


### PR DESCRIPTION
## Description

This PR fixes the bug where bank accounts where deleted before a new one was created, resulting in deleting _all_ bank accounts when there was an error.

It's done by first getting _all_ bank accounts for that customer, then creating a new account, then deleting all of the old ones (most of the time that should be just a single one).

## Testing

Testing this is _hard_, so bring some time.

* First, follow the steps lined out in [this PR](https://github.com/JoinColony/colonyCDapp/pull/2761), to be able to do and bail out of the KYC flow
* Then, create a bank account using USD
* Then, update this bank account to use EUR instead of USD and fill all the forms (EUR will not work in the sandbox and produce an error similar to the one in the issue)
* Then see that the bank details are not deleted

## Diffs

**New stuff** ✨

* Add a `getExternalAccounts` helper method in the `bridgeXYZMutation`

**Changes** 🏗

* Create a new bank account first, then delete old ones
* Delete _all_ old accounts should there be more than one

Resolves #2963 