### PR TITLE
[Dashboard] Income and Payments values with decimals

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/TitledSection.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/TitledSection.tsx
@@ -4,7 +4,7 @@ import React, { type FC, type PropsWithChildren } from 'react';
 import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
 import { currencySymbolMap } from '~constants/currency.ts';
 import { useCurrencyContext } from '~context/CurrencyContext/CurrencyContext.ts';
-import Numeral from '~shared/Numeral/Numeral.tsx';
+import { NumeralCurrency } from '~shared/Numeral/NumeralCurrency.tsx';
 import { getValuesTrend } from '~utils/balance/getValuesTrend.ts';
 import { FundsTrend } from '~v5/frame/ColonyHome/partials/FundsTrend/FundsTrend.tsx';
 
@@ -43,7 +43,10 @@ export const TitledSection: FC<TitledSectionProps> = ({
             className="h-[27px] w-[100px] rounded"
           >
             <div className="text-xl font-semibold">
-              <Numeral prefix={currencySymbolMap[currency]} value={value} />
+              <NumeralCurrency
+                prefix={currencySymbolMap[currency]}
+                value={value}
+              />
             </div>
           </LoadingSkeleton>
           <LoadingSkeleton isLoading={isLoading} className="h-5 w-10 rounded">


### PR DESCRIPTION
## Description

- Use NumeralCurrency component for the income and payments in Total in and out card based on [this PR](https://github.com/JoinColony/colonyCDapp/pull/3126)

## Testing

Check the values displayed in the `Total in and out` card for `Income` and `Payments` include 2 decimals for values having less than 8 digits

**Before**
![Screenshot 2024-09-26 at 16 24 11](https://github.com/user-attachments/assets/717e26af-a9a1-414e-ab5d-3eb7f1ea76e9)
![Screenshot 2024-09-26 at 16 24 15](https://github.com/user-attachments/assets/36772740-22de-48dc-9b2e-93bafd8a9eda)
**After**
![Screenshot 2024-09-26 at 16 24 25](https://github.com/user-attachments/assets/2793469b-d89c-4a10-bc9d-05d1404883db)
![Screenshot 2024-09-26 at 16 24 28](https://github.com/user-attachments/assets/bce93b40-37ab-4de7-a689-86394bc0318b)

Step 1. Transfer `1,500,000` CREDS from `General` to `Andromeda` and check the values
![Screenshot 2024-09-26 at 16 36 50](https://github.com/user-attachments/assets/1d5743b2-3e00-434f-8718-cac6bee3ee15)
Step 2. Now transfer `10,000,000` CREDS from `General` to `Andromeda` and check the values
![Screenshot 2024-09-26 at 16 37 30](https://github.com/user-attachments/assets/26f56862-f744-4812-8c8c-40ed640d1ce7)
Step 3. You can create also some Simple/Advanced payments to check the value changes for the `Payments`


## Diffs

**Changes** 🏗

* Use `NumeralCurrency` for `Income` and `Payments`

Contributes to #3173 
