### PR TITLE
[Dashboard] Update value computed by fetchDomainBalance to 18 decimals and U…

### DIFF
--- a/amplify/backend/function/fetchDomainBalance/src/services/tokens.js
+++ b/amplify/backend/function/fetchDomainBalance/src/services/tokens.js
@@ -28,7 +28,7 @@ const getConvertedTokenAmount = (
     .mul(normalizedTokenExchangeRate) // Adjust amount using the normalized exchange rate
     .mul(BigNumber.from(10).pow(18)) // Scale the result to 10^18 format for consistency
     .div(tokenScaleFactor) // Undo initial scaling of the amount and network fee
-    .div(tokenScaleFactor); // Adjust the final value by the normalized exchange rate scale;
+    .div(tokenScaleFactor); // Undo initial scaling of the exchange rate
 };
 
 const getTotalFiatAmountFor = async (items, exchangeRates) => {

--- a/amplify/backend/function/fetchDomainBalance/src/services/tokens.js
+++ b/amplify/backend/function/fetchDomainBalance/src/services/tokens.js
@@ -7,18 +7,28 @@ const getConvertedTokenAmount = (
   decimals,
   exchangeRate,
 ) => {
-  const tokenScaleFactor = BigNumber.from(10).pow(decimals);
+  // Number of decimals for exchange rate precision
   const exchangeRateDecimals = 9;
+  // Scale factor for exchange rate precision
+  const exchangeRateScaleFactor = BigNumber.from(10).pow(exchangeRateDecimals);
+  // Scale factor based on token's decimals
+  const tokenScaleFactor = BigNumber.from(10).pow(decimals);
+  // Convert exchange rate to BigNumber and normalize it with respect to token scale.
+  // We multiply exchange rate by 10^exchangeRateDecimals to remove decimals, then adjust it by token scale.
   const normalizedTokenExchangeRate = BigNumber.from(
     Math.round(exchangeRate * Math.pow(10, exchangeRateDecimals)),
-  );
+  )
+    .mul(tokenScaleFactor)
+    .div(exchangeRateScaleFactor);
   const formattedNetworkFee = BigNumber.from(networkFee || 0);
 
+  // Calculate final amount considering network fees and exchange rate, normalizing to 10^18 scale
   return BigNumber.from(amount)
-    .add(formattedNetworkFee)
-    .div(tokenScaleFactor)
-    .mul(normalizedTokenExchangeRate)
-    .div(BigNumber.from(10).pow(exchangeRateDecimals));
+    .add(formattedNetworkFee) // Add network fee to the initial amount
+    .mul(normalizedTokenExchangeRate) // Adjust amount using the normalized exchange rate
+    .mul(BigNumber.from(10).pow(18)) // Scale the result to 10^18 format for consistency
+    .div(tokenScaleFactor) // Undo initial scaling of the amount and network fee
+    .div(tokenScaleFactor); // Adjust the final value by the normalized exchange rate scale;
 };
 
 const getTotalFiatAmountFor = async (items, exchangeRates) => {

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsItem.tsx
@@ -38,6 +38,7 @@ export const FundsCardsItem: FC<FundsCardsItemProps> = ({
             <NumeralCurrency
               value={total.toString()}
               prefix={currencySymbolMap[currency]}
+              decimals={18}
             />
           }
         />

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalItem.tsx
@@ -1,4 +1,3 @@
-import Decimal from 'decimal.js';
 import React, { type FC } from 'react';
 
 import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
@@ -48,6 +47,7 @@ export const FundsCardsTotalItem: FC<FundsCardsTotalItemProps> = ({
               <NumeralCurrency
                 value={total ?? '-'}
                 prefix={currencySymbolMap[currency]}
+                decimals={18}
               />
             }
             currency={currency}

--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/consts.ts
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/consts.ts
@@ -48,7 +48,7 @@ export const MSG = defineMessages({
 export const CHART_CONFIG_VALUES = {
   MARGIN_TOP: 8,
   MARGIN_BOTTOM: 24,
-  MARGIN_LEFT: 30,
+  MARGIN_LEFT: 34,
   MARGIN_RIGHT: -8,
   PADDING: 0.3,
   INNER_PADDING: 4,

--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/TitledSection.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/TitledSection.tsx
@@ -46,6 +46,7 @@ export const TitledSection: FC<TitledSectionProps> = ({
               <NumeralCurrency
                 prefix={currencySymbolMap[currency]}
                 value={value}
+                decimals={18}
               />
             </div>
           </LoadingSkeleton>

--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/utils.ts
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/utils.ts
@@ -33,7 +33,7 @@ export const getFallbackData = () => {
 };
 
 export const getFormattedShortAmount = (value) => {
-  const convertedValue = convertToDecimal(value, 0);
+  const convertedValue = convertToDecimal(value, 18);
   return numbro(convertedValue?.toString()).format({
     average: true,
     totalLength: 2,
@@ -41,7 +41,7 @@ export const getFormattedShortAmount = (value) => {
 };
 
 export const getFormattedFullAmount = (value, prefix) => {
-  const convertedValue = convertToDecimal(value, 0);
+  const convertedValue = convertToDecimal(value, 18);
   return numbro(convertedValue?.toString()).format({
     thousandSeparated: true,
     mantissa: 2,


### PR DESCRIPTION
## Description

- This PR addresses the fact that the values retrieved by the `fetchDomainBalance` lambda didn't contain any decimals

## Original issue
I still can't get any value other than `.00` to show at the end of a payment, but as mentioned before I don't think that is related to any changes here and will hopefully be resolved by other branches getting merged in, so approving this one!

<img width="270" alt="Screenshot 2024-09-26 at 20 15 25" src="https://github.com/user-attachments/assets/5a59f660-8f77-4c73-b7a0-a25c8a2494fd">
<img width="268" alt="Screenshot 2024-09-26 at 20 16 17" src="https://github.com/user-attachments/assets/44d76173-d32c-4600-876c-712de2aa29ae">
<img width="267" alt="Screenshot 2024-09-26 at 20 17 01" src="https://github.com/user-attachments/assets/a623d4eb-81f8-4815-975a-808c189f8c23">
<img width="269" alt="Screenshot 2024-09-26 at 20 17 51" src="https://github.com/user-attachments/assets/bfee44e3-18c5-4212-b043-a251c475eb06">

## Testing

TODO: Please test the values shown in the `Total in and out` as well as the `Total` cards display decimals other than `.00`

![Screenshot 2024-09-27 at 11 56 08](https://github.com/user-attachments/assets/ef754e71-c99f-4d11-9c44-3cd57860b16e)

* Step 1. First, let's check the initial values that are displayed in `Andromeda`
![Screenshot 2024-09-27 at 12 02 13](https://github.com/user-attachments/assets/3672086e-6bf7-40be-818f-7a8cabce42c8)

* Step 2. Now create a simple payment to `leela` of `42.2` CREDS in `Andromeda`
![Screenshot 2024-09-27 at 12 02 34](https://github.com/user-attachments/assets/4d05ec5e-bce7-4df7-bd5d-36bce2cbf4c2)

* Step 3. Check the values displayed in the cards, as well as the bar chart (should include also the network fee)
![Screenshot 2024-09-27 at 12 02 45](https://github.com/user-attachments/assets/65f9938f-e3fc-46dc-bc28-4f4af1900232)

* Step 4. Now let's transfer `1,200.57` CREDS from `General` to `Andromeda`
![Screenshot 2024-09-27 at 12 03 26](https://github.com/user-attachments/assets/9e36e68a-a542-4bb6-be3b-25ae4082a6c5)

* Step 5. Check the values displayed in the cards, as well as the bar chart in `Andromeda` (should include also the network fee)
![Screenshot 2024-09-27 at 12 03 34](https://github.com/user-attachments/assets/7f00930b-2fe2-43b6-9217-5161966ef48f)
![Screenshot 2024-09-27 at 12 03 37](https://github.com/user-attachments/assets/3f600ffd-783b-4546-ab0e-e2b3ef4f5268)
![Screenshot 2024-09-27 at 12 03 41](https://github.com/user-attachments/assets/6005f1e6-d6e1-4540-8bef-1adc162d3a21)

* Step 6. Check the values displayed in the cards, as well as the bar chart in `General` (should include also the network fee)
![Screenshot 2024-09-27 at 12 03 47](https://github.com/user-attachments/assets/546fa9f4-9e64-4360-a052-4d7eeb1059ed)

## Further Testing

Please be as creative as possible in your testing ✨ 

## Diffs

**Changes** 🏗

* `fetchDomainBalance` lambda retrieves values with `18 decimals`

Resolves #3196 
