### PR TITLE
feat: make avatars clickable

### DIFF
--- a/src/components/frame/v5/pages/TeamsPage/hooks.tsx
+++ b/src/components/frame/v5/pages/TeamsPage/hooks.tsx
@@ -247,6 +247,9 @@ export const useTeams = () => {
                 ]
               : []),
           ],
+          searchParams: {
+            team: `?${TEAM_SEARCH_PARAM}=${nativeId}`,
+          },
         },
       ];
     }, []) || [];

--- a/src/components/v5/common/TeamCard/TeamCard.tsx
+++ b/src/components/v5/common/TeamCard/TeamCard.tsx
@@ -27,6 +27,7 @@ const TeamCard: FC<TeamCardProps> = ({
   meatBallMenuProps,
   links,
   balance,
+  searchParams,
   className,
 }) => {
   const isMobile = useMobile();
@@ -78,11 +79,11 @@ const TeamCard: FC<TeamCardProps> = ({
             <Link
               to={{
                 pathname: `/${colonyName}/${COLONY_CONTRIBUTORS_ROUTE}`,
-                search: `${links?.[0]?.to.search}`,
+                search: `${searchParams?.team}`,
               }}
             >
               {!!members?.length && (
-                <div className="ml-auto flex-shrink-0">
+                <div className="group ml-auto flex-shrink-0">
                   <UserAvatars
                     maxAvatarsToShow={4}
                     className="[&_.placeholder]:bg-gray-200 [&_.placeholder]:text-gray-900"

--- a/src/components/v5/common/TeamCard/TeamCard.tsx
+++ b/src/components/v5/common/TeamCard/TeamCard.tsx
@@ -2,7 +2,9 @@ import { Cardholder } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { type FC } from 'react';
 
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useMobile } from '~hooks/index.ts';
+import { COLONY_CONTRIBUTORS_ROUTE } from '~routes';
 import Tooltip from '~shared/Extensions/Tooltip/index.ts';
 import { SpinnerLoader } from '~shared/Preloaders/index.ts';
 import Card from '~v5/shared/Card/index.ts';
@@ -28,6 +30,9 @@ const TeamCard: FC<TeamCardProps> = ({
   className,
 }) => {
   const isMobile = useMobile();
+  const {
+    colony: { name: colonyName },
+  } = useColonyContext();
 
   return (
     <Card
@@ -70,7 +75,12 @@ const TeamCard: FC<TeamCardProps> = ({
               />
             </div>
           ) : (
-            <>
+            <Link
+              to={{
+                pathname: `/${colonyName}/${COLONY_CONTRIBUTORS_ROUTE}`,
+                search: `${links?.[0]?.to.search}`,
+              }}
+            >
               {!!members?.length && (
                 <div className="ml-auto flex-shrink-0">
                   <UserAvatars
@@ -81,7 +91,7 @@ const TeamCard: FC<TeamCardProps> = ({
                   />
                 </div>
               )}
-            </>
+            </Link>
           )}
         </div>
         {description ? (

--- a/src/components/v5/common/TeamCard/types.ts
+++ b/src/components/v5/common/TeamCard/types.ts
@@ -16,5 +16,8 @@ export interface TeamCardProps {
   links?: (LinkProps & {
     key: string;
   })[];
+  searchParams?: {
+    team: string;
+  };
   className?: string;
 }

--- a/src/components/v5/shared/UserAvatars/UserAvatars.tsx
+++ b/src/components/v5/shared/UserAvatars/UserAvatars.tsx
@@ -36,7 +36,7 @@ const UserAvatars: FC<UserAvatarsProps> = ({
             userName={slicedAvatar.profile?.displayName ?? undefined}
             size={size}
             className={clsx(
-              'rounded-full border border-base-white bg-base-white group-hover:border-blue-400',
+              'rounded-full border border-base-white bg-base-white transition-colors duration-normal group-hover:border-blue-400',
               {
                 'border-2': withThickerBorder,
               },
@@ -52,7 +52,7 @@ const UserAvatars: FC<UserAvatarsProps> = ({
                 userAddress={ADDRESS_ZERO}
                 size={size}
                 className={clsx(
-                  'rounded-full border border-base-white bg-base-white group-hover:border-blue-400',
+                  'rounded-full border border-base-white bg-base-white transition-colors duration-normal group-hover:border-blue-400',
                   {
                     'border-2': withThickerBorder,
                   },

--- a/src/components/v5/shared/UserAvatars/UserAvatars.tsx
+++ b/src/components/v5/shared/UserAvatars/UserAvatars.tsx
@@ -36,7 +36,7 @@ const UserAvatars: FC<UserAvatarsProps> = ({
             userName={slicedAvatar.profile?.displayName ?? undefined}
             size={size}
             className={clsx(
-              'rounded-full border border-base-white bg-base-white',
+              'rounded-full border border-base-white bg-base-white group-hover:border-blue-400',
               {
                 'border-2': withThickerBorder,
               },
@@ -52,7 +52,7 @@ const UserAvatars: FC<UserAvatarsProps> = ({
                 userAddress={ADDRESS_ZERO}
                 size={size}
                 className={clsx(
-                  'rounded-full border border-base-white bg-base-white',
+                  'rounded-full border border-base-white bg-base-white group-hover:border-blue-400',
                   {
                     'border-2': withThickerBorder,
                   },


### PR DESCRIPTION
## Description
Make avatars on teams page clickable
<img width="560" alt="Screenshot 2024-09-27 at 13 21 20" src="https://github.com/user-attachments/assets/234bdfa4-abb8-4fa3-b4f1-a6e7e9940087">


## Testing
- Go to the `/{colony_name}/teams` page
- Click the avatars on teams card
- After click, You should be redirected to contributors page with the relevant team filter applied

## Diffs

**New stuff** ✨

* New stuff goes here

Add link for avatars inside `TeamCard` component

Resolves [#31415](https://github.com/JoinColony/colonyCDapp/issues/3121)
