### PR TITLE
[Dashboard] Domain balances and total in / out should update on successful advanced payment action

### DIFF
--- a/amplify/backend/function/fetchDomainBalance/src/api/graphql/operations.js
+++ b/amplify/backend/function/fetchDomainBalance/src/api/graphql/operations.js
@@ -108,7 +108,7 @@ const getExpendituresData = async ({
       console.warn('Could not find any expenditures in db.');
     }
 
-    return result.data.listExpenditures;
+    return result.data.getExpendituresByColony;
   }
 
   const result = await graphqlRequest(getDomainExpenditures, {

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -9,7 +9,7 @@ import { Action } from '~constants/actions.ts';
 import { useAdditionalFormOptionsContext } from '~context/AdditionalFormOptionsContext/AdditionalFormOptionsContext.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
-import { SearchActionsDocument } from '~gql';
+import { GetDomainBalanceDocument, SearchActionsDocument } from '~gql';
 import useToggle from '~hooks/useToggle/index.ts';
 import { ActionForm } from '~shared/Fields/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
@@ -266,6 +266,11 @@ const ActionSidebarContent: FC<ActionSidebarContentProps> = ({
             client.cache.evict({
               fieldName: 'getDomainBalance',
             });
+            if (isQueryActive('GetDomainBalanceQuery')) {
+              client.refetchQueries({
+                include: [GetDomainBalanceDocument],
+              });
+            }
           }}
         >
           <ActionSidebarFormContent

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/PaymentBuilderWidget.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/PaymentBuilderWidget.tsx
@@ -1,3 +1,4 @@
+import { useApolloClient } from '@apollo/client';
 import React, { useState, type FC, useEffect } from 'react';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
@@ -33,6 +34,8 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
   });
   const { user } = useAppContext();
   const { walletAddress } = user || {};
+
+  const client = useApolloClient();
 
   const [
     isFundingModalOpen,
@@ -83,6 +86,15 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
       refetchColony();
       refetchExpenditures();
     }
+
+    if (expenditureStep === ExpenditureStep.Payment) {
+      // Payments with 0 claim delay will be paid immediately once at the payment step
+      // we need to remove all getDomainBalance queries to refetch the correct balances
+      client.cache.evict({
+        fieldName: 'getDomainBalance',
+      });
+    }
+
     setActiveStepKey(expenditureStep);
   }, [expenditureStep, refetchColony, refetchExpenditures]);
 

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/PaymentStepDetailsBlock.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentStepDetailsBlock/PaymentStepDetailsBlock.tsx
@@ -1,3 +1,4 @@
+import { useApolloClient } from '@apollo/client';
 import { ArrowsClockwise } from '@phosphor-icons/react';
 import React, { type FC, useMemo } from 'react';
 
@@ -25,6 +26,9 @@ const PaymentStepDetailsBlock: FC<PaymentStepDetailsBlockProps> = ({
   const { colony } = useColonyContext();
   const { currentBlockTime: blockTime, fetchCurrentBlockTime } =
     useCurrentBlockTime();
+
+  const client = useApolloClient();
+
   const { slots = [], finalizedAt, nativeId } = expenditure || {};
 
   const claimablePayouts = useMemo(
@@ -142,6 +146,12 @@ const PaymentStepDetailsBlock: FC<PaymentStepDetailsBlockProps> = ({
                 onSuccess={() => {
                   refetchExpenditure();
                   fetchCurrentBlockTime();
+
+                  // When a payment has been claimed successfully
+                  // we need to remove all getDomainBalance queries to refetch the correct balances
+                  client.cache.evict({
+                    fieldName: 'getDomainBalance',
+                  });
                 }}
               />
             </div>

--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/hooks.ts
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/hooks.ts
@@ -115,7 +115,6 @@ export const useLast30DaysData = () => {
             signal: abortController.signal,
           },
         },
-        fetchPolicy: 'cache-first' as WatchQueryFetchPolicy,
       },
     };
   }, [currency, selectedDomainId, colonyAddress]);


### PR DESCRIPTION
## Description

This PR ensures the domain funds cards and total in / out amounts automatically refresh when an advanced payment is successful.

The `getDomainBalance` cache is evicted after the release transaction successfully completes as any payments with a claim delay of `0` will be paid at this point.

The same cache is also evicted after a successful expenditure claim for payments which have passed their claim delay when the "Make payment" button is clicked.

## Testing

* Step 1 - Create a new colony `node scripts/create-colony-url.js` with a new token
* Step 2 - Mint some tokens in the new colony
* Step 3 - Create an advanced payment action
* Step 4 - Create one row paying 1 token to Leela with a claim delay of 0.

<img width="679" alt="Screenshot 2024-09-27 at 14 49 51" src="https://github.com/user-attachments/assets/419603db-124d-48cc-8ac5-027afc1f0b55">

* Step 5 - Advance through the advanced payment steps, review the expenditure and fund the expenditure.
* Step 6 - Release the expenditure, the expenditure should be paid out.
* Step 7 - Without refreshing, select the "General" team, notice the reduced balance and increase payments value. (Note that it seems the payments are not correctly including advanced payments, at least not in this video, even after refreshing multiple times the amount did not update).

https://github.com/user-attachments/assets/8a503fde-1709-4f31-800c-300baa14c30c

Ideally here I would suggest doing the same again, but setting the claim delay to 1 hour.

<img width="674" alt="Screenshot 2024-09-27 at 14 51 33" src="https://github.com/user-attachments/assets/6382bb3e-9040-4e57-9132-c4a07b70b04e">

However, the claim delays do not seem to be working properly for me so I am unable to test this (the code should however by the correct place and work as expected). (I will investigate if this is an issue on master).

<img width="353" alt="Screenshot 2024-09-27 at 14 52 23" src="https://github.com/user-attachments/assets/d6c1c5a7-2d17-4d9d-a51f-ac89a211d9f6">


## Diffs

**Changes** 🏗

* `getDomainBalance` cache is evicted after the release transaction successfully completes
* `getDomainBalance` cache is evicted when claiming expenditure payments

Resolves #3195
