### PR TITLE
Maintenance: Do not clear existing search params when adding a new one

### DIFF
--- a/src/components/common/ColonyActionsTable/hooks/useRenderRowLink.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useRenderRowLink.tsx
@@ -32,11 +32,9 @@ const useRenderRowLink = (
           'items-end': isRecentActivityVariant,
           'items-start': !isRecentActivityVariant,
         })}
-        to={setQueryParamOnUrl(
-          window.location.search,
-          TX_SEARCH_PARAM,
-          row.original.transactionHash,
-        )}
+        to={setQueryParamOnUrl({
+          params: { [TX_SEARCH_PARAM]: row.original.transactionHash },
+        })}
       >
         {content}
       </Link>

--- a/src/components/common/Extensions/UserHub/partials/StakesTab/partials/StakeItem.tsx
+++ b/src/components/common/Extensions/UserHub/partials/StakesTab/partials/StakeItem.tsx
@@ -56,11 +56,12 @@ const StakeItem: FC<StakeItemProps> = ({ stake }) => {
         type="button"
         onClick={() =>
           navigate(
-            setQueryParamOnUrl(
-              navigatePath,
-              TX_SEARCH_PARAM,
-              stake.action?.transactionHash ?? '',
-            ),
+            setQueryParamOnUrl({
+              path: navigatePath,
+              params: {
+                [TX_SEARCH_PARAM]: stake.action?.transactionHash,
+              },
+            }),
             {
               replace: true,
             },

--- a/src/components/v5/common/ActionSidebar/hooks/useActionFormProps.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useActionFormProps.ts
@@ -1,11 +1,11 @@
 import { useCallback, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { type Action } from '~constants/actions.ts';
 import { ActionTypes } from '~redux/index.ts';
+import { TX_SEARCH_PARAM } from '~routes';
 import { type ActionFormProps } from '~shared/Fields/Form/ActionForm.tsx';
 import { mapPayload, pipe, withMeta } from '~utils/actions.ts';
-import { setQueryParamOnUrl } from '~utils/urls.ts';
 
 import {
   ACTION_BASE_VALIDATION_SCHEMA,
@@ -26,6 +26,7 @@ const useActionFormProps = (
     mode: 'onChange',
     validationSchema: ACTION_BASE_VALIDATION_SCHEMA,
   });
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const getFormOptions = useCallback<ActionFormBaseProps['getFormOptions']>(
     async (formOptions, form) => {
@@ -57,16 +58,8 @@ const useActionFormProps = (
                 })),
                 withMeta({
                   setTxHash: (txHash: string) => {
-                    navigate(
-                      setQueryParamOnUrl(
-                        window.location.pathname,
-                        'tx',
-                        txHash,
-                      ),
-                      {
-                        replace: true,
-                      },
-                    );
+                    searchParams.set(TX_SEARCH_PARAM, txHash);
+                    setSearchParams(searchParams);
                   },
                 }),
               ),

--- a/src/components/v5/frame/ColonyHome/ColonyHome.tsx
+++ b/src/components/v5/frame/ColonyHome/ColonyHome.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 
 import FiltersContextProvider from '~common/ColonyActionsTable/FiltersContext/FiltersContextProvider.tsx';
 import RecentActivityTable from '~common/ColonyActionsTable/RecentActivityTable.tsx';
@@ -26,6 +27,7 @@ const displayName = 'v5.frame.ColonyHome';
 const ColonyHome = () => {
   const isMobile = useMobile();
   const selectedDomain = useGetSelectedDomainFilter();
+  const { colonyName } = useParams();
 
   return (
     <div className="flex flex-col gap-6 md:gap-4.5">
@@ -47,11 +49,12 @@ const ColonyHome = () => {
           </h3>
           <Link
             className="text-sm font-medium text-gray-400 md:hover:text-gray-900"
-            to={setQueryParamOnUrl(
-              COLONY_ACTIVITY_ROUTE,
-              TEAM_SEARCH_PARAM,
-              selectedDomain?.nativeId.toString(),
-            )}
+            to={setQueryParamOnUrl({
+              path: `/${colonyName}/${COLONY_ACTIVITY_ROUTE}`,
+              params: {
+                [TEAM_SEARCH_PARAM]: selectedDomain?.nativeId.toString(),
+              },
+            })}
           >
             {formatText({ id: 'view.all' })}
           </Link>

--- a/src/redux/sagas/actions/createDomain.ts
+++ b/src/redux/sagas/actions/createDomain.ts
@@ -41,7 +41,6 @@ import {
 function* createDomainAction({
   payload: {
     colonyAddress,
-    colonyName,
     domainName,
     domainColor,
     domainPurpose,
@@ -49,7 +48,7 @@ function* createDomainAction({
     parentId = Id.RootDomain,
     customActionTitle,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.ACTION_DOMAIN_CREATE>) {
   let txChannel;
@@ -177,12 +176,6 @@ function* createDomainAction({
       type: ActionTypes.ACTION_DOMAIN_CREATE_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (error) {
     yield putError(ActionTypes.ACTION_DOMAIN_CREATE_ERROR, error, meta);
   } finally {

--- a/src/redux/sagas/actions/editColony.ts
+++ b/src/redux/sagas/actions/editColony.ts
@@ -32,7 +32,7 @@ import {
 function* editColonyAction({
   payload: {
     colony,
-    colony: { colonyAddress, name: colonyName, metadata },
+    colony: { colonyAddress, metadata },
     colonyDisplayName,
     colonyDescription,
     colonyAvatarImage,
@@ -41,7 +41,7 @@ function* editColonyAction({
     annotationMessage,
     customActionTitle,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.ACTION_EDIT_COLONY>) {
   let txChannel;
@@ -198,12 +198,6 @@ function* editColonyAction({
     });
 
     setTxHash?.(txHash);
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (error) {
     yield putError(ActionTypes.ACTION_EDIT_COLONY_ERROR, error, meta);
   } finally {

--- a/src/redux/sagas/actions/editDomain.ts
+++ b/src/redux/sagas/actions/editDomain.ts
@@ -37,7 +37,6 @@ import {
 function* editDomainAction({
   payload: {
     colonyAddress,
-    colonyName,
     domainName,
     domainColor,
     domainPurpose,
@@ -45,7 +44,7 @@ function* editDomainAction({
     annotationMessage,
     customActionTitle,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.ACTION_DOMAIN_EDIT>) {
   let txChannel;
@@ -183,12 +182,6 @@ function* editDomainAction({
       type: ActionTypes.ACTION_DOMAIN_EDIT_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (error) {
     yield putError(ActionTypes.ACTION_DOMAIN_EDIT_ERROR, error, meta);
   } finally {

--- a/src/redux/sagas/actions/initiateSafeTransaction.ts
+++ b/src/redux/sagas/actions/initiateSafeTransaction.ts
@@ -35,12 +35,11 @@ function* initiateSafeTransactionAction({
     transactions,
     customActionTitle: title,
     colonyAddress,
-    colonyName,
     network,
     annotationMessage,
     customActionTitle,
   },
-  meta: { id: metaId, navigate },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.ACTION_INITIATE_SAFE_TRANSACTION>) {
   let txChannel;
@@ -169,11 +168,7 @@ function* initiateSafeTransactionAction({
       meta,
     });
 
-    yield navigate?.(`/${colonyName}?tx=${txHash}`, {
-      state: {
-        isRedirect: true,
-      },
-    });
+    setTxHash?.(txHash);
   } catch (error) {
     yield putError(
       ActionTypes.ACTION_INITIATE_SAFE_TRANSACTION_ERROR,

--- a/src/redux/sagas/actions/manageExistingSafes.ts
+++ b/src/redux/sagas/actions/manageExistingSafes.ts
@@ -30,14 +30,14 @@ import {
 
 function* manageExistingSafesAction({
   payload: {
-    colony: { colonyAddress, name: colonyName },
+    colony: { colonyAddress },
     colony,
     safes,
     annotationMessage,
     isRemovingSafes,
     customActionTitle,
   },
-  meta: { id: metaId, navigate },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.ACTION_MANAGE_EXISTING_SAFES>) {
   let txChannel;
@@ -164,11 +164,7 @@ function* manageExistingSafesAction({
       meta,
     });
 
-    yield navigate?.(`/${colonyName}?=${txHash}`, {
-      state: {
-        isRedirect: true,
-      },
-    });
+    setTxHash?.(txHash);
   } catch (error) {
     yield putError(ActionTypes.ACTION_MANAGE_EXISTING_SAFES_ERROR, error, meta);
   } finally {

--- a/src/redux/sagas/actions/managePermissions.ts
+++ b/src/redux/sagas/actions/managePermissions.ts
@@ -35,13 +35,12 @@ function* managePermissionsAction({
     userAddress,
     roles,
     authority,
-    colonyName,
     annotationMessage,
     customActionTitle,
     colonyRoles,
     colonyDomains,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.ACTION_USER_ROLES_SET>) {
   let txChannel;
@@ -195,12 +194,6 @@ function* managePermissionsAction({
       type: ActionTypes.ACTION_USER_ROLES_SET_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
 
     yield clearContributorsAndRolesCache();
   } catch (error) {

--- a/src/redux/sagas/actions/manageReputation.ts
+++ b/src/redux/sagas/actions/manageReputation.ts
@@ -27,7 +27,6 @@ export type ManageReputationPermissionsPayload =
 function* manageReputationAction({
   payload: {
     colonyAddress,
-    colonyName,
     domainId,
     userAddress,
     amount,
@@ -35,7 +34,7 @@ function* manageReputationAction({
     annotationMessage,
     customActionTitle,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.ACTION_MANAGE_REPUTATION>) {
   let txChannel;
@@ -159,12 +158,6 @@ function* manageReputationAction({
       type: ActionTypes.ACTION_MANAGE_REPUTATION_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (error) {
     yield putError(ActionTypes.ACTION_MANAGE_REPUTATION_ERROR, error, meta);
   } finally {

--- a/src/redux/sagas/actions/manageTokens.ts
+++ b/src/redux/sagas/actions/manageTokens.ts
@@ -24,12 +24,11 @@ import { validateTokenAddresses } from '../utils/validateTokens.ts';
 function* manageTokensAction({
   payload: {
     colonyAddress,
-    colonyName,
     tokenAddresses,
     customActionTitle,
     annotationMessage,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.ACTION_MANAGE_TOKENS>) {
   const batchKey = TRANSACTION_METHODS.ManageTokens;
@@ -111,12 +110,6 @@ function* manageTokensAction({
       type: ActionTypes.ACTION_MANAGE_TOKENS_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (error) {
     return yield putError(ActionTypes.ACTION_MANAGE_TOKENS_ERROR, error, meta);
   } finally {

--- a/src/redux/sagas/actions/manageVerifiedMembers.ts
+++ b/src/redux/sagas/actions/manageVerifiedMembers.ts
@@ -29,12 +29,11 @@ function* manageVerifiedMembersAction({
   payload: {
     operation,
     colonyAddress,
-    colonyName,
     members,
     customActionTitle,
     annotationMessage,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.ACTION_MANAGE_VERIFIED_MEMBERS>) {
   const batchKey =
@@ -140,12 +139,6 @@ function* manageVerifiedMembersAction({
       colonyAddress,
       operation === ManageVerifiedMembersOperation.Add,
     );
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (error) {
     return yield putError(
       ActionTypes.ACTION_MANAGE_VERIFIED_MEMBERS_ERROR,

--- a/src/redux/sagas/actions/mintTokens.ts
+++ b/src/redux/sagas/actions/mintTokens.ts
@@ -21,13 +21,12 @@ import {
 function* createMintTokensAction({
   payload: {
     colonyAddress,
-    colonyName,
     nativeTokenAddress,
     amount,
     annotationMessage,
     customActionTitle,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.ACTION_MINT_TOKENS>) {
   let txChannel;
@@ -128,13 +127,6 @@ function* createMintTokensAction({
       type: ActionTypes.ACTION_MINT_TOKENS_SUCCESS,
       meta,
     });
-
-    // Redirect to actions page
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (caughtError) {
     yield putError(ActionTypes.ACTION_MINT_TOKENS_ERROR, caughtError, meta);
   } finally {

--- a/src/redux/sagas/actions/moveFunds.ts
+++ b/src/redux/sagas/actions/moveFunds.ts
@@ -24,7 +24,6 @@ import {
 function* createMoveFundsAction({
   payload: {
     colonyAddress,
-    colonyName,
     fromDomain,
     toDomain,
     amount,
@@ -34,7 +33,7 @@ function* createMoveFundsAction({
     annotationMessage,
     customActionTitle,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.ACTION_MOVE_FUNDS>) {
   let txChannel;
@@ -159,12 +158,6 @@ function* createMoveFundsAction({
       type: ActionTypes.ACTION_MOVE_FUNDS_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (caughtError) {
     yield putError(ActionTypes.ACTION_MOVE_FUNDS_ERROR, caughtError, meta);
   } finally {

--- a/src/redux/sagas/actions/payment.ts
+++ b/src/redux/sagas/actions/payment.ts
@@ -29,13 +29,12 @@ import {
 function* createPaymentAction({
   payload: {
     colonyAddress,
-    colonyName,
     domainId,
     payments,
     annotationMessage,
     customActionTitle,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.ACTION_EXPENDITURE_PAYMENT>) {
   let txChannel;
@@ -185,14 +184,6 @@ function* createPaymentAction({
       type: ActionTypes.ACTION_EXPENDITURE_PAYMENT_SUCCESS,
       meta,
     });
-
-    // @TODO: In new UI, confirm that the navigate function isn't being passed into the saga
-    // and if not, remove these conditional (and do so for all actions/motions sagas)
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (error) {
     yield putError(ActionTypes.ACTION_EXPENDITURE_PAYMENT_ERROR, error, meta);
   } finally {

--- a/src/redux/sagas/actions/unlockToken.ts
+++ b/src/redux/sagas/actions/unlockToken.ts
@@ -20,8 +20,8 @@ import {
 
 function* tokenUnlockAction({
   meta,
-  meta: { id: metaId, navigate, setTxHash },
-  payload: { colonyAddress, annotationMessage, colonyName, customActionTitle },
+  meta: { id: metaId, setTxHash },
+  payload: { colonyAddress, annotationMessage, customActionTitle },
 }: Action<ActionTypes.ACTION_UNLOCK_TOKEN>) {
   let txChannel;
 
@@ -109,12 +109,6 @@ function* tokenUnlockAction({
       type: ActionTypes.ACTION_UNLOCK_TOKEN_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (error) {
     yield putError(ActionTypes.ACTION_UNLOCK_TOKEN_ERROR, error, meta);
   } finally {

--- a/src/redux/sagas/actions/versionUpgrade.ts
+++ b/src/redux/sagas/actions/versionUpgrade.ts
@@ -21,14 +21,8 @@ import {
 } from '../utils/index.ts';
 
 function* createVersionUpgradeAction({
-  payload: {
-    colonyAddress,
-    colonyName,
-    version,
-    annotationMessage,
-    customActionTitle,
-  },
-  meta: { id: metaId, navigate, setTxHash },
+  payload: { colonyAddress, version, annotationMessage, customActionTitle },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.ACTION_VERSION_UPGRADE>) {
   let txChannel;
@@ -107,18 +101,13 @@ function* createVersionUpgradeAction({
     }
 
     setTxHash?.(txHash);
+
     yield colonyManager.setColonyClient(colonyAddress);
 
     yield put<AllActions>({
       type: ActionTypes.ACTION_VERSION_UPGRADE_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (caughtError) {
     yield putError(ActionTypes.ACTION_VERSION_UPGRADE_ERROR, caughtError, meta);
   } finally {

--- a/src/redux/sagas/motions/createDecisionMotion.ts
+++ b/src/redux/sagas/motions/createDecisionMotion.ts
@@ -26,11 +26,10 @@ import { getColonyManager, initiateTransaction } from '../utils/index.ts';
 
 function* createDecisionMotion({
   payload: {
-    colonyName,
     colonyAddress,
     draftDecision: { motionDomainId, title, description, walletAddress },
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.MOTION_CREATE_DECISION>) {
   const txChannel = yield call(getTxChannel, metaId);
@@ -171,12 +170,6 @@ function* createDecisionMotion({
       type: ActionTypes.MOTION_CREATE_DECISION_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
 
     yield put({
       type: ActionTypes.DECISION_DRAFT_REMOVED,

--- a/src/redux/sagas/motions/domains/createEditDomainMultiSigMotion.ts
+++ b/src/redux/sagas/motions/domains/createEditDomainMultiSigMotion.ts
@@ -30,7 +30,6 @@ import { handleDomainMetadata } from './utils/handleDomainMetadata.ts';
 function* createEditDomainMultiSigMotion({
   payload: {
     colonyAddress,
-    colonyName,
     domainName,
     domainColor,
     domainPurpose,
@@ -42,7 +41,7 @@ function* createEditDomainMultiSigMotion({
     colonyDomains,
     colonyRoles,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.MOTION_MULTISIG_DOMAIN_CREATE_EDIT>) {
   let txChannel;
@@ -194,12 +193,6 @@ function* createEditDomainMultiSigMotion({
       type: ActionTypes.MOTION_MULTISIG_DOMAIN_CREATE_EDIT_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (caughtError) {
     yield putError(
       ActionTypes.MOTION_MULTISIG_DOMAIN_CREATE_EDIT_ERROR,

--- a/src/redux/sagas/motions/domains/createEditDomainReputationMotion.ts
+++ b/src/redux/sagas/motions/domains/createEditDomainReputationMotion.ts
@@ -34,7 +34,6 @@ import { handleDomainMetadata } from './utils/handleDomainMetadata.ts';
 function* createEditDomainReputationMotion({
   payload: {
     colonyAddress,
-    colonyName,
     domainName,
     domainColor,
     domainPurpose,
@@ -45,7 +44,7 @@ function* createEditDomainReputationMotion({
     domainCreatedInNativeId,
     customActionTitle,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.MOTION_REPUTATION_DOMAIN_CREATE_EDIT>) {
   let txChannel;
@@ -213,12 +212,6 @@ function* createEditDomainReputationMotion({
       type: ActionTypes.MOTION_REPUTATION_DOMAIN_CREATE_EDIT_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (caughtError) {
     yield putError(
       ActionTypes.MOTION_REPUTATION_DOMAIN_CREATE_EDIT_ERROR,

--- a/src/redux/sagas/motions/editColonyMotion.ts
+++ b/src/redux/sagas/motions/editColonyMotion.ts
@@ -34,7 +34,7 @@ import {
 
 function* editColonyMotion({
   payload: {
-    colony: { colonyAddress, name: colonyName, metadata },
+    colony: { colonyAddress, metadata },
     colony,
     colonyDisplayName,
     colonyAvatarImage,
@@ -47,7 +47,7 @@ function* editColonyMotion({
     annotationMessage,
     customActionTitle,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.MOTION_EDIT_COLONY>) {
   let txChannel;
@@ -293,12 +293,6 @@ function* editColonyMotion({
       type: ActionTypes.MOTION_EDIT_COLONY_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (caughtError) {
     yield putError(ActionTypes.MOTION_EDIT_COLONY_ERROR, caughtError, meta);
   } finally {

--- a/src/redux/sagas/motions/expenditures/editLockedExpenditureMotion.ts
+++ b/src/redux/sagas/motions/expenditures/editLockedExpenditureMotion.ts
@@ -181,12 +181,6 @@ function* editLockedExpenditureMotion({
         )}?tx=${txHash}`,
       );
     }
-
-    window.history.replaceState(
-      {},
-      '',
-      `${APP_URL}${window.location.pathname.slice(1)}?tx=${txHash}`,
-    );
   } catch (e) {
     console.error(e);
     yield put<Action<ActionTypes.MOTION_EDIT_LOCKED_EXPENDITURE_ERROR>>({

--- a/src/redux/sagas/motions/expenditures/releaseExpenditureStageMotion.ts
+++ b/src/redux/sagas/motions/expenditures/releaseExpenditureStageMotion.ts
@@ -144,12 +144,6 @@ function* releaseExpenditureStageMotion({
       // eslint-disable-next-line no-console
       console.log(`Motion URL: ${APP_URL}${colonyName}?tx=${txHash}`);
     }
-
-    window.history.replaceState(
-      {},
-      '',
-      `${APP_URL}${window.location.pathname}?tx=${txHash}`,
-    );
   } catch (e) {
     console.error(e);
     yield put<Action<ActionTypes.MOTION_RELEASE_EXPENDITURE_STAGE_ERROR>>({

--- a/src/redux/sagas/motions/initiateSafeTransactionMotion.ts
+++ b/src/redux/sagas/motions/initiateSafeTransactionMotion.ts
@@ -40,13 +40,12 @@ function* initiateSafeTransactionMotion({
     safe,
     transactions,
     colonyAddress,
-    colonyName,
     annotationMessage,
     motionDomainId,
     network,
     customActionTitle,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.MOTION_INITIATE_SAFE_TRANSACTION>) {
   let txChannel;
@@ -225,12 +224,6 @@ function* initiateSafeTransactionMotion({
         txHash,
       });
     }
-
-    yield navigate?.(`/${colonyName}?tx=${txHash}`, {
-      state: {
-        isRedirect: true,
-      },
-    });
   } catch (error) {
     return yield putError(
       ActionTypes.MOTION_INITIATE_SAFE_TRANSACTION_ERROR,

--- a/src/redux/sagas/motions/managePermissionsMotion.ts
+++ b/src/redux/sagas/motions/managePermissionsMotion.ts
@@ -32,7 +32,6 @@ function* managePermissionsMotion({
     userAddress,
     roles,
     authority,
-    colonyName,
     annotationMessage,
     customActionTitle,
     motionDomainId: createdInDomainId,
@@ -41,7 +40,7 @@ function* managePermissionsMotion({
     // Is using the multi-sig decision method
     isMultiSig = false,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.MOTION_USER_ROLES_SET>) {
   let txChannel;
@@ -326,12 +325,6 @@ function* managePermissionsMotion({
       type: ActionTypes.MOTION_USER_ROLES_SET_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (caughtError) {
     yield putError(ActionTypes.MOTION_USER_ROLES_SET_ERROR, caughtError, meta);
   } finally {

--- a/src/redux/sagas/motions/manageReputationMotion.ts
+++ b/src/redux/sagas/motions/manageReputationMotion.ts
@@ -36,7 +36,6 @@ export type ManageReputationMotionPayload =
 function* manageReputationMotion({
   payload: {
     colonyAddress,
-    colonyName,
     domainId,
     userAddress,
     amount,
@@ -48,7 +47,7 @@ function* manageReputationMotion({
     colonyDomains,
     colonyRoles,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.MOTION_MANAGE_REPUTATION>) {
   let txChannel;
@@ -295,12 +294,6 @@ function* manageReputationMotion({
       type: ActionTypes.MOTION_MANAGE_REPUTATION_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (error) {
     yield putError(ActionTypes.MOTION_MANAGE_REPUTATION_ERROR, error, meta);
   } finally {

--- a/src/redux/sagas/motions/manageTokens.ts
+++ b/src/redux/sagas/motions/manageTokens.ts
@@ -32,7 +32,6 @@ import { validateTokenAddresses } from '../utils/validateTokens.ts';
 function* manageTokensMotion({
   payload: {
     colonyAddress,
-    colonyName,
     tokenAddresses,
     customActionTitle,
     annotationMessage,
@@ -40,7 +39,7 @@ function* manageTokensMotion({
     colonyDomains,
     isMultiSig = false,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.MOTION_MANAGE_TOKENS>) {
   let txChannel;
@@ -203,16 +202,11 @@ function* manageTokensMotion({
     }
 
     setTxHash?.(txHash);
+
     yield put<AllActions>({
       type: ActionTypes.MOTION_MANAGE_TOKENS_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (caughtError) {
     yield putError(ActionTypes.MOTION_MANAGE_TOKENS_ERROR, caughtError, meta);
   } finally {

--- a/src/redux/sagas/motions/manageVerifiedMembers.ts
+++ b/src/redux/sagas/motions/manageVerifiedMembers.ts
@@ -34,7 +34,6 @@ function* manageVerifiedMembersMotion({
   payload: {
     operation,
     colonyAddress,
-    colonyName,
     colonyRoles,
     colonyDomains,
     isMultiSig,
@@ -42,7 +41,7 @@ function* manageVerifiedMembersMotion({
     customActionTitle,
     annotationMessage,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.MOTION_MANAGE_VERIFIED_MEMBERS>) {
   const txChannel = yield call(getTxChannel, metaId);
@@ -216,12 +215,6 @@ function* manageVerifiedMembersMotion({
       payload: {},
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (error) {
     return yield putError(
       ActionTypes.MOTION_MANAGE_VERIFIED_MEMBERS_ERROR,

--- a/src/redux/sagas/motions/moveFundsMotion.ts
+++ b/src/redux/sagas/motions/moveFundsMotion.ts
@@ -28,7 +28,6 @@ import {
 function* moveFundsMotion({
   payload: {
     colonyAddress,
-    colonyName,
     colonyVersion,
     fromDomain,
     toDomain,
@@ -41,7 +40,7 @@ function* moveFundsMotion({
     colonyRoles,
     createdInDomain,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.MOTION_MOVE_FUNDS>) {
   let txChannel;
@@ -323,12 +322,6 @@ function* moveFundsMotion({
       type: ActionTypes.MOTION_MOVE_FUNDS_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (caughtError) {
     yield putError(ActionTypes.MOTION_MOVE_FUNDS_ERROR, caughtError, meta);
   } finally {

--- a/src/redux/sagas/motions/paymentMotion.ts
+++ b/src/redux/sagas/motions/paymentMotion.ts
@@ -34,7 +34,6 @@ import {
 function* createPaymentMotion({
   payload: {
     colonyAddress,
-    colonyName,
     domainId,
     payments,
     annotationMessage,
@@ -44,7 +43,7 @@ function* createPaymentMotion({
     colonyDomains,
     isMultiSig = false,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.MOTION_EXPENDITURE_PAYMENT>) {
   let txChannel;
@@ -347,16 +346,11 @@ function* createPaymentMotion({
     }
 
     setTxHash?.(txHash);
+
     yield put<AllActions>({
       type: ActionTypes.MOTION_EXPENDITURE_PAYMENT_SUCCESS,
       meta,
     });
-
-    if (navigate && colonyName) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (caughtError) {
     yield putError(
       ActionTypes.MOTION_EXPENDITURE_PAYMENT_ERROR,

--- a/src/redux/sagas/motions/rootMotion.ts
+++ b/src/redux/sagas/motions/rootMotion.ts
@@ -31,7 +31,6 @@ function* createRootMotionSaga({
   payload: {
     operationName,
     colonyAddress,
-    colonyName,
     motionParams,
     annotationMessage,
     customActionTitle,
@@ -39,7 +38,7 @@ function* createRootMotionSaga({
     colonyDomains,
     isMultiSig = false,
   },
-  meta: { id: metaId, navigate, setTxHash },
+  meta: { id: metaId, setTxHash },
   meta,
 }: Action<ActionTypes.ROOT_MOTION>) {
   let txChannel;
@@ -203,16 +202,11 @@ function* createRootMotionSaga({
     }
 
     setTxHash?.(txHash);
+
     yield put<AllActions>({
       type: ActionTypes.ROOT_MOTION_SUCCESS,
       meta,
     });
-
-    if (colonyName && navigate) {
-      navigate(`/${colonyName}?tx=${txHash}`, {
-        state: { isRedirect: true },
-      });
-    }
   } catch (caughtError) {
     yield putError(ActionTypes.ROOT_MOTION_ERROR, caughtError, meta);
   } finally {

--- a/src/redux/types/actions/colonyActions.ts
+++ b/src/redux/types/actions/colonyActions.ts
@@ -49,7 +49,6 @@ export type ColonyActionsActionTypes =
       {
         customActionTitle: string;
         colonyAddress: Address;
-        colonyName: string;
         domainName: string;
         domainColor: DomainColor;
         domainPurpose: string;

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,3 +1,5 @@
+import { type OptionalValue } from '~types';
+
 export const getTransactionHashFromPathName = (pathname: string) =>
   pathname.split('/').pop();
 
@@ -15,17 +17,50 @@ export const removeQueryParamFromUrl = (
   return pathname;
 };
 
-export const setQueryParamOnUrl = (
-  url: string,
-  param: string,
-  value: string | undefined,
-) => {
-  const [pathname, search] = url.split('?');
-  const searchParams = new URLSearchParams(search);
+/**
+ * Please use this function sparingly.
+ * If you have an option to use useSearchParams, please use that instead.
+ *
+ * Updates the URL's query parameters and optionally changes the path.
+ *
+ * (Original behaviour) Only query parameters with truthy values (non-undefined, non-null, non-falsy) will be added to the URL.
+ *
+ * @param params - An object where each key-value pair represents a query parameter to add or update in the URL.
+ * @param path - The optional path to update the URL with. Defaults to the current page's path if not provided.
+ *
+ * @returns The updated URL with the new query parameters and path.
+ *
+ * @example
+ * // Current URL: localhost:9091/planex?name=joe
+ * setQueryParamOnUrl({ params: { name: 'jen' } });
+ * // Returns: '/planex?name=jen'
+ *
+ * @example
+ * // Current URL: localhost:9091/planex?name=joe
+ * setQueryParamOnUrl({ params: { name: 'jen' }, path: '/wayne' });
+ * // Returns: '/wayne?name=jen'
+ *
+ * @example
+ * // Current URL: localhost:9091/planex
+ * setQueryParamOnUrl({ params: { name: '', id: '123' } });
+ * // Returns: '/planex?id=123' (name is omitted because it's falsy)
+ */
+export const setQueryParamOnUrl = ({
+  params,
+  path = window.location.pathname,
+}: {
+  params: Record<string, OptionalValue<string>>;
+  path?: string;
+}) => {
+  const searchParams = new URLSearchParams(window.location.search);
 
-  if (value) {
-    searchParams.set(param, value);
-  }
+  Object.keys(params).forEach((param) => {
+    const paramValue = params[param];
 
-  return [pathname, searchParams.toString()].join('?');
+    if (paramValue) {
+      searchParams.set(param, paramValue);
+    }
+  });
+
+  return `${path}?${searchParams.toString()}`;
 };


### PR DESCRIPTION
## Description

This PR removes the redundant navigation action whenever a saga completes successfully.

An example of this redundancy is:

```js
// In src/redux/sagas/actions/editDomain.ts

// This already has the logic needed to update the URL with the new search param before proceeding to navigate to it
setTxHash?.(txHash);

// Redundant and removed in this PR
navigate(`/${colonyName}?tx=${txHash}`, {
  state: { isRedirect: true },
});
```

The function `setTxHash` is passed in as a meta param via `setActionFormProps`, and you can find this in `useActionFormProps.ts`

```js
withMeta({
  setTxHash: (txHash: string) => {
    navigate(setQueryParamOnUrl(window.location.pathname, 'tx', txHash), {
      replace: true,
    });
  },
});
```

**AND OH YEAH BEFORE I FORGET**, the ACTUAL reason why this PR exists is to make sure that new search params added do not overwrite the existing ones:

![persist params](https://github.com/user-attachments/assets/84a7de0e-543f-4f75-a929-1864c2a4fe79)

## Testing

1. Visit the Colony Dashboard
2. Select Team Andromeda
3. Verify that the URL is now http://localhost:9091/planex?team=2
4. Create and submit a Simple Payment
5. Verify that the URL is http://localhost:9091/planex?team=2&tx={txHash}. Basically, the new search param should just be appended

## Diffs

**Changes** 🏗

- Now using `useSearchParams` when updating the search params after a successful transaction
- Slight tweaks to the `setQueryParamOnUrl` function so that it uses an "update as required" strategy instead of replace and it can now also accept multiple search params as a function argument

**Deletions** ⚰️

* Removed the redundant navigation step whenever a saga completes successfully

Resolves #3176 