### PR TITLE
[Notifications] feat: do not show unread counters and the notification tab if user has notifications disabled

### DIFF
--- a/src/components/common/Extensions/UserHub/UserHub.tsx
+++ b/src/components/common/Extensions/UserHub/UserHub.tsx
@@ -3,20 +3,21 @@ import React, { type FC, useState, useContext } from 'react';
 import { defineMessages } from 'react-intl';
 
 import { FeatureFlagsContext } from '~context/FeatureFlagsContext/FeatureFlagsContext.ts';
-import { useNotificationsContext } from '~context/NotificationsContext/NotificationsContext.ts';
+import { useNotificationsUserContext } from '~context/Notifications/NotificationsUserContext/NotificationsUserContext.ts';
 import CryptoToFiatContextProvider from '~frame/v5/pages/UserCryptoToFiatPage/context/CryptoToFiatContextProvider.tsx';
 import { useMobile } from '~hooks/index.ts';
 import { formatText } from '~utils/intl.ts';
 import Select from '~v5/common/Fields/Select/index.ts';
+import NotificationsEnabledWrapper from '~v5/common/NotificationsEnabledWrapper/NotificationsEnabledWrapper.tsx';
 import TitleLabel from '~v5/shared/TitleLabel/index.ts';
 
 import { tabList } from './consts.ts';
-import CountBadge from './partials/CountBadge.tsx';
 import CryptoToFiatTab from './partials/CryptoToFiatTab/CryptoToFiatTab.tsx';
 import NotificationsTab from './partials/NotificationsTab/NotificationsTab.tsx';
 import ReputationTab from './partials/ReputationTab/index.ts';
 import StakesTab from './partials/StakesTab/index.ts';
 import TransactionsTab from './partials/TransactionsTab/index.ts';
+import UnreadNotifications from './partials/UnreadNotifications.tsx';
 import { UserHubTab } from './types.ts';
 
 // @BETA: Disabled for now
@@ -46,10 +47,7 @@ const UserHub: FC<Props> = ({ initialOpenTab = UserHubTab.Balance }) => {
   const featureFlags = useContext(FeatureFlagsContext);
   const [selectedTab, setSelectedTab] = useState(initialOpenTab);
 
-  // @TODO: get from notifications context
-  const notificationsServiceIsEnabled = true;
-
-  const { unreadCount } = useNotificationsContext();
+  const { areNotificationsEnabled } = useNotificationsUserContext();
 
   const filteredTabList = tabList.filter((tabItem) => {
     const isFeatureFlagEnabled =
@@ -61,7 +59,7 @@ const UserHub: FC<Props> = ({ initialOpenTab = UserHubTab.Balance }) => {
       return isFeatureFlagEnabled;
     }
 
-    return isFeatureFlagEnabled && notificationsServiceIsEnabled;
+    return isFeatureFlagEnabled && areNotificationsEnabled;
   });
 
   const handleTabChange = (newTab: UserHubTab) => {
@@ -127,7 +125,9 @@ const UserHub: FC<Props> = ({ initialOpenTab = UserHubTab.Balance }) => {
                       >
                         <span className="relative mr-2 flex shrink-0">
                           {id === UserHubTab.Notifications && (
-                            <CountBadge count={unreadCount} maximum={99} />
+                            <NotificationsEnabledWrapper>
+                              <UnreadNotifications />
+                            </NotificationsEnabledWrapper>
                           )}
                           <Icon size={14} />
                         </span>

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import React, { useRef } from 'react';
 import { defineMessages } from 'react-intl';
 
-import { useNotificationsContext } from '~context/NotificationsContext/NotificationsContext.ts';
+import { useNotificationsDataContext } from '~context/Notifications/NotificationsDataContext/NotificationsDataContext.ts';
 import { formatText } from '~utils/intl.ts';
 import EmptyContent from '~v5/common/EmptyContent/EmptyContent.tsx';
 import InfiniteScrollTrigger from '~v5/common/InfiniteScrollLoader/InfiniteScrollLoader.tsx';
@@ -37,7 +37,7 @@ const MSG = defineMessages({
 
 const NotificationsTab = () => {
   const { canFetchMore, fetchMore, markAllAsRead, notifications, unreadCount } =
-    useNotificationsContext();
+    useNotificationsDataContext();
   const containerRef = useRef<HTMLDivElement>(null);
 
   const isEmpty = notifications.length === 0;

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/NotificationsList.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/NotificationsList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useNotificationsContext } from '~context/NotificationsContext/NotificationsContext.ts';
+import { useNotificationsDataContext } from '~context/Notifications/NotificationsDataContext/NotificationsDataContext.ts';
 import { type Notification as NotificationInterface } from '~types/notifications.ts';
 
 import Notification from './Notification.tsx';
@@ -8,7 +8,7 @@ import Notification from './Notification.tsx';
 const displayName = 'common.Extensions.UserHub.partials.NotificationsList';
 
 const NotificationsList = () => {
-  const { notifications } = useNotificationsContext();
+  const { notifications } = useNotificationsDataContext();
 
   return (
     <ul className="w-full">

--- a/src/components/common/Extensions/UserHub/partials/UnreadNotifications.tsx
+++ b/src/components/common/Extensions/UserHub/partials/UnreadNotifications.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { useNotificationsDataContext } from '~context/Notifications/NotificationsDataContext/NotificationsDataContext.ts';
+
+import CountBadge from './CountBadge.tsx';
+
+const displayName = 'common.Extensions.UserHub.partials.UnreadNotifications';
+
+const UnreadNotifications = () => {
+  const { unreadCount } = useNotificationsDataContext();
+
+  return <CountBadge count={unreadCount} maximum={99} />;
+};
+
+UnreadNotifications.displayName = displayName;
+export default UnreadNotifications;

--- a/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
+++ b/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
@@ -9,7 +9,6 @@ import { ADDRESS_ZERO } from '~constants';
 import { useAnalyticsContext } from '~context/AnalyticsContext/AnalyticsContext.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
-import { useNotificationsContext } from '~context/NotificationsContext/NotificationsContext.ts';
 import { useTokensModalContext } from '~context/TokensModalContext/TokensModalContext.ts';
 import { TransactionStatus } from '~gql';
 import { useMobile } from '~hooks/index.ts';
@@ -21,6 +20,7 @@ import {
   useGroupedTransactions,
 } from '~state/transactionState.ts';
 import { splitWalletAddress } from '~utils/splitWalletAddress.ts';
+import NotificationsEnabledWrapper from '~v5/common/NotificationsEnabledWrapper/NotificationsEnabledWrapper.tsx';
 import useNavigationSidebarContext from '~v5/frame/NavigationSidebar/partials/NavigationSidebarContext/hooks.ts';
 import Button from '~v5/shared/Button/index.ts';
 import PopoverBase from '~v5/shared/PopoverBase/index.ts';
@@ -29,6 +29,7 @@ import UserAvatar from '~v5/shared/UserAvatar/index.ts';
 import { UserHubTab } from '../UserHub/types.ts';
 
 import { OPEN_USER_HUB_EVENT } from './consts.ts';
+import NotificationDot from './partials/NotificationDot.tsx';
 
 interface Props {
   openTab?: UserHubTab;
@@ -50,8 +51,6 @@ const UserHubButton: FC<Props> = ({ openTab, onOpen }) => {
   const [searchParams] = useSearchParams();
   const transactionId = searchParams?.get(TX_SEARCH_PARAM);
   const previousTransactionId = usePrevious(transactionId);
-
-  const { unreadCount } = useNotificationsContext();
 
   const { trackEvent } = useAnalyticsContext();
   const walletAddress = wallet?.address;
@@ -161,8 +160,6 @@ const UserHubButton: FC<Props> = ({ openTab, onOpen }) => {
     user?.profile?.displayName ??
     splitWalletAddress(walletAddress ?? ADDRESS_ZERO);
 
-  const showNotificationDot = !!unreadCount && unreadCount > 0;
-
   return (
     <div className="flex-shrink-0">
       <Button
@@ -206,9 +203,9 @@ const UserHubButton: FC<Props> = ({ openTab, onOpen }) => {
             </>
           ) : null}
         </div>
-        {showNotificationDot && (
-          <div className="absolute right-[-1.26px] top-[2.28px] h-2.5 w-2.5 rounded-full border border-base-white bg-blue-400" />
-        )}
+        <NotificationsEnabledWrapper>
+          <NotificationDot />
+        </NotificationsEnabledWrapper>
       </Button>
       {visible && (
         <PopoverBase

--- a/src/components/common/Extensions/UserHubButton/partials/NotificationDot.tsx
+++ b/src/components/common/Extensions/UserHubButton/partials/NotificationDot.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { useNotificationsDataContext } from '~context/Notifications/NotificationsDataContext/NotificationsDataContext.ts';
+
+const displayName =
+  'common.Extensions.UserNavigation.partials.UserHubButton.partials.NotificationDot';
+
+const NotificationDot = () => {
+  const { unreadCount } = useNotificationsDataContext();
+
+  const showNotificationDot = !!unreadCount && unreadCount > 0;
+
+  if (showNotificationDot) {
+    return (
+      <div className="absolute right-[-1.26px] top-[2.28px] h-2.5 w-2.5 rounded-full border border-base-white bg-blue-400" />
+    );
+  }
+
+  return null;
+};
+
+NotificationDot.displayName = displayName;
+export default NotificationDot;

--- a/src/components/v5/common/NotificationsEnabledWrapper/NotificationsEnabledWrapper.tsx
+++ b/src/components/v5/common/NotificationsEnabledWrapper/NotificationsEnabledWrapper.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { type FC, type PropsWithChildren } from 'react';
+
+import { useNotificationsUserContext } from '~context/Notifications/NotificationsUserContext/NotificationsUserContext.ts';
+
+const displayName = 'v5.common.NotificationsEnabledWrapper';
+
+interface NotificationsEnabledWrapperProps extends PropsWithChildren {}
+
+/* This component basically does the following:
+ * If user has notifications enabled, it renders whatever children
+ * If not, it returns null
+ * check NotificationsUserContextProvider for implementation details, there is no NotificationsDataContext if user's notifications are disabled
+ */
+
+const NotificationsEnabledWrapper: FC<NotificationsEnabledWrapperProps> = ({
+  children,
+}) => {
+  const { areNotificationsEnabled } = useNotificationsUserContext();
+
+  if (!areNotificationsEnabled) {
+    return null;
+  }
+
+  return <>{children}</>;
+};
+
+NotificationsEnabledWrapper.displayName = displayName;
+export default NotificationsEnabledWrapper;

--- a/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useMuteColonyItem.ts
+++ b/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useMuteColonyItem.ts
@@ -4,7 +4,7 @@ import { defineMessages } from 'react-intl';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
-import { useNotificationsContext } from '~context/NotificationsContext/NotificationsContext.ts';
+import { useNotificationsUserContext } from '~context/Notifications/NotificationsUserContext/NotificationsUserContext.ts';
 import { useUpdateUserNotificationsMutedColoniesMutation } from '~gql';
 import { formatText } from '~utils/intl.ts';
 import { type DropdownMenuItem } from '~v5/common/DropdownMenu/types.ts';
@@ -35,7 +35,7 @@ export const useMuteColonyItem = (): DropdownMenuItem => {
   const {
     colony: { colonyAddress },
   } = useColonyContext();
-  const { mutedColonyAddresses } = useNotificationsContext();
+  const { mutedColonyAddresses } = useNotificationsUserContext();
   const [updateMutedColonies] =
     useUpdateUserNotificationsMutedColoniesMutation();
 

--- a/src/context/Notifications/NotificationsDataContext/NotificationsDataContext.ts
+++ b/src/context/Notifications/NotificationsDataContext/NotificationsDataContext.ts
@@ -1,26 +1,25 @@
 import { type IRemoteNotification } from '@magicbell/react-headless';
 import { createContext, useContext } from 'react';
 
-export interface NotificationsContextValues {
+export interface NotificationsDataContextValues {
   canFetchMore: boolean;
   fetchMore: () => Promise<void>;
   markAllAsRead: () => void;
-  mutedColonyAddresses: string[];
   notifications: IRemoteNotification[];
   totalPages: number;
   unreadCount: number;
 }
 
-export const NotificationsContext = createContext<
-  NotificationsContextValues | undefined
+export const NotificationsDataContext = createContext<
+  NotificationsDataContextValues | undefined
 >(undefined);
 
-export const useNotificationsContext = () => {
-  const ctx = useContext(NotificationsContext);
+export const useNotificationsDataContext = () => {
+  const ctx = useContext(NotificationsDataContext);
 
   if (!ctx) {
     throw new Error(
-      'This hook must be used within the "NotificationsContext" provider',
+      'This hook must be used within the "NotificationsDataContext" provider',
     );
   }
 

--- a/src/context/Notifications/NotificationsDataContext/NotificationsDataContextProvider.tsx
+++ b/src/context/Notifications/NotificationsDataContext/NotificationsDataContextProvider.tsx
@@ -1,7 +1,8 @@
-import { useBell } from '@magicbell/react-headless';
+import { MagicBellProvider, useBell } from '@magicbell/react-headless';
 import React, { type ReactNode, useMemo } from 'react';
 
 import { isDev } from '~constants';
+import { useAppContext } from '~context/AppContext/AppContext.ts';
 
 import {
   NotificationsDataContext,
@@ -13,6 +14,8 @@ const NotificationsDataContextProvider = ({
 }: {
   children: ReactNode;
 }) => {
+  const { user } = useAppContext();
+
   const {
     currentPage,
     fetchNextPage,
@@ -47,10 +50,47 @@ const NotificationsDataContextProvider = ({
     unreadCount,
   ]);
 
+  if (
+    !user?.notificationsData?.magicbellUserId ||
+    !import.meta.env.MAGICBELL_API_KEY
+  ) {
+    return (
+      <NotificationsDataContext.Provider value={value}>
+        {children}
+      </NotificationsDataContext.Provider>
+    );
+  }
+
+  // @NOTE it tripped me up, but it's not an actual provider and this thing works without wrapping it in another provider
   return (
-    <NotificationsDataContext.Provider value={value}>
-      {children}
-    </NotificationsDataContext.Provider>
+    <MagicBellProvider
+      apiKey={import.meta.env.MAGICBELL_API_KEY}
+      userExternalId={user.notificationsData.magicbellUserId}
+      stores={
+        isDev
+          ? [
+              {
+                id: 'dev-store',
+                defaultQueryParams: {
+                  category: import.meta.env.MAGICBELL_DEV_KEY,
+                  // eslint-disable-next-line camelcase
+                  per_page: 10,
+                },
+              },
+            ]
+          : [
+              {
+                id: 'store',
+                // eslint-disable-next-line camelcase
+                defaultQueryParams: { per_page: 10 },
+              },
+            ]
+      }
+    >
+      <NotificationsDataContext.Provider value={value}>
+        {children}
+      </NotificationsDataContext.Provider>
+    </MagicBellProvider>
   );
 };
 

--- a/src/context/Notifications/NotificationsDataContext/NotificationsDataContextProvider.tsx
+++ b/src/context/Notifications/NotificationsDataContext/NotificationsDataContextProvider.tsx
@@ -1,0 +1,57 @@
+import { useBell } from '@magicbell/react-headless';
+import React, { type ReactNode, useMemo } from 'react';
+
+import { isDev } from '~constants';
+
+import {
+  NotificationsDataContext,
+  type NotificationsDataContextValues,
+} from './NotificationsDataContext.ts';
+
+const NotificationsDataContextProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const {
+    currentPage,
+    fetchNextPage,
+    markAllAsRead,
+    notifications,
+    totalPages,
+    unreadCount,
+  } = useBell({ storeId: isDev ? 'dev-store' : 'store' }) || {
+    currentPage: 1,
+    fetchNextPage: () => Promise.resolve(),
+    markAllAsRead: () => null,
+    notifications: [],
+    totalPages: 1,
+    unreadCount: 0,
+  };
+
+  const value = useMemo((): NotificationsDataContextValues => {
+    return {
+      canFetchMore: currentPage < totalPages,
+      fetchMore: fetchNextPage,
+      markAllAsRead: markAllAsRead || (() => null),
+      notifications,
+      totalPages,
+      unreadCount,
+    };
+  }, [
+    currentPage,
+    fetchNextPage,
+    markAllAsRead,
+    notifications,
+    totalPages,
+    unreadCount,
+  ]);
+
+  return (
+    <NotificationsDataContext.Provider value={value}>
+      {children}
+    </NotificationsDataContext.Provider>
+  );
+};
+
+export default NotificationsDataContextProvider;

--- a/src/context/Notifications/NotificationsUserContext/NotificationsUserContext.ts
+++ b/src/context/Notifications/NotificationsUserContext/NotificationsUserContext.ts
@@ -1,0 +1,22 @@
+import { createContext, useContext } from 'react';
+
+export interface NotificationsUserContextValues {
+  areNotificationsEnabled: boolean;
+  mutedColonyAddresses: string[];
+}
+
+export const NotificationsUserContext = createContext<
+  NotificationsUserContextValues | undefined
+>(undefined);
+
+export const useNotificationsUserContext = () => {
+  const ctx = useContext(NotificationsUserContext);
+
+  if (!ctx) {
+    throw new Error(
+      'This hook must be used within the "NotificationsUserContext" provider',
+    );
+  }
+
+  return ctx;
+};

--- a/src/context/Notifications/NotificationsUserContext/NotificationsUserContextProvider.tsx
+++ b/src/context/Notifications/NotificationsUserContext/NotificationsUserContextProvider.tsx
@@ -1,7 +1,5 @@
-import { MagicBellProvider } from '@magicbell/react-headless';
 import React, { type ReactNode, useEffect, useMemo } from 'react';
 
-import { isDev } from '~constants';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useCreateUserNotificationsDataMutation } from '~gql';
 
@@ -62,36 +60,11 @@ const NotificationsUserContextProvider = ({
   }
 
   return (
-    <MagicBellProvider
-      apiKey={import.meta.env.MAGICBELL_API_KEY}
-      userExternalId={user.notificationsData.magicbellUserId}
-      stores={
-        isDev
-          ? [
-              {
-                id: 'dev-store',
-                defaultQueryParams: {
-                  category: import.meta.env.MAGICBELL_DEV_KEY,
-                  // eslint-disable-next-line camelcase
-                  per_page: 10,
-                },
-              },
-            ]
-          : [
-              {
-                id: 'store',
-                // eslint-disable-next-line camelcase
-                defaultQueryParams: { per_page: 10 },
-              },
-            ]
-      }
-    >
-      <NotificationsUserContext.Provider value={value}>
-        <NotificationsDataContextProvider>
-          {children}
-        </NotificationsDataContextProvider>
-      </NotificationsUserContext.Provider>
-    </MagicBellProvider>
+    <NotificationsUserContext.Provider value={value}>
+      <NotificationsDataContextProvider>
+        {children}
+      </NotificationsDataContextProvider>
+    </NotificationsUserContext.Provider>
   );
 };
 

--- a/src/routes/RootRoute.tsx
+++ b/src/routes/RootRoute.tsx
@@ -4,7 +4,7 @@ import { Outlet } from 'react-router-dom';
 import AppContextProvider from '~context/AppContext/AppContextProvider.tsx';
 import CurrencyContextProvider from '~context/CurrencyContext/CurrencyContextProvider.tsx';
 import FeatureFlagsContextProvider from '~context/FeatureFlagsContext/FeatureFlagsContextProvider.tsx';
-import NotificationsContextProvider from '~context/NotificationsContext/NotificationsContextProvider.tsx';
+import NotificationsUserContextProvider from '~context/Notifications/NotificationsUserContext/NotificationsUserContextProvider.tsx';
 import PageHeadingContextProvider from '~context/PageHeadingContext/PageHeadingContextProvider.tsx';
 import { usePageThemeContext } from '~context/PageThemeContext/PageThemeContext.ts';
 import PageThemeContextProvider from '~context/PageThemeContext/PageThemeContextProvider.tsx';
@@ -30,9 +30,9 @@ const RootRoute = () => (
     <AppContextProvider>
       <FeatureFlagsContextProvider>
         <CurrencyContextProvider>
-          <NotificationsContextProvider>
+          <NotificationsUserContextProvider>
             <RootRouteInner />
-          </NotificationsContextProvider>
+          </NotificationsUserContextProvider>
         </CurrencyContextProvider>
       </FeatureFlagsContextProvider>
     </AppContextProvider>


### PR DESCRIPTION
## Description

This PR achieves what the title says by splitting up the `NotificationsContext` into two parts: `NotificationsUserContext` for user's configured data regarding notifications such as muted colonies and if notification are even enabled and `NotificationsDataContext` for reading data from MagicBell and interacting with it.
For ease of use I've created a component called `NotificationsEnabledWrapper` that renders any component conditionally if the user has notifications enabled.

## Testing

Should be relatively straight forward!
In case you haven't tested any other notification PRs add the following to your `.env.local.secrets` and run `npm run prepare`

```
MAGICBELL_API_KEY=<ask somebody for this>
MAGICBELL_API_SECRET=<ask somebody for this>
MAGICBELL_DEV_KEY=
```

1. Login as `leela`, create some simple payment actions paying `leela`
![image](https://github.com/user-attachments/assets/8cebe114-83e2-4849-baeb-78329b28c498)
2. Notice that you get a notification dot on the user hub button (needs a few seconds)
![image](https://github.com/user-attachments/assets/bf58fe08-5e9a-45cd-ab56-8930eeb25be1)
3. Verify that when you open the user hub you get an unread notification count of 2 and you can open the tab
![image](https://github.com/user-attachments/assets/6cb428c7-5e22-4f09-ad4b-3fe9737fdeca)
4. Go to your settings under the advanced tab (`http://localhost:9091/account/advanced`) and disable your notifications
![image](https://github.com/user-attachments/assets/f8bc0e64-e3f0-4708-b68e-61d2462e2a1d)
5. Go back to `/planex` and verify that you can't see the notification dot anymore
![image](https://github.com/user-attachments/assets/727bb0d2-7b35-4190-a9b3-a99f5e83b37d)
6. Open the user hub and verify that you don't see the notifications tab 
![image](https://github.com/user-attachments/assets/8fcc6b47-7ecd-4b6b-ab6f-6de69ed8c1ff)


## Diffs

**New stuff** ✨

* `NotificationsEnabledWrapper` which conditionally renders a component if notifications are enabled

**Changes** 🏗

* Split `NotificationsContext` into `NotificationsUserContext` for user's config data and `NotificationsDataContext` for interacting with notifications
* Split the notification dot into its own component

Resolves  #3168
