### PR TITLE
Feat: Colony-wide team filter persistence

### DIFF
--- a/src/components/v5/frame/ColonyHome/ColonyHome.tsx
+++ b/src/components/v5/frame/ColonyHome/ColonyHome.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
 
 import FiltersContextProvider from '~common/ColonyActionsTable/FiltersContext/FiltersContextProvider.tsx';
 import RecentActivityTable from '~common/ColonyActionsTable/RecentActivityTable.tsx';
 import { useMobile } from '~hooks/index.ts';
-import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
 import {
   // @BETA: Disabled for now
   // COLONY_TEAMS_ROUTE,
   COLONY_ACTIVITY_ROUTE,
-  TEAM_SEARCH_PARAM,
 } from '~routes/index.ts';
 import { formatText } from '~utils/intl.ts';
-import { setQueryParamOnUrl } from '~utils/urls.ts';
 import Link from '~v5/shared/Link/index.ts';
 import TeamFilter from '~v5/shared/TeamFilter/TeamFilter.tsx';
 
@@ -26,17 +22,15 @@ const displayName = 'v5.frame.ColonyHome';
 
 const ColonyHome = () => {
   const isMobile = useMobile();
-  const selectedDomain = useGetSelectedDomainFilter();
-  const { colonyName } = useParams();
 
   return (
-    <div className="flex flex-col gap-6 md:gap-4.5">
+    <div className="md:gap-4.5 flex flex-col gap-6">
       <div className="flex flex-col gap-9 sm:gap-6">
         <DashboardHeader />
         <TeamFilter />
       </div>
       <FundsCards />
-      <div className="flex h-fit w-full flex-col gap-4.5 lg:grid lg:grid-cols-3">
+      <div className="gap-4.5 flex h-fit w-full flex-col lg:grid lg:grid-cols-3">
         <TotalInOutBalance />
         <div className="w-full sm:hidden lg:block">
           <ReputationChart />
@@ -49,12 +43,7 @@ const ColonyHome = () => {
           </h3>
           <Link
             className="text-sm font-medium text-gray-400 md:hover:text-gray-900"
-            to={setQueryParamOnUrl({
-              path: `/${colonyName}/${COLONY_ACTIVITY_ROUTE}`,
-              params: {
-                [TEAM_SEARCH_PARAM]: selectedDomain?.nativeId.toString(),
-              },
-            })}
+            to={COLONY_ACTIVITY_ROUTE}
           >
             {formatText({ id: 'view.all' })}
           </Link>

--- a/src/components/v5/shared/TeamFilter/TeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/TeamFilter.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
+import { useColonyFiltersContext } from '~context/GlobalFiltersContext/ColonyFiltersContext.ts';
 import { useMobile } from '~hooks';
+import { TEAM_SEARCH_PARAM } from '~routes';
 
 import DesktopTeamFilter from './partials/DesktopTeamFilter/DesktopTeamFilter.tsx';
 import MobileTeamFilter from './partials/MobileTeamFilter.tsx';
@@ -9,6 +12,16 @@ const displayName = 'v5.shared.TeamFilter';
 
 const TeamFilter = () => {
   const isMobile = useMobile();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const { filteredTeam } = useColonyFiltersContext();
+
+  useEffect(() => {
+    if (filteredTeam && searchParams.get(TEAM_SEARCH_PARAM) !== filteredTeam) {
+      searchParams.append(TEAM_SEARCH_PARAM, filteredTeam);
+      setSearchParams(searchParams);
+    }
+  }, [filteredTeam, searchParams, setSearchParams]);
 
   if (isMobile) {
     return <MobileTeamFilter />;

--- a/src/components/v5/shared/TeamFilter/partials/AllTeamsItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/AllTeamsItem.tsx
@@ -3,6 +3,7 @@ import React, { type FC } from 'react';
 import { defineMessages } from 'react-intl';
 import { useSearchParams } from 'react-router-dom';
 
+import { useColonyFiltersContext } from '~context/GlobalFiltersContext/ColonyFiltersContext.ts';
 import { TEAM_SEARCH_PARAM } from '~routes/index.ts';
 import { formatText } from '~utils/intl.ts';
 
@@ -21,9 +22,11 @@ interface AllTeamsItemProps {
 
 const AllTeamsItem: FC<AllTeamsItemProps> = ({ selected }) => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { setFilteredTeam } = useColonyFiltersContext();
 
   const handleClick = () => {
     searchParams.delete(TEAM_SEARCH_PARAM);
+    setFilteredTeam(null);
     setSearchParams(searchParams);
   };
 

--- a/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import React, { useEffect, type FC } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
+import { useColonyFiltersContext } from '~context/GlobalFiltersContext/ColonyFiltersContext.ts';
 import { useMobile } from '~hooks/index.ts';
 import { useScrollIntoView } from '~hooks/useScrollIntoView.ts';
 import { TEAM_SEARCH_PARAM } from '~routes/index.ts';
@@ -19,6 +20,7 @@ const TeamItem: FC<TeamItemProps> = ({ domain, selected }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const { ref: teamItemRef, scroll } = useScrollIntoView<HTMLButtonElement>();
   const isMobile = useMobile();
+  const { setFilteredTeam } = useColonyFiltersContext();
 
   const teamColor = getTeamColor(domain.metadata?.color);
 
@@ -35,9 +37,13 @@ const TeamItem: FC<TeamItemProps> = ({ domain, selected }) => {
   const handleClick = () => {
     if (selected) {
       searchParams.delete(TEAM_SEARCH_PARAM);
+      setFilteredTeam(null);
       setSearchParams(searchParams);
     } else {
-      searchParams.set(TEAM_SEARCH_PARAM, domain.nativeId.toString());
+      const domainNativeId = domain.nativeId.toString();
+
+      searchParams.set(TEAM_SEARCH_PARAM, domainNativeId);
+      setFilteredTeam(domainNativeId);
       setSearchParams(searchParams);
     }
   };

--- a/src/context/GlobalFiltersContext/ColonyFiltersContext.ts
+++ b/src/context/GlobalFiltersContext/ColonyFiltersContext.ts
@@ -1,0 +1,25 @@
+import { createContext, useContext } from 'react';
+
+import type React from 'react';
+
+interface ColonyFiltersContextValue {
+  filteredTeam: string | null;
+  setFilteredTeam: React.Dispatch<React.SetStateAction<string | null>>;
+}
+
+export const ColonyFiltersContext = createContext<ColonyFiltersContextValue>({
+  filteredTeam: null,
+  setFilteredTeam: () => {},
+});
+
+export const useColonyFiltersContext = () => {
+  const context = useContext(ColonyFiltersContext);
+
+  if (!context) {
+    throw new Error(
+      'This hook must be used within the "ColonyFiltersContext" provider',
+    );
+  }
+
+  return context;
+};

--- a/src/context/GlobalFiltersContext/ColonyFiltersContextProvider.tsx
+++ b/src/context/GlobalFiltersContext/ColonyFiltersContextProvider.tsx
@@ -1,0 +1,49 @@
+import React, {
+  type FC,
+  type PropsWithChildren,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+
+import { TEAM_SEARCH_PARAM } from '~routes';
+
+import { ColonyFiltersContext } from './ColonyFiltersContext.ts';
+
+const ColonyFiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
+  const { colonyName } = useParams();
+
+  const [filteredTeam, setFilteredTeam] = useState<string | null>(null);
+
+  const [currentColonyName, setCurrentColonyName] = useState(colonyName);
+
+  const [queryParams, setQueryParams] = useSearchParams();
+  const value = useMemo(
+    () => ({
+      filteredTeam,
+      setFilteredTeam,
+    }),
+    [filteredTeam, setFilteredTeam],
+  );
+
+  useEffect(() => {
+    if (currentColonyName !== colonyName) {
+      setFilteredTeam(null);
+      setCurrentColonyName(colonyName);
+      return;
+    }
+
+    if (queryParams.get(TEAM_SEARCH_PARAM)) {
+      setFilteredTeam(queryParams.get(TEAM_SEARCH_PARAM));
+    }
+  }, [colonyName, currentColonyName, queryParams, setQueryParams]);
+
+  return (
+    <ColonyFiltersContext.Provider value={value}>
+      {children}
+    </ColonyFiltersContext.Provider>
+  );
+};
+
+export default ColonyFiltersContextProvider;

--- a/src/routes/RootRoute.tsx
+++ b/src/routes/RootRoute.tsx
@@ -4,6 +4,7 @@ import { Outlet } from 'react-router-dom';
 import AppContextProvider from '~context/AppContext/AppContextProvider.tsx';
 import CurrencyContextProvider from '~context/CurrencyContext/CurrencyContextProvider.tsx';
 import FeatureFlagsContextProvider from '~context/FeatureFlagsContext/FeatureFlagsContextProvider.tsx';
+import ColonyFiltersContextProvider from '~context/GlobalFiltersContext/ColonyFiltersContextProvider.tsx';
 import PageHeadingContextProvider from '~context/PageHeadingContext/PageHeadingContextProvider.tsx';
 import PageLayoutContextProvider from '~context/PageLayoutContext/PageLayoutContextProvider.tsx';
 import { usePageThemeContext } from '~context/PageThemeContext/PageThemeContext.ts';
@@ -29,11 +30,13 @@ const RootRoute = () => (
   <PageThemeContextProvider>
     <PageLayoutContextProvider>
       <AppContextProvider>
-        <FeatureFlagsContextProvider>
-          <CurrencyContextProvider>
-            <RootRouteInner />
-          </CurrencyContextProvider>
-        </FeatureFlagsContextProvider>
+        <ColonyFiltersContextProvider>
+          <FeatureFlagsContextProvider>
+            <CurrencyContextProvider>
+              <RootRouteInner />
+            </CurrencyContextProvider>
+          </FeatureFlagsContextProvider>
+        </ColonyFiltersContextProvider>
       </AppContextProvider>
     </PageLayoutContextProvider>
   </PageThemeContextProvider>


### PR DESCRIPTION
## Description

This PR enables a selected team filter to persist across Colony pages that uses the `<TeamFilter />` component. 

However, it will not persist the selected team filter for a Colony if you:
- Close the tab/browser
- Visit another Colony
- Visit a non-Colony route

![team filters](https://github.com/user-attachments/assets/ca0efa50-470d-4eee-bda1-ad113c2bdf6a)

## Testing

> [!NOTE]
> 1. No, we specifically do not want to persist the selected team filter in between tab sessions. If you open a new tab and you visit the Planex colony, do not expect the filtered team value to persist
> 2. Yes, I also thought about persisting the selected team on a per-Colony basis i.e. Persist Team Andromeda for the Planex Colony & Team Research and Development for the Wayne Colony. It's very doable with what's done on this PR, just have to slightly tweak things around. But that's up to Product to decide if they want it or not

## Soft Navigation Scenario

1. Visit the Planex Colony
2. Visit the Dashboard page
3. Select team Andromeda using the Teams Filter component
4. Verify that the URL is: http://localhost:9091/planex?team=2 and the Team Filter is component is correctly set
5. Click the "View all" button on the Recent Activity table
<img width="1177" alt="Screenshot 2024-09-30 at 17 24 05" src="https://github.com/user-attachments/assets/37957b28-27fd-45de-9954-97e21aaaf844">

6. Verify that the URL is http://localhost:9091/planex/activity?team=2 and the Team Filter is component is correctly set
7. Click Teams on the left Colony sidebar
8. Verify that the URL is http://localhost:9091/planex/teams?team=2 and the Team Filter is component is correctly set
9. Click Extensions on the left Colony sidebar
10. Verify that the URL is http://localhost:9091/planex/extensions because this page does not have a Teams Filter
11. Click Permissions on the left Colony sidebar
12. Verify that the URL is http://localhost:9091/planex/permissions?team=2 and the Team Filter is component is correctly set
13. Visit the account page
<img width="491" alt="Screenshot 2024-09-30 at 17 17 38" src="https://github.com/user-attachments/assets/b3486716-8aff-4751-8a51-856c9283d450">

14. Verify that URL doesn't have a team param and that the Teams Filter component doesn't have a pre-selected value
15. Head back to the Planex Colony
16. Verify that the URL doesn't have a team param
17. Select team Serenity using the Teams Filter component
18. Verify that the URL is http://localhost:9091/planex?team=3
19. Visit the Wayne colony
<img width="528" alt="Screenshot 2024-09-30 at 17 19 37" src="https://github.com/user-attachments/assets/acd5dde4-1ba3-4831-ab91-21d6b19b486a">

20. Verify that the URL doesn't have a team param

## Hard Navigation Scenario

1. Visit http://localhost:9091/planex/activity?team=2
2. Verify that the Team Filter component is correctly set
3. Click Teams on the left Colony sidebar
4. Verify that the URL still has the team query param and that the Team Filters component is still correctly set

## Diffs

**New stuff** ✨

* A new context that handles Colony-wide filters `ColonyFiltersContextProvider`

Resolves #3203 