### PR TITLE
[Dashboard] Total in and out card UI fixes

### DIFF
--- a/src/components/v5/common/Filter/partials/SearchInput/SearchInput.tsx
+++ b/src/components/v5/common/Filter/partials/SearchInput/SearchInput.tsx
@@ -74,7 +74,7 @@ const SearchInput: FC<SearchInputProps> = ({
       <input
         ref={ref}
         className={clsx(
-          'z-base min-h-[2.125rem] w-full rounded-lg border border-gray-300 bg-base-white px-[2.125rem] py-1.5 placeholder:text-gray-400 focus:outline-none group-focus-within:border-blue-200 group-hover:border-blue-200',
+          'z-base min-h-8.5 w-full rounded-lg border border-gray-300 bg-base-white px-8.5 py-1.5 placeholder:text-gray-400 focus:outline-none group-focus-within:border-blue-200 group-hover:border-blue-200',
           isMobile && value && '!pr-[5.375rem]',
         )}
         type="text"

--- a/src/components/v5/common/TableHeader/TableHeader.tsx
+++ b/src/components/v5/common/TableHeader/TableHeader.tsx
@@ -11,7 +11,7 @@ const TableHeader = ({
 }: PropsWithChildren<TableHeaderProps>) => (
   <div className="pb-3.5">
     <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between">
-      <div className="flex flex-shrink-0 items-center sm:min-h-[2.125rem]">
+      <div className="flex flex-shrink-0 items-center sm:min-h-8.5">
         <h4 className="mr-3 heading-5">{title}</h4>
         {additionalHeaderContent}
       </div>

--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/ChartCustomBar.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/ChartCustomBar.tsx
@@ -40,7 +40,7 @@ export const ChartCustomBar: FC<ChartCustomBarProps> = ({
   const mouseInteractionHandler = (event) => {
     showTooltipFromEvent(
       <ChartCustomTooltip>
-        {getFormattedFullAmount(data?.value, currencySymbolMap[currency])}
+        {getFormattedFullAmount(data?.value, currencySymbolMap[currency] ?? '')}
       </ChartCustomTooltip>,
       event,
     );

--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/ClaimFundsButton.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/ClaimFundsButton.tsx
@@ -1,14 +1,14 @@
 import React, { useState, useEffect } from 'react';
 
 import { apolloClient } from '~apollo';
+import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import useAsyncFunction from '~hooks/useAsyncFunction.ts';
 import useColonyFundsClaims from '~hooks/useColonyFundsClaims.ts';
 import { useTimeout } from '~hooks/useTimeout.ts';
 import { ActionTypes } from '~redux/actionTypes.ts';
 import Tooltip from '~shared/Extensions/Tooltip/Tooltip.tsx';
-import { mergePayload } from '~utils/actions.ts';
 import { formatText } from '~utils/intl.ts';
-import ActionButton from '~v5/shared/Button/ActionButton.tsx';
 import Button from '~v5/shared/Button/Button.tsx';
 
 import { MSG } from '../consts.ts';
@@ -22,13 +22,16 @@ export const ClaimFundsButton = () => {
   } = useColonyContext();
 
   const claims = useColonyFundsClaims();
-  const unclaimedClaims = claims.filter((claim) => !claim.isClaimed);
+  const unclaimedClaims = claims.filter(
+    (claim) => !claim.isClaimed && claim.amount !== '0',
+  );
   const hasUnclaimedClaims = !!unclaimedClaims.length;
   const allClaimableTokenAddresses = Array.from(
     new Set(unclaimedClaims.map((claim) => claim.token?.tokenAddress || '')),
   );
 
   const [isClaimed, setIsClaimed] = useState(false);
+  const [isClaiming, setIsClaiming] = useState(false);
   const [isVisible, setIsVisible] = useState(hasUnclaimedClaims);
   const [shouldRefetchData, setShouldRefetchData] = useState(false);
 
@@ -58,20 +61,32 @@ export const ClaimFundsButton = () => {
     },
   });
 
-  const transform = mergePayload({
-    colonyAddress: colony?.colonyAddress,
-    tokenAddresses: allClaimableTokenAddresses,
+  const claimToken = useAsyncFunction({
+    submit: ActionTypes.CLAIM_TOKEN,
+    error: ActionTypes.CLAIM_TOKEN_ERROR,
+    success: ActionTypes.CLAIM_TOKEN_SUCCESS,
   });
-
-  const handleClaimSuccess = () => {
-    setIsClaimed(true);
-    startPollingColonyData(1_000);
-    setTimeout(stopPollingColonyData, 10_000);
-  };
 
   if (!isVisible) {
     return null;
   }
+
+  const handleClick = async () => {
+    setIsClaiming(true);
+    try {
+      await claimToken({
+        colonyAddress: colony?.colonyAddress,
+        tokenAddresses: allClaimableTokenAddresses,
+      });
+      setIsClaimed(true);
+      startPollingColonyData(1_000);
+      setTimeout(stopPollingColonyData, 10_000);
+    } catch {
+      //
+    } finally {
+      setIsClaiming(false);
+    }
+  };
 
   return isClaimed ? (
     <Button
@@ -80,17 +95,20 @@ export const ClaimFundsButton = () => {
       className="pointer-events-none h-fit border border-success-400 bg-success-400 px-3 py-2 !text-base-white"
     />
   ) : (
-    <Tooltip tooltipContent={formatText(MSG.claimFundsTooltip)} placement="top">
-      <ActionButton
-        actionType={ActionTypes.CLAIM_TOKEN}
-        transform={transform}
-        onSuccess={handleClaimSuccess}
-        disabled={!canInteractWithColony}
-        text={formatText(MSG.claimFundsCTA)}
-        mode="primaryOutlineFull"
-        size="small"
-        className="h-fit border-gray-900 px-3 py-2 text-gray-900"
-      />
-    </Tooltip>
+    <LoadingSkeleton isLoading={isClaiming} className="h-8.5 w-14 rounded-lg">
+      <Tooltip
+        tooltipContent={formatText(MSG.claimFundsTooltip)}
+        placement="top"
+      >
+        <Button
+          onClick={handleClick}
+          disabled={!canInteractWithColony}
+          text={formatText(MSG.claimFundsCTA)}
+          mode="primaryOutlineFull"
+          size="small"
+          className="h-fit border-gray-900 px-3 py-2 text-gray-900"
+        />
+      </Tooltip>
+    </LoadingSkeleton>
   );
 };

--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/IncomeSection.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/IncomeSection.tsx
@@ -29,10 +29,16 @@ export const IncomeSection = () => {
       isLoading={isLoading}
     >
       <div className="flex flex-row gap-2">
-        <LoadingSkeleton isLoading={isLoading} className="h-8 w-14 rounded-lg">
+        <LoadingSkeleton
+          isLoading={isLoading}
+          className="h-8.5 w-14 rounded-lg"
+        >
           <ClaimFundsButton />
         </LoadingSkeleton>
-        <LoadingSkeleton isLoading={isLoading} className="h-8 w-12 rounded-lg">
+        <LoadingSkeleton
+          isLoading={isLoading}
+          className="h-8.5 w-12 rounded-lg"
+        >
           <Button
             onClick={toggleAddFundsModalOn}
             text={formatText(MSG.addFundsCTA)}

--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/PaymentsSection.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/PaymentsSection.tsx
@@ -44,7 +44,7 @@ export const PaymentsSection = () => {
       previousValue={previousTotalOut}
       isLoading={isLoading}
     >
-      <LoadingSkeleton isLoading={isLoading} className="h-8 w-11 rounded-lg">
+      <LoadingSkeleton isLoading={isLoading} className="h-8.5 w-11 rounded-lg">
         <Button
           onClick={clickHandler}
           text={formatText(MSG.payCTA)}

--- a/src/components/v5/shared/Button/Button.tsx
+++ b/src/components/v5/shared/Button/Button.tsx
@@ -52,13 +52,13 @@ const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProps>>(
               'flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-all duration-normal',
               `${isFullRounded ? 'rounded-full' : 'rounded-lg'}`,
               {
-                'min-h-[2.5rem] px-4 py-2 text-md': size === 'default',
-                'min-h-[2.5rem] px-[0.875rem] py-[0.625rem] text-md':
+                'min-h-10 px-4 py-2 text-md': size === 'default',
+                'min-h-10 px-[0.875rem] py-[0.625rem] text-md':
                   size === 'large',
                 '!rounded-[0.1875rem] px-2 py-1 capitalize text-4':
                   size === 'extraSmall',
-                'min-h-[2.125rem] px-3 py-2 text-sm': size === 'medium',
-                'min-h-[2.125rem] px-2.5 py-1.5 text-sm': size === 'small',
+                'min-h-8.5 px-3 py-2 text-sm': size === 'medium',
+                'min-h-8.5 px-2.5 py-1.5 text-sm': size === 'small',
                 [buttonClasses.primarySolid]: mode === 'primarySolid',
                 [buttonClasses.primarySolidFull]: mode === 'primarySolidFull',
                 [buttonClasses.primaryOutline]: mode === 'primaryOutline',

--- a/src/components/v5/shared/Button/ButtonLink.tsx
+++ b/src/components/v5/shared/Button/ButtonLink.tsx
@@ -37,12 +37,11 @@ const ButtonLink: FC<PropsWithChildren<ButtonLinkProps>> = ({
           'flex items-center justify-center font-medium transition-all duration-normal',
           `${isFullRounded ? 'rounded-full' : 'rounded-lg'}`,
           {
-            'min-h-[2.5rem] px-4 py-2 text-md': size === 'default',
-            'min-h-[2.5rem] px-[0.875rem] py-[0.625rem] text-md':
-              size === 'large',
+            'min-h-10 px-4 py-2 text-md': size === 'default',
+            'min-h-10 px-[0.875rem] py-[0.625rem] text-md': size === 'large',
             '!rounded-[0.1875rem] px-2 py-1 capitalize text-4':
               size === 'extraSmall',
-            'min-h-[2.125rem] px-3 py-2 text-sm': size === 'small',
+            'min-h-8.5 px-3 py-2 text-sm': size === 'small',
             [buttonClasses.primarySolid]: mode === 'primarySolid',
             [buttonClasses.primarySolid]: mode === 'primarySolid',
             [buttonClasses.primaryOutline]: mode === 'primaryOutline',

--- a/src/components/v5/shared/SearchSelect/partials/SearchInput/SearchInput.tsx
+++ b/src/components/v5/shared/SearchSelect/partials/SearchInput/SearchInput.tsx
@@ -30,7 +30,7 @@ const SearchInput: FC<SearchInputProps> = ({
         onChange={(e) => {
           onChange?.(e.target.value);
         }}
-        className="peer w-full rounded-lg px-[2.125rem] text-3"
+        className="peer w-full rounded-lg px-8.5 text-3"
         placeholder={placeholder}
         value={value}
         ref={searchInputRef}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -154,6 +154,7 @@ module.exports = {
       },
       spacing: {
         4.5: '1.125rem',
+        8.5: '2.125rem'
       },
     },
   },


### PR DESCRIPTION
## Description

This PR fixes the following issues

- [ ] After selecting the claim button, the rows in the activity table flicker between the skeleton loader. It also happens when I trigger an action sidepanel to open. 

![Export-1727694007093](https://github.com/user-attachments/assets/a1e653fd-f8df-4b25-8ad8-c6843aa28b6e)

- [ ] Can we switch the spinner animation to a skeleton when the claim button is selected so it's consistent with other loading states?

Current spinner showing: 

![Export-1727698331117](https://github.com/user-attachments/assets/62af6956-5f4a-4f0c-8788-6e712a48a751)

- [ ] When I switch from a currency to a token and in this case CLNY, the in and out chart displays an error on hover. 

<img width="826" alt="image" src="https://github.com/user-attachments/assets/ff340962-4315-4e3a-9776-86198a8fbcd9">

## Testing

* Step 1. In order to test the `Claim` button part, please create a `.diff` file with the following content
```
diff --git a/src/redux/sagas/actions/mintTokens.ts b/src/redux/sagas/actions/mintTokens.ts
index d13052bee..12c7658e7 100644
--- a/src/redux/sagas/actions/mintTokens.ts
+++ b/src/redux/sagas/actions/mintTokens.ts
@@ -62,18 +62,18 @@ function* createMintTokensAction({
       ready: false,
     });
 
-    yield fork(createTransaction, claimColonyFunds.id, {
-      context: ClientType.ColonyClient,
-      methodName: 'claimColonyFunds',
-      identifier: colonyAddress,
-      params: [nativeTokenAddress],
-      group: {
-        key: batchKey,
-        id: metaId,
-        index: 1,
-      },
-      ready: false,
-    });
+    // yield fork(createTransaction, claimColonyFunds.id, {
+    //   context: ClientType.ColonyClient,
+    //   methodName: 'claimColonyFunds',
+    //   identifier: colonyAddress,
+    //   params: [nativeTokenAddress],
+    //   group: {
+    //     key: batchKey,
+    //     id: metaId,
+    //     index: 1,
+    //   },
+    //   ready: false,
+    // });
 
     if (annotationMessage) {
       yield fork(createTransaction, annotateMintTokens.id, {
@@ -91,7 +91,7 @@ function* createMintTokensAction({
     }
 
     yield takeFrom(mintTokens.channel, ActionTypes.TRANSACTION_CREATED);
-    yield takeFrom(claimColonyFunds.channel, ActionTypes.TRANSACTION_CREATED);
+    // yield takeFrom(claimColonyFunds.channel, ActionTypes.TRANSACTION_CREATED);
 
     if (annotationMessage) {
       yield takeFrom(
@@ -108,9 +108,9 @@ function* createMintTokensAction({
       },
     } = yield waitForTxResult(mintTokens.channel);
 
-    yield initiateTransaction(claimColonyFunds.id);
+    // yield initiateTransaction(claimColonyFunds.id);
 
-    yield waitForTxResult(claimColonyFunds.channel);
+    // yield waitForTxResult(claimColonyFunds.channel);
 
     yield createActionMetadataInDB(txHash, customActionTitle);
 

```
* Step 2. Run `git apply .diff`
* Step 3. Create a `Mint tokens` action
* Step 4. Claim the tokens from the `Income` section in the `Total in and out` card
![Screenshot 2024-09-30 at 20 06 22](https://github.com/user-attachments/assets/c186a150-3275-44b7-9fb6-585ba3920810)
* Step 5. Notice the loading spinner and whether the `Activity feed` still flickers
* Step 6. Select the `CLNY` from the hamburger menu
![Screenshot 2024-09-30 at 20 08 00](https://github.com/user-attachments/assets/b6df62c7-e034-4e51-b065-261add08f3e4)
* Step 7. Hover over the bar chart and check if the error still appears

## Diffs

**New stuff** ✨

* Added `8.5` tailwind spacing variable

**Changes** 🏗

* Replaced usage of `ActionButton` with `Button` for the `ClaimFundsButton`
* Cherry-picked [3178](https://github.com/JoinColony/colonyCDapp/pull/3178) in this PR

## TODO

- [ ] Need to properly convert token to `CLNY` but this will be treated in a separate PR


Resolves #[3211](https://github.com/JoinColony/colonyCDapp/issues/3211)
Resolves #[3212](https://github.com/JoinColony/colonyCDapp/issues/3212)
