### PR TITLE
[Dashboard] Team switcher dropdown fixes

### DIFF
--- a/src/components/v5/shared/TeamFilter/partials/TeamsDropdown/TeamsDropdown.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamsDropdown/TeamsDropdown.tsx
@@ -57,7 +57,7 @@ const TeamsDropdown: FC<TeamsDropdownProps> = ({ domains }) => {
               key={`TeamsDropdown.${domain.nativeId}`}
               onClick={() => handleClick(domain)}
               aria-label={domain.metadata?.name} // Used to set the after content, which is used to pre-reserve the space required for the bold hover state
-              className="w-full text-start text-sm font-medium text-gray-700 after:invisible after:block after:h-0 after:overflow-hidden after:font-semibold after:content-[attr(aria-label)] hover:font-semibold hover:text-gray-900"
+              className="w-full text-start text-sm font-medium text-gray-700 bold-on-hover hover:text-gray-900"
             >
               {domain.metadata?.name}
             </button>

--- a/src/components/v5/shared/TeamFilter/partials/TeamsDropdown/TeamsDropdown.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamsDropdown/TeamsDropdown.tsx
@@ -56,7 +56,8 @@ const TeamsDropdown: FC<TeamsDropdownProps> = ({ domains }) => {
               type="button"
               key={`TeamsDropdown.${domain.nativeId}`}
               onClick={() => handleClick(domain)}
-              className="w-full text-start text-sm font-medium text-gray-700 hover:font-semibold hover:text-gray-900"
+              aria-label={domain.metadata?.name} // Used to set the after content, which is used to pre-reserve the space required for the bold hover state
+              className="w-full text-start text-sm font-medium text-gray-700 after:invisible after:block after:h-0 after:overflow-hidden after:font-semibold after:content-[attr(aria-label)] hover:font-semibold hover:text-gray-900"
             >
               {domain.metadata?.name}
             </button>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -266,6 +266,10 @@ module.exports = {
         '.no-scrollbar': {
           'scrollbar-width': 'none',
         },
+        '.bold-on-hover': {
+          '@apply after:invisible after:block after:h-0 after:overflow-hidden after:font-semibold after:content-[attr(aria-label)] hover:font-semibold':
+            {},
+        },
       });
       addComponents({
         '.inner': {


### PR DESCRIPTION
## Description

This PR addresses an issue where hovering over the team switcher dropdown items would cause the text font weight to change to bold, this would cause the container width to increase. This PR resolves this by adding an after pseudo element with the same text content set to bold to "pre-reserve" the necessary space for the bold text when hovered. It is hidden so shouldn't cause any accessibility concerns, but please raise in the comments if you see any issues with this approach.

## Testing

Shrink the screen width enough so that teams drop into the dropdown filter (or add new teams). Hover each of the items, ensure that the dropdown width does not increase when hovering the longest item.

https://github.com/user-attachments/assets/56c8a191-f28b-4653-a4ad-62fc147b7f13

## Diffs

**Changes** 🏗

* After pseudo element added to dropdown items

## TODO

The original issue also mentioned padding and gap issues, but comparing against figma it seems to line up perfectly already.

<img width="1403" alt="Screenshot 2024-09-30 at 17 25 30" src="https://github.com/user-attachments/assets/63cbff13-2ed3-4b58-a281-d2e6cc7a1f63">

Figma:

<img width="496" alt="Screenshot 2024-10-01 at 09 50 50" src="https://github.com/user-attachments/assets/3a64dfb8-a08f-4d3a-82d3-2551f965c9d0">

<img width="496" alt="Screenshot 2024-10-01 at 09 51 00" src="https://github.com/user-attachments/assets/85fed59a-8b74-4ee6-bcfc-58ba1344b410">

The font size and line heights are also correct. Let me know if I am missing something here.


Resolves #3215
