### PR TITLE
[Dashboard] Fix: Members / followers count

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/MembersInformation/MembersInformation.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/MembersInformation/MembersInformation.tsx
@@ -3,50 +3,24 @@ import { Link, useLocation } from 'react-router-dom';
 
 import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
 import { useMemberContext } from '~context/MemberContext/MemberContext.ts';
-import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
 import { COLONY_MEMBERS_ROUTE } from '~routes/index.ts';
-import { type Domain } from '~types/graphql.ts';
 import { formatText } from '~utils/intl.ts';
 import UserAvatars from '~v5/shared/UserAvatars/index.ts';
 
 const displayName =
   'v5.common.ColonyDashboardHeader.partials.MembersInformation';
 
-type EntityWithDomainNativeId = {
-  domain: Pick<Domain, 'nativeId'>;
-};
-
-const filterByDomainNativeId = (
-  entity: EntityWithDomainNativeId | null,
-  nativeDomainId: number,
-) => entity?.domain.nativeId === nativeDomainId;
-
 const MembersInformation = () => {
   const { search } = useLocation();
 
-  const selectedDomain = useGetSelectedDomainFilter();
-  const nativeDomainId = selectedDomain?.nativeId;
   const {
     loading: membersLoading,
-    filteredMembers,
+    totalContributors,
+    totalContributorCount,
     followersCount,
   } = useMemberContext();
 
-  const selectedMembers = nativeDomainId
-    ? filteredMembers.filter(
-        ({ roles, reputation }) =>
-          roles?.items?.find((role) =>
-            filterByDomainNativeId(role, nativeDomainId),
-          ) ||
-          reputation?.items?.find((rep) =>
-            filterByDomainNativeId(rep, nativeDomainId),
-          ),
-      )
-    : filteredMembers.filter(
-        ({ hasPermissions, hasReputation }) => hasPermissions || hasReputation,
-      );
-
-  const allMembers = selectedMembers.map((member) => ({
+  const allMembers = totalContributors.map((member) => ({
     walletAddress: member.contributorAddress,
     ...member.user,
   }));
@@ -69,7 +43,7 @@ const MembersInformation = () => {
           className="h-4 w-[70px] rounded"
         >
           <p>
-            <span className="font-semibold">{selectedMembers.length}</span>{' '}
+            <span className="font-semibold">{totalContributorCount}</span>{' '}
             {formatText({ id: 'colonyHome.members' })}
           </p>
         </LoadingSkeleton>


### PR DESCRIPTION
## Description

The members / followers count should always be Colony wide and not filter when a team is selected.

This PR removes the now redundant team filtering code from the MembersInformation component.

A "member" is any user who hasPermissions or hasReputation in the colony, referred to as a contributor in the members context just to make it nice and confusing. :)

<img width="251" alt="Screenshot 2024-10-01 at 10 00 10" src="https://github.com/user-attachments/assets/087e1872-b02a-4950-9904-8e91f4d0e318">

## Testing

* Step 1 - Open the dashboard, switch through the different teams, the member / follower count should not change.
* Step 2 - Create a new team
* Step 3 - Select the new team in the team switcher, the member / follower count should not change.

Further testing:

* Step 4 - Give permissions to a member who currently has no permissions. The member count should increase by 1. The follower count should not change.
* Step 5 - Switch to dev wallet 4, create a new user.
* Step 6 - Join the colony (use the listColonies query to get the invite code)
* Step 7 - The followers count should have increased by 1. The members count should not have changed.

## Diffs

**Deletions** ⚰️

* Team filtering code from MembersInformation component is gone!

Resolves #3217
