### PR TITLE
[Dashboard] fix: team filter CSS fixes

### DIFF
--- a/src/components/v5/common/ArrowScroller/ArrowScroller.tsx
+++ b/src/components/v5/common/ArrowScroller/ArrowScroller.tsx
@@ -79,7 +79,7 @@ const ArrowScroller: FC<ArrowScrollerProps> = ({
       {canScrollLeft && (
         <button
           type="button"
-          className="absolute left-0 top-0 h-full"
+          className="absolute left-0 top-0 z-10 h-full"
           onClick={scrollLeft}
         >
           {buttonLeftContent}
@@ -98,7 +98,7 @@ const ArrowScroller: FC<ArrowScrollerProps> = ({
       {canScrollRight && (
         <button
           type="button"
-          className="absolute right-0 top-0 h-full"
+          className="absolute right-0 top-0 z-10 h-full"
           onClick={scrollRight}
         >
           {buttonRightContent}

--- a/src/components/v5/shared/TeamFilter/partials/AllTeamsItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/AllTeamsItem.tsx
@@ -25,20 +25,22 @@ const AllTeamsItem: FC<AllTeamsItemProps> = ({ selected }) => {
     resetTeamFilter();
   };
 
+  const label = formatText(MSG.allTeams);
+
   return (
     <button
       type="button"
+      aria-label={label}
       className={clsx(
-        'inline-flex items-center rounded-l-lg border border-solid border-gray-200 px-4 py-2 text-sm',
+        'inline-flex items-center rounded-l-lg border border-solid border-gray-200 px-4 py-2 text-sm text-transparent bold-on-hover',
         {
-          'bg-base-white font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900':
-            !selected,
-          'bg-gray-50 font-semibold text-gray-900': selected,
+          'bg-base-white hover:bg-gray-50': !selected,
+          'bg-gray-50 after:font-semibold after:text-gray-900': selected,
         },
       )}
       onClick={handleClick}
     >
-      {formatText(MSG.allTeams)}
+      {label}
     </button>
   );
 };

--- a/src/components/v5/shared/TeamFilter/partials/AllTeamsItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/AllTeamsItem.tsx
@@ -16,9 +16,13 @@ const MSG = defineMessages({
 
 interface AllTeamsItemProps {
   selected: boolean;
+  hasDelimiter?: boolean;
 }
 
-const AllTeamsItem: FC<AllTeamsItemProps> = ({ selected }) => {
+const AllTeamsItem: FC<AllTeamsItemProps> = ({
+  selected,
+  hasDelimiter = true,
+}) => {
   const { resetTeamFilter } = useColonyFiltersContext();
 
   const handleClick = () => {
@@ -32,10 +36,11 @@ const AllTeamsItem: FC<AllTeamsItemProps> = ({ selected }) => {
       type="button"
       aria-label={label}
       className={clsx(
-        'inline-flex items-center rounded-l-lg border border-solid border-gray-200 px-4 py-2 text-sm text-transparent bold-on-hover',
+        'inline-flex items-center rounded-l-lg border-y border-l border-solid border-gray-200 px-4 py-2 text-sm text-transparent bold-on-hover',
         {
           'bg-base-white hover:bg-gray-50': !selected,
           'bg-gray-50 after:font-semibold after:text-gray-900': selected,
+          'border-r': hasDelimiter,
         },
       )}
       onClick={handleClick}

--- a/src/components/v5/shared/TeamFilter/partials/AllTeamsItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/AllTeamsItem.tsx
@@ -29,9 +29,10 @@ const AllTeamsItem: FC<AllTeamsItemProps> = ({ selected }) => {
     <button
       type="button"
       className={clsx(
-        'border-r border-solid border-gray-200 px-4 py-2 text-sm',
+        'inline-flex items-center rounded-l-lg border border-solid border-gray-200 px-4 py-2 text-sm',
         {
-          'bg-base-white font-medium text-gray-700': !selected,
+          'bg-base-white font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900':
+            !selected,
           'bg-gray-50 font-semibold text-gray-900': selected,
         },
       )}

--- a/src/components/v5/shared/TeamFilter/partials/CreateNewTeamItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/CreateNewTeamItem.tsx
@@ -21,7 +21,7 @@ const CreateNewTeamItem = () => {
   return (
     <button
       type="button"
-      className="border-gray-200 bg-base-white px-4 py-2 text-sm font-medium text-gray-400 hover:bg-gray-50 hover:text-gray-900"
+      className="border-d box-border inline-flex h-full items-center rounded-r-lg border-y border-r border-gray-200 bg-base-white px-4 py-2 text-sm font-medium text-gray-400 hover:bg-gray-50 hover:text-gray-900"
       onClick={handleClick}
     >
       <Plus size={18} />

--- a/src/components/v5/shared/TeamFilter/partials/DesktopTeamFilter/DesktopTeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/DesktopTeamFilter/DesktopTeamFilter.tsx
@@ -95,7 +95,7 @@ const DesktopTeamFilter = () => {
   }, [allDomains, overflowingItemIndex, selectedDomain]);
 
   return (
-    <div className="flex h-[34px] w-fit overflow-hidden whitespace-nowrap rounded-lg border border-solid border-gray-200">
+    <div className="flex h-[34px] w-fit overflow-hidden whitespace-nowrap">
       <AllTeamsItem selected={isAllTeamsFilterActive} />
       <div className="flex flex-wrap overflow-hidden" ref={containerRef}>
         {displayDomains.map((domain, index) => (
@@ -106,7 +106,7 @@ const DesktopTeamFilter = () => {
               }
             }}
             key={`teamFilter.${domain.id}`}
-            className={clsx('flex-1 flex-shrink-0', {
+            className={clsx('h-full flex-1 flex-shrink-0', {
               'pointer-events-none opacity-0':
                 overflowingItemIndex > -1 && index >= overflowingItemIndex,
             })}

--- a/src/components/v5/shared/TeamFilter/partials/DesktopTeamFilter/DesktopTeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/DesktopTeamFilter/DesktopTeamFilter.tsx
@@ -94,9 +94,21 @@ const DesktopTeamFilter = () => {
     });
   }, [allDomains, overflowingItemIndex, selectedDomain]);
 
+  const selectedDomainIndex = useMemo(
+    () =>
+      displayDomains.findIndex(
+        (domain) => selectedDomain?.nativeId === domain.nativeId,
+      ),
+    [selectedDomain, displayDomains],
+  );
+
   return (
     <div className="flex h-[34px] w-fit overflow-hidden whitespace-nowrap">
-      <AllTeamsItem selected={isAllTeamsFilterActive} />
+      <AllTeamsItem
+        selected={isAllTeamsFilterActive}
+        // The item should have a delimiter only if it is not the first one before the selected team
+        hasDelimiter={selectedDomainIndex !== 0}
+      />
       <div className="flex flex-wrap overflow-hidden" ref={containerRef}>
         {displayDomains.map((domain, index) => (
           <div
@@ -113,6 +125,8 @@ const DesktopTeamFilter = () => {
           >
             <TeamItem
               selected={selectedDomain?.nativeId === domain.nativeId}
+              // The item should have a delimiter only if it is not the first one before the selected team
+              hasDelimiter={index !== selectedDomainIndex - 1}
               domain={domain}
             />
           </div>

--- a/src/components/v5/shared/TeamFilter/partials/MobileTeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/MobileTeamFilter.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
@@ -19,7 +19,18 @@ const MobileTeamFilter = () => {
   } = useColonyContext();
   const selectedDomain = useGetSelectedDomainFilter();
 
-  const allDomains = domains?.items.filter(notMaybe) || [];
+  const allDomains = useMemo(
+    () => domains?.items.filter(notMaybe) || [],
+    [domains?.items],
+  );
+
+  const selectedDomainIndex = useMemo(
+    () =>
+      allDomains.findIndex(
+        (domain) => selectedDomain?.nativeId === domain.nativeId,
+      ),
+    [selectedDomain, allDomains],
+  );
 
   const leftButton = <LeftButton />;
   const rightButton = <RightButton />;
@@ -30,11 +41,17 @@ const MobileTeamFilter = () => {
       buttonLeftContent={leftButton}
       buttonRightContent={rightButton}
     >
-      <AllTeamsItem selected={selectedDomain === undefined} />
-      {allDomains.map((domain) => (
+      <AllTeamsItem
+        selected={selectedDomain === undefined}
+        // The item should have a delimiter only if it is not the first one before the selected team
+        hasDelimiter={selectedDomainIndex !== 0}
+      />
+      {allDomains.map((domain, index) => (
         <TeamItem
           key={`teamFilter.${domain.id}`}
           selected={selectedDomain?.nativeId === domain.nativeId}
+          // The item should have a delimiter only if it is not the first one before the selected team
+          hasDelimiter={index !== selectedDomainIndex - 1}
           domain={domain}
         />
       ))}

--- a/src/components/v5/shared/TeamFilter/partials/MobileTeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/MobileTeamFilter.tsx
@@ -26,7 +26,7 @@ const MobileTeamFilter = () => {
 
   return (
     <ArrowScroller
-      className="flex w-fit whitespace-nowrap rounded-lg border border-solid border-gray-200"
+      className="flex h-[34px] w-fit whitespace-nowrap rounded-lg no-scrollbar"
       buttonLeftContent={leftButton}
       buttonRightContent={rightButton}
     >

--- a/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
@@ -45,12 +45,12 @@ const TeamItem: FC<TeamItemProps> = ({ domain, selected }) => {
       ref={teamItemRef}
       type="button"
       className={clsx(
-        'w-full bg-base-white px-4 py-2 text-sm',
+        'box-border inline-flex h-full w-full items-center justify-center border-y border-r border-solid bg-base-white px-4 py-2 text-sm',
         selected ? teamColor : null,
         {
-          'border-r border-solid border-gray-200 font-medium text-gray-700':
+          'border-gray-200 font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900':
             !selected,
-          'border-0 font-semibold text-base-white': selected,
+          'border-transparent font-semibold text-base-white': selected,
         },
       )}
       onClick={handleClick}

--- a/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
@@ -40,22 +40,25 @@ const TeamItem: FC<TeamItemProps> = ({ domain, selected }) => {
     }
   };
 
+  const label = domain.metadata?.name ?? domain.id;
+
   return (
     <button
       ref={teamItemRef}
       type="button"
+      aria-label={label}
       className={clsx(
-        'box-border inline-flex h-full w-full items-center justify-center border-y border-r border-solid bg-base-white px-4 py-2 text-sm',
+        'box-border inline-flex h-full w-full items-center justify-center border-y border-r border-solid bg-base-white px-4 py-2 text-sm text-transparent bold-on-hover',
         selected ? teamColor : null,
         {
-          'border-gray-200 font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900':
-            !selected,
-          'border-transparent font-semibold text-base-white': selected,
+          'border-gray-200 font-medium hover:bg-gray-50': !selected,
+          'border-transparent after:font-semibold after:text-base-white hover:after:text-base-white':
+            selected,
         },
       )}
       onClick={handleClick}
     >
-      {domain.metadata?.name ?? domain.id}
+      {label}
     </button>
   );
 };

--- a/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
@@ -11,10 +11,15 @@ const displayName = 'v5.shared.TeamFilter.partials.TeamItem';
 
 interface TeamItemProps {
   selected: boolean;
+  hasDelimiter?: boolean;
   domain: Domain;
 }
 
-const TeamItem: FC<TeamItemProps> = ({ domain, selected }) => {
+const TeamItem: FC<TeamItemProps> = ({
+  domain,
+  selected,
+  hasDelimiter = true,
+}) => {
   const { ref: teamItemRef, scroll } = useScrollIntoView<HTMLButtonElement>();
   const isMobile = useMobile();
   const { updateTeamFilter, resetTeamFilter } = useColonyFiltersContext();
@@ -48,12 +53,13 @@ const TeamItem: FC<TeamItemProps> = ({ domain, selected }) => {
       type="button"
       aria-label={label}
       className={clsx(
-        'box-border inline-flex h-full w-full items-center justify-center border-y border-r border-solid bg-base-white px-4 py-2 text-sm text-transparent bold-on-hover',
+        'box-border inline-flex h-full w-full items-center justify-center border-y border-solid bg-base-white px-4 py-2 text-sm text-transparent bold-on-hover',
         selected ? teamColor : null,
         {
           'border-gray-200 font-medium hover:bg-gray-50': !selected,
-          'border-transparent after:font-semibold after:text-base-white hover:after:text-base-white':
+          'border-l border-transparent after:font-semibold after:text-base-white hover:after:text-base-white':
             selected,
+          'border-r': hasDelimiter,
         },
       )}
       onClick={handleClick}

--- a/src/components/v5/shared/TeamFilter/partials/TeamsDropdown/TeamsDropdown.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamsDropdown/TeamsDropdown.tsx
@@ -39,7 +39,7 @@ const TeamsDropdown: FC<TeamsDropdownProps> = ({ domains }) => {
         type="button"
         ref={setTriggerRef}
         className={clsx(
-          'h-full border-r border-gray-200 bg-base-white px-4 py-2 text-gray-700 hover:bg-gray-50',
+          'h-full border-y border-r border-gray-200 bg-base-white px-4 py-2 text-gray-700 hover:bg-gray-50',
           { 'bg-gray-50': visible },
         )}
       >

--- a/src/components/v5/shared/TeamFilter/partials/TeamsDropdown/TeamsDropdown.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamsDropdown/TeamsDropdown.tsx
@@ -49,7 +49,7 @@ const TeamsDropdown: FC<TeamsDropdownProps> = ({ domains }) => {
         <div
           ref={setTooltipRef}
           {...getTooltipProps()}
-          className="z-base flex flex-col gap-2 rounded-b-lg border-b border-l border-r border-gray-200 bg-base-white px-4 py-2"
+          className="z-base flex flex-col gap-2 rounded-b-lg border-b border-l border-r border-gray-200 bg-base-white py-2"
         >
           {domains.map((domain) => (
             <button
@@ -57,7 +57,7 @@ const TeamsDropdown: FC<TeamsDropdownProps> = ({ domains }) => {
               key={`TeamsDropdown.${domain.nativeId}`}
               onClick={() => handleClick(domain)}
               aria-label={domain.metadata?.name} // Used to set the after content, which is used to pre-reserve the space required for the bold hover state
-              className="w-full text-start text-sm font-medium text-gray-700 bold-on-hover hover:text-gray-900"
+              className="mx-4 w-full text-start text-sm text-transparent bold-on-hover"
             >
               {domain.metadata?.name}
             </button>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -267,10 +267,13 @@ module.exports = {
         '.no-scrollbar': {
           'scrollbar-width': 'none',
         },
+        '.no-scrollbar::-webkit-scrollbar': {
+          display: 'none',
+        },
         '.bold-on-hover': {
           '@apply after:invisible after:block after:h-0 after:overflow-hidden after:font-semibold after:content-[attr(aria-label)] hover:font-semibold':
             {},
-        },
+        }
       });
       addComponents({
         '.inner': {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -271,7 +271,7 @@ module.exports = {
           display: 'none',
         },
         '.bold-on-hover': {
-          '@apply after:invisible after:block after:h-0 after:overflow-hidden after:font-semibold after:content-[attr(aria-label)] hover:font-semibold':
+          '@apply relative after:w-full after:h-4.5 after:z-base after:block after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:overflow-hidden after:text-gray-700 hover:after:text-gray-900 after:font-medium hover:after:font-semibold after:content-[attr(aria-label)]':
             {},
         }
       });


### PR DESCRIPTION
## Description

Just a bunch of CSS fixes :melting_face: 
Basically I had to make all the team items border boxes, because in Figma the border is on the inside, so it was either that or make all things 2px less tall and paddings 1px less, which would be a hassle.
Likewise, the parent item doesn't control the outer border anymore, but it's composed from the children, because we need to display a full size background when a team is selected (border included).

## Testing

Go over the cases covered in #3214 and see if it works now! Additionally make sure that hovering on desktop doesn't enlarge the item.

## Diffs

**Changes** 🏗

* All filter items are full height flex align center items with their own border
* Added hover effects to All teams and unselected domain items

Resolves  #3214 
