### PR TITLE
[Dashboard] Recent activity table fixes

### DIFF
--- a/src/components/common/ColonyActionsTable/RecentActivityTable.tsx
+++ b/src/components/common/ColonyActionsTable/RecentActivityTable.tsx
@@ -24,7 +24,6 @@ const RecentActivityTable: FC<ColonyActionsTableProps> = ({ ...props }) => {
   const { tableProps, renderSubComponent } = useActionsTableProps({
     ...props,
     showUserAvatar: false,
-    hasHorizontalPadding: true,
     showTotalPagesNumber: !loadingActionsCount,
     isRecentActivityVariant: true,
   });
@@ -34,7 +33,6 @@ const RecentActivityTable: FC<ColonyActionsTableProps> = ({ ...props }) => {
       {...tableProps}
       showTableHead={false}
       showTableBorder={false}
-      hasHorizontalPadding
       renderSubComponent={renderSubComponent}
       pageCount={pageCount}
       withBorder={false}

--- a/src/components/common/ColonyActionsTable/RecentActivityTable.tsx
+++ b/src/components/common/ColonyActionsTable/RecentActivityTable.tsx
@@ -24,7 +24,7 @@ const RecentActivityTable: FC<ColonyActionsTableProps> = ({ ...props }) => {
   const { tableProps, renderSubComponent } = useActionsTableProps({
     ...props,
     showUserAvatar: false,
-    hasHorizontalPadding: false,
+    hasHorizontalPadding: true,
     showTotalPagesNumber: !loadingActionsCount,
     isRecentActivityVariant: true,
   });
@@ -33,10 +33,12 @@ const RecentActivityTable: FC<ColonyActionsTableProps> = ({ ...props }) => {
     <Table<ColonyAction>
       {...tableProps}
       showTableHead={false}
-      showBorder={false}
-      hasHorizontalPadding={false}
+      showTableBorder={false}
+      hasHorizontalPadding
       renderSubComponent={renderSubComponent}
       pageCount={pageCount}
+      withBorder={false}
+      withNarrowBorder
     />
   );
 };

--- a/src/components/common/ColonyActionsTable/RecentActivityTable.tsx
+++ b/src/components/common/ColonyActionsTable/RecentActivityTable.tsx
@@ -37,6 +37,8 @@ const RecentActivityTable: FC<ColonyActionsTableProps> = ({ ...props }) => {
       pageCount={pageCount}
       withBorder={false}
       withNarrowBorder
+      alwaysShowPagination={totalActions > 0}
+      showTotalPagesNumber={pageCount > 1}
     />
   );
 };

--- a/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
@@ -44,7 +44,6 @@ export const useActionsTableProps = (
     additionalPaginationButtonsContent,
     showTotalPagesNumber,
     showUserAvatar,
-    hasHorizontalPadding,
     isRecentActivityVariant,
     ...rest
   } = props;
@@ -70,7 +69,6 @@ export const useActionsTableProps = (
     loadingMotionStates,
     refetchMotionStates,
     showUserAvatar,
-    hasHorizontalPadding,
   });
   const {
     actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
@@ -141,14 +139,10 @@ export const useActionsTableProps = (
     {
       className: clsx(
         className,
-        'sm:[&_td]:pr-[1.125rem] sm:[&_th:not(:first-child)]:pl-0 sm:[&_th]:pr-[1.125rem]',
+        'sm:[&_td:first-child]:pl-[1.125rem] sm:[&_td]:pr-[1.125rem] sm:[&_th:first-child]:pl-[1.125rem] sm:[&_th:not(:first-child)]:pl-0 sm:[&_th]:pr-[1.125rem]',
         {
           'sm:[&_td]:h-[66px]': isRecentActivityVariant,
           'sm:[&_td]:h-[70px]': !isRecentActivityVariant,
-          'sm:[&_td:first-child]:pl-[1.125rem] sm:[&_th:first-child]:pl-[1.125rem]':
-            hasHorizontalPadding,
-          'sm:[&_td:first-child]:pl-0 [&_td:first-child_div]:pl-0 sm:[&_td:last-child]:pr-0 [&_td:last-child_div]:pr-0 sm:[&_th:first-child]:pl-0 sm:[&_th:last-child]:pr-0 [&_th:last-child_div]:pr-0':
-            !hasHorizontalPadding,
           'sm:[&_tr:hover]:bg-gray-25': data.length > 0 && !loading,
         },
       ),

--- a/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
@@ -141,8 +141,10 @@ export const useActionsTableProps = (
     {
       className: clsx(
         className,
-        'sm:[&_td]:h-[70px] sm:[&_td]:pr-[1.125rem] sm:[&_th:not(:first-child)]:pl-0 sm:[&_th]:pr-[1.125rem]',
+        'sm:[&_td]:pr-[1.125rem] sm:[&_th:not(:first-child)]:pl-0 sm:[&_th]:pr-[1.125rem]',
         {
+          'sm:[&_td]:h-[66px]': isRecentActivityVariant,
+          'sm:[&_td]:h-[70px]': !isRecentActivityVariant,
           'sm:[&_td:first-child]:pl-[1.125rem] sm:[&_th:first-child]:pl-[1.125rem]':
             hasHorizontalPadding,
           'sm:[&_td:first-child]:pl-0 [&_td:first-child_div]:pl-0 sm:[&_td:last-child]:pr-0 [&_td:last-child_div]:pr-0 sm:[&_th:first-child]:pl-0 sm:[&_th:last-child]:pr-0 [&_th:last-child_div]:pr-0':

--- a/src/components/common/ColonyActionsTable/hooks/useColonyActionsTableColumns.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useColonyActionsTableColumns.tsx
@@ -27,7 +27,6 @@ const useColonyActionsTableColumns = ({
   loadingMotionStates,
   refetchMotionStates,
   showUserAvatar = true,
-  hasHorizontalPadding = true,
 }) => {
   const isMobile = useMobile();
 
@@ -102,12 +101,7 @@ const useColonyActionsTableColumns = ({
         },
       }),
       helper.accessor('motionState', {
-        staticSize: (() => {
-          if (isMobile) {
-            return hasHorizontalPadding ? '7.4375rem' : '7rem';
-          }
-          return '6.25rem';
-        })(),
+        staticSize: isMobile ? '7.4375rem' : '6.25rem',
         header: formatText({
           id: 'activityFeedTable.table.header.status',
         }),
@@ -131,7 +125,7 @@ const useColonyActionsTableColumns = ({
       }),
       helper.display({
         id: 'expander',
-        staticSize: hasHorizontalPadding ? '2.25rem' : '1rem',
+        staticSize: '2.25rem',
         header: () => null,
         enableSorting: false,
         cell: ({ row: { getIsExpanded, toggleExpanded } }) => {
@@ -154,7 +148,6 @@ const useColonyActionsTableColumns = ({
     loading,
     loadingMotionStates,
     refetchMotionStates,
-    hasHorizontalPadding,
     showUserAvatar,
   ]);
 };

--- a/src/components/common/ColonyActionsTable/types.ts
+++ b/src/components/common/ColonyActionsTable/types.ts
@@ -6,6 +6,5 @@ export interface ColonyActionsTableProps
   pageSize?: number;
   withHeader?: boolean;
   showUserAvatar?: boolean;
-  hasHorizontalPadding?: boolean;
   isRecentActivityVariant?: boolean;
 }

--- a/src/components/frame/v5/pages/ActivityPage/ActivityPage.tsx
+++ b/src/components/frame/v5/pages/ActivityPage/ActivityPage.tsx
@@ -23,7 +23,7 @@ const ActivityPage: FC = () => {
         <div>
           <FiltersContextProvider>
             <ColonyActionsTable
-              className="[&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none"
+              className="pb-4 [&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none"
               showTotalPagesNumber={false}
               hasHorizontalPadding
             />

--- a/src/components/frame/v5/pages/ActivityPage/ActivityPage.tsx
+++ b/src/components/frame/v5/pages/ActivityPage/ActivityPage.tsx
@@ -25,7 +25,6 @@ const ActivityPage: FC = () => {
             <ColonyActionsTable
               className="pb-4 [&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none"
               showTotalPagesNumber={false}
-              hasHorizontalPadding
             />
           </FiltersContextProvider>
         </div>

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -9,7 +9,11 @@ import { Action } from '~constants/actions.ts';
 import { useAdditionalFormOptionsContext } from '~context/AdditionalFormOptionsContext/AdditionalFormOptionsContext.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
-import { GetDomainBalanceDocument, SearchActionsDocument } from '~gql';
+import {
+  GetDomainBalanceDocument,
+  GetTotalColonyActionsDocument,
+  SearchActionsDocument,
+} from '~gql';
 import useToggle from '~hooks/useToggle/index.ts';
 import { ActionForm } from '~shared/Fields/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
@@ -258,6 +262,12 @@ const ActionSidebarContent: FC<ActionSidebarContentProps> = ({
             if (isQueryActive('SearchActions')) {
               client.refetchQueries({
                 include: [SearchActionsDocument],
+              });
+            }
+
+            if (isQueryActive('GetTotalColonyActions')) {
+              client.refetchQueries({
+                include: [GetTotalColonyActionsDocument],
               });
             }
             /**

--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -50,6 +50,7 @@ const Table = <T,>({
   tableBodyRowKeyProp,
   showTableHead = true,
   showTableBorder = true,
+  alwaysShowPagination = false,
   ...rest
 }: TableProps<T>) => {
   const helper = useMemo(() => createColumnHelper<T>(), []);
@@ -436,7 +437,7 @@ const Table = <T,>({
           </tfoot>
         )}
       </table>
-      {hasPagination &&
+      {(hasPagination || alwaysShowPagination) &&
         showPageNumber &&
         (canGoToPreviousPage || canGoToNextPage) && (
           <TablePagination
@@ -452,7 +453,7 @@ const Table = <T,>({
               },
               {
                 actualPage: table.getState().pagination.pageIndex + 1,
-                pageNumber: table.getPageCount(),
+                pageNumber: pageCount === 0 ? 1 : pageCount,
               },
             )}
             disabled={paginationDisabled}
@@ -460,6 +461,28 @@ const Table = <T,>({
             {additionalPaginationButtonsContent}
           </TablePagination>
         )}
+      {alwaysShowPagination && !hasPagination && (
+        <TablePagination
+          onNextClick={() => {}}
+          onPrevClick={() => {}}
+          canGoToNextPage
+          canGoToPreviousPage={false}
+          pageNumberLabel={formatText(
+            {
+              id: showTotalPagesNumber
+                ? 'table.pageNumberWithTotal'
+                : 'table.pageNumber',
+            },
+            {
+              actualPage: 1,
+              pageNumber: 1,
+            },
+          )}
+          disabled
+        >
+          {additionalPaginationButtonsContent}
+        </TablePagination>
+      )}
     </div>
   );
 };

--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -42,13 +42,14 @@ const Table = <T,>({
   renderSubComponent,
   getRowCanExpand,
   withBorder = true,
+  withNarrowBorder = false,
   isDisabled = false,
   verticalLayout,
   virtualizedProps,
   tableClassName,
   tableBodyRowKeyProp,
   showTableHead = true,
-  showBorder = true,
+  showTableBorder = true,
   hasHorizontalPadding = true,
   ...rest
 }: TableProps<T>) => {
@@ -115,7 +116,7 @@ const Table = <T,>({
           'h-px w-full table-fixed',
           {
             'border-separate border-spacing-0 rounded-lg border border-gray-200':
-              showBorder,
+              showTableBorder,
           },
           tableClassName,
         )}
@@ -316,10 +317,14 @@ const Table = <T,>({
                         itemHeight={virtualizedProps?.virtualizedRowHeight || 0}
                         isEnabled={!!virtualizedProps}
                         className={clsx(getRowClassName(row), {
+                          '[&:not(:first-child)]:after:absolute [&:not(:first-child)]:after:left-4 [&:not(:first-child)]:after:top-0 [&:not(:first-child)]:after:w-[calc(100%-2rem)] [&:not(:first-child)]:after:border-b [&:not(:first-child)]:after:border-gray-100':
+                            withNarrowBorder,
                           'translate-z-0 relative [&>tr:first-child>td]:pr-9 [&>tr:last-child>td]:p-0 [&>tr:last-child>th]:p-0':
                             getMenuProps,
                           '[&:not(:last-child)>td]:border-b [&:not(:last-child)>td]:border-gray-100':
-                            (!showExpandableContent && row.getCanExpand()) ||
+                            (!showExpandableContent &&
+                              row.getCanExpand() &&
+                              !withNarrowBorder) ||
                             withBorder,
                           'expanded-below': showExpandableContent,
                         })}
@@ -389,7 +394,12 @@ const Table = <T,>({
                         })}
                       </TableRow>
                       {showExpandableContent && (
-                        <tr className="[&:not(:last-child)>td]:border-b [&:not(:last-child)>td]:border-gray-100">
+                        <tr
+                          className={clsx({
+                            '[&:not(:last-child)>td]:border-b [&:not(:last-child)>td]:border-gray-100':
+                              !withNarrowBorder,
+                          })}
+                        >
                           <td colSpan={row.getVisibleCells().length}>
                             {renderSubComponent({ row })}
                           </td>

--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -50,7 +50,6 @@ const Table = <T,>({
   tableBodyRowKeyProp,
   showTableHead = true,
   showTableBorder = true,
-  hasHorizontalPadding = true,
   ...rest
 }: TableProps<T>) => {
   const helper = useMemo(() => createColumnHelper<T>(), []);
@@ -457,7 +456,6 @@ const Table = <T,>({
               },
             )}
             disabled={paginationDisabled}
-            hasHorizontalPadding={hasHorizontalPadding}
           >
             {additionalPaginationButtonsContent}
           </TablePagination>

--- a/src/components/v5/common/Table/partials/TablePagination/TablePagination.tsx
+++ b/src/components/v5/common/Table/partials/TablePagination/TablePagination.tsx
@@ -14,7 +14,6 @@ const TablePagination: FC<PropsWithChildren<TablePaginationProps>> = ({
   canGoToNextPage,
   canGoToPreviousPage,
   disabled,
-  hasHorizontalPadding = true,
   children,
 }) => {
   const isMobile = useMobile();
@@ -24,11 +23,13 @@ const TablePagination: FC<PropsWithChildren<TablePaginationProps>> = ({
     canGoToPreviousPage || (children && !isMobile);
   return (
     <div
-      className={clsx('grid grid-cols-[1fr_auto_1fr] items-center gap-2 pt-2', {
-        'px-[1.125rem]': hasHorizontalPadding,
-        'sm:grid-cols-[1fr_auto_auto]': canGoNextOrAdditionalContentOnMobile,
-        'sm:grid-cols-[1fr_auto]': !canGoNextOrAdditionalContentOnMobile,
-      })}
+      className={clsx(
+        'grid grid-cols-[1fr_auto_1fr] items-center gap-2 px-[1.125rem] pt-2',
+        {
+          'sm:grid-cols-[1fr_auto_auto]': canGoNextOrAdditionalContentOnMobile,
+          'sm:grid-cols-[1fr_auto]': !canGoNextOrAdditionalContentOnMobile,
+        },
+      )}
     >
       {canGoPreviousOrAdditionalContentOnDesktop && (
         <div className="col-start-1 row-start-1 flex items-center justify-start gap-3 sm:col-start-2">

--- a/src/components/v5/common/Table/partials/TablePagination/TablePagination.tsx
+++ b/src/components/v5/common/Table/partials/TablePagination/TablePagination.tsx
@@ -24,14 +24,11 @@ const TablePagination: FC<PropsWithChildren<TablePaginationProps>> = ({
     canGoToPreviousPage || (children && !isMobile);
   return (
     <div
-      className={clsx(
-        'grid grid-cols-[1fr_auto_1fr] items-center gap-2 pb-[1.4375rem] pt-2',
-        {
-          'px-[1.125rem]': hasHorizontalPadding,
-          'sm:grid-cols-[1fr_auto_auto]': canGoNextOrAdditionalContentOnMobile,
-          'sm:grid-cols-[1fr_auto]': !canGoNextOrAdditionalContentOnMobile,
-        },
-      )}
+      className={clsx('grid grid-cols-[1fr_auto_1fr] items-center gap-2 pt-2', {
+        'px-[1.125rem]': hasHorizontalPadding,
+        'sm:grid-cols-[1fr_auto_auto]': canGoNextOrAdditionalContentOnMobile,
+        'sm:grid-cols-[1fr_auto]': !canGoNextOrAdditionalContentOnMobile,
+      })}
     >
       {canGoPreviousOrAdditionalContentOnDesktop && (
         <div className="col-start-1 row-start-1 flex items-center justify-start gap-3 sm:col-start-2">

--- a/src/components/v5/common/Table/partials/TablePagination/types.ts
+++ b/src/components/v5/common/Table/partials/TablePagination/types.ts
@@ -5,5 +5,4 @@ export interface TablePaginationProps {
   canGoToPreviousPage?: boolean;
   canGoToNextPage?: boolean;
   disabled?: boolean;
-  hasHorizontalPadding?: boolean;
 }

--- a/src/components/v5/common/Table/types.ts
+++ b/src/components/v5/common/Table/types.ts
@@ -46,5 +46,4 @@ export interface TableProps<T>
   tableBodyRowKeyProp?: Extract<keyof T, React.Key>;
   showTableHead?: boolean;
   showTableBorder?: boolean;
-  hasHorizontalPadding?: boolean;
 }

--- a/src/components/v5/common/Table/types.ts
+++ b/src/components/v5/common/Table/types.ts
@@ -37,6 +37,7 @@ export interface TableProps<T>
   renderSubComponent?: (props: { row: Row<T> }) => React.ReactElement;
   getRowCanExpand?: (row: Row<T>) => boolean;
   withBorder?: boolean;
+  withNarrowBorder?: boolean;
   isDisabled?: boolean;
   virtualizedProps?: {
     virtualizedRowHeight?: number;
@@ -44,6 +45,6 @@ export interface TableProps<T>
   tableClassName?: string;
   tableBodyRowKeyProp?: Extract<keyof T, React.Key>;
   showTableHead?: boolean;
-  showBorder?: boolean;
+  showTableBorder?: boolean;
   hasHorizontalPadding?: boolean;
 }

--- a/src/components/v5/common/Table/types.ts
+++ b/src/components/v5/common/Table/types.ts
@@ -46,4 +46,5 @@ export interface TableProps<T>
   tableBodyRowKeyProp?: Extract<keyof T, React.Key>;
   showTableHead?: boolean;
   showTableBorder?: boolean;
+  alwaysShowPagination?: boolean;
 }

--- a/src/components/v5/frame/ColonyHome/ColonyHome.tsx
+++ b/src/components/v5/frame/ColonyHome/ColonyHome.tsx
@@ -24,7 +24,7 @@ const ColonyHome = () => {
   const isMobile = useMobile();
 
   return (
-    <div className="md:gap-4.5 flex flex-col gap-6">
+    <div className="flex flex-col gap-6 sm:min-h-full md:gap-4.5">
       <div className="flex flex-col gap-9 sm:gap-6">
         <DashboardHeader />
         <TeamFilter />
@@ -36,8 +36,8 @@ const ColonyHome = () => {
           <ReputationChart />
         </div>
       </div>
-      <div className="rounded-lg border border-gray-200 px-5">
-        <div className="flex justify-between py-6">
+      <div className="mb-4 flex-grow rounded-lg border border-gray-200 px-5 pb-[1.4375rem] sm:max-h-[37.625rem]">
+        <div className="flex justify-between pb-[11px] pt-6">
           <h3 className="heading-5">
             {formatText({ id: 'dashboard.recentActivity' })}
           </h3>
@@ -50,7 +50,7 @@ const ColonyHome = () => {
         </div>
         <FiltersContextProvider>
           <RecentActivityTable
-            className="w-full [&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none [&_tr:last-child_td>*:not(.expandable)]:!py-[.9375rem] [&_tr:not(last-child)_td>*:not(.expandable)]:!pb-[.875rem] [&_tr:not(last-child)_td>*:not(.expandable)]:!pt-[.9375rem]"
+            className="w-full [&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none [&_tr:last-child_td>*:not(.expandable)]:!py-[13px] [&_tr:not(last-child)_td>*:not(.expandable)]:!pb-[13px] [&_tr:not(last-child)_td>*:not(.expandable)]:!pt-[13px]"
             pageSize={7}
             state={{
               columnVisibility: isMobile

--- a/src/components/v5/frame/ColonyHome/ColonyHome.tsx
+++ b/src/components/v5/frame/ColonyHome/ColonyHome.tsx
@@ -36,8 +36,8 @@ const ColonyHome = () => {
           <ReputationChart />
         </div>
       </div>
-      <div className="mb-4 flex-grow rounded-lg border border-gray-200 px-5 pb-[1.4375rem] sm:max-h-[37.625rem]">
-        <div className="flex justify-between pb-[11px] pt-6">
+      <div className="mb-4 flex-grow rounded-lg border border-gray-200 pb-[1.4375rem] sm:max-h-[37.625rem]">
+        <div className="flex justify-between px-5 pb-[11px] pt-6">
           <h3 className="heading-5">
             {formatText({ id: 'dashboard.recentActivity' })}
           </h3>

--- a/src/components/v5/frame/ColonyHome/ColonyHome.tsx
+++ b/src/components/v5/frame/ColonyHome/ColonyHome.tsx
@@ -36,7 +36,7 @@ const ColonyHome = () => {
           <ReputationChart />
         </div>
       </div>
-      <div className="mb-4 flex-grow rounded-lg border border-gray-200 pb-[1.4375rem] sm:max-h-[37.625rem]">
+      <div className="mb-4 flex flex-grow flex-col rounded-lg border border-gray-200 pb-[1.4375rem] sm:max-h-[37.625rem]">
         <div className="flex justify-between px-5 pb-[11px] pt-6">
           <h3 className="heading-5">
             {formatText({ id: 'dashboard.recentActivity' })}
@@ -50,7 +50,7 @@ const ColonyHome = () => {
         </div>
         <FiltersContextProvider>
           <RecentActivityTable
-            className="w-full [&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none [&_tr:last-child_td>*:not(.expandable)]:!py-[13px] [&_tr:not(last-child)_td>*:not(.expandable)]:!pb-[13px] [&_tr:not(last-child)_td>*:not(.expandable)]:!pt-[13px]"
+            className="flex w-full flex-grow flex-col justify-between [&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none [&_tr:last-child_td>*:not(.expandable)]:!py-[13px] [&_tr:not(last-child)_td>*:not(.expandable)]:!pb-[13px] [&_tr:not(last-child)_td>*:not(.expandable)]:!pt-[13px]"
             pageSize={7}
             state={{
               columnVisibility: isMobile

--- a/src/components/v5/frame/PageLayout/PageLayout.tsx
+++ b/src/components/v5/frame/PageLayout/PageLayout.tsx
@@ -7,10 +7,8 @@ import { ToastContainer } from 'react-toastify';
 
 import { CSSCustomVariable } from '~constants/cssCustomVariables.ts';
 import { usePageHeadingContext } from '~context/PageHeadingContext/PageHeadingContext.ts';
-import { useTablet } from '~hooks';
 import { useHeightResizeObserver } from '~hooks/useHeightResizeObserver.ts';
 import CloseButton from '~shared/Extensions/Toast/partials/CloseButton.tsx';
-import Breadcrumbs from '~v5/shared/Breadcrumbs/Breadcrumbs.tsx';
 
 import PageHeader from './partials/PageHeader/PageHeader.tsx';
 import { type PageLayoutProps } from './types.ts';
@@ -25,8 +23,6 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
   children,
   enableMobileAndDesktopLayoutBreakpoints,
 }) => {
-  const isTablet = useTablet();
-
   const { title: pageTitle } = usePageHeadingContext();
 
   const topContentContainerRef = useRef<HTMLDivElement | null>(null);
@@ -67,7 +63,7 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
             </section>
             <section
               className={clsx(
-                'modal-blur w-full overflow-auto px-6 md:p-8 md:pt-2',
+                'modal-blur h-full w-full overflow-auto px-6 md:p-8 md:pb-0 md:pt-2',
                 {
                   'md:!pt-[1.125rem]': !pageTitle,
                 },
@@ -75,7 +71,7 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
             >
               <div
                 className={clsx(
-                  'mx-auto max-w-[79.875rem] pb-4 pt-6 md:pt-0',
+                  'mx-auto h-full max-w-[79.875rem] pt-6 md:pt-0',
                   {
                     '!pt-0': enableMobileAndDesktopLayoutBreakpoints,
                   },


### PR DESCRIPTION
## Description

This PR implements many UI changes to address the following 3 issues with the recent activity table.

1. When there are not enough items for there to be more than 1 page, the recent activity table should go as tall as it can until it either fills the bottom of the dashboard area, or reaches the max height it would be with 7 items.

2. The spacing between the table title and the first row was too large.

3. The hover background colour change did not extend to the full width of the table.

## Testing

* Step 1 - Create a new colony using `node scripts/create-colony-url.js`
* Step 2 - Create any action so that at least one appears in the recent activity table.
* Step 3 - Check the table extends to the bottom of the dashboard on desktop and tablet. Figma: https://www.figma.com/design/gac6xVgGNCAge5Bia933dp/Dashboard?node-id=4855-9086&t=befcDDV3DG5JSRM9-4

<img width="1728" alt="Screenshot 2024-10-02 at 09 18 46" src="https://github.com/user-attachments/assets/81a128e2-5323-46a4-81ad-d2ad52f38c60">

<img width="577" alt="Screenshot 2024-10-02 at 09 19 35" src="https://github.com/user-attachments/assets/5b64e4b7-7506-4dd8-9bf0-943d827b863b">

* Step 4 - On a tall screen, the table should extend no taller than the maximum height it would be if it had 7 items (if you really want to check the height matches, open planex in another tab and switch between the two to check the height)

<img width="875" alt="Screenshot 2024-10-02 at 09 19 10" src="https://github.com/user-attachments/assets/16c93f79-a7ae-47db-93b3-c056231bea3f">

* Step 5 - On mobile, check the table does not add any extra height. Figma: https://www.figma.com/design/gac6xVgGNCAge5Bia933dp/Dashboard?node-id=4855-10880&t=befcDDV3DG5JSRM9-4
 
<img width="392" alt="Screenshot 2024-10-02 at 09 19 59" src="https://github.com/user-attachments/assets/1bce8327-360e-434b-8721-ed3660ced20e">

* Step 6 - Check the full activity feed is unaffected.

<img width="1728" alt="Screenshot 2024-10-02 at 09 23 20" src="https://github.com/user-attachments/assets/165c9129-011b-4e0b-9207-8b861ccbee71">

* Step 7 - On a colony with many items, check the recent activity table and full activity table are unaffected.

<img width="1728" alt="Screenshot 2024-10-02 at 09 23 04" src="https://github.com/user-attachments/assets/b34fd51c-453f-493b-8943-62f4ac371fe7">

* Step 8 - And finally check the hover state extends to the full edge of the table. Figma: https://www.figma.com/design/gac6xVgGNCAge5Bia933dp/Dashboard?node-id=6899-48936&t=befcDDV3DG5JSRM9-4

<img width="1078" alt="Screenshot 2024-10-02 at 09 21 38" src="https://github.com/user-attachments/assets/1193d443-da4f-418a-9e3c-ce68e76fb568">

* Step 9 - And check the space between the table title and the top of the first row text is 24px. (11px padding-bottom on the title + 13px padding-top on the row)

<img width="1481" alt="Screenshot 2024-10-02 at 09 21 56" src="https://github.com/user-attachments/assets/55dafd7e-2bd9-4887-8b18-f70b988176d8">

<img width="1485" alt="Screenshot 2024-10-02 at 09 22 16" src="https://github.com/user-attachments/assets/726fe63b-01eb-4d21-af41-b2c066dc1f63">

I also had to add flex and min-h-full to some of the page layout components, so check this hasn't broken any other pages.

## Diffs

**Changes** 🏗

* Added `withNarrowBorder` prop to table component for tables where the dividing line between items should not extend to the full width of the table
* Added `alwaysShowPagination` prop to table component to allow pagination to be shown even when there is only 1 page
* Many UI changes

**Deletions** ⚰️

* Removed now unused hasHorizontalPadding prop from table 

Resolved to #3216 