### PR TITLE
fix: update UI to match the design

### DIFF
--- a/src/components/shared/Numeral/Numeral.tsx
+++ b/src/components/shared/Numeral/Numeral.tsx
@@ -29,7 +29,7 @@ const Numeral = ({
 
   return (
     <NumeralBase
-      prefix={prefix}
+      prefix={prefix && `${prefix} `}
       suffix={suffix}
       className={className}
       appearance={appearance}

--- a/src/components/shared/Numeral/NumeralBase.tsx
+++ b/src/components/shared/Numeral/NumeralBase.tsx
@@ -21,7 +21,7 @@ export const NumeralBase: FC<Props> = ({
       className={classNames(getMainClasses(appearance, styles), className)}
       {...rest}
     >
-      {prefix && `${prefix} `}
+      {prefix}
       {children}
       {suffix}
     </span>

--- a/src/components/shared/Numeral/NumeralCurrency.tsx
+++ b/src/components/shared/Numeral/NumeralCurrency.tsx
@@ -23,10 +23,9 @@ const NumeralCurrency = ({
   appearance,
   ...rest
 }: NumeralProps) => {
-  const fixedValue = value;
-  const convertedValue = convertToDecimal(fixedValue, decimals || 0);
+  const convertedValue = convertToDecimal(value, decimals || 0);
 
-  const formattedValue = getFormattedCurrencyValue(convertedValue, fixedValue);
+  const formattedValue = getFormattedCurrencyValue(convertedValue, value);
 
   return (
     <NumeralBase

--- a/src/components/shared/Numeral/helpers.tsx
+++ b/src/components/shared/Numeral/helpers.tsx
@@ -70,6 +70,10 @@ export const adjustConvertedValue = (
 ) => convertedValue.div(new Decimal(10).pow(decimals));
 
 const CURRENCY_FORMAT = {
+  ZERO: {
+    mantissa: 0,
+    thousandSeparated: true,
+  },
   SMALL: {
     mantissa: 2,
     thousandSeparated: true,
@@ -93,7 +97,9 @@ export const getFormattedCurrencyValue = (
 
   let format: numbro.Format = {};
 
-  if (convertedValue.lt(CURRENCY_THRESHOLD)) {
+  if (convertedValue.eq(0)) {
+    format = CURRENCY_FORMAT.ZERO;
+  } else if (convertedValue.lt(CURRENCY_THRESHOLD)) {
     format = CURRENCY_FORMAT.SMALL;
   } else {
     format = CURRENCY_FORMAT.BIG;

--- a/src/components/v5/common/WidgetCards/WidgetCardsList.tsx
+++ b/src/components/v5/common/WidgetCards/WidgetCardsList.tsx
@@ -37,7 +37,7 @@ export const WidgetCardsList: FC<PropsWithChildren<WidgetCardsListProps>> = ({
 
       <div className="grow cursor-grab overflow-hidden">
         <div ref={emblaRef}>
-          <div className="flex gap-4">{children}</div>
+          <div className="flex gap-4.5">{children}</div>
         </div>
       </div>
 

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/FundsCards.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/FundsCards.tsx
@@ -10,6 +10,7 @@ import { formatText } from '~utils/intl.ts';
 import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import WidgetCards from '~v5/common/WidgetCards/index.ts';
 
+import { useIsAddNewTeamVisible } from './hooks.ts';
 import { FundsCardsItem } from './partials/FundsCardsItem.tsx';
 import { FundsCardsTotalItem } from './partials/FundsCardsTotalItem.tsx';
 
@@ -26,7 +27,7 @@ export const FundsCards = () => {
 
   const subTeams = useSubDomains();
 
-  const isAddNewTeamVisible = !subTeams || subTeams.length < 1;
+  const isAddNewTeamVisible = useIsAddNewTeamVisible();
   return (
     <BalanceCurrencyContextProvider>
       <div className="flex flex-col gap-4 sm:flex-row sm:gap-2 md:pt-2">
@@ -39,6 +40,7 @@ export const FundsCards = () => {
                 key={item?.id}
                 domainId={item?.id}
                 domainName={item?.metadata?.name}
+                nativeId={item.nativeId}
               />
             ))}
 
@@ -46,7 +48,11 @@ export const FundsCards = () => {
             <WidgetCards.Item
               variant="dashed"
               icon={Plus}
-              title={formatText({ id: 'dashboard.team.cards.createTeam' })}
+              title={
+                <div className="text-xs">
+                  {formatText({ id: 'dashboard.team.cards.createTeam' })}
+                </div>
+              }
               onClick={onNewTeamClick}
               className="justify-center uppercase text-gray-200"
             />

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/hooks.ts
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/hooks.ts
@@ -10,6 +10,7 @@ import {
 } from '~gql';
 import { useCurrencyHistoricalConversionRate } from '~hooks/useCurrencyHistoricalConversionRate.ts';
 import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
+import { useSubDomains } from '~hooks/useSubDomains.ts';
 import { convertFromTokenToCurrency } from '~utils/currency/convertFromTokenToCurrency.ts';
 import { type CoinGeckoSupportedCurrencies } from '~utils/currency/index.ts';
 
@@ -134,4 +135,17 @@ export const usePreviousTotalData = () => {
      */
     previousTotal: convertAmount(previousTotal),
   };
+};
+
+export const useIsAddNewTeamVisible = () => {
+  const subTeams = useSubDomains();
+
+  const selectedDomain = useGetSelectedDomainFilter();
+
+  // In case "All teams" selected we have "General" team created by default
+  // @TODO: probably with nested teams this functionality will change
+  if (!selectedDomain && (!subTeams || subTeams.length <= 1)) {
+    return true;
+  }
+  return selectedDomain?.isRoot && (!subTeams || subTeams.length < 1);
 };

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsItem.tsx
@@ -4,12 +4,9 @@ import { useNavigate, useParams } from 'react-router-dom';
 import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
 import { currencySymbolMap } from '~constants/currency.ts';
 import { useCurrencyContext } from '~context/CurrencyContext/CurrencyContext.ts';
-import {
-  COLONY_BALANCES_ROUTE,
-  TEAM_SEARCH_PARAM,
-} from '~routes/routeConstants.ts';
+import { useColonyFiltersContext } from '~context/GlobalFiltersContext/ColonyFiltersContext.ts';
+import { COLONY_BALANCES_ROUTE } from '~routes/routeConstants.ts';
 import { NumeralCurrency } from '~shared/Numeral/index.ts';
-import { setQueryParamOnUrl } from '~utils/urls.ts';
 import WidgetCards from '~v5/common/WidgetCards/index.ts';
 
 import { useTotalData } from '../hooks.ts';
@@ -29,18 +26,15 @@ export const FundsCardsItem: FC<FundsCardsItemProps> = ({
   const { total, loading } = useTotalData(domainId);
   const { currency } = useCurrencyContext();
 
+  const { updateTeamFilter } = useColonyFiltersContext();
   const navigate = useNavigate();
-
   const { colonyName } = useParams();
+
   const onTeamClick = () => {
-    navigate(
-      setQueryParamOnUrl({
-        path: `/${colonyName}/${COLONY_BALANCES_ROUTE}`,
-        params: {
-          [TEAM_SEARCH_PARAM]: nativeId?.toString(),
-        },
-      }),
-    );
+    if (nativeId) {
+      updateTeamFilter(nativeId.toString());
+    }
+    navigate(`/${colonyName}/${COLONY_BALANCES_ROUTE}`);
   };
 
   return (

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsItem.tsx
@@ -52,17 +52,19 @@ export const FundsCardsItem: FC<FundsCardsItemProps> = ({
         </LoadingSkeleton>
       }
       subTitle={
-        <FundsCardsSubTitle
-          currency={currency}
-          isLoading={loading}
-          value={
-            <NumeralCurrency
-              value={total.toString()}
-              prefix={currencySymbolMap[currency]}
-              decimals={18}
-            />
-          }
-        />
+        <div className="pt-0.5">
+          <FundsCardsSubTitle
+            currency={currency}
+            isLoading={loading}
+            value={
+              <NumeralCurrency
+                value={total.toString()}
+                prefix={currencySymbolMap[currency]}
+                decimals={18}
+              />
+            }
+          />
+        </div>
       }
     />
   );

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsItem.tsx
@@ -1,9 +1,15 @@
 import React, { type FC } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
 import { currencySymbolMap } from '~constants/currency.ts';
 import { useCurrencyContext } from '~context/CurrencyContext/CurrencyContext.ts';
+import {
+  COLONY_BALANCES_ROUTE,
+  TEAM_SEARCH_PARAM,
+} from '~routes/routeConstants.ts';
 import { NumeralCurrency } from '~shared/Numeral/index.ts';
+import { setQueryParamOnUrl } from '~utils/urls.ts';
 import WidgetCards from '~v5/common/WidgetCards/index.ts';
 
 import { useTotalData } from '../hooks.ts';
@@ -13,18 +19,33 @@ import { FundsCardsSubTitle } from './FundsCardsSubTitle.tsx';
 interface FundsCardsItemProps {
   domainId?: string;
   domainName?: string;
+  nativeId?: number;
 }
 export const FundsCardsItem: FC<FundsCardsItemProps> = ({
   domainId,
   domainName,
+  nativeId,
 }) => {
   const { total, loading } = useTotalData(domainId);
   const { currency } = useCurrencyContext();
 
+  const navigate = useNavigate();
+
+  const { colonyName } = useParams();
+  const onTeamClick = () => {
+    navigate(
+      setQueryParamOnUrl({
+        path: `/${colonyName}/${COLONY_BALANCES_ROUTE}`,
+        params: {
+          [TEAM_SEARCH_PARAM]: nativeId?.toString(),
+        },
+      }),
+    );
+  };
+
   return (
     <WidgetCards.Item
-      // @TODO: update onClick when it will be ready
-      onClick={() => {}}
+      onClick={onTeamClick}
       title={
         <LoadingSkeleton isLoading={loading} className="mb-1 h-5 w-14 rounded">
           {domainName}

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsSubTitle.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsSubTitle.tsx
@@ -13,7 +13,7 @@ export const FundsCardsSubTitle: FC<FundsCardsSubTitleProps> = ({
   isLoading,
 }) => {
   return (
-    <p className="flex items-center gap-2">
+    <p className="mb-1.5 flex items-center gap-2">
       <LoadingSkeleton
         className="h-[27px] w-[90px] rounded"
         isLoading={isLoading}

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsSubTitle.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsSubTitle.tsx
@@ -13,7 +13,7 @@ export const FundsCardsSubTitle: FC<FundsCardsSubTitleProps> = ({
   isLoading,
 }) => {
   return (
-    <p className="mb-1.5 flex items-center gap-2">
+    <p className="flex items-center gap-2">
       <LoadingSkeleton
         className="h-[27px] w-[90px] rounded"
         isLoading={isLoading}

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalDescription.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalDescription.tsx
@@ -36,7 +36,7 @@ export const FundsCardsTotalDescription: React.FC<
   );
 
   return (
-    <div className="flex w-full justify-between text-xs">
+    <div className="mt-1.5 flex w-full justify-between text-xs">
       <LoadingSkeleton isLoading={isLoading} className="h-4 w-[114px] rounded">
         <span className="uppercase text-gray-400">
           <Numeral

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalItem.tsx
@@ -1,9 +1,12 @@
 import React, { type FC } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
 import { currencySymbolMap } from '~constants/currency.ts';
 import { useCurrencyContext } from '~context/CurrencyContext/CurrencyContext.ts';
+import { useColonyFiltersContext } from '~context/GlobalFiltersContext/ColonyFiltersContext.ts';
 import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
+import { COLONY_BALANCES_ROUTE } from '~routes/routeConstants.ts';
 import { NumeralCurrency } from '~shared/Numeral/index.ts';
 import { getValuesTrend } from '~utils/balance/getValuesTrend.ts';
 import { formatText } from '~utils/intl.ts';
@@ -25,8 +28,20 @@ export const FundsCardsTotalItem: FC<FundsCardsTotalItemProps> = ({
   const { previousTotal } = usePreviousTotalData();
   const { currency } = useCurrencyContext();
 
+  const { updateTeamFilter } = useColonyFiltersContext();
+  const navigate = useNavigate();
+  const { colonyName } = useParams();
+
   const selectedTeamName = selectedDomain?.metadata?.name;
   const trend = getValuesTrend(total, previousTotal);
+
+  const nativeId = selectedDomain?.nativeId;
+  const onItemClick = () => {
+    if (nativeId) {
+      updateTeamFilter(nativeId.toString());
+    }
+    navigate(`/${colonyName}/${COLONY_BALANCES_ROUTE}`);
+  };
 
   return (
     <WidgetCards.Item
@@ -52,6 +67,7 @@ export const FundsCardsTotalItem: FC<FundsCardsTotalItemProps> = ({
           currency={currency}
         />
       }
+      onClick={selectedDomain ? onItemClick : undefined}
     >
       <FundsCardsTotalDescription
         percent={trend.value}

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalItem.tsx
@@ -67,7 +67,7 @@ export const FundsCardsTotalItem: FC<FundsCardsTotalItemProps> = ({
           currency={currency}
         />
       }
-      onClick={selectedDomain ? onItemClick : undefined}
+      onClick={onItemClick}
     >
       <FundsCardsTotalDescription
         percent={trend.value}

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalItem.tsx
@@ -40,19 +40,17 @@ export const FundsCardsTotalItem: FC<FundsCardsTotalItemProps> = ({
         </LoadingSkeleton>
       }
       subTitle={
-        <div className="py-1">
-          <FundsCardsSubTitle
-            isLoading={loading}
-            value={
-              <NumeralCurrency
-                value={total ?? '-'}
-                prefix={currencySymbolMap[currency]}
-                decimals={18}
-              />
-            }
-            currency={currency}
-          />
-        </div>
+        <FundsCardsSubTitle
+          isLoading={loading}
+          value={
+            <NumeralCurrency
+              value={total ?? '-'}
+              prefix={currencySymbolMap[currency]}
+              decimals={18}
+            />
+          }
+          currency={currency}
+        />
       }
     >
       <FundsCardsTotalDescription


### PR DESCRIPTION
## Description
- [x]  The styling of the create team box such as the font size and padding between the icon should match Figma.
- [x]  When individual teams are selected, they should go to the 'Balances' page with the selected team applied. Currently they just have a hover state and don't link anywhere.
- [x]  The 'Create team' card shouldn't apply when a parent team is selected. It should only show where there are no parent teams in the colony.

## Testing
1. Run `node scripts/create-colony-url.js` and create new team
2. See that "Create team" item is shown under "All teams" and "General" filter 
Design requirements:
<img width="527" alt="image" src="https://github.com/user-attachments/assets/f90dfbd3-77c3-4916-87ec-6f6dc107bdeb">
Result:
<img width="877" alt="image" src="https://github.com/user-attachments/assets/6c3a6bb3-4438-472e-b72f-f3b0647b3074">
<img width="611" alt="image" src="https://github.com/user-attachments/assets/057310a9-7d49-4739-8aba-9075b989acb0">

3. Check that all items match the design (link: https://www.figma.com/design/gac6xVgGNCAge5Bia933dp/Dashboard?node-id=4867-40639&node-type=frame&t=yyk6XVtMJFk4l0TJ-0 ):
Pixel perfect example: 
<img width="977" alt="image" src="https://github.com/user-attachments/assets/bef8f885-d972-4c69-afda-f2083c88652e">

4. Create a team and check that the "Create team" item is no longer shown
<img width="943" alt="image" src="https://github.com/user-attachments/assets/0400e12c-6316-499f-92e6-4d3d42ac6439">
<img width="825" alt="image" src="https://github.com/user-attachments/assets/7f18c06d-e6cd-451b-b23d-84f1c53c70d2">

5. Go to planex colony and check that items matches the design (link: https://www.figma.com/design/gac6xVgGNCAge5Bia933dp/Dashboard?node-id=4859-36367&node-type=frame&t=pXOwAsU0iYnga3iH-0 ):

Pixel perfect example:
<img width="1289" alt="image" src="https://github.com/user-attachments/assets/b5a36938-924a-41c5-b53f-95ff679a9c64">

6. Click on any team is selected, it should redirect to balance page with selected team:
![click-on-team-item](https://github.com/user-attachments/assets/1df47c2d-9263-4d40-b872-0015cb2ceeec)


## Diffs
**Changes** 🏗

* Updated NumeralCurrency formating in case value is 0, now instead of 0.00 it will show only 0


Resolves  #3213
