### PR TITLE
[Dashboard] Reputation widget state

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/ReputationChart.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/ReputationChart.tsx
@@ -36,13 +36,11 @@ const MSG = defineMessages({
 const ReputationChart = () => {
   const {
     colony: { domains },
+    isReputationUpdating,
   } = useColonyContext();
 
   const { contributorsList, loading: isContributorsLoading } =
     useContributorsByDomain();
-
-  // @TODO here we should also check if the colony data is loading
-  const isDataLoading = isContributorsLoading;
 
   const selectedDomain = useGetSelectedDomainFilter();
 
@@ -52,7 +50,11 @@ const ReputationChart = () => {
       (a, b) => Number(b.reputationPercentage) - Number(a.reputationPercentage),
     );
 
-  const chartDataTeams = !isThereReputationInDomains(allTeams)
+  const isNoReputationAvailable = !isThereReputationInDomains(allTeams);
+  const isDataLoading =
+    isContributorsLoading || (isReputationUpdating && isNoReputationAvailable);
+
+  const chartDataTeams = isNoReputationAvailable
     ? []
     : getTeamReputationChartData(allTeams);
 

--- a/src/context/ColonyContext/ColonyContext.ts
+++ b/src/context/ColonyContext/ColonyContext.ts
@@ -22,6 +22,7 @@ export interface ColonyContextValue {
   refetchColony: RefetchColonyFn;
   startPollingColonyData: (pollInterval: number) => void;
   stopPollingColonyData: () => void;
+  isReputationUpdating: boolean;
   isSupportedColonyVersion: boolean;
   colonySubscription: {
     canWatch: boolean;


### PR DESCRIPTION
## Description

As mentioned in Discord, when I first load into a Colony or switched to a new colony, the team reputation shows three states.

1. Skeleton loader state.
2. The empty state with no teams or no reputation (ideally this shouldn't show) with vertical height issues.
3. The active state with teams and pic charts.


### Implementation
Given the `updateContributorsWithReputation` finishes before `db` domain reputation data is updated and subscribing to the `OnUpdateColony` will retrieve `lastUpdatedContributorsWithReputation` before the domain reputation data is available, our best approach will be to add an extra `isReputationUpdating` flag to the `ColonyContext` and reset it after a `2s` timeout. However, in the reputation chart in order to prevent the loading skeletons to show when there actually is domain data available, we can use the following piece of code
```
const isNoReputationAvailable = !isThereReputationInDomains(allTeams);
const isDataLoading = isContributorsLoading || (isReputationUpdating && isNoReputationAvailable);
```

## Testing

TODO: Make sure the Reputation chart empty state is not visible (or at least for a small amount of time given we can't really determine when there is reputation data available) if reputation data exists. 

* Step 1. Make sure to start with a clean environment and run `create-data` script first
* Step 2. Visit `planex`
* Step 3. Check reputation chart state
* Step 4. Visit `wayne`
* Step 5. Check reputation chart state

## Diffs

**New stuff** ✨

* `isReputationUpdating` in `ColonyContext`

**Changes** 🏗

* `ReputationChart` loading state

Resolves [#3208](https://github.com/JoinColony/colonyCDapp/issues/3208)
