### PR TITLE
fix: prevent display error banner when extension data is loading

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/hooks.ts
@@ -74,14 +74,20 @@ export const useSubmitButtonDisabled = () => {
 };
 
 export const useIsFieldDisabled = () => {
-  const { extensionData } = useExtensionData(Extension.VotingReputation);
+  const { extensionData, loading } = useExtensionData(
+    Extension.VotingReputation,
+  );
   const selectedAction = useActiveActionType();
   const isExtensionEnabled =
     extensionData &&
     isInstalledExtensionData(extensionData) &&
     extensionData.isEnabled;
 
-  if (selectedAction === Action.CreateDecision && !isExtensionEnabled) {
+  if (
+    selectedAction === Action.CreateDecision &&
+    !isExtensionEnabled &&
+    !loading
+  ) {
     return true;
   }
 


### PR DESCRIPTION
## Description

After open Action Sidebar to create agreement, during fetching extensions data, the no extension error banner is visible even though all required extensions are installed.

![Screenshot 2024-10-02 at 14 11 39](https://github.com/user-attachments/assets/06733609-b4c9-432a-b6c6-882762fce52d)

## Testing
- Set network connection to eg. 3G
- Click `Create agreement` on agreements page
- Error banner should not be visible when data is fetching


## Diffs

**Changes** 🏗

add checking if data is not loading inside `useIsFieldDisabled` hook

Resolves https://github.com/JoinColony/colonyCDapp/issues/3239
