### PR TITLE
[Notifications] feat: open completed action when clicking on notification in list

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification.tsx
@@ -5,9 +5,11 @@ import {
 import clsx from 'clsx';
 import React, { type FC } from 'react';
 import { defineMessages } from 'react-intl';
+import { useNavigate } from 'react-router-dom';
 
 import { ADDRESS_ZERO } from '~constants';
 import { useGetColonyActionQuery } from '~gql';
+import { TX_SEARCH_PARAM } from '~routes';
 import { type Notification as NotificationInterface } from '~types/notifications.ts';
 import { formatText } from '~utils/intl.ts';
 import ColonyAvatar from '~v5/shared/ColonyAvatar/index.ts';
@@ -33,12 +35,16 @@ interface NotificationProps {
 }
 
 const Notification: FC<NotificationProps> = ({ notification }) => {
+  const navigate = useNavigate();
   const { markAsRead } = useNotification(notification as IRemoteNotification);
+
+  const transactionHash = notification.customAttributes?.transactionHash;
+
   const { data: actionData, loading: loadingAction } = useGetColonyActionQuery({
     variables: {
-      transactionHash: notification.customAttributes?.transactionHash || '',
+      transactionHash: transactionHash || '',
     },
-    skip: !notification.customAttributes?.transactionHash,
+    skip: !transactionHash,
   });
 
   const action = actionData?.getColonyAction;
@@ -47,6 +53,15 @@ const Notification: FC<NotificationProps> = ({ notification }) => {
   const handleNotificationClicked = () => {
     if (!notification.readAt) {
       markAsRead();
+    }
+
+    if (transactionHash) {
+      navigate(
+        `${window.location.pathname}?${TX_SEARCH_PARAM}=${transactionHash}`,
+        {
+          replace: true,
+        },
+      );
     }
   };
 


### PR DESCRIPTION
## Description

This PR just adds the navigation part since marking as read was already done :D 

## Testing

As per usual, make sure you have the following in your `.env.local.secrets`
```
MAGICBELL_API_KEY=<ask somebody for this>
MAGICBELL_API_SECRET=<ask somebody for this>
MAGICBELL_DEV_KEY=
```

1. Create a simple payment as `leela` to `leela` two times :D 
![image](https://github.com/user-attachments/assets/f4eb386f-1bf4-409c-8be7-0dfb8bd5be3f)
![image](https://github.com/user-attachments/assets/291f503c-9ad6-4f2d-b0a3-169bcfd1de4a)
2. Wait for them to show up in the notifications list (for sanity's sake, close the sidebar first).
3. Notice they show up and have an unread counter next to them:
![image](https://github.com/user-attachments/assets/f7f6a328-9824-4931-b762-e298210a325b)
4. Click one, it should mark it as read and open up the action sidebar. Verify that the action doesn't load from scratch, since it was prepopulated into the cache by this component :sunglasses: 
![image](https://github.com/user-attachments/assets/43dca4b0-c02a-4bc3-93b5-4239df3beffa)
![image](https://github.com/user-attachments/assets/5ffeb43c-4768-4bdb-96cd-8ecd4338bd69)
5. After clicking another notification it should open up another action, closing the UserHub
6. Clicking on a notification for an action that's open and unread, should just mark it as read and now load anew
https://github.com/user-attachments/assets/cf36a341-8dc0-4115-b50b-34d8a781882f

## Diffs

**New stuff** ✨

* `handleNotificationClicked` now opens the sidebar and loads the action

Resolves #3194
