### PR TITLE
[Dashboard] Mobile navigation menu opened by default

### DIFF
--- a/src/context/PageLayoutContext/PageLayoutContextProvider.tsx
+++ b/src/context/PageLayoutContext/PageLayoutContextProvider.tsx
@@ -7,6 +7,8 @@ import React, {
 } from 'react';
 
 import { type UserHubTab } from '~common/Extensions/UserHub/types.ts';
+import { useTablet } from '~hooks';
+import { useResize } from '~hooks/useResize.ts';
 
 import { PageLayoutContext } from './PageLayoutContext.ts';
 
@@ -14,6 +16,16 @@ const PageLayoutContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const [showTabletSidebar, setShowTabletSidebar] = useState(false);
   const [showTabletColonyPicker, setShowTabletColonyPicker] = useState(false);
   const [userHubTab, setUserHubTab] = useState<UserHubTab | undefined>();
+  const isTablet = useTablet();
+
+  const resetSidebars = useCallback(() => {
+    if (!isTablet) {
+      setShowTabletSidebar(false);
+      setShowTabletColonyPicker(false);
+    }
+  }, [isTablet, setShowTabletSidebar, setShowTabletColonyPicker]);
+
+  useResize(resetSidebars);
 
   const toggleTabletSidebar = useCallback(() => {
     setShowTabletSidebar((state) => !state);

--- a/src/hooks/useResize.ts
+++ b/src/hooks/useResize.ts
@@ -1,11 +1,17 @@
+import { throttle } from 'lodash';
 import { useEffect } from 'react';
 
-export const useResize = (callback: () => void) => {
+export const useResize = (callback: () => void, wait: number = 200) => {
   useEffect(() => {
-    callback();
+    const throttledCallback = throttle(callback, wait);
 
-    window.addEventListener('resize', callback);
+    throttledCallback();
 
-    return () => window.removeEventListener('resize', callback);
-  }, [callback]);
+    window.addEventListener('resize', throttledCallback);
+
+    return () => {
+      window.removeEventListener('resize', throttledCallback);
+      throttledCallback.cancel();
+    };
+  }, [callback, wait]);
 };


### PR DESCRIPTION
## Description

When I minimise the browser, the mobile nav is automatically triggered open. This shouldn't be triggered and take over the UI, instead the closed default mobile header should be displayed. 

![Export-1727697383382](https://github.com/user-attachments/assets/7c4be856-177d-4b6e-b740-3f1c6b97a77f)

This PR addresses this issue by introducing a `resetSidebars` function that resets the navigation or colony switcher upon window resizing if on a device > `table`

## Testing

TODO: Please test opening either the navigation or colony switcher and then resize to a viewport wider than > `1024px`. Then switch again to a viewport less wide than < `1024px`. None of these sidebars should be opened by default.


https://github.com/user-attachments/assets/7ba3beb6-7d68-44fd-b9b1-a62c0c85ccf7



## Diffs

**New stuff** ✨

* `resetSidebars` callback used for `useResize` in `PageLayoutContextProvider`


Resolves [#3218](https://github.com/JoinColony/colonyCDapp/issues/3218)
