### PR TITLE
feat: show newest agreement

### DIFF
--- a/src/components/frame/v5/pages/AgreementsPage/AgreementsPage.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/AgreementsPage.tsx
@@ -1,14 +1,13 @@
 import { Binoculars, FilePlus } from '@phosphor-icons/react';
 import { motion } from 'framer-motion';
 import React, { type FC } from 'react';
-import { useSelector } from 'react-redux';
 
 import { Action } from '~constants/actions.ts';
 import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useSetPageHeadingTitle } from '~context/PageHeadingContext/PageHeadingContext.ts';
-import { getDraftDecisionFromStore } from '~utils/decisions.ts';
+import { getDraftDecisionFromLocalStorage } from '~utils/decisions.ts';
 import { formatText } from '~utils/intl.ts';
 import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import EmptyContent from '~v5/common/EmptyContent/EmptyContent.tsx';
@@ -21,6 +20,7 @@ import AgreementCard from './partials/AgreementCard/index.ts';
 import AgreementCardSkeleton from './partials/AgreementCardSkeleton.tsx';
 import AgreementsPageFilters from './partials/AgreementsPageFilters/AgreementsPageFilters.tsx';
 import DraftSection from './partials/DraftSection/DraftSection.tsx';
+import { sortAgreementsByDate } from './utils.ts';
 
 const displayName = 'v5.pages.AgreementsPage';
 
@@ -43,9 +43,27 @@ const AgreementsPage: FC = () => {
     !!activeFilters.motionStates ||
     !!activeFilters.search;
 
-  const draftAgreement = useSelector(
-    getDraftDecisionFromStore(user?.walletAddress || '', colonyAddress),
+  const draftAgreement = getDraftDecisionFromLocalStorage(
+    user?.walletAddress || '',
+    colonyAddress,
   );
+
+  const passedAgreements = searchedAgreements.filter(
+    (agreement) => agreement.showInActionsList,
+  );
+
+  const notPassedAgreements = searchedAgreements.filter(
+    (agreement) =>
+      agreement.initiatorUser?.walletAddress === user?.walletAddress &&
+      !agreement.showInActionsList,
+  );
+
+  const allAgreements =
+    notPassedAgreements.length > 0
+      ? [...notPassedAgreements, ...passedAgreements]
+      : [...passedAgreements];
+
+  const sortedAgreeements = sortAgreementsByDate(allAgreements);
 
   return (
     <ContentWithTeamFilter>
@@ -85,9 +103,9 @@ const AgreementsPage: FC = () => {
         </ul>
       ) : (
         <>
-          {searchedAgreements && searchedAgreements?.length > 0 && (
+          {allAgreements && allAgreements?.length > 0 && (
             <ul className="grid auto-rows-fr grid-cols-1 gap-6 sm:auto-rows-auto sm:grid-cols-2">
-              {searchedAgreements.map(({ transactionHash }) => (
+              {sortedAgreeements.map(({ transactionHash }) => (
                 <motion.li
                   initial={{ opacity: 0 }}
                   whileInView={{
@@ -105,7 +123,7 @@ const AgreementsPage: FC = () => {
               ))}
             </ul>
           )}
-          {searchedAgreements?.length === 0 &&
+          {allAgreements?.length === 0 &&
             !loading &&
             !loadingMotionStateFilter &&
             !isFilterActive && (
@@ -122,7 +140,7 @@ const AgreementsPage: FC = () => {
                 withBorder
               />
             )}
-          {searchedAgreements?.length === 0 &&
+          {allAgreements?.length === 0 &&
             !loading &&
             !loadingMotionStateFilter &&
             isFilterActive && (

--- a/src/components/frame/v5/pages/AgreementsPage/AgreementsPage.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/AgreementsPage.tsx
@@ -51,19 +51,22 @@ const AgreementsPage: FC = () => {
   const passedAgreements = searchedAgreements.filter(
     (agreement) => agreement.showInActionsList,
   );
-
   const notPassedAgreements = searchedAgreements.filter(
     (agreement) =>
       agreement.initiatorUser?.walletAddress === user?.walletAddress &&
       !agreement.showInActionsList,
   );
-
   const allAgreements =
     notPassedAgreements.length > 0
       ? [...notPassedAgreements, ...passedAgreements]
       : [...passedAgreements];
-
   const sortedAgreeements = sortAgreementsByDate(allAgreements);
+
+  const hasAgreements = allAgreements && allAgreements.length > 0;
+  const showCreateDecision =
+    !hasAgreements && !loading && !loadingMotionStateFilter && !isFilterActive;
+  const showNoResults =
+    !hasAgreements && !loading && !loadingMotionStateFilter && isFilterActive;
 
   return (
     <ContentWithTeamFilter>
@@ -103,7 +106,7 @@ const AgreementsPage: FC = () => {
         </ul>
       ) : (
         <>
-          {allAgreements && allAgreements?.length > 0 && (
+          {hasAgreements && (
             <ul className="grid auto-rows-fr grid-cols-1 gap-6 sm:auto-rows-auto sm:grid-cols-2">
               {sortedAgreeements.map(({ transactionHash }) => (
                 <motion.li
@@ -123,35 +126,29 @@ const AgreementsPage: FC = () => {
               ))}
             </ul>
           )}
-          {allAgreements?.length === 0 &&
-            !loading &&
-            !loadingMotionStateFilter &&
-            !isFilterActive && (
-              <EmptyContent
-                description={{ id: 'agreementsPage.empty.description' }}
-                className="border-dashed px-5 py-[5.75rem]"
-                buttonText={{ id: 'agreementsPage.empty.button' }}
-                onClick={() => {
-                  toggleActionSidebarOn({
-                    [ACTION_TYPE_FIELD_NAME]: Action.CreateDecision,
-                  });
-                }}
-                buttonIcon={FilePlus}
-                withBorder
-              />
-            )}
-          {allAgreements?.length === 0 &&
-            !loading &&
-            !loadingMotionStateFilter &&
-            isFilterActive && (
-              <EmptyContent
-                title={{ id: 'agreementsPage.empty.title.filter' }}
-                description={{ id: 'agreementsPage.empty.description.filter' }}
-                className="px-6 pb-9 pt-10"
-                icon={Binoculars}
-                withBorder
-              />
-            )}
+          {showCreateDecision && (
+            <EmptyContent
+              description={{ id: 'agreementsPage.empty.description' }}
+              className="border-dashed px-5 py-[5.75rem]"
+              buttonText={{ id: 'agreementsPage.empty.button' }}
+              onClick={() => {
+                toggleActionSidebarOn({
+                  [ACTION_TYPE_FIELD_NAME]: Action.CreateDecision,
+                });
+              }}
+              buttonIcon={FilePlus}
+              withBorder
+            />
+          )}
+          {showNoResults && (
+            <EmptyContent
+              title={{ id: 'agreementsPage.empty.title.filter' }}
+              description={{ id: 'agreementsPage.empty.description.filter' }}
+              className="px-6 pb-9 pt-10"
+              icon={Binoculars}
+              withBorder
+            />
+          )}
         </>
       )}
     </ContentWithTeamFilter>

--- a/src/components/frame/v5/pages/AgreementsPage/hooks.ts
+++ b/src/components/frame/v5/pages/AgreementsPage/hooks.ts
@@ -31,9 +31,6 @@ const useGetAllAgreements = () => {
       colonyAddress,
       filter: {
         type: { eq: ColonyActionType.CreateDecisionMotion },
-        showInActionsList: {
-          eq: true,
-        },
       },
       sortDirection: ModelSortDirection.Desc,
       limit: QUERY_PAGE_SIZE,

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementCard/AgreementCard.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementCard/AgreementCard.tsx
@@ -1,6 +1,7 @@
-import { FilePlus, ShareNetwork } from '@phosphor-icons/react';
+import { FilePlus, ShareNetwork, WarningCircle } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { type FC, useEffect } from 'react';
+import { defineMessages } from 'react-intl';
 import { generatePath, useNavigate } from 'react-router-dom';
 
 import MeatballMenuCopyItem from '~common/ColonyActionsTable/partials/MeatballMenuCopyItem/MeatballMenuCopyItem.tsx';
@@ -11,12 +12,14 @@ import {
   COLONY_HOME_ROUTE,
   TX_SEARCH_PARAM,
 } from '~routes/index.ts';
+import Tooltip from '~shared/Extensions/Tooltip/Tooltip.tsx';
 import { MotionState } from '~utils/colonyMotions.ts';
 import { getFormattedDateFrom } from '~utils/getFormattedDateFrom.ts';
 import { formatText } from '~utils/intl.ts';
 import useGetColonyAction from '~v5/common/ActionSidebar/hooks/useGetColonyAction.ts';
 import MotionCountDownTimer from '~v5/common/ActionSidebar/partials/Motions/partials/MotionCountDownTimer/MotionCountDownTimer.tsx';
 import MotionStateBadge from '~v5/common/Pills/MotionStateBadge/MotionStateBadge.tsx';
+import PillsBase from '~v5/common/Pills/PillsBase.tsx';
 import TeamBadge from '~v5/common/Pills/TeamBadge/TeamBadge.tsx';
 import MeatBallMenu from '~v5/shared/MeatBallMenu/MeatBallMenu.tsx';
 import RichTextDisplay from '~v5/shared/RichTextDisplay/index.ts';
@@ -26,6 +29,20 @@ import UserInfoPopover from '~v5/shared/UserInfoPopover/UserInfoPopover.tsx';
 import AgreementCardSkeleton from '../AgreementCardSkeleton.tsx';
 
 import { type AgreementCardProps } from './types.ts';
+
+const displayName = 'frame.v5.pages.AgreementsPage.partials.AgreementCard';
+
+const MSG = defineMessages({
+  belowThresholdStatus: {
+    id: `${displayName}.belowThresholdStatus`,
+    defaultMessage: 'Below threshold',
+  },
+  belowThresholdStatusTooltip: {
+    id: `${displayName}.belowThresholdStatusTooltip`,
+    defaultMessage:
+      'This agreement is below the 10% staking threshold and will not be visible to others by default.',
+  },
+});
 
 const AgreementCard: FC<AgreementCardProps> = ({ transactionId }) => {
   const isMobile = useMobile();
@@ -38,7 +55,7 @@ const AgreementCard: FC<AgreementCardProps> = ({ transactionId }) => {
     startPollingForAction,
     stopPollingForAction,
   } = useGetColonyAction(transactionId);
-  const { decisionData, motionData } = action || {};
+  const { decisionData, motionData, showInActionsList } = action || {};
   const {
     createdAt,
     description,
@@ -75,7 +92,22 @@ const AgreementCard: FC<AgreementCardProps> = ({ transactionId }) => {
       ) : (
         <>
           <div className="mb-4 flex items-center justify-between">
-            {motionState && <MotionStateBadge state={motionState} />}
+            <div className="flex items-center gap-1">
+              {motionState && <MotionStateBadge state={motionState} />}
+              {!showInActionsList && (
+                <Tooltip
+                  tooltipContent={formatText(MSG.belowThresholdStatusTooltip)}
+                >
+                  <PillsBase
+                    icon={WarningCircle}
+                    iconSize={12}
+                    className="bg-warning-100 text-warning-400"
+                  >
+                    {formatText(MSG.belowThresholdStatus)}
+                  </PillsBase>
+                </Tooltip>
+              )}
+            </div>
             {isMotionActive && (
               <MotionCountDownTimer
                 prefix={formatText({ id: 'agreementsPage.endsIn' })}

--- a/src/components/frame/v5/pages/AgreementsPage/utils.ts
+++ b/src/components/frame/v5/pages/AgreementsPage/utils.ts
@@ -1,0 +1,8 @@
+import { type ActivityFeedColonyAction } from '~hooks/useActivityFeed/types.ts';
+
+export const sortAgreementsByDate = (agreements: ActivityFeedColonyAction[]) =>
+  agreements.sort((a, b) => {
+    const aDate = new Date(a?.decisionData?.createdAt || '');
+    const bDate = new Date(b?.decisionData?.createdAt || '');
+    return bDate.getTime() - aDate.getTime();
+  });

--- a/src/components/v5/common/ActionSidebar/partials/SaveDraftButton/SaveDraftButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/SaveDraftButton/SaveDraftButton.tsx
@@ -15,7 +15,7 @@ import Button from '~v5/shared/Button/index.ts';
 const SaveDraftButton: FC = () => {
   const [isDraftSaved, setIsDraftSaved] = useState(false);
   const isMobile = useMobile();
-  const { colony } = useColonyContext();
+  const { colony, refetchColony } = useColonyContext();
   const { wallet } = useAppContext();
   const dispatch = useDispatch();
   const {
@@ -38,12 +38,13 @@ const SaveDraftButton: FC = () => {
       );
 
       setIsDraftSaved(true);
+      refetchColony();
 
       setTimeout(() => {
         setIsDraftSaved(false);
       }, 3000);
     },
-    [colony.colonyAddress, dispatch],
+    [colony.colonyAddress, dispatch, refetchColony],
   );
 
   if (!wallet?.address) {

--- a/src/components/v5/common/Pills/PillsBase.tsx
+++ b/src/components/v5/common/Pills/PillsBase.tsx
@@ -11,6 +11,7 @@ const PillsBase: FC<PropsWithChildren<PillsProps>> = ({
   text,
   icon: Icon,
   iconClassName,
+  iconSize,
   pillSize = 'medium',
   isCapitalized = true,
   textClassName,
@@ -32,7 +33,7 @@ const PillsBase: FC<PropsWithChildren<PillsProps>> = ({
       {Icon && (
         <span className="flex shrink-0">
           <Icon
-            size={pillSize === 'medium' ? 14 : 12}
+            size={iconSize || (pillSize === 'medium' ? 14 : 12)}
             className={iconClassName}
           />
         </span>

--- a/src/components/v5/common/Pills/types.ts
+++ b/src/components/v5/common/Pills/types.ts
@@ -34,15 +34,13 @@ export type UserStatusMode =
   | 'team'
   | 'verified';
 
-export type IconSize = 'extraTiny' | 'tiny';
-
 export type PillSize = 'medium' | 'small';
 
 export interface PillsProps {
   mode?: ExtensionStatusBadgeMode | UserStatusMode;
   text?: React.ReactNode;
   icon?: Icon;
-  iconSize?: IconSize;
+  iconSize?: number;
   iconClassName?: string;
   pillSize?: PillSize;
   className?: string;


### PR DESCRIPTION
## Description

- display the most recent agreement, but only to the creator, even if staking threshold is not met
- fixed an issue where the entire list was reloaded on add. Now, only the first item is added to the list without refreshing the entire content

<img width="484" alt="image" src="https://github.com/user-attachments/assets/0db95fc5-3d1e-4cb0-889b-4c5186523945">

## Testing

* Go to agreements page.
* Create a agreements using Reputation decision method. Some passing 10% threshold and some not.
* After adding new agreements, check if it's visible without staking and if whole list is not reloading when adding new agreements.

Resolves https://github.com/JoinColony/colonyCDapp/issues/3240
