### PR TITLE
fix: input background in darkmode

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
@@ -189,7 +189,7 @@ const AmountField: FC<AmountFieldProps> = ({
         disabled={isDisabled}
         name={name}
         className={clsx(
-          'col-start-1 row-start-1 w-auto min-w-[0.5em] flex-shrink resize-none appearance-none text-md outline-none outline-0',
+          'col-start-1 row-start-1 w-auto min-w-[0.5em] flex-shrink resize-none appearance-none bg-base-white text-md outline-none outline-0',
           {
             'text-gray-900 placeholder:text-gray-400': !isError && !isDisabled,
             'text-gray-400 placeholder:text-gray-300':


### PR DESCRIPTION
## Description

Input background not change color when dark mode is active

![image](https://github.com/user-attachments/assets/e016f23f-1db6-47cf-b60a-15b6766753bd)

## Testing

-Create new Advanced payment action
-The `Enter amount` input should follow current theme background color

## Diffs

**Changes** 🏗

Add `bg-base-white` to input class

The background is displaying correctly when theme color is changed

![Screenshot 2024-10-03 at 11 40 16](https://github.com/user-attachments/assets/953295dc-7971-42fd-a5f4-69fa636109db)

Resolves https://github.com/JoinColony/colonyCDapp/issues/3241
