### PR TITLE
Fix: Unable to reveal motion oppose

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarLoadingSkeleton/ActionSidebarLoadingSkeleton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarLoadingSkeleton/ActionSidebarLoadingSkeleton.tsx
@@ -23,7 +23,8 @@ const ActionSidebarLoadingSkeleton = () => {
       </div>
       <div>
         {new Array(7).fill(0).map((_, index) => (
-          <div className="mt-2 flex w-full max-w-[25rem] gap-2">
+          // eslint-disable-next-line react/no-array-index-key
+          <div key={index} className="mt-2 flex w-full max-w-[25rem] gap-2">
             <div className="mt-2 flex w-1/2 items-center gap-2">
               <LoadingSkeleton
                 isLoading
@@ -107,8 +108,10 @@ const ActionSidebarLoadingSkeleton = () => {
       >
         <div className="flex">
           <div className="mr-[-.3450rem] mt-2">
-            {new Array(72).fill(0).map(() => (
+            {new Array(72).fill(0).map((_, index) => (
               <LoadingSkeleton
+                // eslint-disable-next-line react/no-array-index-key
+                key={index}
                 isLoading
                 className="mb-[.0625rem] h-[.1875rem] w-[.0625rem] rounded"
               />
@@ -150,7 +153,11 @@ const ActionSidebarLoadingSkeleton = () => {
                       <div className="flex gap-4">
                         <div className="w-full">
                           {new Array(4).fill(0).map((_, index) => (
-                            <div className="mt-2 items-center gap-2">
+                            <div
+                              // eslint-disable-next-line react/no-array-index-key
+                              key={index}
+                              className="mt-2 items-center gap-2"
+                            >
                               <LoadingSkeleton
                                 isLoading
                                 className={clsx('h-5 rounded', {
@@ -192,7 +199,8 @@ const ActionSidebarLoadingSkeleton = () => {
               />
             </div>
             {new Array(3).fill(0).map((_, index) => (
-              <div className="mt-4 flex items-center gap-4">
+              // eslint-disable-next-line react/no-array-index-key
+              <div key={index} className="mt-4 flex items-center gap-4">
                 <LoadingSkeleton
                   isLoading
                   className={clsx('h-[.625rem] w-[.625rem] rounded-3xl')}

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/RevealStep/RevealStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/RevealStep/RevealStep.tsx
@@ -8,6 +8,7 @@ import useToggle from '~hooks/useToggle/index.ts';
 import { ActionTypes } from '~redux/index.ts';
 import { ActionForm } from '~shared/Fields/index.ts';
 import Numeral from '~shared/Numeral/index.ts';
+import { MotionVote } from '~utils/colonyMotions.ts';
 import { formatText } from '~utils/intl.ts';
 import MotionVoteBadge from '~v5/common/Pills/MotionVoteBadge/index.ts';
 import AccordionItem from '~v5/shared/Accordion/partials/AccordionItem/index.ts';
@@ -118,7 +119,8 @@ const RevealStep: FC<RevealStepProps> = ({
               transform={transform}
               onSuccess={handleSuccess}
             >
-              {hasUserVoted && !!userVote ? (
+              {hasUserVoted &&
+              (userVote === MotionVote.Nay || userVote === MotionVote.Yay) ? (
                 <div className="mb-1.5">
                   <div className={clsx({ 'mb-6': !userVoteRevealed })}>
                     <div className="mb-2 flex items-center justify-between gap-2">


### PR DESCRIPTION
## Description

This PR addresses an issue introduced by #3108 which caused oppose motions to be revealed. `!!userVote` was incorrectly validating MotionVote.Nay as false and has been replaced with a more explicit check `(userVote === MotionVote.Nay || userVote === MotionVote.Yay)`.

Completely unrelated, but I also fixed up a tiny key issue with the ActionSidebarLoadingSkeleton which was causing console errors.

## Testing

* Step 1 - Install the reputation voting extension
* Step 2 - Create a motion, stake it on both sides.
* Step 3 - Vote to oppose the motion. When the sidebar updates to the reveal stage, it should be possible to reveal your oppose vote.

https://github.com/user-attachments/assets/b5a1a6d8-c67e-47a1-9f72-3eac7b294c71

Compared to master:

https://github.com/user-attachments/assets/20606992-f1e7-4bdb-8af8-13c68df450a7

## Diffs

**Changes** 🏗

* Fixed vote reveal if statement
* Added missing ActionSidebarLoadingSkeleton keys

Resolves #3258 
