### PR TITLE
fix: add hover to action dropdown menu

### DIFF
--- a/src/components/v5/shared/SearchSelect/partials/CheckboxSearchItem/CheckboxSearchItem.tsx
+++ b/src/components/v5/shared/SearchSelect/partials/CheckboxSearchItem/CheckboxSearchItem.tsx
@@ -66,7 +66,7 @@ const CheckboxSearchItem: FC<CheckboxSearchItemProps> = ({
             >
               <label
                 className={clsx(
-                  'flex w-full items-center rounded px-2 py-1.5 text-left text-md transition-colors',
+                  'flex w-full items-center rounded px-2 py-1.5 text-left text-md transition-colors hover:bg-gray-50 hover:font-medium',
                   {
                     'justify-between': !hasAvatar,
                     'justify-start': hasAvatar,

--- a/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
+++ b/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
@@ -63,7 +63,7 @@ const SearchItem: FC<SearchItemProps> = ({
               <button
                 type="button"
                 className={clsx(
-                  'flex w-full items-center rounded px-2 text-left text-md transition-colors',
+                  'flex w-full items-center rounded px-2 text-left text-md transition-colors hover:bg-gray-50 hover:font-medium',
                   {
                     'justify-between': !hasAvatar,
                     'justify-start': hasAvatar,


### PR DESCRIPTION
## Description
- Action dropdown menu doesn't have hover state

Example of hover state that is expected:
![image](https://github.com/user-attachments/assets/31f73486-5fc5-48af-8d63-be846a6c1edc)

## Testing
1. Open Motion modal
2. Check Action type hover:
<img width="641" alt="image" src="https://github.com/user-attachments/assets/be1596be-e2cd-47cb-816f-b44342c8173b">

3. Check UserSelect. Select "Manage permissions" and check "Select member" dropdown:
<img width="680" alt="image" src="https://github.com/user-attachments/assets/952b23f8-33eb-413f-a310-16f37a599287">

4. Check NonVerifiedMembersSelect. Select "Manage verified members" action type. Select "Add members"
<img width="507" alt="image" src="https://github.com/user-attachments/assets/749c47d4-8098-4587-9b8d-ed9000067b39">

5. Check VerifiedMembersSelect. Select "Manage verified members" action type. Select "Remove members":
<img width="542" alt="image" src="https://github.com/user-attachments/assets/05773743-eab6-47f8-9159-60371566a297">

6. Check TeamsSelect. Select "Manage permissions" and check "Select team" dropdown.
<img width="622" alt="image" src="https://github.com/user-attachments/assets/eb124fcd-56c3-43e9-a325-5275b42acecb">


Resolves #2898
