### PR TITLE
fix: replace div with span in SkeletonLoading component for html cons…

### DIFF
--- a/src/components/common/LoadingSkeleton/LoadingSkeleton.tsx
+++ b/src/components/common/LoadingSkeleton/LoadingSkeleton.tsx
@@ -11,7 +11,7 @@ const LoadingSkeleton: React.FC<LoadingSkeletonProps> = ({
   children,
 }) =>
   isLoading ? (
-    <div className={clsx('overflow-hidden skeleton', className)} />
+    <span className={clsx('block overflow-hidden skeleton', className)} />
   ) : (
     <>{children}</>
   );


### PR DESCRIPTION
## Description

Before:
![image](https://github.com/user-attachments/assets/a8aa33ef-136d-45cd-8a06-0e220dcec8bf)


## Testing

Step 1. Check that there is no errors in the console
<img width="652" alt="image" src="https://github.com/user-attachments/assets/3c3b8516-c132-445e-a4c0-c3f345215af3">

Step 2. Check that all Skeletons still shown correctly:
<img width="1211" alt="image" src="https://github.com/user-attachments/assets/05b892ea-07e2-412d-bee5-faea5d44f52d">


Resolves #3268
