### PR TITLE
[Dashboard]: fix: align funding cards with the design

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsItem.tsx
@@ -46,19 +46,17 @@ export const FundsCardsItem: FC<FundsCardsItemProps> = ({
         </LoadingSkeleton>
       }
       subTitle={
-        <div className="pt-0.5">
-          <FundsCardsSubTitle
-            currency={currency}
-            isLoading={loading}
-            value={
-              <NumeralCurrency
-                value={total.toString()}
-                prefix={currencySymbolMap[currency]}
-                decimals={18}
-              />
-            }
-          />
-        </div>
+        <FundsCardsSubTitle
+          currency={currency}
+          isLoading={loading}
+          value={
+            <NumeralCurrency
+              value={total.toString()}
+              prefix={currencySymbolMap[currency]}
+              decimals={18}
+            />
+          }
+        />
       }
     />
   );

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalDescription.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalDescription.tsx
@@ -36,7 +36,7 @@ export const FundsCardsTotalDescription: React.FC<
   );
 
   return (
-    <div className="mt-1.5 flex w-full justify-between text-xs">
+    <div className="mt-1 flex w-full justify-between text-xs">
       <LoadingSkeleton isLoading={isLoading} className="h-4 w-[114px] rounded">
         <span className="uppercase text-gray-400">
           <Numeral

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalItem.tsx
@@ -55,7 +55,7 @@ export const FundsCardsTotalItem: FC<FundsCardsTotalItemProps> = ({
         </LoadingSkeleton>
       }
       subTitle={
-        <div className="pb-1 pt-0.5">
+        <div className="pt-0.5">
           <FundsCardsSubTitle
             isLoading={loading}
             value={


### PR DESCRIPTION
## Description
Seems like during merge or a lot of changes UI brake a little bit

## Testing

Check that Funding cards align with the design:

<img width="1182" alt="image" src="https://github.com/user-attachments/assets/e4aa5e5f-6c0c-476e-93d8-0e9b9154c344">
