### PR TITLE
Fix: set current wallet address as the default getSigner address

### DIFF
--- a/src/redux/sagas/wallet/RetryProvider.ts
+++ b/src/redux/sagas/wallet/RetryProvider.ts
@@ -3,6 +3,7 @@ import { providers, utils } from 'ethers';
 import { backOff } from 'exponential-backoff';
 
 import { GANACHE_LOCAL_RPC_URL } from '~constants/index.ts';
+import { type Address } from '~types/index.ts';
 import {
   RetryProviderMethod,
   IColonyContractMethodSignature,
@@ -13,7 +14,10 @@ type RetryProviderOptions = {
   delay?: number; // in milliseconds
 };
 
-const classFactory = (walletType: 'MetaMask' | string = '') => {
+const classFactory = (
+  walletType: 'MetaMask' | string = '',
+  walletAddress?: Address,
+) => {
   const devWallet = walletType !== 'MetaMask';
 
   const Extender = devWallet
@@ -54,7 +58,10 @@ const classFactory = (walletType: 'MetaMask' | string = '') => {
       return super.getBlock(blockHashOrBlockTag);
     }
 
-    getSigner(addressOrIndex?: string | number): providers.JsonRpcSigner {
+    getSigner(
+      // If custom address not provided, return the signer of the wallet
+      addressOrIndex: string | number | undefined = walletAddress,
+    ): providers.JsonRpcSigner {
       return super.getSigner(addressOrIndex);
     }
 

--- a/src/redux/sagas/wallet/index.ts
+++ b/src/redux/sagas/wallet/index.ts
@@ -82,7 +82,7 @@ export const getWallet = async (lastWallet: LastWallet | null) => {
   const [account] = wallet.accounts;
   setLastWallet({ type: wallet.label, address: account.address });
 
-  const RetryProvider = retryProviderFactory(wallet.label);
+  const RetryProvider = retryProviderFactory(wallet.label, account.address);
   const provider = new RetryProvider();
 
   return {


### PR DESCRIPTION
## Description

Please see linked issue #3275 for more details.

This PR ensures that `getSigner` will return the signer for the current wallet unless a different address is specified. Apparently not providing an address makes it return the very first address it gets from `eth_accounts`. 

## Testing

I noticed this issue in the notifications branch, but it also affects other areas, for example when updating a user profile. The auth proxy performs a similar check, comparing the GraphQL mutation's address variable with the authenticated wallet address. And because it always thinks it's the first dev wallet address, updating any other profile will fail.

1. Disconnect your wallet and clear your browser data, including cookies.
2. Connect any dev wallet other than the first one.
3. Navigate to User account and update any of the information on that page. The mutation should be allowed by auth proxy.

You can also inspect the network tab to see the `/auth` request contains the correct wallet address.

Resolves #3275 