### PR TITLE
Send notifications on multisig actions

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=18e95a601b529ef1694da9e34ad22f288f09828e
+ENV BLOCK_INGESTOR_HASH=968d1ca3994202506b3467d1b7155c997a68d186
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=ea3bd8fdea00565268ca42bd518181e6abaccfb1
+ENV BLOCK_INGESTOR_HASH=18e95a601b529ef1694da9e34ad22f288f09828e
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/ActionNotification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/ActionNotification.tsx
@@ -7,11 +7,15 @@ import {
   useGetUserByAddressQuery,
 } from '~gql';
 import { TX_SEARCH_PARAM } from '~routes';
-import { type Notification as NotificationInterface } from '~types/notifications.ts';
+import {
+  NotificationType,
+  type Notification as NotificationInterface,
+} from '~types/notifications.ts';
 
 import NotificationWrapper from '../NotificationWrapper.tsx';
 
 import ActionNotificationMessage from './ActionNotificationMessage.tsx';
+import MultisigNotificationMessage from './MultisigNotificationMessage.tsx';
 
 const displayName = 'common.Extensions.UserHub.partials.ActionNotification';
 
@@ -28,7 +32,8 @@ const ActionNotification: FC<NotificationProps> = ({
 }) => {
   const navigate = useNavigate();
 
-  const { creator, transactionHash } = notification.customAttributes || {};
+  const { creator, notificationType, transactionHash } =
+    notification.customAttributes || {};
 
   const { data: userData, loading: loadingUser } = useGetUserByAddressQuery({
     variables: { address: creator || '' },
@@ -64,13 +69,33 @@ const ActionNotification: FC<NotificationProps> = ({
       notification={notification}
       onClick={handleNotificationClicked}
     >
-      <ActionNotificationMessage
-        action={action}
-        colony={colony}
-        creator={creatorName}
-        loading={loadingColony || loadingAction || loadingUser}
-        notification={notification}
-      />
+      {notificationType &&
+        [NotificationType.PermissionsAction, NotificationType.Mention].includes(
+          notificationType,
+        ) && (
+          <ActionNotificationMessage
+            action={action}
+            colony={colony}
+            creator={creatorName}
+            loading={loadingColony || loadingAction || loadingUser}
+            notification={notification}
+          />
+        )}
+      {notificationType &&
+        [
+          NotificationType.MultiSigActionCreated,
+          NotificationType.MultiSigActionFinalized,
+          NotificationType.MultiSigActionApproved,
+          NotificationType.MultiSigActionRejected,
+        ].includes(notificationType) && (
+          <MultisigNotificationMessage
+            action={action}
+            colony={colony}
+            creator={creatorName}
+            loading={loadingColony || loadingAction || loadingUser}
+            notification={notification}
+          />
+        )}
     </NotificationWrapper>
   );
 };

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
@@ -36,11 +36,16 @@ const Notification: FC<NotificationProps> = ({ notification }) => {
     return null;
   }
 
-  // If the notification type is permissions action, or a mention (always tied to an action):
+  // If the notification type is permissions action, a multisig action, or a mention (always tied to an action):
   if (
-    [NotificationType.PermissionsAction, NotificationType.Mention].includes(
-      notificationType,
-    )
+    [
+      NotificationType.PermissionsAction,
+      NotificationType.Mention,
+      NotificationType.MultiSigActionCreated,
+      NotificationType.MultiSigActionFinalized,
+      NotificationType.MultiSigActionApproved,
+      NotificationType.MultiSigActionRejected,
+    ].includes(notificationType)
   ) {
     return (
       <ActionNotification

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -1,14 +1,27 @@
 import { type IRemoteNotification } from '@magicbell/react-headless';
 
 export enum NotificationType {
+  // Expenditures
   ExpenditureReadyForReview = 'ExpenditureReadyForReview',
   ExpenditureReadyForFunding = 'ExpenditureReadyForFunding',
   ExpenditureReadyForRelease = 'ExpenditureReadyForRelease',
   ExpenditureFinalized = 'ExpenditureFinalized',
   ExpenditureCancelled = 'ExpenditureCancelled',
-  PermissionsAction = 'PermissionsAction',
+
+  // Funds
   FundsClaimed = 'FundsClaimed',
+
+  // Mentions
   Mention = 'Mention',
+
+  // Multisig
+  MultiSigActionCreated = 'MultiSigActionCreated',
+  MultiSigActionFinalized = 'MultiSigActionFinalized',
+  MultiSigActionApproved = 'MultiSigActionApproved',
+  MultiSigActionRejected = 'MultiSigActionRejected',
+
+  // Actions made with permissions
+  PermissionsAction = 'PermissionsAction',
 }
 
 export interface NotificationAttributes {


### PR DESCRIPTION
## Description

- Send notifications for multisig actions. This includes creation, full approval, rejection and finalization.

Part of the work for this PR was done in the block ingestor here: https://github.com/JoinColony/block-ingestor/pull/275

## Testing

Ensure that the following is added to your .env.local.secrets and run npm run prepare.

```
MAGICBELL_API_KEY=<ask me for this>
MAGICBELL_API_SECRET=<ask me for this>
MAGICBELL_DEV_KEY=
```

Also ensure the API_KEY and SECRET are both in the .env file inside `amplify/backend/function/createUserNotificationsData`

* Log in as Leela in one browser, and Amy in another incognito browser. As Leela, install the multisig extension. Set the threshold to be fixed at "2".
<img width="1518" alt="Screenshot 2024-10-08 at 11 43 13" src="https://github.com/user-attachments/assets/bf3f1ee5-c6cb-47ca-b32d-332aa865ee00">

* Give Leela and Amy multisig owner permissions. Check that you receive notifications for these.
<img width="1049" alt="Screenshot 2024-10-08 at 11 47 57" src="https://github.com/user-attachments/assets/9e27ce8e-cab9-4881-9bef-b279f0f08e27">
<img width="1058" alt="Screenshot 2024-10-08 at 11 48 52" src="https://github.com/user-attachments/assets/835b634f-173c-4c2e-836e-282e45b8c596">
<img width="453" alt="Screenshot 2024-10-08 at 11 49 25" src="https://github.com/user-attachments/assets/d95beeac-a70e-42c2-a12c-a286917dc7c4">

* Create a multisig action. It can be any type of action as long as it is multisig. Check that you receive a notification when this is created.
<img width="1057" alt="Screenshot 2024-10-08 at 11 50 21" src="https://github.com/user-attachments/assets/1e04948f-cc8c-47f1-824d-778bc9666c0d">
<img width="447" alt="Screenshot 2024-10-08 at 11 50 39" src="https://github.com/user-attachments/assets/55da9a5a-40e5-44a7-af23-769c3e8d5831">

* As Amy, add a second approval to the multi sig action. Go back to Leela and check that she received a new notification for the approval. Then finalize the motion as Leela, and check that she also received a notification for that.
<img width="366" alt="Screenshot 2024-10-08 at 11 51 43" src="https://github.com/user-attachments/assets/4604ca89-9210-47cc-8c86-d8781c84cec2">
<img width="442" alt="Screenshot 2024-10-08 at 11 52 12" src="https://github.com/user-attachments/assets/bc129bab-01fe-48ae-9523-10257c58ef3c">
<img width="442" alt="Screenshot 2024-10-08 at 11 52 41" src="https://github.com/user-attachments/assets/7b9721bd-745a-4fe8-a17f-8f1e3da4f293">

* As Leela, make another multisig motion. Immediately go back to the approval step in the sidebar and remove her approval, then reject the motion. Check that a notification arrived for this rejection.
<img width="363" alt="Screenshot 2024-10-08 at 11 53 14" src="https://github.com/user-attachments/assets/61197f22-1f4c-413c-8494-e5552f4a8c30">
<img width="365" alt="Screenshot 2024-10-08 at 11 53 23" src="https://github.com/user-attachments/assets/9d812d41-3808-4795-9eef-d3453d472884">
<img width="440" alt="Screenshot 2024-10-08 at 11 53 51" src="https://github.com/user-attachments/assets/d6f90592-1568-4b9a-a41a-b10795d58000">

## Diffs

**New stuff** ✨

* New component: `MultisigNotificationMessage`
* New notification types

**Changes** 🏗

* Changes to some notification categories to match specs
* New block ingestor hash, and more changes there: https://github.com/JoinColony/block-ingestor/pull/275

Resolves #3221
