### PR TITLE
[Notifications] Feat: Extensions notifications

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=968d1ca3994202506b3467d1b7155c997a68d186
+ENV BLOCK_INGESTOR_HASH=1e2c9ba395558c32ea5bfd018334565db8578d24
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=1e2c9ba395558c32ea5bfd018334565db8578d24
+ENV BLOCK_INGESTOR_HASH=1052069e47cf26eada1f7d8eb2161d389e86095f
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/common/Extensions/UserHub/UserHub.tsx
+++ b/src/components/common/Extensions/UserHub/UserHub.tsx
@@ -27,6 +27,7 @@ import { UserHubTab } from './types.ts';
 
 interface Props {
   initialOpenTab?: UserHubTab;
+  closeUserHub: () => void;
 }
 
 const displayName = 'common.Extensions.UserHub.partials.UserHub';
@@ -42,7 +43,10 @@ const MSG = defineMessages({
   },
 });
 
-const UserHub: FC<Props> = ({ initialOpenTab = UserHubTab.Balance }) => {
+const UserHub: FC<Props> = ({
+  initialOpenTab = UserHubTab.Balance,
+  closeUserHub,
+}) => {
   const isMobile = useMobile();
   const featureFlags = useContext(FeatureFlagsContext);
   const [selectedTab, setSelectedTab] = useState(initialOpenTab);
@@ -147,7 +151,9 @@ const UserHub: FC<Props> = ({ initialOpenTab = UserHubTab.Balance }) => {
         {selectedTab === UserHubTab.Balance && (
           <BalanceTab onTabChange={handleTabChange} />
         )}
-        {selectedTab === UserHubTab.Notifications && <NotificationsTab />}
+        {selectedTab === UserHubTab.Notifications && (
+          <NotificationsTab closeUserHub={closeUserHub} />
+        )}
         {selectedTab === UserHubTab.Transactions && (
           <TransactionsTab appearance={{ interactive: true }} />
         )}

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
@@ -35,7 +35,7 @@ const MSG = defineMessages({
   },
 });
 
-const NotificationsTab = () => {
+const NotificationsTab = ({ closeUserHub }: { closeUserHub: () => void }) => {
   const { canFetchMore, fetchMore, markAllAsRead, notifications, unreadCount } =
     useNotificationsDataContext();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -94,7 +94,7 @@ const NotificationsTab = () => {
           </>
         ) : (
           <>
-            <NotificationsList />
+            <NotificationsList closeUserHub={closeUserHub} />
             <InfiniteScrollTrigger
               canFetchMore={canFetchMore}
               containerRef={containerRef}

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Extension/ExtensionNotification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Extension/ExtensionNotification.tsx
@@ -1,0 +1,96 @@
+import { getExtensionHash } from '@colony/colony-js';
+import React, { type FC } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { supportedExtensionsConfig } from '~constants';
+import {
+  type NotificationColonyFragment,
+  useGetUserByAddressQuery,
+} from '~gql';
+import { COLONY_EXTENSIONS_ROUTE } from '~routes';
+import { type Notification as NotificationInterface } from '~types/notifications.ts';
+
+import NotificationWrapper from '../NotificationWrapper.tsx';
+
+import ExtensionNotificationMessage from './ExtensionNotificationMessage.tsx';
+
+const displayName = 'common.Extensions.UserHub.partials.ExtensionNotification';
+
+interface NotificationProps {
+  colony: NotificationColonyFragment | null | undefined;
+  loadingColony: boolean;
+  notification: NotificationInterface;
+  closeUserHub: () => void;
+}
+
+const getExtensionByHash = (extensionHash?: string) => {
+  if (!extensionHash) {
+    return undefined;
+  }
+
+  const extensionsWithHash = supportedExtensionsConfig.map((extension) => {
+    return {
+      ...extension,
+      hash: getExtensionHash(extension.extensionId),
+    };
+  });
+
+  const extension = extensionsWithHash.find(
+    (extensionWithHash) => extensionWithHash.hash === extensionHash,
+  );
+
+  return extension;
+};
+
+const ExtensionNotification: FC<NotificationProps> = ({
+  colony,
+  loadingColony,
+  notification,
+  closeUserHub,
+}) => {
+  const navigate = useNavigate();
+
+  const { creator, extensionHash } = notification.customAttributes || {};
+
+  const { data: userData, loading: loadingUser } = useGetUserByAddressQuery({
+    variables: { address: creator || '' },
+    skip: !creator,
+  });
+
+  const extension = getExtensionByHash(extensionHash);
+
+  const creatorName =
+    userData?.getUserByAddress?.items[0]?.profile?.displayName ?? '';
+
+  const handleNotificationClicked = () => {
+    if (colony && extension) {
+      navigate(
+        `/${colony.name}/${COLONY_EXTENSIONS_ROUTE}/${extension.extensionId}`,
+        {
+          replace: true,
+        },
+      );
+      closeUserHub();
+    }
+  };
+
+  return (
+    <NotificationWrapper
+      colony={colony}
+      loadingColony={loadingColony}
+      notification={notification}
+      onClick={handleNotificationClicked}
+    >
+      <ExtensionNotificationMessage
+        creator={creatorName}
+        extensionName={extension?.name}
+        loading={loadingUser}
+        notification={notification}
+      />
+    </NotificationWrapper>
+  );
+};
+
+ExtensionNotification.displayName = displayName;
+
+export default ExtensionNotification;

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Extension/ExtensionNotificationMessage.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Extension/ExtensionNotificationMessage.tsx
@@ -46,6 +46,10 @@ const MSG = defineMessages({
     id: `${displayName}.uninstalled`,
     defaultMessage: 'extension uninstalled by {name}',
   },
+  settingsChanged: {
+    id: `${displayName}.settingsChanged`,
+    defaultMessage: 'extension settings changed by {name}',
+  },
 });
 
 const ExtensionNotificationMessage: FC<ExtensionNotificationMessageProps> = ({
@@ -83,6 +87,8 @@ const ExtensionNotificationMessage: FC<ExtensionNotificationMessageProps> = ({
         return renderNotificationMessage(MSG.deprecated);
       case NotificationType.ExtensionUninstalled:
         return renderNotificationMessage(MSG.uninstalled);
+      case NotificationType.ExtensionSettingsChanged:
+        return renderNotificationMessage(MSG.settingsChanged);
       default:
         return null;
     }

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Extension/ExtensionNotificationMessage.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Extension/ExtensionNotificationMessage.tsx
@@ -1,0 +1,96 @@
+import React, { useMemo, type FC } from 'react';
+import { type MessageDescriptor, defineMessages } from 'react-intl';
+
+import { NotificationType, type Notification } from '~types/notifications.ts';
+import { formatText } from '~utils/intl.ts';
+import { formatMessage } from '~utils/yup/tests/helpers.ts';
+
+import NotificationMessage from '../NotificationMessage.tsx';
+
+const displayName =
+  'common.Extensions.UserHub.partials.ExtensionNotificationMessage';
+
+interface ExtensionNotificationMessageProps {
+  creator?: string;
+  extensionName?: MessageDescriptor;
+  loading: boolean;
+  notification: Notification;
+}
+
+const MSG = defineMessages({
+  unknownExtensionName: {
+    id: `${displayName}.unknown`,
+    defaultMessage: 'Unknown',
+  },
+  someone: {
+    id: `${displayName}.someone`,
+    defaultMessage: 'Someone',
+  },
+  installed: {
+    id: `${displayName}.installed`,
+    defaultMessage: 'extension installed by {name}',
+  },
+  upgraded: {
+    id: `${displayName}.upgraded`,
+    defaultMessage: 'extension upgraded by {name}',
+  },
+  enabled: {
+    id: `${displayName}.enabled`,
+    defaultMessage: 'extension enabled by {name}',
+  },
+  deprecated: {
+    id: `${displayName}.deprecated`,
+    defaultMessage: 'extension deprecated by {name}',
+  },
+  uninstalled: {
+    id: `${displayName}.uninstalled`,
+    defaultMessage: 'extension uninstalled by {name}',
+  },
+});
+
+const ExtensionNotificationMessage: FC<ExtensionNotificationMessageProps> = ({
+  creator,
+  extensionName,
+  loading,
+  notification,
+}) => {
+  const extensionNameDescriptor = extensionName ?? MSG.unknownExtensionName;
+
+  const Message = useMemo(() => {
+    if (!notification.customAttributes?.notificationType) {
+      return null;
+    }
+
+    const { notificationType } = notification.customAttributes;
+
+    const renderNotificationMessage = (message: MessageDescriptor) => (
+      <>
+        {formatMessage(extensionNameDescriptor)}{' '}
+        {formatText(message, {
+          name: creator || formatText(MSG.someone),
+        })}
+      </>
+    );
+
+    switch (notificationType) {
+      case NotificationType.ExtensionInstalled:
+        return renderNotificationMessage(MSG.installed);
+      case NotificationType.ExtensionUpgraded:
+        return renderNotificationMessage(MSG.upgraded);
+      case NotificationType.ExtensionEnabled:
+        return renderNotificationMessage(MSG.enabled);
+      case NotificationType.ExtensionDeprecated:
+        return renderNotificationMessage(MSG.deprecated);
+      case NotificationType.ExtensionUninstalled:
+        return renderNotificationMessage(MSG.uninstalled);
+      default:
+        return null;
+    }
+  }, [creator, notification.customAttributes, extensionNameDescriptor]);
+
+  return <NotificationMessage loading={loading}>{Message}</NotificationMessage>;
+};
+
+ExtensionNotificationMessage.displayName = displayName;
+
+export default ExtensionNotificationMessage;

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
@@ -9,14 +9,19 @@ import {
 import ActionNotification from './Action/ActionNotification.tsx';
 import ExpenditureNotification from './Expenditure/ExpenditureNotification.tsx';
 import FundsClaimedNotification from './FundsClaimed/FundsClaimedNotification.tsx';
+import ExtensionNotification from './Extension/ExtensionNotification.tsx';
 
 const displayName = 'common.Extensions.UserHub.partials.Notification';
 
 interface NotificationProps {
   notification: NotificationInterface;
+  closeUserHub: () => void;
 }
 
-const Notification: FC<NotificationProps> = ({ notification }) => {
+const Notification: FC<NotificationProps> = ({
+  notification,
+  closeUserHub,
+}) => {
   const { colonyAddress, notificationType } =
     notification.customAttributes || {};
 
@@ -81,6 +86,26 @@ const Notification: FC<NotificationProps> = ({ notification }) => {
         colony={colony}
         loadingColony={loadingColony}
         notification={notification}
+      />
+    );
+  }
+
+  // If the notification type is an extension update:
+  if (
+    [
+      NotificationType.ExtensionInstalled,
+      NotificationType.ExtensionUpgraded,
+      NotificationType.ExtensionEnabled,
+      NotificationType.ExtensionDeprecated,
+      NotificationType.ExtensionUninstalled,
+    ].includes(notificationType)
+  ) {
+    return (
+      <ExtensionNotification
+        colony={colony}
+        loadingColony={loadingColony}
+        notification={notification}
+        closeUserHub={closeUserHub}
       />
     );
   }

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
@@ -98,6 +98,7 @@ const Notification: FC<NotificationProps> = ({
       NotificationType.ExtensionEnabled,
       NotificationType.ExtensionDeprecated,
       NotificationType.ExtensionUninstalled,
+      NotificationType.ExtensionSettingsChanged,
     ].includes(notificationType)
   ) {
     return (

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/NotificationsList.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/NotificationsList.tsx
@@ -7,7 +7,7 @@ import Notification from './Notification/Notification.tsx';
 
 const displayName = 'common.Extensions.UserHub.partials.NotificationsList';
 
-const NotificationsList = () => {
+const NotificationsList = ({ closeUserHub }: { closeUserHub: () => void }) => {
   const { notifications } = useNotificationsDataContext();
 
   return (
@@ -16,6 +16,7 @@ const NotificationsList = () => {
         <Notification
           notification={notification as NotificationInterface}
           key={notification.id}
+          closeUserHub={closeUserHub}
         />
       ))}
     </ul>

--- a/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
+++ b/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
@@ -219,7 +219,10 @@ const UserHubButton: FC<Props> = ({ openTab, onOpen }) => {
             },
           )}
         >
-          <UserHub initialOpenTab={initialOpenTab} />
+          <UserHub
+            initialOpenTab={initialOpenTab}
+            closeUserHub={closeUserHub}
+          />
         </PopoverBase>
       )}
     </div>

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -22,6 +22,13 @@ export enum NotificationType {
 
   // Actions made with permissions
   PermissionsAction = 'PermissionsAction',
+
+  // Extensions
+  ExtensionInstalled = 'ExtensionInstalled',
+  ExtensionUpgraded = 'ExtensionUpgraded',
+  ExtensionEnabled = 'ExtensionEnabled',
+  ExtensionDeprecated = 'ExtensionDeprecated',
+  ExtensionUninstalled = 'ExtensionUninstalled',
 }
 
 export interface NotificationAttributes {
@@ -32,6 +39,7 @@ export interface NotificationAttributes {
   expenditureID?: string;
   tokenAmount?: string;
   tokenAddress?: string;
+  extensionHash?: string;
 }
 
 // Create our own notification type so that we have types for the custom attributes, instead of

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -29,6 +29,7 @@ export enum NotificationType {
   ExtensionEnabled = 'ExtensionEnabled',
   ExtensionDeprecated = 'ExtensionDeprecated',
   ExtensionUninstalled = 'ExtensionUninstalled',
+  ExtensionSettingsChanged = 'ExtensionSettingsChanged',
 }
 
 export interface NotificationAttributes {


### PR DESCRIPTION
## Description

[See block-ingestor counterpart](https://github.com/JoinColony/block-ingestor/pull/278)

This PR adds notifications whenever an extension is installed, upgraded, enabled, deprecated, uninstalled or has settings changed.

## Testing

* Step 1 - Install the "Weighted Voting Reputation" extension - you should see the notification appear a few seconds later

<img width="1728" alt="Screenshot 2024-10-10 at 08 31 54" src="https://github.com/user-attachments/assets/1ca7a722-1dfa-4aa0-b1a2-6e70450a3ac8">

* Step 2 - Select a "Governance style" and click enable - check for a notification.

<img width="780" alt="Screenshot 2024-10-10 at 08 32 21" src="https://github.com/user-attachments/assets/81c934ae-f9d6-457e-a5bf-083d748de2f6">

* Step 3 -  Click the deprecate button - check for a notification.

<img width="794" alt="Screenshot 2024-10-10 at 08 32 41" src="https://github.com/user-attachments/assets/938c6a12-ef44-4170-a615-2a12ff3098bd">

* Step 4 - Re-enable the extension, check you get a notification for re-enabling.

<img width="797" alt="Screenshot 2024-10-10 at 08 33 21" src="https://github.com/user-attachments/assets/60a241b0-95a6-4422-b14c-5498a40f9ae8">

* Step 5 - Deprecate the extension again and also uninstall it. You should get notifications for both.

<img width="772" alt="Screenshot 2024-10-10 at 08 35 44" src="https://github.com/user-attachments/assets/d05b3d85-d071-4060-b24c-7652bfdd0e67">

* Step 6 -  Navigate to the Staking Advanced Payments extension and go to the extension settings tab.
* Step 7 - Change the stake amount and save changes. Check for a notification.

<img width="776" alt="Screenshot 2024-10-10 at 09 52 06" src="https://github.com/user-attachments/assets/7767e018-c2a6-4795-a393-31d74df10da0">

* Step 8 - Install the Multi-Sig extension.
* Step 9 - Change any of the extension settings and save changes. Check for a notification.

<img width="769" alt="Screenshot 2024-10-10 at 09 52 37" src="https://github.com/user-attachments/assets/5cc20ba0-b4b9-4445-b190-a8be1489a7ed">

* Step 10 - Click on any of these notifications, check that you are navigated to the relevant extension page. This should also work from other colonies.

## Diffs

**New stuff** ✨

* New ExtensionNotification types and components
* Extension block-ingestor handlers now create notifications

Resolves #3192 
