### PR TITLE
[Notifications] Feat: Notification should take you to relevant colony

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/ActionNotification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/ActionNotification.tsx
@@ -21,12 +21,14 @@ const displayName = 'common.Extensions.UserHub.partials.ActionNotification';
 
 interface NotificationProps {
   colony: NotificationColonyFragment | null | undefined;
+  isCurrentColony: boolean;
   loadingColony: boolean;
   notification: NotificationInterface;
 }
 
 const ActionNotification: FC<NotificationProps> = ({
   colony,
+  isCurrentColony,
   loadingColony,
   notification,
 }) => {
@@ -52,14 +54,17 @@ const ActionNotification: FC<NotificationProps> = ({
   const action = actionData?.getColonyAction;
 
   const handleNotificationClicked = () => {
-    if (transactionHash) {
-      navigate(
-        `${window.location.pathname}?${TX_SEARCH_PARAM}=${transactionHash}`,
-        {
-          replace: true,
-        },
-      );
+    if (!transactionHash) {
+      return;
     }
+
+    const path = isCurrentColony
+      ? window.location.pathname
+      : `/${colony?.name}`;
+
+    navigate(`${path}?${TX_SEARCH_PARAM}=${transactionHash}`, {
+      replace: true,
+    });
   };
 
   return (

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureNotification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureNotification.tsx
@@ -19,12 +19,14 @@ const displayName =
 
 interface NotificationProps {
   colony: NotificationColonyFragment | null | undefined;
+  isCurrentColony: boolean;
   loadingColony: boolean;
   notification: NotificationInterface;
 }
 
 const ExpenditureNotification: FC<NotificationProps> = ({
   colony,
+  isCurrentColony,
   loadingColony,
   notification,
 }) => {
@@ -62,14 +64,17 @@ const ExpenditureNotification: FC<NotificationProps> = ({
   const action = actionData?.getColonyAction;
 
   const handleNotificationClicked = () => {
-    if (transactionHash) {
-      navigate(
-        `${window.location.pathname}?${TX_SEARCH_PARAM}=${transactionHash}`,
-        {
-          replace: true,
-        },
-      );
+    if (!transactionHash) {
+      return;
     }
+
+    const path = isCurrentColony
+      ? window.location.pathname
+      : `/${colony?.name}`;
+
+    navigate(`${path}?${TX_SEARCH_PARAM}=${transactionHash}`, {
+      replace: true,
+    });
   };
 
   return (

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/FundsClaimed/FundsClaimedNotification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/FundsClaimed/FundsClaimedNotification.tsx
@@ -24,6 +24,7 @@ interface FundsClaimedNotificationProps {
   colony: NotificationColonyFragment | null | undefined;
   loadingColony: boolean;
   notification: NotificationInterface;
+  closeUserHub: () => void;
 }
 
 const MSG = defineMessages({
@@ -41,6 +42,7 @@ const FundsClaimedNotification: FC<FundsClaimedNotificationProps> = ({
   colony,
   loadingColony,
   notification,
+  closeUserHub,
 }) => {
   const navigate = useNavigate();
   const { tokenAmount, tokenAddress } = notification.customAttributes || {};
@@ -54,6 +56,7 @@ const FundsClaimedNotification: FC<FundsClaimedNotificationProps> = ({
   const handleNotificationClicked = () => {
     if (colony) {
       navigate(`/${colony.name}/${COLONY_BALANCES_ROUTE}`);
+      closeUserHub();
     }
   };
 

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
@@ -1,5 +1,6 @@
 import React, { type FC } from 'react';
 
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useGetColonyForNotificationQuery } from '~gql';
 import {
   NotificationType,
@@ -22,6 +23,8 @@ const Notification: FC<NotificationProps> = ({
   notification,
   closeUserHub,
 }) => {
+  const { colony: currentColony } = useColonyContext();
+
   const { colonyAddress, notificationType } =
     notification.customAttributes || {};
 
@@ -33,7 +36,9 @@ const Notification: FC<NotificationProps> = ({
       skip: !colonyAddress || !notificationType,
     });
 
-  const colony = colonyData?.getColonyByAddress?.items[0];
+  const notificationColony = colonyData?.getColonyByAddress?.items[0];
+
+  const isCurrentColony = currentColony.name === notificationColony?.name;
 
   // If there is no notification type, something is wrong with this notification
   // and we won't know what to display, so skip it.
@@ -54,7 +59,8 @@ const Notification: FC<NotificationProps> = ({
   ) {
     return (
       <ActionNotification
-        colony={colony}
+        colony={notificationColony}
+        isCurrentColony={isCurrentColony}
         loadingColony={loadingColony}
         notification={notification}
       />
@@ -73,7 +79,8 @@ const Notification: FC<NotificationProps> = ({
   ) {
     return (
       <ExpenditureNotification
-        colony={colony}
+        colony={notificationColony}
+        isCurrentColony={isCurrentColony}
         loadingColony={loadingColony}
         notification={notification}
       />
@@ -83,7 +90,7 @@ const Notification: FC<NotificationProps> = ({
   if (notificationType === NotificationType.FundsClaimed) {
     return (
       <FundsClaimedNotification
-        colony={colony}
+        colony={notificationColony}
         loadingColony={loadingColony}
         notification={notification}
       />
@@ -103,7 +110,7 @@ const Notification: FC<NotificationProps> = ({
   ) {
     return (
       <ExtensionNotification
-        colony={colony}
+        colony={notificationColony}
         loadingColony={loadingColony}
         notification={notification}
         closeUserHub={closeUserHub}

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
@@ -9,8 +9,8 @@ import {
 
 import ActionNotification from './Action/ActionNotification.tsx';
 import ExpenditureNotification from './Expenditure/ExpenditureNotification.tsx';
-import FundsClaimedNotification from './FundsClaimed/FundsClaimedNotification.tsx';
 import ExtensionNotification from './Extension/ExtensionNotification.tsx';
+import FundsClaimedNotification from './FundsClaimed/FundsClaimedNotification.tsx';
 
 const displayName = 'common.Extensions.UserHub.partials.Notification';
 
@@ -93,6 +93,7 @@ const Notification: FC<NotificationProps> = ({
         colony={notificationColony}
         loadingColony={loadingColony}
         notification={notification}
+        closeUserHub={closeUserHub}
       />
     );
   }


### PR DESCRIPTION
## Description

This PR ensures that when you click a notification that it opens actions in the colony in which it was created. (Note: Similar fixes will be required for some of the other open notifications PRs, it's a very small change being added here so it can be easily copied across regardless of which order the PRs are merged.)

## Testing

* Step 1 - Create a simple payment action in planex, the notification indicator should appear, don't click on the notification yet.
* Step 2 - Switch to the wayne colony.
* Step 3 - Open the UserHub and click on the notification. You should be redirected to the planex colony and the action sidebar should open with the relevant action open. Note also that the notification should be marked as read.
* Step 4 - Navigate to another page on planex, balances for example. Click the notification again. It should open in the sidebar without redirecting you away from the balances page.
* Step 5 - Switch to the wayne colony and create an advanced payment and advance it to the funding stage without checking any of the notifications.
* Step 6 - Switch to the planex colony. Click on any of the advanced payments notifications, you should be redirected to the wayne colony.

## Diffs

**New stuff** ✨

* handleNotificationClicked function now redirects if the notification was not created in the currently open colony

Resolves #3281
