### PR TITLE
Fix: Activity feed description should use correct amount value

### DIFF
--- a/src/components/common/ColonyActions/helpers/getActionTitleValues.ts
+++ b/src/components/common/ColonyActions/helpers/getActionTitleValues.ts
@@ -164,11 +164,13 @@ const getActionTitleValues = ({
   colony,
   keyFallbackValues,
   expenditureData,
+  networkInverseFee,
 }: {
   actionData: ColonyAction;
   colony: Pick<Colony, 'metadata' | 'nativeToken'>;
   keyFallbackValues?: Partial<Record<ActionTitleMessageKeys, React.ReactNode>>;
   expenditureData?: Expenditure;
+  networkInverseFee?: string;
 }) => {
   const { isMotion, pendingColonyMetadata } = actionData;
 
@@ -177,6 +179,7 @@ const getActionTitleValues = ({
     colony,
     keyFallbackValues,
     expenditureData,
+    networkInverseFee,
   });
 
   const actionType = getExtendedActionType(

--- a/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
@@ -5,7 +5,7 @@ import { getActionTitleValues } from '~common/ColonyActions/helpers/index.ts';
 import { ADDRESS_ZERO } from '~constants/index.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useMobile } from '~hooks';
-import { useAmountLessFee } from '~hooks/useAmountLessFee.ts';
+import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
 import useShouldDisplayMotionCountdownTime from '~hooks/useShouldDisplayMotionCountdownTime.ts';
 import useUserByAddress from '~hooks/useUserByAddress.ts';
 import { formatText } from '~utils/intl.ts';
@@ -32,8 +32,6 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
     motionState,
     expenditureId,
     recipientAddress,
-    amount,
-    networkFee,
   } = action;
 
   const { user: recipientUser, loading: loadingUser } = useUserByAddress(
@@ -60,7 +58,7 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
     motionState || null,
   );
 
-  const amountLessFee = useAmountLessFee(amount, networkFee);
+  const { networkInverseFee } = useNetworkInverseFee();
 
   const actionMetadataDescription = formatText(
     { id: 'action.title' },
@@ -69,10 +67,10 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
         ...action,
         recipientAddress: recipientUser?.walletAddress ?? recipientAddress,
         recipientUser: recipientUser ?? action.recipientUser,
-        amount: amountLessFee,
       },
       colony,
       expenditureData: expenditure ?? undefined,
+      networkInverseFee,
     }),
   );
 

--- a/src/components/common/ColonyActionsTable/partials/ActionMobileDescription/ActionMobileDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionMobileDescription/ActionMobileDescription.tsx
@@ -3,6 +3,7 @@ import React, { type FC } from 'react';
 
 import getActionTitleValues from '~common/ColonyActions/helpers/getActionTitleValues.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
 import useShouldDisplayMotionCountdownTime from '~hooks/useShouldDisplayMotionCountdownTime.ts';
 import { getFormattedDateFrom } from '~utils/getFormattedDateFrom.ts';
 import { formatText } from '~utils/intl.ts';
@@ -43,6 +44,8 @@ const ActionMobileDescription: FC<ActionMobileDescriptionProps> = ({
     motionState || null,
   );
 
+  const { networkInverseFee } = useNetworkInverseFee();
+
   const refetchMotionState = () => {
     if (!motionData) {
       return;
@@ -57,6 +60,7 @@ const ActionMobileDescription: FC<ActionMobileDescriptionProps> = ({
       actionData: action,
       colony,
       expenditureData: expenditure ?? undefined,
+      networkInverseFee,
     }),
   );
   const team = fromDomain?.metadata || motionData?.motionDomain.metadata;

--- a/src/components/common/Extensions/UserHub/partials/StakesTab/partials/StakeItem.tsx
+++ b/src/components/common/Extensions/UserHub/partials/StakesTab/partials/StakeItem.tsx
@@ -3,6 +3,7 @@ import { FormattedDate, useIntl } from 'react-intl';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { getActionTitleValues } from '~common/ColonyActions/index.ts';
+import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
 import { TX_SEARCH_PARAM } from '~routes';
 import Numeral from '~shared/Numeral/index.ts';
 import { setQueryParamOnUrl } from '~utils/urls.ts';
@@ -18,6 +19,7 @@ const StakeItem: FC<StakeItemProps> = ({ stake }) => {
   const { formatMessage } = useIntl();
   const navigate = useNavigate();
   const { expenditure } = useGetExpenditureData(stake.action?.expenditureId);
+  const { networkInverseFee } = useNetworkInverseFee();
 
   const stakeItemTitle =
     stake.action?.metadata?.customTitle ||
@@ -99,6 +101,7 @@ const StakeItem: FC<StakeItemProps> = ({ stake }) => {
                       actionData: stake.action,
                       colony: partialStakeColony,
                       expenditureData: expenditure ?? undefined,
+                      networkInverseFee,
                     }),
                   )
                 : '-'}

--- a/src/constants/actions.ts
+++ b/src/constants/actions.ts
@@ -1,5 +1,7 @@
 import { ColonyRole } from '@colony/colony-js';
 
+import { ColonyActionType } from '~gql';
+
 // Expected to return ColonyRole[][]
 export const PERMISSIONS_NEEDED_FOR_ACTION = {
   // Simple Payment requires all of funding, arbitration and administration roles
@@ -59,3 +61,12 @@ export enum Action {
   SimpleDiscussion = 'simple-discussion',
   ManageVerifiedMembers = 'manage-verified-members',
 }
+
+export const ACTIONS_WITH_NETWORK_FEE = new Set([
+  ColonyActionType.Payment,
+  ColonyActionType.PaymentMotion,
+  ColonyActionType.PaymentMultisig,
+  ColonyActionType.MultiplePayment,
+  ColonyActionType.MultiplePaymentMotion,
+  ColonyActionType.MultiplePaymentMultisig,
+]);

--- a/src/hooks/useAmountLessFee.ts
+++ b/src/hooks/useAmountLessFee.ts
@@ -1,6 +1,5 @@
-import { BigNumber } from 'ethers';
-
 import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
+import { getAmountLessFee } from '~utils/getAmountLessFee.ts';
 
 export const useAmountLessFee = (
   amount?: string | null,
@@ -8,21 +7,5 @@ export const useAmountLessFee = (
 ): string => {
   const { networkInverseFee } = useNetworkInverseFee();
 
-  // If a networkFee has been provided, then we assume the amount already excludes the networkFee
-  if (networkFee) {
-    return amount || '1';
-  }
-
-  const feeNumber = BigNumber.from(networkInverseFee || 1);
-
-  if (!feeNumber.gt(0)) {
-    return amount || '1';
-  }
-
-  const feePercentage = BigNumber.from(100).div(feeNumber);
-
-  return BigNumber.from(amount || '1')
-    .mul(BigNumber.from(100).sub(feePercentage))
-    .div(100)
-    .toString();
+  return getAmountLessFee(amount, networkFee, networkInverseFee);
 };

--- a/src/utils/getAmountLessFee.ts
+++ b/src/utils/getAmountLessFee.ts
@@ -1,0 +1,25 @@
+import { BigNumber } from 'ethers';
+
+export const getAmountLessFee = (
+  amount?: string | null,
+  networkFee?: string | null,
+  networkInverseFee?: string,
+): string => {
+  // If a networkFee has been provided, then we assume the amount already excludes the networkFee
+  if (networkFee) {
+    return amount || '1';
+  }
+
+  const feeNumber = BigNumber.from(networkInverseFee || 1);
+
+  if (!feeNumber.gt(0)) {
+    return amount || '1';
+  }
+
+  const feePercentage = BigNumber.from(100).div(feeNumber);
+
+  return BigNumber.from(amount || '1')
+    .mul(BigNumber.from(100).sub(feePercentage))
+    .div(100)
+    .toString();
+};


### PR DESCRIPTION
## Description

This PR fixes an issue where all amounts in the activity feed were assumed to include a network fee. This resulted in Mint Token actions and Move Funds actions to show an incorrect amount. This PR updates the `mapColonyActionToExpectedFormat` function to show the correct amount including or excluding the network fee based on the action type.

Note: Once this is merged and `feat/in-app-notifications` is rebased, we should update the uses of `getActionTitleValues` within the notification components to include the `networkInverseFee`.

## Testing

Mint Tokens

* Step 1 - Create a Mint Tokens action (I like to include the amount in the custom title to make it easier to check the correct amount is shown in the description line)
* Step 2 - Check the action has the correct amount in the activity feed

<img width="778" alt="Screenshot 2024-10-11 at 15 10 37" src="https://github.com/user-attachments/assets/c937603c-1376-488f-9359-7065e3f5db70">

Transfer Funds

* Step 3 - Create a Transfer Funds action and check the action has the correct amount in the activity feed

<img width="777" alt="Screenshot 2024-10-11 at 15 12 55" src="https://github.com/user-attachments/assets/809a554b-b3b5-4474-b33f-bdce06f8462d">

Simple Payments

* Step 4 - Create a Simple Payment action and check it has the correct amount in the activity feed

<img width="774" alt="Screenshot 2024-10-11 at 15 16 27" src="https://github.com/user-attachments/assets/62963222-bf9e-447e-a160-a3b20dc3ac00">

* Step 5 - Install the Weighted Voting Reputation extension
* Step 6 - Create a Simple Payment motion
* Step 7 - Stake the motion on both sides, but do not vote yet.

<img width="1055" alt="Screenshot 2024-10-11 at 15 18 49" src="https://github.com/user-attachments/assets/80c95b00-2536-4f97-9354-1ea01b691436">

* Step 8 - Check the amount in the activity feed is correct

<img width="771" alt="Screenshot 2024-10-11 at 15 18 54" src="https://github.com/user-attachments/assets/9e5c22c1-ffb0-4b4d-9110-397423ec2ccd">

* Step 9 - Check the amount in the stake description in the userhub is correct.

<img width="724" alt="Screenshot 2024-10-11 at 15 20 38" src="https://github.com/user-attachments/assets/419fa798-d3e6-49fd-9fc9-f70391d0dc2f">

* Step 10 - Run the following mutation in GraphiQL to change the network fee stored in the database - pick any value between 0 - 99.

```
mutation MyMutation {
  updateCurrentNetworkInverseFee(
    input: {id: "networkInverseFee", inverseFee: "50"}
  ) {
    id
    inverseFee
  }
}
```

* Step 11 - Refresh the app. Check the amount in the activity feed has changed to account for the change in network fee.

<img width="780" alt="Screenshot 2024-10-11 at 15 20 10" src="https://github.com/user-attachments/assets/adf242d5-e5ce-4603-90bc-37070b2b3e7c">

* Step 12 - Check the amount in the stake description in the userhub has also changed to account for the change in network fee.

<img width="707" alt="Screenshot 2024-10-11 at 15 20 20" src="https://github.com/user-attachments/assets/e83c1fc5-4b71-4a72-af4f-44c790e5a732">

* Step 13 - Check that none of the amounts for our previous actions have changed.

<img width="770" alt="Screenshot 2024-10-11 at 15 26 25" src="https://github.com/user-attachments/assets/683ed9f5-e27d-4222-91ef-c8b70e3989e7">

* Step 14 - Complete the motion and finalize it. Check the amount in the activity feed is still the adjusted value.

<img width="791" alt="Screenshot 2024-10-11 at 15 23 09" src="https://github.com/user-attachments/assets/21b7a90f-99db-4eba-b42a-0b0f72571aa3">

* Step 15 - Run the mutation again to change the amount back to 100.

```
mutation MyMutation {
  updateCurrentNetworkInverseFee(
    input: {id: "networkInverseFee", inverseFee: "100"}
  ) {
    id
    inverseFee
  }
}
```

* Step 16 - Refresh the app, now that the motion has finalized the amount should not have changed in either the activity feed or the stakes tab.

<img width="717" alt="Screenshot 2024-10-11 at 15 24 03" src="https://github.com/user-attachments/assets/9a8095bc-8097-4137-8280-0ae8100719e7">

Manage Reputation

* Step 17 - Create a manage reputation action. Award an amount of reputation points. Check the amount in the activity feed and the completed action screen description and table all match.

<img width="780" alt="Screenshot 2024-10-14 at 12 03 52" src="https://github.com/user-attachments/assets/2d1b9ff5-dc7c-41ff-b9da-4c018ef982c0">

<img width="680" alt="Screenshot 2024-10-14 at 12 06 26" src="https://github.com/user-attachments/assets/da09dda6-5be8-461d-aca0-6cce0574cab7">


## Diffs

**Changes** 🏗

* `mapColonyActionToExpectedFormat` now calculates amount based on action type

Resolves #3069
Resolves #3253
