### PR TITLE
fix: pagination inside incoming founds table

### DIFF
--- a/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
@@ -1,5 +1,8 @@
 import { CaretDown, WarningCircle } from '@phosphor-icons/react';
-import { getSortedRowModel } from '@tanstack/react-table';
+import {
+  getPaginationRowModel,
+  getSortedRowModel,
+} from '@tanstack/react-table';
 import clsx from 'clsx';
 import { BigNumber } from 'ethers';
 import React, { type FC } from 'react';
@@ -134,6 +137,7 @@ const TokenTable: FC<TokenTableProps> = ({ token }) => {
         <Table
           data={currentClaims}
           getSortedRowModel={getSortedRowModel()}
+          getPaginationRowModel={getPaginationRowModel()}
           columns={columns}
           className="-mx-[1.125rem] !w-[calc(100%+2.25rem)] px-[1.125rem] [&_td]:px-[1.125rem] [&_td]:py-4 [&_th]:!rounded-none [&_th]:border-y"
           tableClassName="rounded-none border-none"
@@ -148,6 +152,9 @@ const TokenTable: FC<TokenTableProps> = ({ token }) => {
                 desc: true,
               },
             ],
+            pagination: {
+              pageSize: 10,
+            },
           }}
           // This ensures that all sort actions made by the user are multisort.
           // In other words, it's always sorting by all columns.


### PR DESCRIPTION
## Description

Fix pagination inside `Incoming funds` table

## Testing

-Send multiple payments to a colony of the same token, 16 or more.
-Navigate to the Incoming funds page.
-Expand the token to see the individual incoming funds.
-Pagination should work now properly

https://github.com/user-attachments/assets/4445b75c-6799-4965-aeb7-4c7f8630b23f

## Diffs

**Changes** 🏗

Add pagination props for table

Resolves https://github.com/JoinColony/colonyCDapp/issues/3282
