### PR TITLE
fix: split payment table ui

### DIFF
--- a/src/components/shared/Numeral/Numeral.tsx
+++ b/src/components/shared/Numeral/Numeral.tsx
@@ -8,11 +8,11 @@ import numbroLanguage from './numbroLanguage.ts';
 import { NumeralBase } from './NumeralBase.tsx';
 import { type NumeralProps } from './types.ts';
 
+const displayName = 'Numeral';
+
 // needed for capitalized abbreviations
 numbro.registerLanguage(numbroLanguage);
 numbro.setLanguage('en-GB');
-
-const displayName = 'Numeral';
 
 const Numeral = ({
   value,

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentPayoutsTotal/SplitPaymentPayoutsTotal.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentPayoutsTotal/SplitPaymentPayoutsTotal.tsx
@@ -13,6 +13,7 @@ const SplitPaymentPayoutsTotal: FC<SplitPaymentPayoutsTotalProps> = ({
   token,
   convertToWEI,
   className,
+  value,
 }) => {
   const summedAmount =
     useMemo(() => {
@@ -44,7 +45,7 @@ const SplitPaymentPayoutsTotal: FC<SplitPaymentPayoutsTotalProps> = ({
         'flex items-center gap-3 text-gray-900 text-1',
       )}
     >
-      <Numeral value={summedAmount} decimals={token.decimals} />
+      <Numeral value={value || summedAmount} decimals={token.decimals} />
       <div className="flex items-center gap-1">
         <TokenAvatar
           tokenAddress={token.tokenAddress}

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentPayoutsTotal/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentPayoutsTotal/types.ts
@@ -7,4 +7,5 @@ export interface SplitPaymentPayoutsTotalProps {
   token: Token;
   convertToWEI?: boolean;
   className?: string;
+  value?: string;
 }

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentPercentField/SplitPaymentPercentField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentPercentField/SplitPaymentPercentField.tsx
@@ -26,7 +26,8 @@ const SplitPaymentPercentField: FC<SplitPaymentPercentFieldProps> = ({
         }
       }}
       wrapperClassName="flex-row flex text-md"
-      type="number"
+      type="text"
+      shouldAllowOnlyNumbers
       mode="secondary"
       placeholder={formatText({ id: 'actionSidebar.enterValue' })}
       suffix="%"

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/SplitPaymentRecipientsField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/SplitPaymentRecipientsField.tsx
@@ -45,6 +45,7 @@ const SplitPaymentRecipientsField: FC<SplitPaymentRecipientsFieldProps> = ({
     amount,
     fieldArrayMethods,
     disabled,
+    distributionMethod,
   });
   const isTablet = useTablet();
   const getMenuProps = ({ index }) => ({

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/hooks.tsx
@@ -1,5 +1,6 @@
 import { createColumnHelper, type ColumnDef } from '@tanstack/react-table';
 import Decimal from 'decimal.js';
+import moveDecimal from 'move-decimal-point';
 import React, { useMemo, useCallback, useEffect } from 'react';
 import { type FieldValues, type UseFieldArrayReturn } from 'react-hook-form';
 
@@ -31,6 +32,7 @@ export const useRecipientsFieldTableColumns = ({
   amount,
   fieldArrayMethods: { update },
   disabled,
+  distributionMethod,
 }: {
   name: string;
   token: Token;
@@ -38,6 +40,7 @@ export const useRecipientsFieldTableColumns = ({
   amount: string | undefined;
   fieldArrayMethods: UseFieldArrayReturn<FieldValues, string, 'id'>;
   disabled?: boolean;
+  distributionMethod?: SplitPaymentDistributionType;
 }): ColumnDef<SplitPaymentRecipientsTableModel, string>[] => {
   const isTablet = useTablet();
   const columnHelper = useMemo(
@@ -106,6 +109,10 @@ export const useRecipientsFieldTableColumns = ({
               <SplitPaymentPayoutsTotal
                 data={dataRef.current || []}
                 token={token}
+                value={
+                  distributionMethod === SplitPaymentDistributionType.Equal &&
+                  (amount ? moveDecimal(amount, token.decimals) : 0)
+                }
                 convertToWEI
               />
               {isTablet && (
@@ -113,7 +120,8 @@ export const useRecipientsFieldTableColumns = ({
                   {parseFloat(
                     (
                       dataRef.current?.reduce(
-                        (acc, _, index) => acc + getPercentValue(index),
+                        (acc, _, index) =>
+                          Number(acc) + Number(getPercentValue(index)),
                         0,
                       ) || 0
                     ).toFixed(4),
@@ -161,19 +169,23 @@ export const useRecipientsFieldTableColumns = ({
             />
           ),
           footer: !isTablet
-            ? () => (
-                <span className="text-md font-medium text-gray-900">
-                  {parseFloat(
-                    (
-                      dataRef.current?.reduce(
-                        (acc, _, index) => acc + getPercentValue(index),
-                        0,
-                      ) || 0
-                    ).toFixed(4),
-                  )}
-                  %
-                </span>
-              )
+            ? () => {
+                return (
+                  <span className="text-md font-medium text-gray-900">
+                    {distributionMethod === SplitPaymentDistributionType.Equal
+                      ? '100%'
+                      : `${Number(
+                          dataRef.current
+                            ?.reduce(
+                              (acc, _, index) =>
+                                Number(acc) + Number(getPercentValue(index)),
+                              0,
+                            )
+                            .toFixed(4) || 0,
+                        )}%`}
+                  </span>
+                );
+              }
             : undefined,
         }),
       ],
@@ -210,8 +222,7 @@ export const useDistributionMethodUpdate = ({
               percent: Number(percentPerRecipient.toFixed(4)),
               amount: amount
                 ? new Decimal(amount)
-                    .mul(percentPerRecipient)
-                    .div(100)
+                    .div(data.length || 1)
                     .toDecimalPlaces(
                       getSelectedToken(colony, data[index].tokenAddress || '')
                         ?.decimals || DEFAULT_TOKEN_DECIMALS,

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/hooks.tsx
@@ -48,6 +48,7 @@ export const useRecipientsFieldTableColumns = ({
     [],
   );
   const dataRef = useWrapWithRef(data);
+  const distributionMethodRef = useWrapWithRef(distributionMethod);
   const getPercentValue = useCallback((index: number): number => {
     const percent = dataRef.current?.[index]?.percent || 0;
 
@@ -110,7 +111,8 @@ export const useRecipientsFieldTableColumns = ({
                 data={dataRef.current || []}
                 token={token}
                 value={
-                  distributionMethod === SplitPaymentDistributionType.Equal &&
+                  distributionMethodRef?.current ===
+                    SplitPaymentDistributionType.Equal &&
                   (amount ? moveDecimal(amount, token.decimals) : 0)
                 }
                 convertToWEI
@@ -172,7 +174,8 @@ export const useRecipientsFieldTableColumns = ({
             ? () => {
                 return (
                   <span className="text-md font-medium text-gray-900">
-                    {distributionMethod === SplitPaymentDistributionType.Equal
+                    {distributionMethodRef?.current ===
+                    SplitPaymentDistributionType.Equal
                       ? '100%'
                       : `${Number(
                           dataRef.current

--- a/src/components/v5/common/CompletedAction/partials/SplitPayment/SplitPayment.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SplitPayment/SplitPayment.tsx
@@ -153,6 +153,7 @@ const SplitPayment = ({ action }: SplitPaymentProps) => {
     amount,
     -getTokenDecimalsWithFallback(splitToken?.decimals),
   );
+  const redoAmount = getNumeralTokenAmount(amount, splitToken?.decimals);
 
   const expenditureMeatballOptions: MeatBallMenuItem[] = [
     {
@@ -168,10 +169,10 @@ const SplitPayment = ({ action }: SplitPaymentProps) => {
             [ACTION_TYPE_FIELD_NAME]: Action.SplitPayment,
             distributionMethod: distributionType,
             [TEAM_FIELD_NAME]: fundFromDomainNativeId,
-            [AMOUNT_FIELD_NAME]: getNumeralTokenAmount(
-              amount,
-              splitToken?.decimals,
-            ),
+            [AMOUNT_FIELD_NAME]:
+              typeof redoAmount === 'string'
+                ? redoAmount.replace(',', '')
+                : redoAmount,
             payments: slots.map((slot) => {
               const currentAmount = moveDecimal(
                 slot.payouts?.[0].amount,

--- a/src/components/v5/common/Fields/InputBase/FormInputBase.tsx
+++ b/src/components/v5/common/Fields/InputBase/FormInputBase.tsx
@@ -17,6 +17,7 @@ const FormInputBase: FC<FormInputBaseProps> = ({
   onBlur: onBlurProp,
   readOnly,
   onChange: onChangeProp,
+  shouldAllowOnlyNumbers,
   ...rest
 }) => {
   const {
@@ -47,7 +48,14 @@ const FormInputBase: FC<FormInputBaseProps> = ({
         if (type === 'number') {
           onChange(Number.isNaN(valueAsNumber) ? 0 : valueAsNumber);
         } else {
-          onChange(inputValue);
+          onChange(
+            shouldAllowOnlyNumbers
+              ? inputValue
+                  .replace(/[^0-9.]/g, '')
+                  .replace(/(\..*?)\..*/g, '$1')
+                  .replace(/^0[^.]/, '0')
+              : inputValue,
+          );
         }
       }}
       state={invalid ? FieldState.Error : undefined}

--- a/src/components/v5/common/Fields/InputBase/types.ts
+++ b/src/components/v5/common/Fields/InputBase/types.ts
@@ -23,6 +23,7 @@ export interface FormInputBaseProps
   extends Omit<InputBaseProps, 'onChange' | 'state' | 'value'> {
   name: string;
   onChange?: () => void;
+  shouldAllowOnlyNumbers?: boolean;
 }
 
 export interface FormattedInputProps extends Omit<InputBaseProps, 'prefix'> {


### PR DESCRIPTION
## Description

- Equal distribution method now uses fractions to calculate amount instead of percentages
- Changed decimals to dots everywhere in payment table
- Total amounts is not higher then the originally intended value
<img width="658" alt="image" src="https://github.com/user-attachments/assets/68bcaf75-2c8c-4ce8-8b42-e1fbf7e668b7">


## Testing

* Create a split payment and play with it

Closed PR with comments - https://github.com/JoinColony/colonyCDapp/pull/3042

Resolves https://github.com/JoinColony/colonyCDapp/issues/3012
