### PR TITLE
Feat: Add new pill for advanced payments

### DIFF
--- a/src/components/v5/common/ActionSidebar/hooks/useActionsList.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useActionsList.ts
@@ -23,6 +23,7 @@ const useActionsList = () => {
           {
             label: { id: 'actions.paymentBuilder' },
             value: Action.PaymentBuilder,
+            isNew: true,
           },
           // @BETA: Disabled for now
           // {

--- a/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
+++ b/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
@@ -38,6 +38,7 @@ const SearchItem: FC<SearchItemProps> = ({
           value,
           isDisabled,
           isComingSoon,
+          isNew,
           avatar,
           showAvatar,
           color,
@@ -123,7 +124,15 @@ const SearchItem: FC<SearchItemProps> = ({
                     <div className="absolute right-0 top-1/2 -translate-y-1/2 transform">
                       <ExtensionsStatusBadge
                         mode="coming-soon"
-                        text="Coming soon"
+                        text={formatText({ id: 'status.comingSoon' })}
+                      />
+                    </div>
+                  )}
+                  {isNew && (
+                    <div className="absolute right-0 top-1/2 -translate-y-1/2 transform">
+                      <ExtensionsStatusBadge
+                        mode="new"
+                        text={formatText({ id: 'status.new' })}
                       />
                     </div>
                   )}

--- a/src/components/v5/shared/SearchSelect/types.ts
+++ b/src/components/v5/shared/SearchSelect/types.ts
@@ -28,6 +28,7 @@ export interface SearchSelectOption {
   value: string | number;
   isDisabled?: boolean;
   isComingSoon?: boolean;
+  isNew?: boolean;
   avatar?: string;
   thumbnail?: string;
   showAvatar?: boolean;


### PR DESCRIPTION
## Description

This PR adds a "New" pill which appears next to newly added actions in the action select menu to make them stand out.

## Testing

* Step 1: Create a new action and open the "Choose action type" select menu
* Step 2: Check the "Advanced payment" has the "New" pill next to it

<img width="633" alt="Screenshot 2024-10-14 at 11 19 57" src="https://github.com/user-attachments/assets/f4672e26-9fee-4d8e-aa70-c396811a4dee">


## Diffs

**New stuff** ✨

* 'isNew' prop added to the SearchItem component

Resolves #2709
