### PR TITLE
Fix: ManageVerifiedMembers action saga should use correct annotation channel

### DIFF
--- a/src/redux/sagas/actions/manageVerifiedMembers.ts
+++ b/src/redux/sagas/actions/manageVerifiedMembers.ts
@@ -99,7 +99,7 @@ function* manageVerifiedMembersAction({
     );
     if (annotationMessage) {
       yield takeFrom(
-        manageVerifiedMembers.channel,
+        annotateManageVerifiedMembers.channel,
         ActionTypes.TRANSACTION_CREATED,
       );
     }


### PR DESCRIPTION
## Description

This PR fixes an issue with the Manage Verified Members action saga which was preventing actions with descriptions from being created.

## Testing

Create a Manage verified members action, make sure you enter a description. It should be created without issue.

## Diffs

**Changes** 🏗

* Manage Verified Members action saga takes from the correct channel

Resolves #3285
