### PR TITLE
[Notifications-ish] Action Sidebar should automatically close when tx params is removed from the URL

### DIFF
--- a/src/components/frame/Extensions/layouts/ColonyLayout.tsx
+++ b/src/components/frame/Extensions/layouts/ColonyLayout.tsx
@@ -95,7 +95,7 @@ const ColonyLayout: FC<PropsWithChildren> = ({ children }) => {
   const previousTransactionId = usePrevious(transactionId);
 
   useLocationChange(() => {
-    if ((!!previousTransactionId && !transactionId) || isActionSidebarOpen) {
+    if (!!previousTransactionId && !transactionId && isActionSidebarOpen) {
       toggleActionSidebarOff();
     }
   });

--- a/src/components/frame/Extensions/layouts/ColonyLayout.tsx
+++ b/src/components/frame/Extensions/layouts/ColonyLayout.tsx
@@ -21,6 +21,8 @@ import { useColonyCreatedModalContext } from '~context/ColonyCreateModalContext/
 import { useMemberModalContext } from '~context/MemberModalContext/MemberModalContext.ts';
 import { usePageHeadingContext } from '~context/PageHeadingContext/PageHeadingContext.ts';
 import { useTablet } from '~hooks';
+import useLocationChange from '~hooks/useLocationChange.ts';
+import usePrevious from '~hooks/usePrevious.ts';
 import { TX_SEARCH_PARAM } from '~routes/index.ts';
 import ActionSidebar from '~v5/common/ActionSidebar/index.ts';
 import ColonyCreatedModal from '~v5/common/Modals/ColonyCreatedModal/index.ts';
@@ -55,8 +57,10 @@ const ColonyLayout: FC<PropsWithChildren> = ({ children }) => {
   // @TODO: Eventually we want the action sidebar context to be better intergrated in the layout (maybe only used here and not in UserNavigation(Wrapper))
   const { actionSidebarToggle, actionSidebarInitialValues } =
     useActionSidebarContext();
-  const [isActionSidebarOpen, { toggleOn: toggleActionSidebarOn }] =
-    actionSidebarToggle;
+  const [
+    isActionSidebarOpen,
+    { toggleOn: toggleActionSidebarOn, toggleOff: toggleActionSidebarOff },
+  ] = actionSidebarToggle;
   const isTablet = useTablet();
 
   const [userHubTab, setUserHubTab] = useState<UserHubTab>();
@@ -88,6 +92,13 @@ const ColonyLayout: FC<PropsWithChildren> = ({ children }) => {
   const hasRecentlyCreatedColony = locationState?.hasRecentlyCreatedColony;
   const [searchParams] = useSearchParams();
   const transactionId = searchParams?.get(TX_SEARCH_PARAM);
+  const previousTransactionId = usePrevious(transactionId);
+
+  useLocationChange(() => {
+    if ((!!previousTransactionId && !transactionId) || isActionSidebarOpen) {
+      toggleActionSidebarOff();
+    }
+  });
 
   useEffect(() => {
     if (transactionId) {

--- a/src/hooks/useLocationChange.ts
+++ b/src/hooks/useLocationChange.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const useLocationChange = (callback) => {
+  const location = useLocation();
+  useEffect(() => {
+    callback();
+    // We want to react only to location changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location]);
+};
+
+export default useLocationChange;


### PR DESCRIPTION
## Description

- This PR fixes the issue of having the `Create new action` sidebar replacing the completed action sidebar when navigating to another route by closing it if previously the `tx` parameter was present or the action sidebar is opened.

## Testing

TODO: Please check the action sidebar is closed when navigating to another route which removes the `tx` parameter. Easiest way to test this is via the notifications

* Step 1. Create a mint tokens action

![Screenshot 2024-10-15 at 16 22 15](https://github.com/user-attachments/assets/89201fb7-f95a-486c-bbc3-127b1ecad92e)

* Step 2. Click the "mint tokens" notification to have a transaction open in the sidebar.
* Step 3. Click the "incoming funds" notification which will navigate you to the balances page.


https://github.com/user-attachments/assets/c3ac460e-abea-4f26-bff5-ac8669adac2f


## Diffs

**New stuff** ✨

* `useLocationChange` hook

Resolves #3311 
