### PR TITLE
Hotfix: Advanced payments production issues

### DIFF
--- a/src/components/v5/common/ActionSidebar/hooks/useGetActionData.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useGetActionData.ts
@@ -253,7 +253,7 @@ const useGetActionData = (transactionId: string | undefined) => {
               return {
                 milestone: stage.name,
                 amount: moveDecimal(
-                  currentSlot?.payouts?.[0].amount,
+                  currentSlot?.payouts?.[0].amount ?? '0',
                   -getTokenDecimalsWithFallback(stagedToken?.token.decimals),
                 ),
                 tokenAddress: currentSlot?.payouts?.[0].tokenAddress,
@@ -275,7 +275,7 @@ const useGetActionData = (transactionId: string | undefined) => {
             return {
               recipient: slot.recipientAddress,
               amount: moveDecimal(
-                slot.payouts?.[0].amount,
+                slot.payouts?.[0].amount ?? '0',
                 -getTokenDecimalsWithFallback(paymentToken?.token.decimals),
               ),
               tokenAddress: slot.payouts?.[0].tokenAddress,
@@ -311,7 +311,7 @@ const useGetActionData = (transactionId: string | undefined) => {
           [AMOUNT_FIELD_NAME]: formattedAmount,
           payments: slots?.map((slot) => {
             const currentAmount = moveDecimal(
-              slot.payouts?.[0].amount,
+              slot.payouts?.[0].amount ?? '0',
               -getTokenDecimalsWithFallback(splitToken?.decimals),
             );
 

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/CancelModal/CancelModal.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/CancelModal/CancelModal.tsx
@@ -148,7 +148,7 @@ const CancelModal: FC<CancelModalProps> = ({
                       />
                     ) : (
                       <Button mode="primarySolid" isFullSize type="submit">
-                        {formatText({ id: 'cancelModal.locked.submit' })}
+                        {formatText({ id: 'cancelModal.submit' })}
                       </Button>
                     )}
                   </div>

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/MilestoneReleaseModal.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/MilestoneReleaseModal.tsx
@@ -228,13 +228,14 @@ const MilestoneReleaseModal: FC<MilestoneReleaseModalProps> = ({
         userAddress: user?.walletAddress || '',
       };
 
+      setIsWaitingForStagesRelease(true);
+
       if (
         decisionMethod &&
         decisionMethod.value === DecisionMethod.Reputation
       ) {
         await releaseExpenditureStageMotion(motionPayload);
       } else {
-        setIsWaitingForStagesRelease(true);
         await releaseExpenditureStage(payload);
       }
 

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/MilestoneReleaseModal.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/MilestoneReleaseModal.tsx
@@ -234,10 +234,10 @@ const MilestoneReleaseModal: FC<MilestoneReleaseModalProps> = ({
       ) {
         await releaseExpenditureStageMotion(motionPayload);
       } else {
+        setIsWaitingForStagesRelease(true);
         await releaseExpenditureStage(payload);
       }
 
-      setIsWaitingForStagesRelease(true);
       onClose();
     } catch (err) {
       console.error(err);

--- a/src/hooks/useActivityFeed/helpers.ts
+++ b/src/hooks/useActivityFeed/helpers.ts
@@ -114,6 +114,7 @@ const ACTION_TYPES_TO_HIDE = [
   ColonyActionType.EditExpenditure,
   ColonyActionType.EditExpenditureMotion,
   ColonyActionType.ReleaseStagedPaymentsMotion,
+  ColonyActionType.ReleaseStagedPayments,
 ];
 
 export const filterByActionTypes = (

--- a/src/redux/sagas/expenditures/releaseExpenditureStages.ts
+++ b/src/redux/sagas/expenditures/releaseExpenditureStages.ts
@@ -13,7 +13,6 @@ import {
   waitForTxResult,
 } from '../transactions/index.ts';
 import {
-  claimExpenditurePayouts,
   getColonyManager,
   initiateTransaction,
   putError,
@@ -166,24 +165,6 @@ function* releaseExpenditureStages({
         txHash,
       });
     }
-    const slotsToClaim = expenditure.slots.filter((slot) =>
-      slotIds.includes(slot.id),
-    );
-    const payoutsWithSlotIds = slotsToClaim.flatMap(
-      (slot) =>
-        slot.payouts?.map((payout) => ({
-          ...payout,
-          slotId: slot.id,
-        })) ?? [],
-    );
-
-    yield claimExpenditurePayouts({
-      colonyAddress,
-      claimablePayouts: payoutsWithSlotIds,
-      metaId: meta.id,
-      nativeExpenditureId: expenditure.nativeId,
-      colonyClient,
-    });
 
     yield put<AllActions>({
       type: ActionTypes.RELEASE_EXPENDITURE_STAGES_SUCCESS,


### PR DESCRIPTION
## Description

This PR contains changes aimed at resolving advanced payment issues identified in production deployment:
- Split payment crashing: A race condition that only occurred when fetched expenditure contained a slot but no payouts (UI needed to poll it right in between 2 chain events) and unsafe array access led to the entire app intermittently crashing while creating a split payment.
- "Make next payment" button stuck: When releasing milestone using permissions, the button could get stuck in Pending state. The app had to be refreshed.
- Release expenditure stages action was showing in the activity feed as a Generic action.
- Cancel expenditure modal was missing a translation for its submit button.
- `releaseExpenditureStages` saga was unnecessarily claiming payouts twice.
