### PR TITLE
 fix: permissions inherited roles visability

### DIFF
--- a/src/components/frame/v5/pages/MembersPage/utils.ts
+++ b/src/components/frame/v5/pages/MembersPage/utils.ts
@@ -1,14 +1,85 @@
 import { Id } from '@colony/colony-js';
 
-import { getRole } from '~constants/permissions.ts';
+import {
+  getInheritedPermissions,
+  getRole,
+  type UserRoleMeta,
+} from '~constants/permissions.ts';
 import { type ColonyContributorFragment, type ColonyFragment } from '~gql';
 import {
   getHighestTierRoleForUser,
   getUserRolesForDomain,
-} from '~transformers';
+} from '~transformers/index.ts';
 import { extractColonyRoles } from '~utils/colonyRoles.ts';
 
 import { type MemberItem } from './types.ts';
+
+interface RoleInfo {
+  role: UserRoleMeta | undefined;
+  isInherited: boolean;
+}
+
+interface GetRoleInfoParams {
+  colonyRoles: ReturnType<typeof extractColonyRoles>;
+  contributorAddress: string;
+  selectedTeamId: number | undefined;
+  isRootDomain: boolean;
+  isMultiSig: boolean;
+}
+
+const getRoleInfo = ({
+  colonyRoles,
+  contributorAddress,
+  selectedTeamId,
+  isRootDomain,
+  isMultiSig,
+}: GetRoleInfoParams): RoleInfo => {
+  const currentTeamPermissions = getUserRolesForDomain({
+    colonyRoles,
+    userAddress: contributorAddress,
+    domainId: selectedTeamId || Id.RootDomain,
+    excludeInherited: true,
+    isMultiSig,
+  });
+
+  const parentPermissions = getUserRolesForDomain({
+    colonyRoles,
+    userAddress: contributorAddress,
+    domainId: Id.RootDomain,
+    isMultiSig,
+  });
+
+  const inheritedPermissions = getInheritedPermissions({
+    parentPermissions,
+    currentPermissions: currentTeamPermissions,
+    isRootDomain,
+  });
+
+  // inheritedPermissions contains only a difference between parrent and current permissions
+  // in case current role is higher inheritedPermissions.length would be 0
+  if (inheritedPermissions.length > 0) {
+    return { role: getRole(parentPermissions), isInherited: true };
+  }
+
+  if (currentTeamPermissions.length > 0) {
+    return { role: getRole(currentTeamPermissions), isInherited: false };
+  }
+
+  return { role: undefined, isInherited: false };
+};
+
+export const getHighestTierRoleMeta = ({
+  colonyRoles,
+  contributorAddress,
+  isMultiSig = false,
+}) => {
+  const highestTierRole = getHighestTierRoleForUser(
+    colonyRoles,
+    contributorAddress,
+    isMultiSig,
+  );
+  return highestTierRole ? getRole(highestTierRole) : undefined;
+};
 
 export const getMembersList = (
   members: ColonyContributorFragment[],
@@ -16,6 +87,7 @@ export const getMembersList = (
   colony: ColonyFragment,
 ): MemberItem[] => {
   const isAllTeamsSelected = selectedTeamId === undefined;
+  const isRootDomain = selectedTeamId === Id.RootDomain;
   const colonyRoles = extractColonyRoles(colony.roles);
 
   return members.map((contributor) => {
@@ -28,66 +100,41 @@ export const getMembersList = (
       type,
     } = contributor;
 
-    const domainRoles = getUserRolesForDomain({
-      colonyRoles,
-      userAddress: contributorAddress,
-      domainId: selectedTeamId || Id.RootDomain,
-      intersectingRoles: true,
-    });
-
-    const domainRolesMeta = domainRoles.length
-      ? getRole(domainRoles)
-      : undefined;
-
-    const domainRolesWithoutInherited = getUserRolesForDomain({
-      colonyRoles,
-      userAddress: contributorAddress,
-      domainId: selectedTeamId || Id.RootDomain,
-      excludeInherited: true,
-    });
-
-    const highestTierRole = getHighestTierRoleForUser(
-      colonyRoles,
-      contributorAddress,
+    const { role: domainRolesMeta, isInherited: isRoleInherited } = getRoleInfo(
+      {
+        colonyRoles,
+        contributorAddress,
+        selectedTeamId,
+        isRootDomain,
+        isMultiSig: false,
+      },
     );
 
-    const highestTierRoleMeta = highestTierRole
-      ? getRole(highestTierRole)
-      : undefined;
+    const highestTierRoleMeta = getHighestTierRoleMeta({
+      colonyRoles,
+      contributorAddress,
+    });
+
+    const {
+      role: domainMultiSigRolesMeta,
+      isInherited: isMultiSigRoleInherited,
+    } = getRoleInfo({
+      colonyRoles,
+      contributorAddress,
+      selectedTeamId,
+      isRootDomain,
+      isMultiSig: true,
+    });
+
+    const highestTierMultiSigRoleMeta = getHighestTierRoleMeta({
+      colonyRoles,
+      contributorAddress,
+      isMultiSig: true,
+    });
 
     const teamReputationPercentage = reputation?.items?.find(
       (item) => item?.domain?.nativeId === selectedTeamId,
     )?.reputationPercentage;
-
-    const domainMultiSigRoles = getUserRolesForDomain({
-      colonyRoles,
-      userAddress: contributorAddress,
-      domainId: selectedTeamId || Id.RootDomain,
-      intersectingRoles: true,
-      isMultiSig: true,
-    });
-
-    const domainMultiSigRolesMeta = domainMultiSigRoles.length
-      ? getRole(domainMultiSigRoles)
-      : undefined;
-
-    const domainMultiSigRolesWithoutInherited = getUserRolesForDomain({
-      colonyRoles,
-      userAddress: contributorAddress,
-      domainId: selectedTeamId || Id.RootDomain,
-      excludeInherited: true,
-      isMultiSig: true,
-    });
-
-    const highestTierMultiSigRole = getHighestTierRoleForUser(
-      colonyRoles,
-      contributorAddress,
-      true,
-    );
-
-    const highestTierMultiSigRoleMeta = highestTierMultiSigRole
-      ? getRole(highestTierMultiSigRole, true)
-      : undefined;
 
     return {
       user,
@@ -97,17 +144,11 @@ export const getMembersList = (
         ? colonyReputationPercentage
         : teamReputationPercentage,
       role: isAllTeamsSelected ? highestTierRoleMeta : domainRolesMeta,
-      isRoleInherited:
-        isAllTeamsSelected || selectedTeamId === Id.RootDomain
-          ? false
-          : !domainRolesWithoutInherited.length,
+      isRoleInherited,
       multiSigRole: isAllTeamsSelected
         ? highestTierMultiSigRoleMeta
         : domainMultiSigRolesMeta,
-      isMultiSigRoleInherited:
-        isAllTeamsSelected || selectedTeamId === Id.RootDomain
-          ? false
-          : !domainMultiSigRolesWithoutInherited.length,
+      isMultiSigRoleInherited,
       contributorType: type ?? undefined,
     };
   });

--- a/src/components/frame/v5/pages/MembersPage/utils.ts
+++ b/src/components/frame/v5/pages/MembersPage/utils.ts
@@ -54,18 +54,17 @@ const getRoleInfo = ({
     currentPermissions: currentTeamPermissions,
     isRootDomain,
   });
-
-  // inheritedPermissions contains only a difference between parrent and current permissions
-  // in case current role is higher inheritedPermissions.length would be 0
-  if (inheritedPermissions.length > 0) {
-    return { role: getRole(parentPermissions), isInherited: true };
+  if (!inheritedPermissions.length && !currentTeamPermissions.length) {
+    return { role: undefined, isInherited: false };
   }
 
-  if (currentTeamPermissions.length > 0) {
-    return { role: getRole(currentTeamPermissions), isInherited: false };
-  }
-
-  return { role: undefined, isInherited: false };
+  const mergedPermissions = [
+    ...new Set([...parentPermissions, ...currentTeamPermissions]),
+  ];
+  return {
+    role: getRole(mergedPermissions),
+    isInherited: inheritedPermissions.length > 0,
+  };
 };
 
 export const getHighestTierRoleMeta = ({

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -156,18 +156,23 @@ export const getHighestTierRoleForUser = (
       domainWhereUserHasARole?.domain.nativeId === Id.RootDomain,
   );
 
-  if (rootDomainRole) {
-    return convertRolesToArray(rootDomainRole);
-  }
+  const rootRoles = convertRolesToArray(rootDomainRole);
 
-  const result = domainsWhereUserHasARole.reduce(
-    (maxObj, currentObj) =>
-      Object.values(currentObj ?? {}).filter(True).length >
-      Object.values(maxObj ?? {}).filter(True).length
-        ? currentObj
-        : maxObj,
-    {} as ColonyRoleFragment,
-  );
+  const result = domainsWhereUserHasARole
+    .filter(
+      (domainWhereUserHasARole) =>
+        domainWhereUserHasARole?.domain.nativeId !== Id.RootDomain,
+    )
+    .reduce(
+      (maxObj, currentObj) =>
+        Object.values(currentObj ?? {}).filter(True).length >
+        Object.values(maxObj ?? {}).filter(True).length
+          ? currentObj
+          : maxObj,
+      {} as ColonyRoleFragment,
+    );
 
-  return convertRolesToArray(result);
+  const maxResult = convertRolesToArray(result);
+
+  return [...new Set([...rootRoles, ...maxResult])];
 };


### PR DESCRIPTION
## Description

Funny thing, this bug has been fixed at least three times, but it’s still present. 😁

Here is previous fixes for reference: https://github.com/JoinColony/colonyCDapp/pull/2971 , https://github.com/JoinColony/colonyCDapp/pull/3024 , https://github.com/JoinColony/colonyCDapp/pull/2485 

<img width="1459" alt="image" src="https://github.com/user-attachments/assets/aee05995-5965-469a-9905-e00e31706ac7">

I decided to use the implementation from my last PR, but if you have any concerns, I’m open to refactoring.  🙌

## Testing

Step 1. Assign Admin permissions to fry in Andromeda
Step 2. Assign Payer permissions to fry in General
Step 3. Assign Payer permissions to amy in Andromeda
Step 4. Assign Admin permissions to amy in General
Step 5. Navigate to the permissions page to check fry's and amy's roles in Andromeda
Step 6. fry should be an admin, amy should be an admin with inherited pill

<img width="1505" alt="image" src="https://github.com/user-attachments/assets/c8f792ec-ac9a-4708-bb95-d7dbd90c7711">

Step 7. Install multi-sig extension
Step 8. Assign Admin permissions to amy in Serenity
Step 9. Assign Payer permissions to amy in General
Step 10. Assign Payer permissions to fry in Serenity
Step 11. Assign Admin permissions to fry in General
Step 12. Navigate to the permissions page to check fry's and amy's roles in Serenity
Step 13. amy should be an admin, fry should be an admin with inherited pill

<img width="1035" alt="image" src="https://github.com/user-attachments/assets/9962b7d3-1631-41f7-8075-b7492bac42b2">


Step 14. Add **Bella** as a Payer in team Andromeda
Step 15. Add **Bella** as an Admin in team Serenity
Step 16. Add **Alex** as an Owner in team General
Step 17. Change **Alex** permission in team Andromeda to Arbitration only (Custom)
Step 18. Set the Permissions page filter to All Teams
Step 19. Verify that:
- You don't see the "Inherited" badge on any user tile
- Leela & **Alex** are both under the Owner category
- **Bella** is under the Admin category, because this is the highest permission they across all subdomains

Step 20. Set the Permissions page filter to General
Step 21. Verify that:
- You don't see **Bella** in the list
- Leela & **Alex** are both under the Owner category and their tiles do not have the "Inherited" badge

Step 22. Set the Permissions page filter to Andromeda
Step 23. Verify that:
- Both Leela and **Alex** are under the Owner category and they both have the "Inherited" badge
- **Bella** is under the Payer category and her tile does not have the "inherited" badge

Step 24. Set the Permissions page filter to Serenity
Step 25. Verify that:
- Both Leela and **Alex** are under the Owner category and they both have the "Inherited" badge
- **Bella** is under the Admin category and her tile does not have the "inherited" badge

Thanks to @bassgeta for the case with custom roles:

Step 26. Assign fry custom Administration role in General
Step 27. Assign fry Architecture, Arbitration and Funding in Andromeda
Step 28. Set the Permissions page filter to Andromeda
Step 29. Verify that fry is under Admin role with "inherited" badge
Step 30. Set the Permissions page filter to All teams
Step 31. Verify that fry is under Admin role without "inherited" badge

Resolves #2785
