### PR TITLE
fix: update padding according to the design system

### DIFF
--- a/src/components/v5/common/TableHeader/TableHeader.tsx
+++ b/src/components/v5/common/TableHeader/TableHeader.tsx
@@ -9,7 +9,7 @@ const TableHeader = ({
   additionalHeaderContent,
   children,
 }: PropsWithChildren<TableHeaderProps>) => (
-  <div className="pb-4">
+  <div className="pb-3.5">
     <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between">
       <div className="flex flex-shrink-0 items-center sm:min-h-8.5">
         <h4 className="mr-3 heading-5">{title}</h4>


### PR DESCRIPTION
## Description
According to descussion here - https://github.com/JoinColony/colonyCDapp/pull/3257#issuecomment-2393667391 padding should be updated to 14px to match the Design System

## Testing

1. Open Balance table
2. Ensure that padding is 14px
3. Open incoming table
4. Ensure that padding is 14px

<img width="609" alt="image" src="https://github.com/user-attachments/assets/f0f8bc8c-02f0-4bfe-9b4c-c1d509919dae">


Resolves #3353
