### PR TITLE
fix: InputBase dark mode background

### DIFF
--- a/src/components/v5/common/Fields/InputBase/InputBase.tsx
+++ b/src/components/v5/common/Fields/InputBase/InputBase.tsx
@@ -65,7 +65,7 @@ const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
         className={clsx(
           className,
           state && !disabled ? stateClassNames[state] : undefined,
-          'w-full text-md outline-0 focus:outline-none',
+          'w-full bg-transparent text-md outline-0 focus:outline-none',
           {
             'text-gray-900 placeholder:text-gray-400': !disabled,
             'pointer-events-none bg-transparent text-gray-400 placeholder:text-gray-300':


### PR DESCRIPTION
## Description

Motions "Create new team", "Edit a team" or "Edit colony" have input with white bg in dark mode.

![image](https://github.com/user-attachments/assets/001c5ec5-0ae0-4c03-aa20-eb78d00d239b)


## Testing

1. Enable "Dark mode"
2. Open "Create new team" motion
3. Ensure that there is no white bg for inputs
<img width="618" alt="image" src="https://github.com/user-attachments/assets/6b3681ee-df11-4136-be8b-e181303559ea">

4. Check "Edit a team", "Edit colony" as well
5. Check "Split payments":
<img width="598" alt="image" src="https://github.com/user-attachments/assets/723fbc6c-4922-4ac2-94aa-5a8b4346b3b2">


Resolves #3319
