### PR TITLE
[Notifications] feat: send notifications when there is a new extension version available

### DIFF
--- a/amplify/backend/api/colonycdapp/schema/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema/schema.graphql
@@ -1020,6 +1020,7 @@ enum NotificationType {
   PERMISSIONS_ACTION
   # versions
   NEW_COLONY_VERSION
+  NEW_EXTENSION_VERSION
 }
 
 """

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=5d5ac5f8817c76521f366112db23905f07b68d78
+ENV BLOCK_INGESTOR_HASH=3565741c8049ee01e994dcb8a32558070c1eea88
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Extension/ExtensionNotificationMessage.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Extension/ExtensionNotificationMessage.tsx
@@ -51,6 +51,11 @@ const MSG = defineMessages({
     id: `${displayName}.settingsChanged`,
     defaultMessage: 'extension settings changed by {name}',
   },
+  newExtensionVersion: {
+    id: `${displayName}.newExtensionVersion`,
+    defaultMessage:
+      'Extension {extension} has a new version ({version}) available.',
+  },
 });
 
 const ExtensionNotificationMessage: FC<ExtensionNotificationMessageProps> = ({
@@ -90,10 +95,17 @@ const ExtensionNotificationMessage: FC<ExtensionNotificationMessageProps> = ({
         return renderNotificationMessage(MSG.uninstalled);
       case NotificationType.ExtensionSettingsChanged:
         return renderNotificationMessage(MSG.settingsChanged);
+      case NotificationType.NewExtensionVersion:
+        return formatText(MSG.newExtensionVersion, {
+          version:
+            notification.customAttributes.newExtensionVersion ||
+            formatText(MSG.unknownExtensionName),
+          extension: formatText(extensionNameDescriptor),
+        });
       default:
         return null;
     }
-  }, [creator, notification.customAttributes, extensionNameDescriptor]);
+  }, [notification.customAttributes, extensionNameDescriptor, creator]);
 
   return <NotificationMessage loading={loading}>{Message}</NotificationMessage>;
 };

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
@@ -122,6 +122,7 @@ const Notification: FC<NotificationProps> = ({
       NotificationType.ExtensionDeprecated,
       NotificationType.ExtensionUninstalled,
       NotificationType.ExtensionSettingsChanged,
+      NotificationType.NewExtensionVersion,
     ].includes(notificationType)
   ) {
     return (

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -6174,6 +6174,7 @@ export enum NotificationType {
   MultisigActionFinalized = 'MULTISIG_ACTION_FINALIZED',
   MultisigActionRejected = 'MULTISIG_ACTION_REJECTED',
   NewColonyVersion = 'NEW_COLONY_VERSION',
+  NewExtensionVersion = 'NEW_EXTENSION_VERSION',
   PermissionsAction = 'PERMISSIONS_ACTION'
 }
 

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -12,6 +12,7 @@ export interface NotificationAttributes {
   tokenAddress?: string;
   extensionHash?: string;
   newColonyVersion?: string;
+  newExtensionVersion?: string;
 }
 
 // Create our own notification type so that we have types for the custom attributes, instead of


### PR DESCRIPTION
## Description

This PR implements notifications when a new extension version has been added to the network.
[Block-ingestor PR](https://github.com/JoinColony/block-ingestor/pull/281)

## Testing

Not that different from testing the colony versions!
__Note:__ I've actually accidentally gave `amy` permissions in `wayne`, not `planex`, but you can test it that way too, doesn't matter :')

1. Open the app as `leela` and also as `amy` to get necessary notification data on both of them
2. As `leela` assign `amy` `Owner` permissions in `wayne`
![image](https://github.com/user-attachments/assets/05050c65-fa2d-40bf-b2c0-a9ba01e3307a)
3. Run `npm run hardhat`. In the console, run the following to generate a new extension version of `OneTxPayment` (you can use any of these as the second argument)
![image](https://github.com/user-attachments/assets/eed1648b-222c-4bd9-9757-21c412a253bd)
```
deployNext=require("./scripts/deployOldUpgradeableVersion.js").deployNextExtensionVersion
cn = await artifacts.require("IColonyNetwork").at("0x777760996135F0791E2e1a74aFAa060711197777")
await deployNext(cn, "OneTxPayment")
```
![image](https://github.com/user-attachments/assets/68ee3dd4-7175-4727-a78a-f6398e56ac5a)
5. Verify that `leela` has received notifications for `wayne` and `planex`
![image](https://github.com/user-attachments/assets/b4eb2baa-6a6e-45e5-94ed-4b1ef4cad942)
6. Verify that clicking on these notifications navigates to the colony's extension page
7. Verify that `amy` got a notification for `wayne` only
![image](https://github.com/user-attachments/assets/1ee4d16f-621c-47a2-a7ab-e8ae0d4ee9f5)
8. Test notifications when upgrading any unsupported extensions (e.g. `CoinMachine`). Run
`await deployNext(cn, "CoinMachine")` in the hardhat console and wait for it to finish. Verify that you don't get notifications.
 ![image](https://github.com/user-attachments/assets/3c019f06-06c1-490c-905d-b34ac4de9cf0)
![image](https://github.com/user-attachments/assets/f4b64e2f-e64f-47fc-abc8-d102fbc3a607)


## Diffs

**New stuff** ✨

* block-ingestor now has a `sendExtensionVersionAddedNotifications` handler

**Changes** 🏗

* The `ExtensionMessage` component now displays a message for new extension versions

Resolves  #3284
