### PR TITLE
fix: display characters length in colony name input

### DIFF
--- a/src/components/common/Onboarding/wizardSteps/CreateColony/StepColonyNameInputs.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/StepColonyNameInputs.tsx
@@ -64,6 +64,7 @@ const StepColonyNameInputs = ({
         defaultValue={wizardDisplayName}
         labelMessage={{ id: 'colonyName' }}
         shouldFocus
+        shouldNumberOfCharsBeVisible
       />
       <div className="flex flex-col gap-2 pt-6">
         <label className="flex flex-col text-1" htmlFor="id-colonyName">


### PR DESCRIPTION
## Description

Display characters length inside colony name input 

## Testing

- Start "Create colony" flow
- Enter some chars in the Colony name field

## Diffs

**Changes** 🏗

Add flag `shouldNumberOfCharsBeVisible` to input

Before:

![Screenshot 2024-10-16 at 15 03 39](https://github.com/user-attachments/assets/c7ddf777-f8d4-4096-adbd-a57fb03b4d9f)

After:

![Screenshot 2024-10-16 at 15 03 00](https://github.com/user-attachments/assets/159b6586-3a86-42d4-997b-fc149acd9b67)

Resolves https://github.com/JoinColony/colonyCDapp/issues/3294
