### PR TITLE
fix: get permissions for the extension for the payment domain instead of motion domain

### DIFF
--- a/src/redux/sagas/motions/paymentMotion.ts
+++ b/src/redux/sagas/motions/paymentMotion.ts
@@ -241,7 +241,7 @@ function* createPaymentMotion({
           networkClient: colonyClient.networkClient,
           colonyRoles,
           colonyDomains,
-          requiredDomainId: safeMotionId,
+          requiredDomainId: domainId,
           requiredColonyRoles: requiredRoles,
           permissionAddress: votingReputationClient.address,
           isMultiSig: false,


### PR DESCRIPTION
## Description

O N E L I N E R

Basically, the lookup for the voting reputation's permission proofs was done for the motion domain instead of the domain the funds are getting sent from.

## Testing

1. Install the voting reputation extension
2. Create a simple payment motion sending some CREDS to `leela` from `Andromeda`, but create the motion in `General` (you can note how many CREDS she has)
![image](https://github.com/user-attachments/assets/4f0a41c0-8242-415b-b889-5f4dde7404bf)
3. Fully support it and run `npm run forward-time 1` to get to the finalization step
![image](https://github.com/user-attachments/assets/27204d48-1fc0-4803-90b3-2b8a73765562)
![image](https://github.com/user-attachments/assets/ad6f45dc-dba0-495a-9fe8-f31fd72b12c5)
4. Try finalizing it, it should pass (double check if the CREDS came to `leela`'s wallet
![image](https://github.com/user-attachments/assets/963b177b-ebf0-46a2-8264-7d03dbc6a095)
5. For a sanity check, create a simple payment motion paying some CREDS from `Serenity` and create the motion in `Serenity`, support it, forward time, finalize it
![image](https://github.com/user-attachments/assets/13eb2a93-9f71-43ef-a553-981eeb883a7c)
![image](https://github.com/user-attachments/assets/5e553ec6-2595-46be-97fa-a1ef715d6375)


## Diffs

**Changes** 🏗

* use `domainId` instead of `motionId` for permission proofs lookup of the voting reputation extension

Resolves  #3287
