### PR TITLE
[Dashboard] UI fixes after review

### DIFF
--- a/src/components/common/ColonyActionsTable/hooks/useColonyActionsTableColumns.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useColonyActionsTableColumns.tsx
@@ -69,7 +69,7 @@ const useColonyActionsTableColumns = ({
           return team || loading ? (
             <TeamBadge
               className={clsx({
-                skeleton: loading,
+                'overflow-hidden rounded border-none skeleton': loading,
               })}
               textClassName="line-clamp-1 break-all"
               name={team?.name || ''.padEnd(6, '-')}
@@ -91,7 +91,7 @@ const useColonyActionsTableColumns = ({
               className={clsx(
                 'whitespace-nowrap text-md font-normal text-gray-600',
                 {
-                  skeleton: loading,
+                  'overflow-hidden rounded skeleton': loading,
                 },
               )}
             >

--- a/src/components/common/ColonyActionsTable/partials/ActionBadge/ActionBadge.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionBadge/ActionBadge.tsx
@@ -23,14 +23,14 @@ const ActionBadge: FC<ActionBadgeProps> = ({
     <ExpenditureActionStatusBadge
       expenditure={expenditure}
       className={clsx(className, {
-        skeleton: isLoading,
+        'overflow-hidden skeleton': isLoading,
       })}
     />
   ) : (
     <MotionStateBadge
       state={motionState || MotionState.Unknown}
       className={clsx(className, {
-        skeleton: isLoading,
+        'overflow-hidden skeleton': isLoading,
       })}
     />
   );

--- a/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
@@ -102,7 +102,7 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
             className={clsx(
               'line-clamp-2 text-md font-medium text-gray-900 md:line-clamp-1',
               {
-                skeleton: isLoading,
+                'overflow-hidden rounded skeleton sm:w-64': isLoading,
               },
             )}
           >
@@ -116,7 +116,7 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
               className={clsx(
                 'mt-0.5 line-clamp-2 text-sm font-normal text-gray-600 md:line-clamp-1',
                 {
-                  skeleton: isLoading,
+                  'overflow-hidden rounded skeleton sm:w-48': isLoading,
                   hidden: hideDetails,
                 },
               )}

--- a/src/components/common/ColonyActionsTable/partials/ActionMobileDescription/ActionMobileDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionMobileDescription/ActionMobileDescription.tsx
@@ -86,7 +86,7 @@ const ActionMobileDescription: FC<ActionMobileDescriptionProps> = ({
         )}
         <p
           className={clsx(textClassName, 'text-gray-600', {
-            skeleton: isLoading,
+            'overflow-hidden rounded skeleton': isLoading,
           })}
         >
           {actionMetadataDescription}

--- a/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/MembersInformation/MembersInformation.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/MembersInformation/MembersInformation.tsx
@@ -3,7 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 
 import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
 import { useMemberContext } from '~context/MemberContext/MemberContext.ts';
-import { COLONY_MEMBERS_ROUTE } from '~routes/index.ts';
+import { COLONY_FOLLOWERS_ROUTE, COLONY_MEMBERS_ROUTE } from '~routes/index.ts';
 import { formatText } from '~utils/intl.ts';
 import UserAvatars from '~v5/shared/UserAvatars/index.ts';
 
@@ -54,8 +54,7 @@ const MembersInformation = () => {
       >
         <Link
           className="md:hover:text-blue-400"
-          // @TODO: Update this to COLONY_FOLLOWERS_ROUTE once implemented
-          to={{ pathname: COLONY_MEMBERS_ROUTE, search: search || '' }}
+          to={{ pathname: COLONY_FOLLOWERS_ROUTE, search: search || '' }}
         >
           <p>
             <span className="font-semibold">{followersCount}</span>{' '}

--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/ReputationChart.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/ReputationChart.tsx
@@ -32,6 +32,14 @@ const MSG = defineMessages({
     id: `${displayName}.influenceTitleContributors`,
     defaultMessage: 'Top members',
   },
+  noColonyReputationLabel: {
+    id: `${displayName}.noColonyReputationLabel`,
+    defaultMessage: 'There is no reputation in the colony yet',
+  },
+  noTeamReputationLabel: {
+    id: `${displayName}.noTeamReputationLabel`,
+    defaultMessage: 'There is no reputation in the team yet',
+  },
 });
 
 const ReputationChart = () => {
@@ -68,6 +76,15 @@ const ReputationChart = () => {
     ? MSG.reputationTitleContributors
     : MSG.reputationTitleTeam;
 
+  const emptyChartItem = {
+    id: 'noReputation',
+    label: formatText(
+      isNoSubDomains ? MSG.noTeamReputationLabel : MSG.noColonyReputationLabel,
+    ),
+    value: 100,
+    color: '--color-gray-200',
+  };
+
   const ActionsMenu = isNoSubDomains ? ContributorActionsMenu : TeamActionsMenu;
 
   return (
@@ -84,7 +101,11 @@ const ReputationChart = () => {
         <ActionsMenu isDisabled={isDataLoading} />
       </div>
       <ReputationChartContextProvider>
-        <Chart data={chartData} isLoading={isDataLoading} />
+        <Chart
+          data={chartData}
+          emptyChartItem={emptyChartItem}
+          isLoading={isDataLoading}
+        />
       </ReputationChartContextProvider>
     </div>
   );

--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/Chart.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/Chart.tsx
@@ -1,9 +1,7 @@
 import { ResponsivePie } from '@nivo/pie';
 import React, { type FC } from 'react';
-import { defineMessages } from 'react-intl';
 
 import { useReputationChartContext } from '~context/ReputationChartContext/ReputationChartContext.ts';
-import { formatText } from '~utils/intl.ts';
 
 import { pieChartConfig } from '../consts.ts';
 import { type ReputationChartDataItem } from '../types.ts';
@@ -14,28 +12,13 @@ import Legend from './Legend.tsx';
 import LegendItem from './LegendItem.tsx';
 import LegendLoadingItem from './LegendLoadingItem.tsx';
 
-const displayName = 'v5.frame.ColonyHome.ReputationChart.partials.Chart';
-
-const MSG = defineMessages({
-  noReputationLabel: {
-    id: `${displayName}.noReputationLabel`,
-    defaultMessage: 'There is no reputation in the colony yet',
-  },
-});
-
-const EMPTY_CHART_ITEM = {
-  id: 'noReputation',
-  label: formatText(MSG.noReputationLabel),
-  value: 100,
-  color: '--color-gray-200',
-};
-
 interface ChartProps {
   data: ReputationChartDataItem[];
+  emptyChartItem: ReputationChartDataItem;
   isLoading?: boolean;
 }
 
-export const Chart: FC<ChartProps> = ({ data, isLoading }) => {
+export const Chart: FC<ChartProps> = ({ data, emptyChartItem, isLoading }) => {
   const { setActiveLegendItem } = useReputationChartContext();
   return (
     <>
@@ -43,7 +26,7 @@ export const Chart: FC<ChartProps> = ({ data, isLoading }) => {
         {isLoading ? <ChartLoadingLayer /> : null}
         <ResponsivePie
           {...pieChartConfig}
-          data={data.length ? data : [EMPTY_CHART_ITEM]}
+          data={data.length ? data : [emptyChartItem]}
           isInteractive={!!data.length}
           onActiveIdChange={setActiveLegendItem}
           tooltip={ChartTooltip}
@@ -60,11 +43,11 @@ export const Chart: FC<ChartProps> = ({ data, isLoading }) => {
         <Legend>
           {!data.length && (
             <LegendItem
-              key={EMPTY_CHART_ITEM.id}
+              key={emptyChartItem.id}
               chartItem={{
-                id: EMPTY_CHART_ITEM.id,
-                label: EMPTY_CHART_ITEM.label,
-                color: EMPTY_CHART_ITEM.color,
+                id: emptyChartItem.id,
+                label: emptyChartItem.label,
+                color: emptyChartItem.color,
                 shouldTruncateLegendLabel: false,
               }}
             />

--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/Legend.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/Legend.tsx
@@ -9,7 +9,7 @@ const Legend: FC<LegendProps> = ({ children, className }) => {
     <div
       className={clsx(
         className,
-        'flex w-full flex-row flex-wrap items-end justify-start gap-x-4 gap-y-2',
+        'mt-auto flex w-full flex-row flex-wrap items-end justify-start gap-x-4 gap-y-2',
       )}
     >
       {children}

--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/ClaimFundsButton.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/ClaimFundsButton.tsx
@@ -92,7 +92,7 @@ export const ClaimFundsButton = () => {
     <Button
       text={formatText(MSG.fundsClaimedCTA)}
       size="small"
-      className="pointer-events-none h-fit border border-success-400 bg-success-400 px-3 py-2 !text-base-white"
+      className="pointer-events-none h-8.5 border border-success-400 bg-success-400 px-3 py-2 !text-base-white"
     />
   ) : (
     <LoadingSkeleton isLoading={isClaiming} className="h-8.5 w-14 rounded-lg">


### PR DESCRIPTION
## Description

- This PR addresses several issues

- [x] For the recent activity table, can we match the design including the rounded corners closer to Figma (specifically the right side with the date and pills?) 

The rounded corners don't match the components above the table, and it would be nice to closer match the data coming into the table. 

Currently: 
<img width="480" alt="image" src="https://github.com/user-attachments/assets/744f4652-291c-48fa-828c-562d36066517">

Figma:
<img width="1096" alt="image" src="https://github.com/user-attachments/assets/6bfe048d-3334-4e23-94c9-9cb30ce7ae3f">


- [x] When I select the 'followers' in the top header, it takes me to the members page with the members tab selected. 

Hover: 
<img width="179" alt="image" src="https://github.com/user-attachments/assets/18a8da7e-7cb1-47f0-8dab-d79017d36058">

Once selected: 
<img width="204" alt="image" src="https://github.com/user-attachments/assets/ac3c0ff3-92a8-4773-9ccd-e2c08976fc4d">


- [x] When selecting a new team who has no members with rep, the copy in the empty state of the team rep widget should read:

"There is no reputation in the team yet"

<img width="424" alt="image" src="https://github.com/user-attachments/assets/e895c299-ecfa-4df3-aa2c-90f97853737d">


- [x] When there is only one line of teams, members or the empty state text, can this row be positioned to match the Figma design.

Row in question:
<img width="435" alt="image" src="https://github.com/user-attachments/assets/73e42dbf-5f43-430c-9e6a-828fc5f4bbe5">


Currently positioned at the top close to the bottom of the chart:

<img width="435" alt="image" src="https://github.com/user-attachments/assets/7d8018a4-6466-4177-a586-97969d590d05">


Figma, positioned at the bottom of the widget:

<img width="621" alt="image" src="https://github.com/user-attachments/assets/f78afbcd-3acb-4d91-b308-3c26f93fadb0">


- [x] Once the claim button changes to the green success state, the vertical height of the button gets heigher causing a slight jump.

![Export-1729076600734](https://github.com/user-attachments/assets/674a3698-189a-47cf-9c82-01cd11a5e249)

## Testing

TODO: Please test the above mentioned issues are solved

* Step 1. For first issue you need to check the loading state of the `Recent activity table` rows. 

So either refresh the page or set `loading` in `useColonyActionsTableColumns.tsx` and `isLoading` in `ActionDescription.tsx` to `true`

![Screenshot 2024-10-16 at 21 53 43](https://github.com/user-attachments/assets/919e1ebe-1a38-46db-bab8-7ace61454436)

* Step 2. Check the `members` and `folowers` links in the Dashboard page header link to the correct page


https://github.com/user-attachments/assets/a3c70985-1db9-47d9-9d3c-291a0875ed96



* Step 3. Run `node scripts/create-colony-url.js` and create a new colony
* Step 3.1. Create a new team inside the colony

![Screenshot 2024-10-16 at 21 58 31](https://github.com/user-attachments/assets/526e7fe4-6c5f-479c-96a0-351c8918df84)


* Step 3.2. Select the new team and check the reputation chart legend. the copy text should be `There is no reputation in the team yet`

![Screenshot 2024-10-16 at 21 58 40](https://github.com/user-attachments/assets/a407eff0-834f-473d-bfd0-f99611bd1d76)

* Step 3.3. To be sure nothing else got affected select `All teams` or `General` and check the legend in the reputation chart.

![Screenshot 2024-10-16 at 21 58 55](https://github.com/user-attachments/assets/7255fd60-f891-4e7f-8603-ae3eefdaed30)

* Step 4. Now go back to `planex` and switch between the teams and check the legend items are positioned to the `bottom`. This is easily visible if there is only one line of legend items

![Screenshot 2024-10-16 at 22 03 00](https://github.com/user-attachments/assets/0db0ffda-2626-4cf3-b41c-5b40a352838b)
![Screenshot 2024-10-16 at 22 03 08](https://github.com/user-attachments/assets/baec081a-83fd-4c80-9982-f5b2c58969ec)


* Step 5. Now click on the `Claim` button in the `Total in and out` card. The `Claimed` success message should be of the same height as the `Add` button - unfortunately I have already claimed my tokens, so adding a screenshot from the designs

![Screenshot 2024-10-16 at 22 06 44](https://github.com/user-attachments/assets/4cca3d6b-58da-49dd-b0a1-50e397c2a5f7)

Resolves #3361
Resolves #3356
Resolves #3357
Resolves #3360
