### PR TITLE
[New Navigation] Update Colony Switcher hover style

### DIFF
--- a/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesPopover/JoinedColoniesPopover.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesPopover/JoinedColoniesPopover.tsx
@@ -26,6 +26,9 @@ const JoinedColoniesPopover = ({
   const handleCreateColonyRedirect = useCreateColonyRedirect();
   const { isDarkMode } = usePageThemeContext();
 
+  const ctaCopy = wallet ? 'button.createNewColony' : 'button.connectWallet';
+  const handleCTAClick = wallet ? handleCreateColonyRedirect : connectWallet;
+
   return visible ? (
     <PopoverBase
       setTooltipRef={setTooltipRef}
@@ -50,23 +53,13 @@ const JoinedColoniesPopover = ({
           </div>
         )}
         <div className="w-full flex-shrink-0 px-4">
-          {wallet ? (
-            <Button
-              mode="primaryOutline"
-              text={{ id: 'button.createNewColony' }}
-              size="small"
-              className="w-full border-gray-300"
-              onClick={handleCreateColonyRedirect}
-            />
-          ) : (
-            <Button
-              mode="primaryOutline"
-              text={{ id: 'button.connectWallet' }}
-              size="small"
-              className="w-full border-gray-300"
-              onClick={connectWallet}
-            />
-          )}
+          <Button
+            mode="quinary"
+            text={{ id: ctaCopy }}
+            size="small"
+            className="w-full !border-gray-300 hover:!border-gray-900"
+            onClick={handleCTAClick}
+          />
         </div>
       </div>
     </PopoverBase>


### PR DESCRIPTION
## Description

This PR updates the hover style of the Colony Switcher component's CTA button.

It should follow the [following design](https://www.figma.com/design/l1dOM5qiQYwF0ElvKDqqjg/Design-System---Colony-v3?node-id=1801-442&t=nv2Gpt6jBfFgIjrI-4):

<img width="812" alt="image" src="https://github.com/user-attachments/assets/22f2f2b8-cd1d-46d6-b1d9-a28e0b960852">

## Testing

1. Open the Colony Switcher component
2. Hover on the button
3. Make sure that the hover state follows the Figma design

Resolves #3369 