### PR TITLE
[Dashboard] Update Account Page Headings

### DIFF
--- a/src/components/frame/v5/pages/UserAdvancedPage/UserAdvancedPage.tsx
+++ b/src/components/frame/v5/pages/UserAdvancedPage/UserAdvancedPage.tsx
@@ -22,7 +22,7 @@ const MSG = defineMessages({
 const UserAdvancedPage = () => {
   const { user, userLoading, walletConnecting } = useAppContext();
 
-  useSetPageHeadingTitle(formatText({ id: 'userProfile.title' }));
+  useSetPageHeadingTitle(formatText({ id: 'advancedSettings.title' }));
 
   if (userLoading || walletConnecting) {
     return <LoadingTemplate loadingText={MSG.loadingText} />;

--- a/src/components/frame/v5/pages/UserAdvancedPage/partials/UserAdvancedSettings/UserAdvancedSettings.tsx
+++ b/src/components/frame/v5/pages/UserAdvancedPage/partials/UserAdvancedSettings/UserAdvancedSettings.tsx
@@ -3,7 +3,6 @@ import React, {
   // @BETA: Disabled for now
   // useState
 } from 'react';
-import { useIntl } from 'react-intl';
 
 // @BETA: Disabled for now
 // import Checkbox from '~v5/common/Checkbox';
@@ -23,13 +22,8 @@ const UserAdvancedSettings: FC = () => {
   // @BETA: Disabled for now
   // const [isChecked, setIsChecked] = useState(false);
   // const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const { formatMessage } = useIntl();
-
   return (
     <div className="flex flex-col gap-6">
-      <h4 className="heading-4">
-        {formatMessage({ id: 'advancedSettings.title' })}
-      </h4>
       <FeesForm />
       {/* @BETA: Disabled for noew */}
       {/* <span className="divider" /> */}

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/CryptoToFiatPage.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/CryptoToFiatPage.tsx
@@ -23,10 +23,6 @@ import Verification from './partials/Verification/Verification.tsx';
 const displayName = 'v5.pages.UserCryptoToFiatPage';
 
 const MSG = defineMessages({
-  pageHeading: {
-    id: `${displayName}.pageHeading`,
-    defaultMessage: 'Crypto to fiat settings',
-  },
   pageSubHeading: {
     id: `${displayName}.pageSubHeading`,
     defaultMessage:
@@ -39,7 +35,7 @@ const UserCryptoToFiatPage = () => {
   const featureFlags = useContext(FeatureFlagsContext);
   const cryptoToFiatFeatureFlag = featureFlags[FeatureFlag.CRYPTO_TO_FIAT];
 
-  useSetPageHeadingTitle(formatText({ id: 'userProfile.title' }));
+  useSetPageHeadingTitle(formatText({ id: 'userCryptoToFiatPage.title' }));
 
   if (
     !cryptoToFiatFeatureFlag?.isLoading &&
@@ -57,12 +53,9 @@ const UserCryptoToFiatPage = () => {
   return (
     <CryptoToFiatContextProvider>
       <div className="flex flex-col gap-6">
-        <section className="flex flex-col gap-1">
-          <h4 className="heading-4">{formatText(MSG.pageHeading)}</h4>
-          <span className="text-md text-gray-500">
-            {formatText(MSG.pageSubHeading)}
-          </span>
-        </section>
+        <p className="text-md text-gray-500">
+          {formatText(MSG.pageSubHeading)}
+        </p>
         <Verification />
         <hr />
         <BankDetails />

--- a/src/components/frame/v5/pages/UserPreferencesPage/UserPreferencesPage.tsx
+++ b/src/components/frame/v5/pages/UserPreferencesPage/UserPreferencesPage.tsx
@@ -25,7 +25,7 @@ const UserPreferencesPage: FC = () => {
   const { user, userLoading, walletConnecting } = useAppContext();
   const { handleSubmit, onSubmit, columnsList } = useUserPreferencesPage();
 
-  useSetPageHeadingTitle(formatText({ id: 'userProfile.title' }));
+  useSetPageHeadingTitle(formatText({ id: 'userPreferencesPage.title' }));
 
   if (userLoading || walletConnecting) {
     return <LoadingTemplate loadingText={MSG.loadingText} />;
@@ -38,9 +38,6 @@ const UserPreferencesPage: FC = () => {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <div className="flex flex-col gap-6">
-        <h4 className="heading-4">
-          {formatText({ id: 'userPreferencesPage.accountPreferences' })}
-        </h4>
         <Rows groups={columnsList} className="flex-row" />
       </div>
     </form>

--- a/src/components/frame/v5/pages/UserProfilePage/UserProfilePage.tsx
+++ b/src/components/frame/v5/pages/UserProfilePage/UserProfilePage.tsx
@@ -5,7 +5,6 @@ import { Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useBreadcrumbsContext } from '~context/BreadcrumbsContext/BreadcrumbsContext.ts';
 import { useFeatureFlagsContext } from '~context/FeatureFlagsContext/FeatureFlagsContext.ts';
 import { FeatureFlag } from '~context/FeatureFlagsContext/types.ts';
-import { useSetPageHeadingTitle } from '~context/PageHeadingContext/PageHeadingContext.ts';
 import { useTablet } from '~hooks';
 import {
   USER_CRYPTO_TO_FIAT_ROUTE,
@@ -94,8 +93,6 @@ const UserProfilePage: FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useSetPageHeadingTitle(formatText({ id: 'userProfile.title' }));
-
   if (activeTab === undefined) {
     return <Navigate to="/account/profile" />;
   }
@@ -103,7 +100,7 @@ const UserProfilePage: FC = () => {
   return (
     <Tabs
       activeTab={activeTab}
-      className="pt-6 md:pt-4"
+      className="pt-6 md:pt-2"
       onTabClick={(_, id) =>
         navigate(tabRoutes.find((route) => route.id === id)?.route ?? '')
       }

--- a/src/components/frame/v5/pages/UserProfilePage/partials/UserAccountForm/UserAccountForm.tsx
+++ b/src/components/frame/v5/pages/UserProfilePage/partials/UserAccountForm/UserAccountForm.tsx
@@ -15,11 +15,10 @@ const UserAccountForm: FC = () => {
   const isMobile = useMobile();
   const { columnsList } = useUserProfilePageForm();
 
-  useSetPageHeadingTitle(formatText({ id: 'userProfile.title' }));
+  useSetPageHeadingTitle(formatText({ id: 'userProfileTab.title' }));
 
   return (
     <div className="flex flex-col gap-6">
-      <h4 className="heading-4">{formatText({ id: 'profile.page' })}</h4>
       <Row groups={columnsList} />
       <div className="flex justify-end">
         <Button type="submit" isFullSize={isMobile} mode="primarySolid">

--- a/src/components/frame/v5/pages/UserProfilePage/partials/UserAccountPage/UserAccountPage.tsx
+++ b/src/components/frame/v5/pages/UserProfilePage/partials/UserAccountPage/UserAccountPage.tsx
@@ -27,7 +27,7 @@ const UserAccountPage: FC = () => {
   const { user, userLoading, walletConnecting } = useAppContext();
   const { handleSubmit } = useUserProfile();
 
-  useSetPageHeadingTitle(formatText({ id: 'userProfile.title' }));
+  useSetPageHeadingTitle(formatText({ id: 'userProfileTab.title' }));
 
   if (userLoading || walletConnecting) {
     return <LoadingTemplate loadingText={MSG.loadingText} />;

--- a/src/components/v5/frame/PageLayout/PageLayout.tsx
+++ b/src/components/v5/frame/PageLayout/PageLayout.tsx
@@ -89,9 +89,9 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
                   >
                     {isTablet && <Breadcrumbs />}
                     {pageTitle && (
-                      <h1 className="pt-2 text-gray-900 heading-3 md:pt-0">
+                      <h3 className="pt-2 text-gray-900 heading-3 md:pt-0">
                         {pageTitle}
-                      </h1>
+                      </h3>
                     )}
                   </section>
                 )}

--- a/src/hooks/useTitle.ts
+++ b/src/hooks/useTitle.ts
@@ -34,6 +34,7 @@ import {
   COLONY_INCORPORATION_ROUTE,
   COLONY_BALANCES_ROUTE,
   COLONY_MULTISIG_ROUTE,
+  USER_CRYPTO_TO_FIAT_ROUTE,
 } from '~routes/routeConstants.ts';
 import { type SimpleMessageValues } from '~types/index.ts';
 import { notNull } from '~utils/arrays/index.ts';
@@ -56,19 +57,24 @@ const MSG = defineMessages({
     defaultMessage: `Create a Profile | Colony`,
   },
 
-  editProfile: {
-    id: `${displayName}.useTitle.editProfile`,
-    defaultMessage: `Account Profile | Colony`,
+  profile: {
+    id: `${displayName}.useTitle.profile`,
+    defaultMessage: `Profile | Colony`,
   },
 
-  editPreferences: {
-    id: `${displayName}.useTitle.editPreferences`,
-    defaultMessage: `Account Preferences | Colony`,
+  preferences: {
+    id: `${displayName}.useTitle.preferences`,
+    defaultMessage: `Preferences | Colony`,
   },
 
   advancedSettings: {
     id: `${displayName}.useTitle.advancedSettings`,
-    defaultMessage: `Advanced Settings | Colony`,
+    defaultMessage: `Advanced settings | Colony`,
+  },
+
+  cryptoToFiat: {
+    id: `${displayName}.useTitle.cryptoToFiat`,
+    defaultMessage: `Crypto to fiat | Colony`,
   },
 
   notFound: {
@@ -189,9 +195,10 @@ interface MessageWithValues {
 }
 
 const routeMessages: Record<string, MessageDescriptor> = {
-  [`${USER_HOME_ROUTE}/${USER_EDIT_PROFILE_ROUTE}`]: MSG.editProfile,
-  [`${USER_HOME_ROUTE}/${USER_PREFERENCES_ROUTE}`]: MSG.editPreferences,
+  [`${USER_HOME_ROUTE}/${USER_EDIT_PROFILE_ROUTE}`]: MSG.profile,
+  [`${USER_HOME_ROUTE}/${USER_PREFERENCES_ROUTE}`]: MSG.preferences,
   [`${USER_HOME_ROUTE}/${USER_ADVANCED_ROUTE}`]: MSG.advancedSettings,
+  [`${USER_HOME_ROUTE}/${USER_CRYPTO_TO_FIAT_ROUTE}`]: MSG.cryptoToFiat,
 
   '/': MSG.landing,
   [COLONY_HOME_ROUTE]: MSG.colonyHome,


### PR DESCRIPTION
## Description

This PR aims to align the latest breadcrumb with the account page headings.

![account updates](https://github.com/user-attachments/assets/0dda2247-c06d-423b-9f29-3ec1c1eccf15)

## Testing

> [!NOTE]
> The only exception is the Advanced settings page. Even though the breadcrumb says "Advanced", we're still expecting the page heading to be "Advanced settings"

1. Visit http://localhost:9091/account/profile
2. Verify that the page heading is "Profile"

<img width="578" alt="image" src="https://github.com/user-attachments/assets/51e9b982-a806-4815-98f5-45df1779adc8">

3. Click the "Preferences tab" on the left sidebar
4. Verify that the page heading is "Preferences"
5. Click the "Advanced settings tab" on the left sidebar
6. Verify that the page heading is "Advanced settings"
7. Click the "Crypto to fiat" on the left sidebar
8. Verify that the page heading is "Crypto to fiat"

Resolves #3371 