### PR TITLE
fix: change loading skeleton gradient for dark mode

### DIFF
--- a/src/components/common/LoadingSkeleton/LoadingSkeleton.tsx
+++ b/src/components/common/LoadingSkeleton/LoadingSkeleton.tsx
@@ -11,12 +11,7 @@ const LoadingSkeleton: React.FC<LoadingSkeletonProps> = ({
   children,
 }) =>
   isLoading ? (
-    <span
-      className={clsx(
-        'from-neutral-300 to-stone-400 block overflow-hidden skeleton',
-        className,
-      )}
-    />
+    <span className={clsx('block overflow-hidden skeleton', className)} />
   ) : (
     <>{children}</>
   );

--- a/src/components/common/LoadingSkeleton/LoadingSkeleton.tsx
+++ b/src/components/common/LoadingSkeleton/LoadingSkeleton.tsx
@@ -1,8 +1,6 @@
 import clsx from 'clsx';
 import React from 'react';
 
-import { usePageThemeContext } from '~context/PageThemeContext/PageThemeContext.ts';
-
 import { type LoadingSkeletonProps } from './types.ts';
 
 const displayName = 'LoadingSkeleton';
@@ -11,24 +9,17 @@ const LoadingSkeleton: React.FC<LoadingSkeletonProps> = ({
   isLoading = false,
   className,
   children,
-}) => {
-  const { isDarkMode } = usePageThemeContext();
-
-  return isLoading ? (
+}) =>
+  isLoading ? (
     <span
       className={clsx(
         'from-neutral-300 to-stone-400 block overflow-hidden skeleton',
         className,
-        {
-          'skeleton-dark': isDarkMode,
-        },
       )}
     />
   ) : (
     <>{children}</>
   );
-};
-
 LoadingSkeleton.displayName = displayName;
 
 export default LoadingSkeleton;

--- a/src/components/common/LoadingSkeleton/LoadingSkeleton.tsx
+++ b/src/components/common/LoadingSkeleton/LoadingSkeleton.tsx
@@ -1,6 +1,8 @@
 import clsx from 'clsx';
 import React from 'react';
 
+import { usePageThemeContext } from '~context/PageThemeContext/PageThemeContext.ts';
+
 import { type LoadingSkeletonProps } from './types.ts';
 
 const displayName = 'LoadingSkeleton';
@@ -9,12 +11,23 @@ const LoadingSkeleton: React.FC<LoadingSkeletonProps> = ({
   isLoading = false,
   className,
   children,
-}) =>
-  isLoading ? (
-    <span className={clsx('block overflow-hidden skeleton', className)} />
+}) => {
+  const { isDarkMode } = usePageThemeContext();
+
+  return isLoading ? (
+    <span
+      className={clsx(
+        'from-neutral-300 to-stone-400 block overflow-hidden skeleton',
+        className,
+        {
+          'skeleton-dark': isDarkMode,
+        },
+      )}
+    />
   ) : (
     <>{children}</>
   );
+};
 
 LoadingSkeleton.displayName = displayName;
 

--- a/src/components/frame/Extensions/themes/consts.ts
+++ b/src/components/frame/Extensions/themes/consts.ts
@@ -65,6 +65,7 @@ export const light = {
   teamsGrey50: '#F4F4F4',
   teamsGrey100: '#D7E2EE',
   teamsGrey500: '#415A77',
+  skeletonGradient: 'rgba(255, 255, 255, 0.5)',
 };
 
 export const dark = {
@@ -134,4 +135,5 @@ export const dark = {
   teamsGrey50: '#2E405E',
   teamsGrey100: '#314972',
   teamsGrey500: '#5A7BA0',
+  skeletonGradient: 'rgba(146, 149, 152, 0.5)',
 };

--- a/src/components/frame/Extensions/themes/utils.ts
+++ b/src/components/frame/Extensions/themes/utils.ts
@@ -69,6 +69,7 @@ export const mapTheme = (variables: ITheme): IMappedTheme => {
     '--color-teams-grey-50': variables.teamsGrey50 || '',
     '--color-teams-grey-100': variables.teamsGrey100 || '',
     '--color-teams-grey-500': variables.teamsGrey500 || '',
+    '--color-skeleton-gradient': variables.skeletonGradient || '',
   };
 };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -257,6 +257,12 @@ module.exports = {
             animation: 'shine 1.125s ease infinite',
           },
         },
+        '.skeleton-dark': {
+          '.skeleton&::before': {
+            'background-image':
+              'linear-gradient(90deg,rgba(146, 149, 152, 0),rgba(146, 149, 152, 0.5),rgba(146, 149, 152, 0))',
+          },
+        },
         '.break-word': {
           'word-break': 'break-word',
         },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -107,6 +107,9 @@ module.exports = {
         100: 'var(--color-teams-grey-100)',
         500: 'var(--color-teams-grey-500)',
       },
+      gradient: {
+        base: 'var(--color-skeleton-gradient)',
+      },
     },
     fontFamily: {
       inter: ['Inter', 'sans-serif'],
@@ -250,17 +253,10 @@ module.exports = {
             'background-color': theme('colors.gray.100'),
             'background-repeat': 'no-repeat',
             'min-height': '1em',
-            'background-image':
-              'linear-gradient(90deg,rgba(255, 255, 255, 0),rgba(255, 255, 255, 0.5),rgba(255, 255, 255, 0))',
+            'background-image': `linear-gradient(90deg,rgba(255, 255, 255, 0),${theme('colors.gradient.base')},rgba(255, 255, 255, 0))`,
             'background-size': '2.5rem 100%',
             'background-position': 'left -2.5rem top 0',
             animation: 'shine 1.125s ease infinite',
-          },
-        },
-        '.skeleton-dark': {
-          '.skeleton&::before': {
-            'background-image':
-              'linear-gradient(90deg,rgba(146, 149, 152, 0),rgba(146, 149, 152, 0.5),rgba(146, 149, 152, 0))',
           },
         },
         '.break-word': {


### PR DESCRIPTION
## Description

Change gradient color for loading skeleton in dark mode

## Testing

- Set app to dark mode
- Open any loading skeleton while fetching data

**Changes** 🏗

Before:

![Screenshot 2024-10-17 at 15 07 28](https://github.com/user-attachments/assets/6a886113-dec0-4fec-86a7-0fa3ba044bd6)

After:

![Screenshot 2024-10-17 at 15 08 09](https://github.com/user-attachments/assets/a33c87e6-d5b1-44be-842a-d70993f2cc6c)


Resolves [#31415](https://github.com/JoinColony/colonyCDapp/issues/3293)
