### PR TITLE
Fix: Persist selected Token logo during Colony creation

### DIFF
--- a/src/components/common/Onboarding/wizardSteps/CreateColony/StepCreateToken.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/StepCreateToken.tsx
@@ -33,7 +33,13 @@ type Props = Pick<
 
 const StepCreateToken = ({
   nextStep,
-  wizardValues: { tokenChoice, tokenName, tokenSymbol, tokenAddress },
+  wizardValues: {
+    tokenChoice,
+    tokenName,
+    tokenSymbol,
+    tokenAddress,
+    tokenAvatar,
+  },
   previousStep,
 }: Props) => (
   <Form<Step3>
@@ -58,6 +64,7 @@ const StepCreateToken = ({
             <TokenInputs
               wizardTokenName={tokenName || ''}
               wizardTokenSymbol={tokenSymbol || ''}
+              wizardTokenAvatar={tokenAvatar || ''}
             />
           ) : (
             <TokenSelectorInput wizardTokenAddress={tokenAddress} />

--- a/src/components/common/Onboarding/wizardSteps/CreateColony/StepCreateTokenInputs.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/StepCreateTokenInputs.tsx
@@ -1,5 +1,5 @@
 import { Image } from '@phosphor-icons/react';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -19,6 +19,7 @@ const displayName = 'common.CreateColonyWizard.StepCreateTokenInputs';
 interface StepCreateTokenInputsProps {
   wizardTokenName: string;
   wizardTokenSymbol: string;
+  wizardTokenAvatar: string;
 }
 
 const MSG = defineMessages({
@@ -44,6 +45,7 @@ const MSG = defineMessages({
 const StepCreateTokenInputs = ({
   wizardTokenName,
   wizardTokenSymbol,
+  wizardTokenAvatar,
 }: StepCreateTokenInputsProps) => {
   const {
     register,
@@ -57,8 +59,6 @@ const StepCreateTokenInputs = ({
     getInputError(errors, 'tokenName', submitCount);
   const { error: tokenSymbolError, showError: showTokenSymbolError } =
     getInputError(errors, 'tokenSymbol', submitCount);
-
-  const tokenAvatarUrl = watch('tokenAvatar');
 
   const updateFn: UseAvatarUploaderProps['updateFn'] = async (
     avatar,
@@ -76,6 +76,14 @@ const StepCreateTokenInputs = ({
 
     setProgress(100);
   };
+
+  useEffect(() => {
+    if (!watch('tokenAvatar') && wizardTokenAvatar) {
+      setValue('tokenAvatar', wizardTokenAvatar);
+    }
+  }, [wizardTokenAvatar, setValue, watch]);
+
+  const tokenAvatarUrl = watch('tokenAvatar');
 
   return (
     <>


### PR DESCRIPTION
## Description

This PR makes sure that the selected Token logo is persisted even if you leave the page where you get to select/modify the Token logo.

![token logo](https://github.com/user-attachments/assets/b5a0fe78-2c7d-46a1-b045-118f797d8bdf)

## Testing

1. Generate a create colony URL: `node scripts/create-colony-url.js`
2. Set a Colony name and a Custom Colony URL and click Continue
3. Select Create a new token and click Continue
4. Set a Token name and a Token symbol
5. Select a Token logo
6. Click the Back button
7. Click Continue
8. Verify that the Token logo persists
9. Click the Continue button
10. Click the Back button
11. Verify that the Token logo persists
12. Finish up the Colony creation flow
13. Visit the Balances page http://localhost:9091/{yourColonyName}/balances
14. Verify that your Token logo is definitely uploaded properly

Resolves #3300 