### PR TITLE
Fix: UI fixes for in app notifications after review

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
@@ -53,12 +53,12 @@ const NotificationsTab = ({ closeUserHub }: { closeUserHub: () => void }) => {
 
   return (
     <div
-      className={clsx('h-full px-6 pb-6 pt-6 sm:pb-2', {
+      className={clsx('h-full pb-6 pt-6 sm:pb-2', {
         'overflow-auto': !isEmpty,
       })}
       ref={containerRef}
     >
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between px-6">
         <div className="flex items-center">
           <p className="heading-5">{formatText(MSG.notifications)}</p>
           {hasUnreadNotifications && (

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
@@ -6,7 +6,7 @@ import { defineMessages } from 'react-intl';
 import { useNotificationsDataContext } from '~context/Notifications/NotificationsDataContext/NotificationsDataContext.ts';
 import { formatText } from '~utils/intl.ts';
 import EmptyContent from '~v5/common/EmptyContent/EmptyContent.tsx';
-import InfiniteScrollTrigger from '~v5/common/InfiniteScrollLoader/InfiniteScrollLoader.tsx';
+import InfiniteScrollTrigger from '~v5/common/InfiniteScrollTrigger/InfiniteScrollTrigger.tsx';
 
 import NotificationsList from './partials/NotificationsList.tsx';
 

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/ActionNotificationMessage.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/ActionNotificationMessage.tsx
@@ -18,6 +18,10 @@ interface ActionNotificationMessageProps {
 }
 
 const MSG = defineMessages({
+  actionCreated: {
+    id: `${displayName}.actionCreated`,
+    defaultMessage: 'Permissions used:',
+  },
   mention: {
     id: `${displayName}.mention`,
     defaultMessage: '{name} has mentioned you in: ',
@@ -40,33 +44,21 @@ const ActionNotificationMessage: FC<ActionNotificationMessageProps> = ({
   notificationType,
 }) => {
   const Message = useMemo(() => {
-    if (notificationType === NotificationType.PermissionsAction) {
-      return (
-        <>
-          {actionTitle ? `${actionTitle}: ` : ''}
-          {actionMetadataDescription || formatText(MSG.unknownAction)}
-        </>
-      );
-    }
-
-    if (notificationType === NotificationType.Mention) {
-      const firstPart = formatText(MSG.mention, {
+    const firstPart = {
+      [NotificationType.PermissionsAction]: formatText(MSG.actionCreated),
+      [NotificationType.Mention]: formatText(MSG.mention, {
         name: creator || formatText(MSG.someone),
-      });
+      }),
+    }[notificationType];
 
-      const secondPart =
-        actionTitle ||
-        actionMetadataDescription ||
-        formatText(MSG.unknownAction);
+    const secondPart =
+      actionTitle || actionMetadataDescription || formatText(MSG.unknownAction);
 
-      return (
-        <>
-          {firstPart} {secondPart}
-        </>
-      );
-    }
-
-    return formatText(MSG.unknownAction);
+    return (
+      <>
+        {firstPart} {secondPart}
+      </>
+    );
   }, [actionMetadataDescription, actionTitle, creator, notificationType]);
 
   return <NotificationMessage loading={loading}>{Message}</NotificationMessage>;

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/MotionNotificationMessage.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/MotionNotificationMessage.tsx
@@ -17,6 +17,10 @@ interface MotionNotificationMessageProps {
 }
 
 const MSG = defineMessages({
+  created: {
+    id: `${displayName}.created`,
+    defaultMessage: 'Reputation decision:',
+  },
   opposed: {
     id: `${displayName}.opposed`,
     defaultMessage: 'Opposed, will fail: ',
@@ -41,10 +45,6 @@ const MSG = defineMessages({
     id: `${displayName}.unknownAction`,
     defaultMessage: 'Unknown motion',
   },
-  unknownChange: {
-    id: `${displayName}.unknownChange`,
-    defaultMessage: 'Motion updated: ',
-  },
 });
 
 const MotionNotificationMessage: FC<MotionNotificationMessageProps> = ({
@@ -54,22 +54,13 @@ const MotionNotificationMessage: FC<MotionNotificationMessageProps> = ({
   notificationType,
 }) => {
   const Message = useMemo(() => {
-    if (notificationType === NotificationType.MotionCreated) {
-      return (
-        <>
-          {actionTitle ? `${actionTitle}: ` : formatText(MSG.unknownChange)}
-          {actionMetadataDescription || formatText(MSG.unknownAction)}
-        </>
-      );
-    }
-
     const firstPart = {
+      [NotificationType.MotionCreated]: formatText(MSG.created),
       [NotificationType.MotionOpposed]: formatText(MSG.opposed),
       [NotificationType.MotionSupported]: formatText(MSG.supported),
       [NotificationType.MotionVoting]: formatText(MSG.voting),
       [NotificationType.MotionReveal]: formatText(MSG.reveal),
       [NotificationType.MotionFinalized]: formatText(MSG.finalized),
-      default: formatText(MSG.unknownChange),
     }[notificationType];
 
     const secondPart =

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/MultisigNotificationMessage.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/MultisigNotificationMessage.tsx
@@ -17,6 +17,10 @@ interface MultisigNotificationMessageProps {
 }
 
 const MSG = defineMessages({
+  created: {
+    id: `${displayName}.created`,
+    defaultMessage: 'Multi-sig decision:',
+  },
   finalized: {
     id: `${displayName}.finalized`,
     defaultMessage: 'Finalized:',
@@ -33,10 +37,6 @@ const MSG = defineMessages({
     id: `${displayName}.unknownAction`,
     defaultMessage: 'Unknown multisig action',
   },
-  unknownChange: {
-    id: `${displayName}.unknownChange`,
-    defaultMessage: 'Multisig action updated: ',
-  },
 });
 
 const MultisigNotificationMessage: FC<MultisigNotificationMessageProps> = ({
@@ -46,20 +46,11 @@ const MultisigNotificationMessage: FC<MultisigNotificationMessageProps> = ({
   notificationType,
 }) => {
   const Message = useMemo(() => {
-    if (notificationType === NotificationType.MultisigActionCreated) {
-      return (
-        <>
-          {actionTitle ? `${actionTitle}: ` : formatText(MSG.unknownChange)}
-          {actionMetadataDescription || formatText(MSG.unknownAction)}
-        </>
-      );
-    }
-
     const firstPart = {
+      [NotificationType.MultisigActionCreated]: formatText(MSG.created),
       [NotificationType.MultisigActionFinalized]: formatText(MSG.finalized),
       [NotificationType.MultisigActionApproved]: formatText(MSG.approved),
       [NotificationType.MultisigActionRejected]: formatText(MSG.rejected),
-      default: formatText(MSG.unknownChange),
     }[notificationType];
 
     const secondPart =

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/FundsClaimed/FundsClaimedNotification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/FundsClaimed/FundsClaimedNotification.tsx
@@ -7,7 +7,7 @@ import {
   NotificationType,
   useGetTokenFromEverywhereQuery,
 } from '~gql';
-import { COLONY_BALANCES_ROUTE } from '~routes';
+import { COLONY_INCOMING_ROUTE } from '~routes';
 import { type Notification as NotificationInterface } from '~types/notifications.ts';
 import { formatText } from '~utils/intl.ts';
 import { getNumeralTokenAmount } from '~utils/tokens.ts';
@@ -53,7 +53,7 @@ const FundsClaimedNotification: FC<FundsClaimedNotificationProps> = ({
 
   const handleNotificationClicked = () => {
     if (colony) {
-      navigate(`/${colony.name}/${COLONY_BALANCES_ROUTE}`);
+      navigate(`/${colony.name}/${COLONY_INCOMING_ROUTE}`);
       closeUserHub();
     }
   };

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/NotificationWrapper.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/NotificationWrapper.tsx
@@ -47,11 +47,14 @@ const NotificationWrapper: FC<NotificationWrapperProps> = ({
   };
 
   return (
-    <li className="w-full py-3.5 first-of-type:pt-0">
+    <li className="w-full ">
       <button
-        className={clsx('relative  flex w-full gap-2 text-left', {
-          skeleton: loadingColony,
-        })}
+        className={clsx(
+          'relative flex w-full gap-2 px-6 py-3.5 text-left sm:hover:bg-gray-50',
+          {
+            skeleton: loadingColony,
+          },
+        )}
         onClick={handleNotificationClicked}
         type="button"
       >

--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/TransactionsTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/TransactionsTab.tsx
@@ -4,7 +4,7 @@ import React, { useRef, type FC } from 'react';
 import { useGroupedTransactions } from '~state/transactionState.ts';
 import { formatText } from '~utils/intl.ts';
 import EmptyContent from '~v5/common/EmptyContent/index.ts';
-import InfiniteScrollTrigger from '~v5/common/InfiniteScrollLoader/index.ts';
+import InfiniteScrollTrigger from '~v5/common/InfiniteScrollTrigger/index.ts';
 
 import TransactionList from './partials/TransactionList.tsx';
 import { type TransactionsProps } from './types.ts';

--- a/src/components/v5/common/DropdownMenu/partials/DropdownMenuItem/DropdownMenuItem.tsx
+++ b/src/components/v5/common/DropdownMenu/partials/DropdownMenuItem/DropdownMenuItem.tsx
@@ -13,10 +13,12 @@ import { type DropdownMenuItemProps } from './types.ts';
 
 const DropdownMenuItem: FC<DropdownMenuItemProps> = (props) => {
   const [isOpen, { toggle, registerContainerRef }] = useToggle();
-  const { icon: Icon } = props;
+  const { disabled, icon: Icon } = props;
 
-  const itemClassName =
-    'py-2 px-3.5 rounded-s rounded-e !text-md md:hover:font-medium md:hover:bg-gray-50 md:hover:text-gray-900 flex items-center !duration-0 gap-3 w-full';
+  const itemClassName = clsx(
+    'flex w-full items-center gap-3 rounded-e rounded-s px-3.5 py-2 !text-md !duration-0 md:hover:bg-gray-50 md:hover:font-medium md:hover:text-gray-900',
+    { 'text-gray-300': disabled },
+  );
   const content = (
     <>
       {Icon && <Icon size={16} className="flex-shrink-0" />}

--- a/src/components/v5/common/DropdownMenu/partials/DropdownMenuItem/types.ts
+++ b/src/components/v5/common/DropdownMenu/partials/DropdownMenuItem/types.ts
@@ -8,6 +8,7 @@ export type DropdownMenuItemProps = (
   | Omit<LinkProps, 'text' | 'textValues'>
   | ButtonHTMLAttributes<HTMLButtonElement>
 ) & {
+  disabled?: boolean;
   label: string;
   icon?: ComponentType<IconProps>;
   chevronIcon?: ComponentType<IconProps>;

--- a/src/components/v5/common/InfiniteScrollLoader/index.ts
+++ b/src/components/v5/common/InfiniteScrollLoader/index.ts
@@ -1,1 +1,0 @@
-export { default } from './InfiniteScrollLoader.tsx';

--- a/src/components/v5/common/InfiniteScrollTrigger/InfiniteScrollTrigger.tsx
+++ b/src/components/v5/common/InfiniteScrollTrigger/InfiniteScrollTrigger.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
   useCallback,
+  useEffect,
 } from 'react';
 
 import useOnScrolledIntoView from '~hooks/useOnScrollIedntoView.ts';
@@ -17,7 +18,7 @@ interface Props {
   fetchMore: () => Promise<void>;
 }
 
-const displayName = 'v5.common.InfiniteScrollLoader';
+const displayName = 'v5.common.InfiniteScrollTrigger';
 
 const InfiniteScrollTrigger: FC<Props> = ({
   canFetchMore,
@@ -27,6 +28,7 @@ const InfiniteScrollTrigger: FC<Props> = ({
   const ref = useRef<HTMLDivElement>(null);
 
   const [isFetching, setIsFetching] = useState(false);
+  const [hasFetchedAtLeastOnce, setHasFetchedAtLeastOnce] = useState(false);
 
   const onScrolledIntoView = useCallback(() => {
     if (!isFetching && canFetchMore) {
@@ -44,6 +46,12 @@ const InfiniteScrollTrigger: FC<Props> = ({
     onScrolledIntoView,
   });
 
+  useEffect(() => {
+    if (isFetching) {
+      setHasFetchedAtLeastOnce(true);
+    }
+  }, [isFetching]);
+
   return (
     <div
       ref={ref}
@@ -57,12 +65,14 @@ const InfiniteScrollTrigger: FC<Props> = ({
           </span>
         </>
       ) : (
-        <div className="text-gray-400">
-          <Smiley className="mr-1 inline-block" />
-          <span className="text-xs">
-            {formatText({ id: 'loader.noMoreResults' })}
-          </span>
-        </div>
+        hasFetchedAtLeastOnce && (
+          <div className="text-gray-400">
+            <Smiley className="mr-1 inline-block" />
+            <span className="text-xs">
+              {formatText({ id: 'loader.noMoreResults' })}
+            </span>
+          </div>
+        )
       )}
     </div>
   );

--- a/src/components/v5/common/InfiniteScrollTrigger/index.ts
+++ b/src/components/v5/common/InfiniteScrollTrigger/index.ts
@@ -1,0 +1,1 @@
+export { default } from './InfiniteScrollTrigger.tsx';

--- a/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useHeaderLinks.ts
+++ b/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useHeaderLinks.ts
@@ -23,7 +23,7 @@ import {
 import { COLONY_LINK_CONFIG } from '~v5/shared/SocialLinks/colonyLinks.ts';
 
 import { sortExternalLinks } from './helpers.ts';
-import { useMuteColonyItem } from './useMuteColonyItem.ts';
+import useMuteColonyItem from './useMuteColonyItem.tsx';
 
 export const useHeaderLinks = (): { dropdownMenuProps: DropdownMenuProps } => {
   const { areNotificationsEnabled } = useNotificationsUserContext();

--- a/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useMuteColonyItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useMuteColonyItem.tsx
@@ -1,6 +1,6 @@
 import { BellRinging, BellSimpleSlash } from '@phosphor-icons/react';
 import React, { useCallback, useState } from 'react';
-import { defineMessages } from 'react-intl';
+import { defineMessages, type MessageDescriptor } from 'react-intl';
 import { toast } from 'react-toastify';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
@@ -13,27 +13,31 @@ import { type DropdownMenuItem } from '~v5/common/DropdownMenu/types.ts';
 
 const ITEM_KEY = 'headerDropdown.section3.toggleMute';
 
-const useMuteColonyItem = (): DropdownMenuItem => {
-  const MSG = defineMessages({
-    mute: {
-      id: 'headerDropdown.muteNotifications',
-      defaultMessage: 'Mute notifications',
-    },
-    unmute: {
-      id: 'headerDropdown.unmuteNotifications',
-      defaultMessage: 'Unmute notifications',
-    },
-    toastNotificationsUnmuted: {
-      id: `headerDropdown.toastNotificationsUnmuted`,
-      defaultMessage: 'You will now receive notifications from this colony.',
-    },
-    toastNotificationsMuted: {
-      id: `headerDropdown.toastNotificationsMuted`,
-      defaultMessage:
-        'You will no longer receive notifications from this colony.',
-    },
-  });
+// Disabling this eslint rule since it seems that it is a false positive. There is only one export from this file,
+// but for some reason if we keep MSG outside of the hook it thinks that there is two exports. It does not break the fast refresh.
 
+// eslint-disable-next-line react-refresh/only-export-components
+const MSG = defineMessages({
+  mute: {
+    id: 'headerDropdown.muteNotifications',
+    defaultMessage: 'Mute notifications',
+  },
+  unmute: {
+    id: 'headerDropdown.unmuteNotifications',
+    defaultMessage: 'Unmute notifications',
+  },
+  toastNotificationsUnmuted: {
+    id: `headerDropdown.toastNotificationsUnmuted`,
+    defaultMessage: 'You will now receive notifications from this colony.',
+  },
+  toastNotificationsMuted: {
+    id: `headerDropdown.toastNotificationsMuted`,
+    defaultMessage:
+      'You will no longer receive notifications from this colony.',
+  },
+});
+
+const useMuteColonyItem = (): DropdownMenuItem => {
   const { user, updateUser } = useAppContext();
   const {
     colony: { colonyAddress },
@@ -46,6 +50,16 @@ const useMuteColonyItem = (): DropdownMenuItem => {
   const [isMuteToggling, setIsMuteToggling] = useState(false);
 
   const isColonyMuted = mutedColonyAddresses.includes(colonyAddress);
+
+  const showSuccessToast = (message: MessageDescriptor) => {
+    toast.success(
+      <Toast
+        type="success"
+        title={{ id: 'advancedSettings.toast.changesSaved' }}
+        description={formatText(message)}
+      />,
+    );
+  };
 
   const handleUnmuteColonyNotifications = useCallback(() => {
     if (!user) {
@@ -65,14 +79,7 @@ const useMuteColonyItem = (): DropdownMenuItem => {
       onCompleted: async () => {
         await updateUser(user.walletAddress, true);
         setIsMuteToggling(false);
-
-        toast.success(
-          <Toast
-            type="success"
-            title={{ id: 'advancedSettings.toast.changesSaved' }}
-            description={formatText(MSG.toastNotificationsUnmuted)}
-          />,
-        );
+        showSuccessToast(MSG.toastNotificationsUnmuted);
       },
     });
   }, [
@@ -100,14 +107,7 @@ const useMuteColonyItem = (): DropdownMenuItem => {
       onCompleted: async () => {
         await updateUser(user.walletAddress, true);
         setIsMuteToggling(false);
-
-        toast.success(
-          <Toast
-            type="success"
-            title={{ id: 'advancedSettings.toast.changesSaved' }}
-            description={formatText(MSG.toastNotificationsMuted)}
-          />,
-        );
+        showSuccessToast(MSG.toastNotificationsMuted);
       },
     });
   }, [

--- a/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useMuteColonyItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useMuteColonyItem.tsx
@@ -1,36 +1,39 @@
 import { BellRinging, BellSimpleSlash } from '@phosphor-icons/react';
-import { useCallback, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { defineMessages } from 'react-intl';
+import { toast } from 'react-toastify';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useNotificationsUserContext } from '~context/Notifications/NotificationsUserContext/NotificationsUserContext.ts';
 import { useUpdateUserNotificationDataMutation } from '~gql';
+import Toast from '~shared/Extensions/Toast/index.ts';
 import { formatText } from '~utils/intl.ts';
 import { type DropdownMenuItem } from '~v5/common/DropdownMenu/types.ts';
 
-const MSG = defineMessages({
-  mute: {
-    id: 'headerDropdown.muteNotifications',
-    defaultMessage: 'Mute notifications',
-  },
-  unmute: {
-    id: 'headerDropdown.unmuteNotifications',
-    defaultMessage: 'Unmute notifications',
-  },
-  muting: {
-    id: 'headerDropdown.mutingNotifications',
-    defaultMessage: 'Muting...',
-  },
-  unmuting: {
-    id: 'headerDropdown.unmutingNotifications',
-    defaultMessage: 'Unmuting...',
-  },
-});
-
 const ITEM_KEY = 'headerDropdown.section3.toggleMute';
 
-export const useMuteColonyItem = (): DropdownMenuItem => {
+const useMuteColonyItem = (): DropdownMenuItem => {
+  const MSG = defineMessages({
+    mute: {
+      id: 'headerDropdown.muteNotifications',
+      defaultMessage: 'Mute notifications',
+    },
+    unmute: {
+      id: 'headerDropdown.unmuteNotifications',
+      defaultMessage: 'Unmute notifications',
+    },
+    toastNotificationsUnmuted: {
+      id: `headerDropdown.toastNotificationsUnmuted`,
+      defaultMessage: 'You will now receive notifications from this colony.',
+    },
+    toastNotificationsMuted: {
+      id: `headerDropdown.toastNotificationsMuted`,
+      defaultMessage:
+        'You will no longer receive notifications from this colony.',
+    },
+  });
+
   const { user, updateUser } = useAppContext();
   const {
     colony: { colonyAddress },
@@ -62,9 +65,18 @@ export const useMuteColonyItem = (): DropdownMenuItem => {
       onCompleted: async () => {
         await updateUser(user.walletAddress, true);
         setIsMuteToggling(false);
+
+        toast.success(
+          <Toast
+            type="success"
+            title={{ id: 'advancedSettings.toast.changesSaved' }}
+            description={formatText(MSG.toastNotificationsUnmuted)}
+          />,
+        );
       },
     });
   }, [
+    MSG.toastNotificationsUnmuted,
     colonyAddress,
     mutedColonyAddresses,
     updateMutedColonies,
@@ -88,9 +100,18 @@ export const useMuteColonyItem = (): DropdownMenuItem => {
       onCompleted: async () => {
         await updateUser(user.walletAddress, true);
         setIsMuteToggling(false);
+
+        toast.success(
+          <Toast
+            type="success"
+            title={{ id: 'advancedSettings.toast.changesSaved' }}
+            description={formatText(MSG.toastNotificationsMuted)}
+          />,
+        );
       },
     });
   }, [
+    MSG.toastNotificationsMuted,
     colonyAddress,
     mutedColonyAddresses,
     updateMutedColonies,
@@ -99,30 +120,12 @@ export const useMuteColonyItem = (): DropdownMenuItem => {
   ]);
 
   if (isColonyMuted) {
-    if (isMuteToggling) {
-      return {
-        key: ITEM_KEY,
-        label: formatText(MSG.unmuting),
-        icon: BellSimpleSlash,
-        disabled: true,
-      };
-    }
-
     return {
       key: ITEM_KEY,
       label: formatText(MSG.unmute),
       icon: BellRinging,
       onClick: handleUnmuteColonyNotifications,
-    };
-  }
-
-  // if unmuted and mutation is in place, we are muting it
-  if (isMuteToggling) {
-    return {
-      key: ITEM_KEY,
-      label: formatText(MSG.muting),
-      icon: BellRinging,
-      disabled: true,
+      disabled: isMuteToggling,
     };
   }
 
@@ -131,5 +134,8 @@ export const useMuteColonyItem = (): DropdownMenuItem => {
     label: formatText(MSG.mute),
     icon: BellSimpleSlash,
     onClick: handleMuteColonyNotifications,
+    disabled: isMuteToggling,
   };
 };
+
+export default useMuteColonyItem;

--- a/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useMuteColonyItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useMuteColonyItem.tsx
@@ -83,7 +83,6 @@ const useMuteColonyItem = (): DropdownMenuItem => {
       },
     });
   }, [
-    MSG.toastNotificationsUnmuted,
     colonyAddress,
     mutedColonyAddresses,
     updateMutedColonies,
@@ -111,7 +110,6 @@ const useMuteColonyItem = (): DropdownMenuItem => {
       },
     });
   }, [
-    MSG.toastNotificationsMuted,
     colonyAddress,
     mutedColonyAddresses,
     updateMutedColonies,

--- a/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useMuteColonyItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useMuteColonyItem.tsx
@@ -13,31 +13,27 @@ import { type DropdownMenuItem } from '~v5/common/DropdownMenu/types.ts';
 
 const ITEM_KEY = 'headerDropdown.section3.toggleMute';
 
-// Disabling this eslint rule since it seems that it is a false positive. There is only one export from this file,
-// but for some reason if we keep MSG outside of the hook it thinks that there is two exports. It does not break the fast refresh.
-
-// eslint-disable-next-line react-refresh/only-export-components
-const MSG = defineMessages({
-  mute: {
-    id: 'headerDropdown.muteNotifications',
-    defaultMessage: 'Mute notifications',
-  },
-  unmute: {
-    id: 'headerDropdown.unmuteNotifications',
-    defaultMessage: 'Unmute notifications',
-  },
-  toastNotificationsUnmuted: {
-    id: `headerDropdown.toastNotificationsUnmuted`,
-    defaultMessage: 'You will now receive notifications from this colony.',
-  },
-  toastNotificationsMuted: {
-    id: `headerDropdown.toastNotificationsMuted`,
-    defaultMessage:
-      'You will no longer receive notifications from this colony.',
-  },
-});
-
 const useMuteColonyItem = (): DropdownMenuItem => {
+  const MSG = defineMessages({
+    mute: {
+      id: 'headerDropdown.muteNotifications',
+      defaultMessage: 'Mute notifications',
+    },
+    unmute: {
+      id: 'headerDropdown.unmuteNotifications',
+      defaultMessage: 'Unmute notifications',
+    },
+    toastNotificationsUnmuted: {
+      id: `headerDropdown.toastNotificationsUnmuted`,
+      defaultMessage: 'You will now receive notifications from this colony.',
+    },
+    toastNotificationsMuted: {
+      id: `headerDropdown.toastNotificationsMuted`,
+      defaultMessage:
+        'You will no longer receive notifications from this colony.',
+    },
+  });
+
   const { user, updateUser } = useAppContext();
   const {
     colony: { colonyAddress },


### PR DESCRIPTION
## Description

After an in-depth review of the in app notifications branch with product and design, there were a few minor UI fixes / changes which needed to happen. This PR is a small bundle of these minor fixes (the big ones have been split out into their own separate tickets)

The changes include:
* Adding a hover state to the notifications in the user hub
* Navigate to the incoming funds page (instead of the balances page) when a user clicks on an incoming funds notification
* Don't show "No more results" at the end of the notifications list unless there has been pagination loaded
* Show a toast when a colony is muted / unmuted, and change the loading state slightly
* Edit the action created notification messages to differentiate between different decision methods

## Testing

As always, please ensure you have the correct notifications environment variables first. If you haven't tested or worked on a notifications ticket yet, let me know and I can supply these.

We'll need to test each one of these fixes (don't worry, they're all tiny!)

Here's the optimal order of testing: 😆 

* As Leela, log in and make a mint tokens action using permissions. Check that you receive two notifications, one of them should specifically be worded like: "Permissions used: {custom_action_title}" and one should be about incoming funds being claimed.
<img width="1055" alt="Screenshot 2024-10-17 at 16 18 51" src="https://github.com/user-attachments/assets/9b8a9c11-d3f9-4b08-b646-b79be451a83e">

* Check that at the bottom of the notifications list, there is no line saying "No more results". This should only show once we have more than 10 notifications and need to scroll to load more.

* Hover over both notifications, there should be a hover state. Then click on the incoming funds notification, which should then navigate you to the incoming funds page. (There's a bug where the action sidebar remains open, but this will be fixed on a rebase)
<img width="484" alt="Screenshot 2024-10-17 at 16 19 27" src="https://github.com/user-attachments/assets/78824b0e-dff4-4367-8112-219d0bf48756">
<img width="1611" alt="Screenshot 2024-10-17 at 16 19 38" src="https://github.com/user-attachments/assets/2c272312-6c40-41aa-8e9c-62725c80ad28">

* Install the reputation voting and multi sig extensions, and give Leela multi sig owner permissions.

* Then create any action using reputation as a decision method and stake it to at least 10% support, and then any action using multi sig as a decision method.
<img width="1066" alt="Screenshot 2024-10-17 at 16 24 19" src="https://github.com/user-attachments/assets/8fe6458a-e57a-4a8d-839c-19028e22c6c7">
<img width="1049" alt="Screenshot 2024-10-17 at 16 24 33" src="https://github.com/user-attachments/assets/6b9ce4b0-06d2-4552-a938-832b9449befb">


* You should receive a notification for each of the above actions. One should say "Reputation decision: {custom_action_title}" and one should say "Multi-sig decision: {custom_action_title}". (You may also receive a weird number of approval notifications for the multi sig action. This is being worked on in a separate ticket).
<img width="454" alt="Screenshot 2024-10-17 at 16 23 56" src="https://github.com/user-attachments/assets/77815db5-c5b6-4d7b-810f-674f8ab22796">


* Create an advanced payment action, and check that you receive a notification using this wording: "Payment ready for review: {custom_action_title}"
<img width="1056" alt="Screenshot 2024-10-17 at 19 15 26" src="https://github.com/user-attachments/assets/7556c275-d48b-4ea0-ab82-427f7e0bed71">

* If by now you still have less that 10 notifications for whatever reason, create some more actions until you have over 10. Then open the user hub and scroll the notifications until you reach the bottom of the list and they are all loaded. At the bottom, you should see a message saying "No more results".
<img width="458" alt="Screenshot 2024-10-17 at 19 16 18" src="https://github.com/user-attachments/assets/97e6473e-e056-41dc-82a2-d101aff62250">

* Finally, go to the colony dashboard and use the dropdown menu to toggle mute and unmute of this colony's notifications. You should see a toast message come up informing you of the toggle.
<img width="1718" alt="Screenshot 2024-10-17 at 19 17 04" src="https://github.com/user-attachments/assets/1343e7be-4a14-43ab-8d3d-3999f95fba16">
<img width="612" alt="Screenshot 2024-10-17 at 19 16 43" src="https://github.com/user-attachments/assets/7f7a0220-7e3e-4d6b-9623-24a1bbfa36e3">


## Diffs

**Changes** 🏗

* Add a hover state to the notifications in the user hub
* Navigate to the incoming funds page (instead of the balances page) when a user clicks on an incoming funds notification
* Don't show "No more results" at the end of the notifications list unless there has been pagination loaded
* Show a toast when a colony is muted / unmuted, and change the loading state slightly
* Edit the action created notification messages to differentiate between different decision methods
