### PR TITLE
fix: multisig widget UI tweaks

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/MultiSigWidget/partials/ApprovalStep/ApprovalStep.tsx
@@ -60,7 +60,7 @@ const MSG = defineMessages({
   multipleRolesHeading: {
     id: `${displayName}.multipleRolesHeading`,
     defaultMessage:
-      'Multiple permissions are required for this action.\nEach permission held counts as an approval',
+      'This action requires a bundled approval. Each approval is based on the permissions you hold.',
   },
   approvals: {
     id: `${displayName}.approvals`,
@@ -337,7 +337,7 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
           content: (
             <div>
               <Tooltip
-                placement="bottom-start"
+                placement="top-start"
                 offset={[0, 4]}
                 tooltipContent={formatText(MSG.tooltip, {
                   permission: findFirstUserRoleWithColonyRoles({

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/Signees/partials/RoleApprovalTooltip/RoleApprovalTooltip.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/partials/Signees/partials/RoleApprovalTooltip/RoleApprovalTooltip.tsx
@@ -21,17 +21,17 @@ const MSG = defineMessages({
   rolesTooltipApproved: {
     id: `${displayName}.rolesTooltipApproved`,
     defaultMessage:
-      'Approved using {numberOfRolesSigned} core {numberOfRolesSigned, plural, one {permission} other {permissions}}:',
+      'Approved using {numberOfRolesSigned} core multi-sig {numberOfRolesSigned, plural, one {permission} other {permissions}}:',
   },
   rolesTooltipRejected: {
     id: `${displayName}.rolesTooltipRejected`,
     defaultMessage:
-      'Rejected using {numberOfRolesSigned} core {numberOfRolesSigned, plural, one {permission} other {permissions}}:',
+      'Rejected using {numberOfRolesSigned} core multi-sig {numberOfRolesSigned, plural, one {permission} other {permissions}}:',
   },
   rolesTooltipPending: {
     id: `${displayName}.rolesTooltipPending`,
     defaultMessage:
-      'Can approve using {numberOfRolesPending} core {numberOfRolesPending, plural, one {permission} other {permissions}}:',
+      'Can approve using {numberOfRolesPending} core multi-sig {numberOfRolesPending, plural, one {permission} other {permissions}}:',
   },
 });
 

--- a/src/components/v5/shared/Button/ActionButton.tsx
+++ b/src/components/v5/shared/Button/ActionButton.tsx
@@ -35,6 +35,7 @@ const ActionButton: FC<ActionButtonProps> = ({
     success: successAction,
     transform,
   });
+  const shouldShowLoading = loading || isLoading;
 
   const handleClick = async () => {
     if (props.disabled) return;
@@ -53,26 +54,28 @@ const ActionButton: FC<ActionButtonProps> = ({
     }
   };
 
-  if (loadingBehavior === LoadingBehavior.TxLoader && (isLoading || loading)) {
-    <IconButton
-      rounded="s"
-      isFullSize={props.isFullSize || isMobile}
-      text={{ id: 'button.pending' }}
-      icon={
-        <span className="ml-2 flex shrink-0">
-          <SpinnerGap size={18} className="animate-spin" />
-        </span>
-      }
-      className="!px-4 !text-md"
-    />;
+  if (loadingBehavior === LoadingBehavior.TxLoader && shouldShowLoading) {
+    return (
+      <IconButton
+        rounded="s"
+        isFullSize={props.isFullSize || isMobile}
+        text={{ id: 'button.pending' }}
+        icon={
+          <span className="ml-2 flex shrink-0">
+            <SpinnerGap size={18} className="animate-spin" />
+          </span>
+        }
+        className="!px-4 !text-md"
+      />
+    );
   }
 
-  if (loadingBehavior === LoadingBehavior.Disabled && (isLoading || loading)) {
+  if (loadingBehavior === LoadingBehavior.Disabled && shouldShowLoading) {
     return <Button onClick={handleClick} disabled {...props} />;
   }
 
   return (
-    <Button onClick={handleClick} loading={loading || isLoading} {...props} />
+    <Button onClick={handleClick} loading={shouldShowLoading} {...props} />
   );
 };
 

--- a/src/hooks/multiSig/useDomainThreshold.ts
+++ b/src/hooks/multiSig/useDomainThreshold.ts
@@ -88,6 +88,6 @@ export const useDomainThreshold = ({
 
   return {
     thresholdPerRole: getDomainThreshold(),
-    isLoading: loadingExtension,
+    isLoading: loadingExtension || loadingEligibleSignees,
   };
 };


### PR DESCRIPTION
## Description

Just tidying up stuff according to the issue :broom: 
Check out the issue for some more details.

## Testing

1. Install the multisig extension, set the global threshold to 2
2. Give `leela` the multisig owner role in `General` and `amy` a multisig payer role in `General`
3. Create a simple payment multisig motion in `General`
![image](https://github.com/user-attachments/assets/39c83ddc-c211-42f0-afb1-73498f8babeb)
4. Verify that the tooltip over `Signatories` is aligned to the top
![image](https://github.com/user-attachments/assets/32e90eb5-eb85-40ec-ac80-239e559aea12)
5. Verify that the text in the top is reworded to `This action requires a bundled approval. Each approval is based on the permissions you hold.`
![image](https://github.com/user-attachments/assets/398023c5-90f0-4c6a-b65c-d23d51ea3a78)
6. The tooltip over the role counter should say "core multi-sig permissions" instead of just "core permissions"
![image](https://github.com/user-attachments/assets/7767aca8-3273-4457-bf82-007f9f6bba97)
7. Try removing a vote, voting again, the loader should now not be a spinner
![image](https://github.com/user-attachments/assets/26a89096-18c1-4e59-b4a3-20d802ff5177)
![image](https://github.com/user-attachments/assets/9792088a-8b6c-4541-b49d-2691aa6519f7)
8. Finally, try refreshing the page with the action txHash in the URL, the `Invalid threshold` banner should not pop in


## Diffs

**Changes** 🏗

* `ActionButton` now returns the tx loader button :D 
* aligned texts
* `useDomainThreshold` now returns `isLoading` when the signees are loading

Resolves  #3245 
