### PR TITLE
Fix: Dont send mention notifications to the same address as the creator

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=5e0b8ab6ac67f6f0ae1f3d9ded95e7c78577e0a3
+ENV BLOCK_INGESTOR_HASH=839cdea3a1347ba622b8aa166102ceb88cad0f2b
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=3565741c8049ee01e994dcb8a32558070c1eea88
+ENV BLOCK_INGESTOR_HASH=5e0b8ab6ac67f6f0ae1f3d9ded95e7c78577e0a3
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]


### PR DESCRIPTION
## Description

New block ingestor hash which contains work to not show users mentions from actions that they created themselves.

Block ingestor PR: https://github.com/JoinColony/block-ingestor/pull/282

## Testing

* First, log in as both Leela and Amy.

* As Leela, create a simple payment to Leela.
<img width="1060" alt="Screenshot 2024-10-18 at 11 18 19" src="https://github.com/user-attachments/assets/28d47a1c-e634-47ae-82ac-efd465777240">

* As Leela, create a simple payment to Amy.
<img width="1064" alt="Screenshot 2024-10-18 at 11 18 25" src="https://github.com/user-attachments/assets/7f852367-dc8c-4e0b-b9f6-ae16e58d1807">

* Check Leela's notifications - there should not be a **mention notification** about either action.
<img width="673" alt="Screenshot 2024-10-18 at 11 17 41" src="https://github.com/user-attachments/assets/ef6c67ac-6aad-468a-a6ac-5995aef3bfec">

* Check Amy's notifications - there should be one **mention notification**, about the action which sent a payment to Amy.
<img width="672" alt="Screenshot 2024-10-18 at 11 17 21" src="https://github.com/user-attachments/assets/cf74658e-9b9f-47b6-8ea5-14b0ea515dcd">


## Diffs

**Changes** 🏗

* Changes in block ingestor: https://github.com/JoinColony/block-ingestor/pull/282

Resolves #3387
