### PR TITLE
Fix: Only fire one notification on multisig approval

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=dbaecbaec80f14499968188761cb965d2dbb08f1
+ENV BLOCK_INGESTOR_HASH=ca0ae56e51db8880b186530690268f627514bc6d
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]


### PR DESCRIPTION
## Description

When a multisig is fully approved, we should ensure that only one notification is fired about this approval.

Previously one notification was being sent for each role the user voted with, which in the case of a simple payment for example is three, so you would end up with three notifications all at the same time saying that the multisig motion was approved.

Block ingestor changes here: https://github.com/JoinColony/block-ingestor/pull/283

## Testing

* Install the multisig extension and set the threshold to 2
<img width="1385" alt="Screenshot 2024-10-18 at 14 31 24" src="https://github.com/user-attachments/assets/a0c3b99a-8625-4eb7-85a5-44a4bba8b8f1">

* Give both Leela and Amy owner permissions for multisig
<img width="1056" alt="Screenshot 2024-10-18 at 14 32 04" src="https://github.com/user-attachments/assets/14a06eab-7ba3-4140-82cb-67724baf55f1">
<img width="1054" alt="Screenshot 2024-10-18 at 14 32 40" src="https://github.com/user-attachments/assets/ba4b3cab-b87e-4993-9536-cc51ebc0ce2c">

* Create a simple payment multi sig action
<img width="1054" alt="Screenshot 2024-10-18 at 14 34 01" src="https://github.com/user-attachments/assets/320a4178-cfaf-4254-af5f-631a5391e7ac">

* You should not receive an "approved: " notification about the multisig yet since the threshold wasn't yet met, although Leela should have had her approval automatically added as the creator
<img width="664" alt="Screenshot 2024-10-18 at 14 34 11" src="https://github.com/user-attachments/assets/d21b49d9-91c7-4698-a7d7-534a2edae92b">

* Log in as Amy and approve the multisig motion
<img width="1054" alt="Screenshot 2024-10-18 at 14 34 56" src="https://github.com/user-attachments/assets/a5b8018f-484a-4080-b32d-8d14d28f9986">

* Go back to Leela and check her notifications, and ensure that only **one** "Approved: " notification has arrived
<img width="663" alt="Screenshot 2024-10-18 at 14 35 35" src="https://github.com/user-attachments/assets/f6191cb6-7038-40ad-a08b-ad975669f246">


## Diffs

**Changes** 🏗

* Changes in block ingestor: https://github.com/JoinColony/block-ingestor/pull/283

Resolves #3386
