### PR TITLE
fix: update table for mobile view

### DIFF
--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransferDescription.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransferDescription.tsx
@@ -1,0 +1,75 @@
+import { ArrowSquareOut } from '@phosphor-icons/react';
+import { type Row } from '@tanstack/react-table';
+import clsx from 'clsx';
+import React, { type FC } from 'react';
+
+import ExternalLink from '~shared/ExternalLink/ExternalLink.tsx';
+import { type BridgeDrain } from '~types/graphql.ts';
+import { getFormattedDateFrom } from '~utils/getFormattedDateFrom.ts';
+import { formatText } from '~utils/intl.ts';
+import PillsBase from '~v5/common/Pills/PillsBase.tsx';
+
+import { statusPillScheme, STATUS_MSGS } from './consts.ts';
+import { FiatTransferDescriptionRow } from './FiatTransferDescriptionRow.tsx';
+
+export interface FiatTransferDescriptionProps {
+  actionRow: Row<BridgeDrain>;
+  loading: boolean;
+}
+
+const FiatTransferDescription: FC<FiatTransferDescriptionProps> = ({
+  actionRow,
+  loading,
+}) => {
+  const status = actionRow.getValue('state') as keyof typeof statusPillScheme;
+  const statusScheme = statusPillScheme[status] || statusPillScheme.default;
+
+  return (
+    <div className="expandable flex items-start justify-between gap-1 pb-5 pl-[1.125rem] pr-[.9375rem]">
+      <div className="flex flex-col gap-3 text-gray-500">
+        <FiatTransferDescriptionRow
+          loading={loading}
+          title={formatText({ id: 'table.row.date' })}
+        >
+          <span className="text-md">
+            {getFormattedDateFrom(actionRow.getValue('createdAt'))}
+          </span>
+        </FiatTransferDescriptionRow>
+        <FiatTransferDescriptionRow
+          loading={loading}
+          title={formatText({ id: 'table.row.status' })}
+        >
+          <PillsBase
+            isCapitalized={false}
+            className={clsx(statusScheme.bgClassName, 'text-sm font-medium')}
+          >
+            <span className={statusScheme.textClassName}>
+              {formatText(STATUS_MSGS[status as keyof typeof STATUS_MSGS])}
+            </span>
+          </PillsBase>
+        </FiatTransferDescriptionRow>
+        <FiatTransferDescriptionRow
+          loading={loading}
+          title={formatText({ id: 'table.row.receipt' })}
+        >
+          {!actionRow.original.receipt ? (
+            <div className="text-gray-400">
+              {formatText({ id: 'table.content.receiptGenerating' })}
+            </div>
+          ) : (
+            <ExternalLink
+              href={actionRow.original.receipt.url}
+              key={actionRow.original.receipt.url}
+              className="ml-1 flex items-center gap-2 text-gray-700 underline transition-colors hover:text-blue-400"
+            >
+              <ArrowSquareOut size={18} />
+              {formatText({ id: 'table.content.viewReceipt' })}
+            </ExternalLink>
+          )}
+        </FiatTransferDescriptionRow>
+      </div>
+    </div>
+  );
+};
+
+export default FiatTransferDescription;

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransferDescription.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransferDescription.tsx
@@ -17,56 +17,71 @@ export interface FiatTransferDescriptionProps {
   loading: boolean;
 }
 
+interface ContentObject {
+  title: string;
+  content: React.ReactNode;
+}
+
+const generateContentObjects = ({ status, date, receipt }): ContentObject[] => {
+  const statusScheme = statusPillScheme[status] || statusPillScheme.default;
+  return [
+    {
+      title: formatText({ id: 'table.row.date' }),
+      content: <span className="text-md">{getFormattedDateFrom(date)}</span>,
+    },
+    {
+      title: formatText({ id: 'table.row.status' }),
+      content: (
+        <PillsBase
+          isCapitalized={false}
+          className={clsx(statusScheme.bgClassName, 'text-sm font-medium')}
+        >
+          <span className={statusScheme.textClassName}>
+            {formatText(STATUS_MSGS[status as keyof typeof STATUS_MSGS])}
+          </span>
+        </PillsBase>
+      ),
+    },
+    {
+      title: formatText({ id: 'table.row.receipt' }),
+      content: !receipt ? (
+        <div className="text-gray-400">
+          {formatText({ id: 'table.content.receiptGenerating' })}
+        </div>
+      ) : (
+        <ExternalLink
+          href={receipt.url}
+          key={receipt.url}
+          className="ml-1 flex items-center gap-2 text-gray-700 underline transition-colors hover:text-blue-400"
+        >
+          <ArrowSquareOut size={18} />
+          {formatText({ id: 'table.content.viewReceipt' })}
+        </ExternalLink>
+      ),
+    },
+  ];
+};
+
 const FiatTransferDescription: FC<FiatTransferDescriptionProps> = ({
   actionRow,
   loading,
 }) => {
   const status = actionRow.getValue('state') as keyof typeof statusPillScheme;
-  const statusScheme = statusPillScheme[status] || statusPillScheme.default;
-
+  const contentObjects = generateContentObjects({
+    status,
+    date: actionRow.getValue('createdAt'),
+    receipt: actionRow.original.receipt,
+  });
   return (
-    <div className="expandable flex items-start justify-between gap-1 pb-5 pl-[1.125rem] pr-[.9375rem]">
+    <div className="expandable flex items-start justify-between gap-1 pb-4 pl-[1.125rem] pr-[.9375rem] pt-1">
       <div className="flex flex-col gap-3 text-gray-500">
-        <FiatTransferDescriptionRow
-          loading={loading}
-          title={formatText({ id: 'table.row.date' })}
-        >
-          <span className="text-md">
-            {getFormattedDateFrom(actionRow.getValue('createdAt'))}
-          </span>
-        </FiatTransferDescriptionRow>
-        <FiatTransferDescriptionRow
-          loading={loading}
-          title={formatText({ id: 'table.row.status' })}
-        >
-          <PillsBase
-            isCapitalized={false}
-            className={clsx(statusScheme.bgClassName, 'text-sm font-medium')}
-          >
-            <span className={statusScheme.textClassName}>
-              {formatText(STATUS_MSGS[status as keyof typeof STATUS_MSGS])}
-            </span>
-          </PillsBase>
-        </FiatTransferDescriptionRow>
-        <FiatTransferDescriptionRow
-          loading={loading}
-          title={formatText({ id: 'table.row.receipt' })}
-        >
-          {!actionRow.original.receipt ? (
-            <div className="text-gray-400">
-              {formatText({ id: 'table.content.receiptGenerating' })}
-            </div>
-          ) : (
-            <ExternalLink
-              href={actionRow.original.receipt.url}
-              key={actionRow.original.receipt.url}
-              className="ml-1 flex items-center gap-2 text-gray-700 underline transition-colors hover:text-blue-400"
-            >
-              <ArrowSquareOut size={18} />
-              {formatText({ id: 'table.content.viewReceipt' })}
-            </ExternalLink>
-          )}
-        </FiatTransferDescriptionRow>
+        {contentObjects.map(({ title, content }) => {
+          return (
+            <FiatTransferDescriptionRow loading={loading} title={title}>
+              {content}
+            </FiatTransferDescriptionRow>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransferDescriptionRow.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransferDescriptionRow.tsx
@@ -1,0 +1,23 @@
+import clsx from 'clsx';
+import React, { type PropsWithChildren, type FC } from 'react';
+
+interface FiatTransferDescriptionRowProps {
+  title: string;
+  loading: boolean;
+}
+
+export const FiatTransferDescriptionRow: FC<
+  PropsWithChildren<FiatTransferDescriptionRowProps>
+> = ({ title, children, loading }) => {
+  const textClassName = 'font-normal text-sm flex items-center';
+  return (
+    <p
+      className={clsx(textClassName, 'text-gray-600', {
+        skeleton: loading,
+      })}
+    >
+      <span>{title}:</span>
+      <span className="ml-1">{children}</span>
+    </p>
+  );
+};

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransfersTable.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransfersTable.tsx
@@ -76,7 +76,7 @@ const FiatTransfersTable = () => {
         renderSubComponent={({ row }) => (
           <FiatTransferDescription actionRow={row} loading={loading} />
         )}
-        className="[&_td:nth-child(1)>div]:font-medium [&_td:nth-child(1)>div]:text-gray-900 [&_td:nth-child(2)>div]:text-gray-600 [&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none"
+        className="pb-8 pt-1.5 [&_td:nth-child(1)>div]:font-medium [&_td:nth-child(1)>div]:text-gray-900 [&_td:nth-child(2)>div]:text-gray-600 [&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none"
         emptyContent={
           !sortedData.length &&
           !loading && (

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransfersTable.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransfersTable.tsx
@@ -72,7 +72,6 @@ const FiatTransfersTable = () => {
         getSortedRowModel={getSortedRowModel()}
         getPaginationRowModel={getPaginationRowModel()}
         getRowCanExpand={() => isMobile}
-        shouldHideSortingArrow={false}
         renderSubComponent={({ row }) => (
           <FiatTransferDescription actionRow={row} loading={loading} />
         )}

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransfersTable.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransfersTable.tsx
@@ -41,7 +41,6 @@ const FiatTransfersTable = () => {
   const { formatMessage } = useIntl();
   const [sorting, setSorting] = useState<SortingState>([
     { desc: true, id: 'createdAt' },
-    { desc: true, id: 'state' },
   ]);
 
   const isMobile = useMobile();
@@ -73,6 +72,7 @@ const FiatTransfersTable = () => {
         getSortedRowModel={getSortedRowModel()}
         getPaginationRowModel={getPaginationRowModel()}
         getRowCanExpand={() => isMobile}
+        shouldHideSortingArrow={false}
         renderSubComponent={({ row }) => (
           <FiatTransferDescription actionRow={row} loading={loading} />
         )}

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/consts.ts
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/consts.ts
@@ -29,11 +29,11 @@ export const STATUS_MSGS = defineMessages({
   },
   [FiatTransferState.PaymentSubmitted]: {
     id: `${displayName}.paymentSubmitted`,
-    defaultMessage: 'Payment submitted',
+    defaultMessage: 'Submitted',
   },
   [FiatTransferState.PaymentProcessed]: {
     id: `${displayName}.paymentProcessed`,
-    defaultMessage: 'Payment processed',
+    defaultMessage: 'Processed',
   },
   [FiatTransferState.Canceled]: {
     id: `${displayName}.canceled`,

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/hooks.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/hooks.tsx
@@ -66,7 +66,7 @@ export const useFiatTransfersTableColumns = (
             return <div className="h-4 w-20 skeleton" />;
           }
           return (
-            <div className="my-2">
+            <div>
               {getFormattedAmount(
                 row.original.amount,
                 SupportedCurrencies[row.original.currency.toUpperCase()] ??
@@ -84,7 +84,7 @@ export const useFiatTransfersTableColumns = (
       columnHelper.accessor('createdAt', {
         header: () => formatText({ id: 'table.row.date' }),
         headCellClassName: isMobile ? 'pr-2' : undefined,
-        staticSize: '180px',
+        staticSize: '150px',
         cell: ({ row }) => {
           if (loading) {
             return <div className="h-4 w-20 skeleton" />;
@@ -95,7 +95,7 @@ export const useFiatTransfersTableColumns = (
       columnHelper.accessor('state', {
         header: () => formatText({ id: 'table.row.status' }),
         headCellClassName: isMobile ? 'pr-2' : undefined,
-        staticSize: isMobile ? '155px' : '180px',
+        staticSize: isMobile ? '145px' : '170px',
         cell: ({ row: { original, getIsExpanded } }) => {
           const status = original.state as keyof typeof statusPillScheme;
           const statusScheme =
@@ -128,7 +128,7 @@ export const useFiatTransfersTableColumns = (
       columnHelper.accessor('receipt', {
         header: () => formatText({ id: 'table.row.receipt' }),
         headCellClassName: isMobile ? 'pr-2 pl-0' : undefined,
-        staticSize: '180px',
+        staticSize: '165px',
         cell: ({ row }) => {
           if (loading) {
             return <div className="h-4 w-12 skeleton" />;
@@ -146,7 +146,7 @@ export const useFiatTransfersTableColumns = (
             <ExternalLink
               href={row.original.receipt.url}
               key={row.original.receipt.url}
-              className="flex items-center gap-2 text-md text-gray-700 underline transition-colors hover:text-blue-400"
+              className="flex items-center gap-2 text-sm text-gray-700 underline transition-colors hover:text-blue-400"
             >
               <ArrowSquareOut size={18} />
               {formatText({ id: 'table.content.viewReceipt' })}

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/hooks.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/hooks.tsx
@@ -128,6 +128,7 @@ export const useFiatTransfersTableColumns = (
       columnHelper.accessor('receipt', {
         header: () => formatText({ id: 'table.row.receipt' }),
         headCellClassName: isMobile ? 'pr-2 pl-0' : undefined,
+        enableSorting: false,
         staticSize: '165px',
         cell: ({ row }) => {
           if (loading) {

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/hooks.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/hooks.tsx
@@ -1,4 +1,4 @@
-import { ArrowSquareOut } from '@phosphor-icons/react';
+import { ArrowSquareOut, CaretDown } from '@phosphor-icons/react';
 import {
   type ColumnDef,
   createColumnHelper,
@@ -61,15 +61,12 @@ export const useFiatTransfersTableColumns = (
     return [
       columnHelper.accessor('amount', {
         header: () => formatText({ id: 'table.row.amount' }),
-        headCellClassName: clsx({
-          'pl-0 pr-2': isMobile,
-        }),
         cell: ({ row }) => {
           if (loading) {
             return <div className="h-4 w-20 skeleton" />;
           }
           return (
-            <div>
+            <div className="my-2">
               {getFormattedAmount(
                 row.original.amount,
                 SupportedCurrencies[row.original.currency.toUpperCase()] ??
@@ -98,18 +95,21 @@ export const useFiatTransfersTableColumns = (
       columnHelper.accessor('state', {
         header: () => formatText({ id: 'table.row.status' }),
         headCellClassName: isMobile ? 'pr-2' : undefined,
-        staticSize: '180px',
-        cell: ({ row }) => {
-          const status = row.original.state as keyof typeof statusPillScheme;
+        staticSize: isMobile ? '155px' : '180px',
+        cell: ({ row: { original, getIsExpanded } }) => {
+          const status = original.state as keyof typeof statusPillScheme;
           const statusScheme =
             statusPillScheme[status] || statusPillScheme.default;
           if (loading) {
             return <div className="h-4 w-12 skeleton" />;
           }
-          return (
+          return getIsExpanded() ? undefined : (
             <PillsBase
               isCapitalized={false}
-              className={clsx(statusScheme.bgClassName, 'text-sm font-medium')}
+              className={clsx(
+                statusScheme.bgClassName,
+                'truncate text-sm font-medium',
+              )}
             >
               <span className={statusScheme.textClassName}>
                 {formatText(STATUS_MSGS[status as keyof typeof STATUS_MSGS])}
@@ -153,6 +153,25 @@ export const useFiatTransfersTableColumns = (
             </ExternalLink>
           );
         },
+      }),
+      columnHelper.display({
+        id: 'expander',
+        staticSize: '2.25rem',
+        header: () => null,
+        enableSorting: false,
+        cell: ({ row: { getIsExpanded, toggleExpanded } }) => {
+          return (
+            <button type="button" onClick={() => toggleExpanded()}>
+              <CaretDown
+                size={18}
+                className={clsx('transition', {
+                  'rotate-180': getIsExpanded(),
+                })}
+              />
+            </button>
+          );
+        },
+        cellContentWrapperClassName: 'pl-0',
       }),
     ];
   }, [isMobile, columnHelper, loading]);

--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -52,7 +52,6 @@ const Table = <T,>({
   showTableBorder = true,
   alwaysShowPagination = false,
   footerColSpan,
-  shouldHideSortingArrow = true,
   ...rest
 }: TableProps<T>) => {
   const helper = useMemo(() => createColumnHelper<T>(), []);
@@ -239,7 +238,7 @@ const Table = <T,>({
                         key={header.id}
                         className={clsx(
                           header.column.columnDef.headCellClassName,
-                          'border-b border-b-gray-200 bg-gray-50 px-[1.125rem] py-2.5 text-left text-sm font-normal text-gray-600 first:rounded-tl-lg last:rounded-tr-lg empty:p-0',
+                          'group border-b border-b-gray-200 bg-gray-50 px-[1.125rem] py-2.5 text-left text-sm font-normal text-gray-600 first:rounded-tl-lg last:rounded-tr-lg empty:p-0',
                           {
                             'cursor-pointer':
                               header.column.getCanSort() &&
@@ -277,10 +276,9 @@ const Table = <T,>({
                                 'rotate-0':
                                   header.column.getIsSorted() === 'desc' &&
                                   !shouldShowEmptyContent,
-                                hidden:
-                                  shouldHideSortingArrow &&
-                                  (header.column.getIsSorted() === false ||
-                                    shouldShowEmptyContent),
+                                'opacity-0 group-hover:opacity-100':
+                                  header.column.getIsSorted() === false ||
+                                  shouldShowEmptyContent,
                               },
                             )}
                           />

--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -333,7 +333,7 @@ const Table = <T,>({
                         {row.getVisibleCells().map((cell, index) => {
                           const renderCellWrapperCommonArgs = [
                             clsx(
-                              'flex h-full flex-col items-start justify-center p-[1.1rem] text-md',
+                              'flex h-full flex-col items-start justify-center p-4 text-md',
                               {
                                 'text-gray-500': !isDisabled,
                                 'text-gray-300': isDisabled,

--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -52,6 +52,7 @@ const Table = <T,>({
   showTableBorder = true,
   alwaysShowPagination = false,
   footerColSpan,
+  shouldHideSortingArrow = true,
   ...rest
 }: TableProps<T>) => {
   const helper = useMemo(() => createColumnHelper<T>(), []);
@@ -277,8 +278,9 @@ const Table = <T,>({
                                   header.column.getIsSorted() === 'desc' &&
                                   !shouldShowEmptyContent,
                                 hidden:
-                                  header.column.getIsSorted() === false ||
-                                  shouldShowEmptyContent,
+                                  shouldHideSortingArrow &&
+                                  (header.column.getIsSorted() === false ||
+                                    shouldShowEmptyContent),
                               },
                             )}
                           />

--- a/src/components/v5/common/Table/types.ts
+++ b/src/components/v5/common/Table/types.ts
@@ -48,4 +48,5 @@ export interface TableProps<T>
   showTableHead?: boolean;
   showTableBorder?: boolean;
   alwaysShowPagination?: boolean;
+  shouldHideSortingArrow?: boolean;
 }

--- a/src/components/v5/common/Table/types.ts
+++ b/src/components/v5/common/Table/types.ts
@@ -48,5 +48,4 @@ export interface TableProps<T>
   showTableHead?: boolean;
   showTableBorder?: boolean;
   alwaysShowPagination?: boolean;
-  shouldHideSortingArrow?: boolean;
 }


### PR DESCRIPTION
## Description

- [x] The status arrow should show by default, it's currently not showing, and the user do not know it's available for sorting. The table should stay by default sorted by date, so no change here. 

<img width="146" alt="image" src="https://github.com/JoinColony/colonyCDapp/assets/82127904/f0c957a3-0d7b-418f-99f6-4df72a790ea1">

- [x] Mobile table styling should match Figma designs on mobile figma: https://www.figma.com/design/C2grfQysdsYXz0j4rADR6K/Crypto-to-Fiat?node-id=4456-37629&node-type=frame&t=jlSKOZ8yTQr98oqZ-0

| **Before** | **Now** |
| ----- | ----- |
| ![Screenshot 2024-07-29 at 12 24 20](https://github.com/user-attachments/assets/8fa675b4-9ea6-4e1a-9800-a0d4d2446bef) | <img width="589" alt="image" src="https://github.com/user-attachments/assets/8d983f0b-fcdf-4ae8-a8ee-fa24a998d4a5"> |


## Testing
1. Create `.diff` file in your root direction
2. Insert this changes:
```
diff --git a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransfersTable.tsx b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransfersTable.tsx
index 6108cd1dc..167bc241a 100644
--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransfersTable.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransfersTable.tsx
@@ -45,7 +45,58 @@ const FiatTransfersTable = () => {
   ]);
 
   const isMobile = useMobile();
-  const { sortedData, loading } = useFiatTransfersData(sorting);
+  const { sortedData: data, loading } = useFiatTransfersData(sorting);
+
+  const sortedData: typeof data = [
+    {
+      __typename: 'BridgeDrain',
+      id: '12343',
+      amount: '1234.22',
+      currency: 'usdc',
+      state: 'payment_processed',
+      createdAt: '2024-09-20T13:11:22.310Z',
+      receipt: {
+        __typename: 'BridgeDrainReceipt',
+        url: '#',
+      },
+    },
+    {
+      __typename: 'BridgeDrain',
+      id: '12344',
+      amount: '24689.00',
+      currency: 'usdc',
+      state: 'in_review',
+      createdAt: '2024-08-17T10:14:08.450Z',
+      receipt: {
+        __typename: 'BridgeDrainReceipt',
+        url: '#',
+      },
+    },
+    {
+      __typename: 'BridgeDrain',
+      id: '12345',
+      amount: '2230.77',
+      currency: 'usdc',
+      state: 'awaiting_funds',
+      createdAt: '2024-07-16T06:04:23.100Z',
+      receipt: {
+        __typename: 'BridgeDrainReceipt',
+        url: '#',
+      },
+    },
+    {
+      __typename: 'BridgeDrain',
+      id: '12346',
+      amount: '1200662.77',
+      currency: 'usdc',
+      state: 'awaiting_funds',
+      createdAt: '2024-07-16T06:04:23.100Z',
+      receipt: {
+        __typename: 'BridgeDrainReceipt',
+        url: '#',
+      },
+    },
+  ];
 
   const columns = useFiatTransfersTableColumns(loading);
 
```
3. `git apply .diff`
4. Navigate to Crypto to fiat tab http://localhost:9091/account/crypto-to-fiat 
5. Check that the Drain history matches the design
6. Check that the Status column has an arrow.

Resolves #2662
