### PR TITLE
Notifications: Send motion notifications for expenditures funded with motions

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=468620f04140ca9bc2857f0eea720336d51376dd
+ENV BLOCK_INGESTOR_HASH=ce282d002d1cd74d70d91bb26d97d8d379e83811
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=ca0ae56e51db8880b186530690268f627514bc6d
+ENV BLOCK_INGESTOR_HASH=468620f04140ca9bc2857f0eea720336d51376dd
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureFundingMotionNotificationMessage.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureFundingMotionNotificationMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, type FC } from 'react';
+import React, { useMemo, type FC, type ReactNode } from 'react';
 import { defineMessages } from 'react-intl';
 
 import { NotificationType } from '~gql';
@@ -10,6 +10,7 @@ const displayName =
   'common.Extensions.UserHub.partials.ExpenditureMotionNotificationMessage';
 
 interface ExpenditureFundingMotionNotificationMessageProps {
+  actionMetadataDescription: ReactNode;
   actionTitle: string;
   loading: boolean;
   notificationType: NotificationType;
@@ -18,49 +19,71 @@ interface ExpenditureFundingMotionNotificationMessageProps {
 const MSG = defineMessages({
   opposed: {
     id: `${displayName}.opposed`,
-    defaultMessage: 'Opposed, will fail: Funding for {action}',
+    defaultMessage: 'Opposed, will fail:',
   },
   supported: {
     id: `${displayName}.supported`,
-    defaultMessage: 'Supported, will pass: Funding for {action}',
+    defaultMessage: 'Supported, will pass:',
   },
   voting: {
     id: `${displayName}.opposed`,
-    defaultMessage: 'Voting started: Funding for {action}',
+    defaultMessage: 'Voting started:',
   },
   reveal: {
     id: `${displayName}.reveal`,
-    defaultMessage: 'Reveal votes: Funding for {action}',
+    defaultMessage: 'Reveal votes:',
   },
   finalized: {
     id: `${displayName}.finalized`,
-    defaultMessage: 'Finalized: Funding for {action}',
+    defaultMessage: 'Finalized:',
   },
   created: {
     id: `${displayName}.created`,
-    defaultMessage: 'Reputation decision: Funding for {action}',
+    defaultMessage: 'Reputation decision:',
   },
   unknownChange: {
     id: `${displayName}.unknownChange`,
-    defaultMessage: 'Action updated: Funding for {action}',
+    defaultMessage: 'Action updated:',
+  },
+  unknownAction: {
+    id: `${displayName}.unknownAction`,
+    defaultMessage: 'A payment was funded',
+  },
+  fundingFor: {
+    id: `${displayName}.fundingFor`,
+    defaultMessage: 'Funding for',
   },
 });
 
 const ExpenditureFundingMotionNotificationMessage: FC<
   ExpenditureFundingMotionNotificationMessageProps
-> = ({ actionTitle, loading, notificationType }) => {
+> = ({ actionTitle, actionMetadataDescription, loading, notificationType }) => {
   const Message = useMemo(() => {
-    const msgKey = {
-      [NotificationType.MotionCreated]: MSG.created,
-      [NotificationType.MotionOpposed]: MSG.opposed,
-      [NotificationType.MotionSupported]: MSG.supported,
-      [NotificationType.MotionVoting]: MSG.voting,
-      [NotificationType.MotionReveal]: MSG.reveal,
-      [NotificationType.MotionFinalized]: MSG.finalized,
+    const firstPart = {
+      [NotificationType.MotionCreated]: formatText(MSG.created),
+      [NotificationType.MotionOpposed]: formatText(MSG.opposed),
+      [NotificationType.MotionSupported]: formatText(MSG.supported),
+      [NotificationType.MotionVoting]: formatText(MSG.voting),
+      [NotificationType.MotionReveal]: formatText(MSG.reveal),
+      [NotificationType.MotionFinalized]: formatText(MSG.finalized),
     }[notificationType];
 
-    return <>{formatText(msgKey, { action: actionTitle })}</>;
-  }, [actionTitle, notificationType]);
+    const secondPart =
+      actionTitle || actionMetadataDescription ? (
+        <>
+          {formatText(MSG.fundingFor)}{' '}
+          {actionTitle || actionMetadataDescription}
+        </>
+      ) : (
+        formatText(MSG.unknownAction)
+      );
+
+    return (
+      <>
+        {firstPart} {secondPart}
+      </>
+    );
+  }, [actionTitle, actionMetadataDescription, notificationType]);
 
   return <NotificationMessage loading={loading}>{Message}</NotificationMessage>;
 };

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureFundingMotionNotificationMessage.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureFundingMotionNotificationMessage.tsx
@@ -1,0 +1,70 @@
+import React, { useMemo, type FC } from 'react';
+import { defineMessages } from 'react-intl';
+
+import { NotificationType } from '~gql';
+import { formatText } from '~utils/intl.ts';
+
+import NotificationMessage from '../NotificationMessage.tsx';
+
+const displayName =
+  'common.Extensions.UserHub.partials.ExpenditureMotionNotificationMessage';
+
+interface ExpenditureFundingMotionNotificationMessageProps {
+  actionTitle: string;
+  loading: boolean;
+  notificationType: NotificationType;
+}
+
+const MSG = defineMessages({
+  opposed: {
+    id: `${displayName}.opposed`,
+    defaultMessage: 'Opposed, will fail: Funding for {action}',
+  },
+  supported: {
+    id: `${displayName}.supported`,
+    defaultMessage: 'Supported, will pass: Funding for {action}',
+  },
+  voting: {
+    id: `${displayName}.opposed`,
+    defaultMessage: 'Voting started: Funding for {action}',
+  },
+  reveal: {
+    id: `${displayName}.reveal`,
+    defaultMessage: 'Reveal votes: Funding for {action}',
+  },
+  finalized: {
+    id: `${displayName}.finalized`,
+    defaultMessage: 'Finalized: Funding for {action}',
+  },
+  created: {
+    id: `${displayName}.created`,
+    defaultMessage: 'Reputation decision: Funding for {action}',
+  },
+  unknownChange: {
+    id: `${displayName}.unknownChange`,
+    defaultMessage: 'Action updated: Funding for {action}',
+  },
+});
+
+const ExpenditureFundingMotionNotificationMessage: FC<
+  ExpenditureFundingMotionNotificationMessageProps
+> = ({ actionTitle, loading, notificationType }) => {
+  const Message = useMemo(() => {
+    const msgKey = {
+      [NotificationType.MotionCreated]: MSG.created,
+      [NotificationType.MotionOpposed]: MSG.opposed,
+      [NotificationType.MotionSupported]: MSG.supported,
+      [NotificationType.MotionVoting]: MSG.voting,
+      [NotificationType.MotionReveal]: MSG.reveal,
+      [NotificationType.MotionFinalized]: MSG.finalized,
+    }[notificationType];
+
+    return <>{formatText(msgKey, { action: actionTitle })}</>;
+  }, [actionTitle, notificationType]);
+
+  return <NotificationMessage loading={loading}>{Message}</NotificationMessage>;
+};
+
+ExpenditureFundingMotionNotificationMessage.displayName = displayName;
+
+export default ExpenditureFundingMotionNotificationMessage;

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureNotification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureNotification.tsx
@@ -7,6 +7,7 @@ import {
   NotificationType,
   useGetColonyActionQuery,
   useGetExpenditureQuery,
+  ColonyActionType,
 } from '~gql';
 import { TX_SEARCH_PARAM } from '~routes';
 import { type Notification as NotificationInterface } from '~types/notifications.ts';
@@ -14,6 +15,7 @@ import { formatText } from '~utils/intl.ts';
 
 import NotificationWrapper from '../NotificationWrapper.tsx';
 
+import ExpenditureFundingMotionNotificationMessage from './ExpenditureFundingMotionNotificationMessage.tsx';
 import ExpenditureNotificationMessage from './ExpenditureNotificationMessage.tsx';
 
 const displayName =
@@ -34,8 +36,32 @@ const ExpenditureNotification: FC<NotificationProps> = ({
 }) => {
   const navigate = useNavigate();
 
-  const { expenditureID, notificationType } =
-    notification.customAttributes || {};
+  const {
+    expenditureID,
+    notificationType,
+    transactionHash: notificationTransactionHash,
+  } = notification.customAttributes || {};
+
+  const isExpenditureNotification =
+    !!notificationType &&
+    [
+      NotificationType.ExpenditureReadyForReview,
+      NotificationType.ExpenditureReadyForFunding,
+      NotificationType.ExpenditureReadyForRelease,
+      NotificationType.ExpenditureCancelled,
+      NotificationType.ExpenditureFinalized,
+    ].includes(notificationType);
+
+  const isExpenditureMotionNotification =
+    !!notificationType &&
+    [
+      NotificationType.MotionCreated,
+      NotificationType.MotionOpposed,
+      NotificationType.MotionSupported,
+      NotificationType.MotionVoting,
+      NotificationType.MotionReveal,
+      NotificationType.MotionFinalized,
+    ].includes(notificationType);
 
   const { data: expenditureData, loading: loadingExpenditure } =
     useGetExpenditureQuery({
@@ -58,6 +84,32 @@ const ExpenditureNotification: FC<NotificationProps> = ({
   });
 
   const action = actionData?.getColonyAction;
+
+  const { data: notificationActionData, loading: loadingNotificationAction } =
+    useGetColonyActionQuery({
+      variables: {
+        transactionHash: notificationTransactionHash || '',
+      },
+      skip:
+        !notificationTransactionHash ||
+        notificationTransactionHash === transactionHash,
+    });
+
+  const notificationAction = notificationActionData?.getColonyAction;
+
+  let isExpenditureFundingMotionNotification = isExpenditureMotionNotification;
+
+  if (notificationTransactionHash !== transactionHash) {
+    isExpenditureFundingMotionNotification =
+      isExpenditureFundingMotionNotification &&
+      notificationAction?.type === ColonyActionType.FundExpenditureMotion;
+  }
+
+  const loading =
+    loadingColony ||
+    loadingAction ||
+    loadingNotificationAction ||
+    loadingExpenditure;
 
   const handleNotificationClicked = () => {
     if (!transactionHash) {
@@ -102,21 +154,21 @@ const ExpenditureNotification: FC<NotificationProps> = ({
       notification={notification}
       onClick={handleNotificationClicked}
     >
-      {notificationType &&
-        [
-          NotificationType.ExpenditureReadyForReview,
-          NotificationType.ExpenditureReadyForFunding,
-          NotificationType.ExpenditureReadyForRelease,
-          NotificationType.ExpenditureCancelled,
-          NotificationType.ExpenditureFinalized,
-        ].includes(notificationType) && (
-          <ExpenditureNotificationMessage
-            actionTitle={actionTitle}
-            actionMetadataDescription={actionMetadataDescription}
-            loading={loadingColony || loadingAction || loadingExpenditure}
-            notificationType={notificationType}
-          />
-        )}
+      {isExpenditureNotification && (
+        <ExpenditureNotificationMessage
+          actionTitle={actionTitle}
+          actionMetadataDescription={actionMetadataDescription}
+          loading={loading}
+          notificationType={notificationType}
+        />
+      )}
+      {isExpenditureFundingMotionNotification && (
+        <ExpenditureFundingMotionNotificationMessage
+          actionTitle={actionTitle}
+          loading={loading}
+          notificationType={notificationType as NotificationType}
+        />
+      )}
     </NotificationWrapper>
   );
 };

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureNotification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureNotification.tsx
@@ -165,6 +165,7 @@ const ExpenditureNotification: FC<NotificationProps> = ({
       {isExpenditureFundingMotionNotification && (
         <ExpenditureFundingMotionNotificationMessage
           actionTitle={actionTitle}
+          actionMetadataDescription={actionMetadataDescription}
           loading={loading}
           notificationType={notificationType as NotificationType}
         />

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
@@ -87,34 +87,31 @@ const Notification: FC<NotificationProps> = ({
 
   // If the notification type is an expenditure update:
   // Or a motion supporting an expenditure (eg. for funding)
-  if (hasExpenditureId) {
-    if (
-      [
-        NotificationType.MotionCreated,
-        NotificationType.MotionOpposed,
-        NotificationType.MotionSupported,
-        NotificationType.MotionVoting,
-        NotificationType.MotionReveal,
-        NotificationType.MotionFinalized,
-        NotificationType.ExpenditureReadyForReview,
-        NotificationType.ExpenditureReadyForFunding,
-        NotificationType.ExpenditureReadyForRelease,
-        NotificationType.ExpenditureFinalized,
-        NotificationType.ExpenditureCancelled,
-        NotificationType.ExpenditurePayoutClaimed,
-      ].includes(notificationType)
-    ) {
-      return (
-        <ExpenditureNotification
-          colony={notificationColony}
-          isCurrentColony={isCurrentColony}
-          loadingColony={loadingColony}
-          notification={notification}
-        />
-      );
-    }
-    // if isExpenditure is true but we have a mention notification we'll not display it
-    return null;
+  if (
+    hasExpenditureId &&
+    [
+      NotificationType.MotionCreated,
+      NotificationType.MotionOpposed,
+      NotificationType.MotionSupported,
+      NotificationType.MotionVoting,
+      NotificationType.MotionReveal,
+      NotificationType.MotionFinalized,
+      NotificationType.ExpenditureReadyForReview,
+      NotificationType.ExpenditureReadyForFunding,
+      NotificationType.ExpenditureReadyForRelease,
+      NotificationType.ExpenditureFinalized,
+      NotificationType.ExpenditureCancelled,
+      NotificationType.ExpenditurePayoutClaimed,
+    ].includes(notificationType)
+  ) {
+    return (
+      <ExpenditureNotification
+        colony={notificationColony}
+        isCurrentColony={isCurrentColony}
+        loadingColony={loadingColony}
+        notification={notification}
+      />
+    );
   }
 
   if (notificationType === NotificationType.FundsClaimed) {

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
@@ -34,7 +34,7 @@ const Notification: FC<NotificationProps> = ({
 }) => {
   const { colony: currentColony } = useColonyContext();
 
-  const { colonyAddress, notificationType } =
+  const { colonyAddress, notificationType, expenditureID } =
     notification.customAttributes || {};
 
   const { data: colonyData, loading: loadingColony } =
@@ -49,6 +49,8 @@ const Notification: FC<NotificationProps> = ({
 
   const isCurrentColony = currentColony.name === notificationColony?.name;
 
+  const hasExpenditureId = !!expenditureID;
+
   // If there is no notification type, something is wrong with this notification
   // and we won't know what to display, so skip it.
   if (!notificationType) {
@@ -57,6 +59,7 @@ const Notification: FC<NotificationProps> = ({
 
   // If the notification type is permissions action, a multisig action, a motion, or a mention (always tied to an action):
   if (
+    !hasExpenditureId &&
     [
       NotificationType.PermissionsAction,
       NotificationType.Mention,
@@ -83,24 +86,35 @@ const Notification: FC<NotificationProps> = ({
   }
 
   // If the notification type is an expenditure update:
-  if (
-    [
-      NotificationType.ExpenditureReadyForReview,
-      NotificationType.ExpenditureReadyForFunding,
-      NotificationType.ExpenditureReadyForRelease,
-      NotificationType.ExpenditureFinalized,
-      NotificationType.ExpenditureCancelled,
-      NotificationType.ExpenditurePayoutClaimed,
-    ].includes(notificationType)
-  ) {
-    return (
-      <ExpenditureNotification
-        colony={notificationColony}
-        isCurrentColony={isCurrentColony}
-        loadingColony={loadingColony}
-        notification={notification}
-      />
-    );
+  // Or a motion supporting an expenditure (eg. for funding)
+  if (hasExpenditureId) {
+    if (
+      [
+        NotificationType.MotionCreated,
+        NotificationType.MotionOpposed,
+        NotificationType.MotionSupported,
+        NotificationType.MotionVoting,
+        NotificationType.MotionReveal,
+        NotificationType.MotionFinalized,
+        NotificationType.ExpenditureReadyForReview,
+        NotificationType.ExpenditureReadyForFunding,
+        NotificationType.ExpenditureReadyForRelease,
+        NotificationType.ExpenditureFinalized,
+        NotificationType.ExpenditureCancelled,
+        NotificationType.ExpenditurePayoutClaimed,
+      ].includes(notificationType)
+    ) {
+      return (
+        <ExpenditureNotification
+          colony={notificationColony}
+          isCurrentColony={isCurrentColony}
+          loadingColony={loadingColony}
+          notification={notification}
+        />
+      );
+    }
+    // if isExpenditure is true but we have a mention notification we'll not display it
+    return null;
   }
 
   if (notificationType === NotificationType.FundsClaimed) {


### PR DESCRIPTION
## Description

- This PR handles the notifications sent for the `FundExpenditureMotion` actions when an expenditure is funded with reputation.

[Block ingestor PR](https://github.com/JoinColony/block-ingestor/pull/286)

## Testing

TODO: Let's test the notifications indeed appear when we fund an expenditure with Reputation. 

* Step 1. Install the `Reputation weighted` extension
![Screenshot 2024-10-21 at 17 33 02](https://github.com/user-attachments/assets/e718dfba-6f14-4f53-9318-8fcc8d099d22)

* Step 2. Create an advanced payment
![Screenshot 2024-10-21 at 17 34 05](https://github.com/user-attachments/assets/73a61dd0-5e4b-4cc8-814e-5aa5031473e0)

* Step 3. At the `funding` step, please select `Reputation`
![Screenshot 2024-10-21 at 17 34 21](https://github.com/user-attachments/assets/5a201c3a-15ba-4c93-ad9f-559ad1c581cb)

* Step 4. Up until this point you should see only the notifications related to the extension installation and advanced payment creation
![Screenshot 2024-10-21 at 17 34 46](https://github.com/user-attachments/assets/35e30fe9-c234-4bc0-9edf-85767bec3b47)

* Step 5. Now let's support the motion
![Screenshot 2024-10-21 at 17 34 54](https://github.com/user-attachments/assets/60dcb2e8-6f9b-4ef0-8b9a-1cd7c2c1c243)

* Step 6. Two more notifications should have appeared 
- one for the motion creation: Reputation decision: Funding for `advanced_payment_title`
- and the other one for being fully supported
![Screenshot 2024-10-21 at 17 35 10](https://github.com/user-attachments/assets/28663756-c087-4694-908a-e5fa671d1bb9)

* Step 7. Run `npm run forward-time 1` and refresh the page
* Step 8. You should be able to finalise the advanced payment
![Screenshot 2024-10-21 at 17 36 57](https://github.com/user-attachments/assets/458ade01-1759-4ac7-ad9a-50a43980cfd9)

* Step 9. Two more notifications should have appeared, one for the reputation motion finalisation and one for the advanced payment
![Screenshot 2024-10-21 at 17 37 22](https://github.com/user-attachments/assets/40ed4efa-ae89-4206-8498-161e70a9b97c)

* Step 10. Release the payment
![Screenshot 2024-10-21 at 17 37 34](https://github.com/user-attachments/assets/8260a7a5-69a0-4a54-922a-737e0f597a6b)

* Step 11. One more notification should show up for the advanced payment being made
![Screenshot 2024-10-21 at 17 37 44](https://github.com/user-attachments/assets/d98ebf6d-0922-4d29-8367-94456878db97)

* Step 12. Close the action sidebar, open the notifications and click on any of the funding motions - the previously created advanced payment action should open

https://github.com/user-attachments/assets/a173db80-3fad-48e8-a587-0b8ef91b4e18

## Further testing:

Try to oppose the funding for another advanced payment and check the correct notification is showing up

![Screenshot 2024-10-21 at 17 52 34](https://github.com/user-attachments/assets/79ea5a32-8199-443b-a4fe-d2e668bb7488)


## Diffs

**New stuff** ✨

* Added `ExpenditureFundingMotionNotificationMessage` for handling expenditure funding motions

Resolves #3388
