### PR TITLE
[Dashboard] Update Colony Page sidebar and non-mobile Breadcrumbs paddings

### DIFF
--- a/src/components/v5/shared/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/v5/shared/Breadcrumbs/Breadcrumbs.tsx
@@ -44,7 +44,7 @@ const Breadcrumbs: FC<BreadcrumbsProps> = ({ className }) => {
     <ul
       className={clsx(
         className,
-        'modal-blur flex items-center gap-2 text-sm text-gray-700',
+        'modal-blur flex items-center gap-2 text-sm text-gray-700 md:pt-2.5',
       )}
     >
       {rootBreadcrumbItem ? (

--- a/src/components/v5/shared/Navigation/Sidebar/Sidebar.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/Sidebar.tsx
@@ -34,7 +34,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
         ref={ref}
         className={clsx(
           'modal-blur top-[calc(var(--header-nav-section-height)+var(--top-content-height))]',
-          'z-sidebar hidden h-full w-fit flex-col items-start rounded-lg bg-gray-900 px-2 pb-4.5 pt-[13.5px] md:flex',
+          'z-sidebar hidden h-full w-fit flex-col items-start rounded-lg bg-gray-900 px-2 pb-5 pt-[15.5px] md:flex',
           {
             '!bg-gray-100': isDarkMode,
           },

--- a/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/ColonyPageSidebar.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/ColonyPageSidebar.tsx
@@ -95,7 +95,7 @@ const ColonyPageSidebar = () => {
     <Sidebar
       className={colonyPageSidebarDesktopClass}
       showColonySwitcher={!isTablet}
-      headerClassName="mb-[27px]"
+      headerClassName="mb-[1.563rem]"
       footerClassName="!items-start !gap-2"
       colonySwitcherProps={{ showColonySwitcherText: true }}
       feedbackButtonProps={{


### PR DESCRIPTION
## Description

This applies the suggested padding adjustments to both the Colony Sidebar and the Breadcrumbs.

## Testing

> [!NOTE]
> I appreciate that it might be quite tricky to test the paddings using a Browser's inspect element tool if you used the Figma examples as a reference. This is because the Figma example is showing the distance from the Colony Logo and not from the Colony Switcher button's border.
>
> A good way to test the Colony Page sidebar top padding is using the Pixel Perfect extension:

**Pixel perfect: Colony Page Sidebar**
![sidebar top](https://github.com/user-attachments/assets/b24075c3-a63a-47ac-8d92-6f0d9b4e07e4)

As for the Breadcrumbs component, I simply added a 10px top padding as per the instruction on the issue.
A good way to check the alignment is to make sure that the bottom part of the letters of the Colony name and the bottom part of the Breadcrumbs letters are aligned.

<img width="1347" alt="image" src="https://github.com/user-attachments/assets/60adcab8-d25a-4e5c-9ccc-3beb4c2c09b5">


## Diffs

**Changes** 🏗

* 10px top padding added for the Breadcrumbs component
* 2px top padding addition for the Colony Page Sidebar then 2px is removed between the Colony Switcher and the Action buttons to compensate
* Sidebar component bottom padding updated to 20px

Resolves #3367 
