### PR TITLE
fix: validation mode for checking if colony url exists form

### DIFF
--- a/src/components/common/Onboarding/wizardSteps/CreateColony/StepColonyName.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/StepColonyName.tsx
@@ -45,7 +45,11 @@ const StepColonyName = ({
     user?.profile?.displayName ?? splitWalletAddress(user?.walletAddress ?? '');
 
   return (
-    <Form<Step1> onSubmit={nextStep} validationSchema={validationSchema}>
+    <Form<Step1>
+      onSubmit={nextStep}
+      validationSchema={validationSchema}
+      mode="onChange"
+    >
       <HeaderRow
         heading={MSG.heading}
         headingValues={{ username }}


### PR DESCRIPTION
## Description

I solved this by comparing it to the colony name creation, figuring out that one works and this one doesn't, what's the difference?
Well basically it wasn't a race condition, but it instead "revalidated" when the field changed focus :melting_face: 

## Testing

1. Run the create data script
2. Run `node ./scripts/create-colony-url.js` and open the URL
![image](https://github.com/user-attachments/assets/3653654f-16b7-4957-9d20-6f056928b411)
3. Into the URL field, enter `planex` and wait for this to appear
![image](https://github.com/user-attachments/assets/dd4612ba-64c9-4227-ad2b-4ffca9fada1e)
4. Enter something else and URL should be available
![image](https://github.com/user-attachments/assets/e7d5f8bf-012d-417f-b9e4-04c3bdfc0bac)

Notice how you don't see the URL available flashing into URL already taken behaviour described in the original issue

## Diffs

**Changes** 🏗

* `onChange` revalidation mode to the colony name step

Resolves #3309 
