### PR TITLE
Feat: Allow overriding user's liquidation address

### DIFF
--- a/amplify/backend/function/bridgeXYZMutation/src/index.js
+++ b/amplify/backend/function/bridgeXYZMutation/src/index.js
@@ -18,15 +18,24 @@ let graphqlURL = 'http://localhost:20002/graphql';
 let appSyncApiKey = 'da2-fakeApiId123456';
 let apiUrl = process.env.BRIDGE_API_URL;
 let apiKey = process.env.BRIDGE_API_KEY;
+let temp_liquidationAddressOverrides =
+  process.env.LIQUIDATION_ADDRESS_OVERRIDES;
 
 const setEnvVariables = async () => {
   if (!isDev) {
     const { getParams } = require('/opt/nodejs/getParams');
-    [appSyncApiKey, apiKey, apiUrl, graphqlURL] = await getParams([
+    [
+      appSyncApiKey,
+      apiKey,
+      apiUrl,
+      graphqlURL,
+      temp_liquidationAddressOverrides,
+    ] = await getParams([
       'appsyncApiKey',
       'bridgeXYZApiKey',
       'bridgeXYZApiUrl',
       'graphqlUrl',
+      'liquidationAddressOverrides',
     ]);
   }
 };
@@ -68,7 +77,13 @@ exports.handler = async (event) => {
     handlers[path] || handlers[event.fieldName] || handlers.default;
 
   try {
-    return await handler(event, { appSyncApiKey, apiKey, apiUrl, graphqlURL });
+    return await handler(event, {
+      appSyncApiKey,
+      apiKey,
+      apiUrl,
+      graphqlURL,
+      temp_liquidationAddressOverrides,
+    });
   } catch (error) {
     console.error(
       `bridgeXYZMutation handler ${handler.name} failed with error: ${error}`,

--- a/amplify/backend/function/colonycdappSSMAccess/lib/nodejs/getParams.js
+++ b/amplify/backend/function/colonycdappSSMAccess/lib/nodejs/getParams.js
@@ -16,6 +16,7 @@ const ParamNames = {
   etherscanApiKey: `%2Famplify%2Fcdapp%2F${ENV}%2FETHERSCAN_API_KEY`,
   bridgeXYZApiKey: `%2Famplify%2Fcdapp%2F${ENV}%2FBRIDGEXYZ_API_KEY`,
   bridgeXYZApiUrl: `%2Famplify%2Fcdapp%2F${ENV}%2FBRIDGEXYZ_API_URL`,
+  liquidationAddressOverrides: `%2Famplify%2Fcdapp%2F${ENV}%2FLIQUIDATION_ADDRESS_OVERRIDES`,
 };
 
 const getParam = async (paramName) => {


### PR DESCRIPTION
## Description

In preparation for this month's payroll, we needed a way to override some of the liquidation addresses returned from Bridge and replace them with ones created under Metacolony. This PR adds the ability to override liquidation address for a given wallet address using env variable (locally) and SSM parameter (in QA and prod).

## Testing

Create or update the .env file of the bridgeXYZMutation lambda (`amplify/backend/function/bridgeXYZMutation/.env`). It should have the following 3 values in it:
```
BRIDGE_API_URL=https://api.sandbox.bridge.xyz
BRIDGE_API_KEY=<sandbox key, ping me if you don't know it>
LIQUIDATION_ADDRESS_OVERRIDES="{"0xb77D57F4959eAfA0339424b83FcFaf9c15407461": "test address override"}"
```

The last variable is a JSON object mapping wallet addresses to their respective overrides. In the example, it will return the test string for leela's address. 

**Important:** Restart your dev env for the changes to take effect.

Run the following query:
```gql
query {
  bridgeGetUserLiquidationAddress(userAddress:"0xb77D57F4959eAfA0339424b83FcFaf9c15407461")
}
```

Confirm the value you get back matches the override.

Note: This will not impact the address shown in the C2F account tab, only the address that is retrieved when making payments.
