### PR TITLE
fix: validate that token name doesn't contain only spaces

### DIFF
--- a/src/components/common/Onboarding/wizardSteps/CreateColony/validation.ts
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/validation.ts
@@ -42,6 +42,7 @@ const { formatMessage } = intl({
   'error.invalidToken': 'Invalid address.',
   'error.tokenNotFound':
     'Token data not found. Please check the token contract address.',
+  'error.tokenNameInvalid': 'Invalid token name',
   'error.tokenNameRequired': 'Enter a token name to continue',
   'error.tokenSymbolRequired': 'Enter a token symbol to continue',
   'error.tokenNameLength': 'Token name should be 255 characters or fewer',
@@ -116,6 +117,11 @@ export const createTokenValidationSchema = object({
       then: (schema) =>
         schema
           .max(MAX_TOKEN_NAME, '')
+          .test(
+            'isNotOnlySpaces',
+            formatMessage({ id: 'error.tokenNameInvalid' }),
+            (value) => value.trim().length > 0,
+          )
           .required(formatMessage({ id: 'error.tokenNameRequired' })),
       otherwise: (schema) => schema.notRequired(),
     }),


### PR DESCRIPTION
## Description

Added a validation test to check if the string isn't just whitespaces. I however allow for leading and trailing whitespaces, but they get trimmed out when creating the token? :shrug: 

## Testing

1. Start up your dev env and run `node ./scripts/create-colony-url.js`
2. Select "Create a new token"
![image](https://github.com/user-attachments/assets/db4aee21-35ea-45e4-a6dd-1590ebd36a8f)
3. Now try to break the token name validation, entering only spaces should fail
![image](https://github.com/user-attachments/assets/c9184f3c-4ff8-4788-bc2f-c79b89dede47)
But spaces at the start/end should work if you have any content
![image](https://github.com/user-attachments/assets/0cf26fe1-0050-4cd3-8adc-2a9937362ba6)


## Diffs

**Changes** 🏗

* `createTokenValidationSchema` now includes whitespace only validation for `tokenName` 

Resolves #3298
