### PR TITLE
Fix: Modal button alignment on mobile

### DIFF
--- a/src/components/v5/common/TokensModal/TokensModal.tsx
+++ b/src/components/v5/common/TokensModal/TokensModal.tsx
@@ -36,6 +36,7 @@ const TokensModal: FC<TokensModalProps> = ({ type, onClose, ...props }) => {
     <Modal {...props} onClose={onClose} shouldShowHeader>
       <ActionForm
         actionType={actionType}
+        className="flex flex-grow flex-col"
         // defaultValues={{ amount: '0' }} // Disable default value
         validationSchema={validationSchema}
         transform={transform}
@@ -46,64 +47,66 @@ const TokensModal: FC<TokensModalProps> = ({ type, onClose, ...props }) => {
         }}
       >
         {({ setValue, formState: { isSubmitting, isLoading } }) => (
-          <>
-            <h4 className="mb-1.5 heading-5">
-              {formatText({ id: `tokensModal.${type}.title` })}
-            </h4>
-            <p className="mb-6 text-md text-gray-600">
-              {formatText({ id: `tokensModal.${type}.description` })}
-            </p>
-            <div className="mb-1 flex items-center justify-between gap-2">
-              <p className="text-1">
-                {formatText({ id: `tokensModal.${type}.input` })}
+          <div className="flex flex-grow flex-col justify-between">
+            <div>
+              <h4 className="mb-1.5 heading-5">
+                {formatText({ id: `tokensModal.${type}.title` })}
+              </h4>
+              <p className="mb-6 text-md text-gray-600">
+                {formatText({ id: `tokensModal.${type}.description` })}
               </p>
-              <span className="flex items-center gap-1 text-sm text-gray-600">
-                {formatText(
-                  { id: 'tokensModal.balance' },
-                  {
-                    value: loading ? (
-                      <SpinnerLoader appearance={{ size: 'small' }} />
-                    ) : (
-                      <Numeral
-                        value={tokenBalanceData || 0}
-                        decimals={tokenDecimals}
-                        suffix={` ${tokenSymbol}`}
-                      />
-                    ),
+              <div className="mb-1 flex items-center justify-between gap-2">
+                <p className="text-1">
+                  {formatText({ id: `tokensModal.${type}.input` })}
+                </p>
+                <span className="flex items-center gap-1 text-sm text-gray-600">
+                  {formatText(
+                    { id: 'tokensModal.balance' },
+                    {
+                      value: loading ? (
+                        <SpinnerLoader appearance={{ size: 'small' }} />
+                      ) : (
+                        <Numeral
+                          value={tokenBalanceData || 0}
+                          decimals={tokenDecimals}
+                          suffix={` ${tokenSymbol}`}
+                        />
+                      ),
+                    },
+                  )}
+                </span>
+              </div>
+              <FormFormattedInput
+                name="amount"
+                placeholder={formatMessage({ id: 'tokensModal.placeholder' })}
+                customPrefix={
+                  nativeToken ? (
+                    <TokenAvatar
+                      size={18}
+                      tokenName={nativeToken.name}
+                      tokenAddress={nativeToken.tokenAddress}
+                      tokenAvatarSrc={nativeToken.avatar ?? undefined}
+                    />
+                  ) : undefined
+                }
+                options={{
+                  numeralDecimalScale: tokenDecimals,
+                  numeralPositiveOnly: true,
+                  tailPrefix: true,
+                }}
+                buttonProps={{
+                  label: formatText({ id: 'button.max' }) || '',
+                  onClick: () => {
+                    setValue('amount', tokenBalanceInEthers, {
+                      shouldTouch: true,
+                      shouldValidate: true,
+                      shouldDirty: true,
+                    });
                   },
-                )}
-              </span>
+                }}
+                wrapperClassName="mb-8"
+              />
             </div>
-            <FormFormattedInput
-              name="amount"
-              placeholder={formatMessage({ id: 'tokensModal.placeholder' })}
-              customPrefix={
-                nativeToken ? (
-                  <TokenAvatar
-                    size={18}
-                    tokenName={nativeToken.name}
-                    tokenAddress={nativeToken.tokenAddress}
-                    tokenAvatarSrc={nativeToken.avatar ?? undefined}
-                  />
-                ) : undefined
-              }
-              options={{
-                numeralDecimalScale: tokenDecimals,
-                numeralPositiveOnly: true,
-                tailPrefix: true,
-              }}
-              buttonProps={{
-                label: formatText({ id: 'button.max' }) || '',
-                onClick: () => {
-                  setValue('amount', tokenBalanceInEthers, {
-                    shouldTouch: true,
-                    shouldValidate: true,
-                    shouldDirty: true,
-                  });
-                },
-              }}
-              wrapperClassName="mb-8"
-            />
             <div className="flex flex-col-reverse gap-3 sm:flex-row">
               <Button
                 mode="primaryOutline"
@@ -133,7 +136,7 @@ const TokensModal: FC<TokensModalProps> = ({ type, onClose, ...props }) => {
                 />
               )}
             </div>
-          </>
+          </div>
         )}
       </ActionForm>
     </Modal>

--- a/src/components/v5/shared/Modal/Modal.tsx
+++ b/src/components/v5/shared/Modal/Modal.tsx
@@ -63,9 +63,9 @@ const Modal: FC<PropsWithChildren<ModalProps>> = ({
       withPaddingBottom={withPaddingBottom}
     >
       <div
-        className={`${styles.modalContentWrapper} overflow-y-auto overflow-x-hidden`}
+        className={`${styles.modalContentWrapper} min-h-full overflow-y-auto overflow-x-hidden`}
       >
-        <div ref={contentRef} className="relative">
+        <div ref={contentRef} className="relative flex min-h-full flex-col">
           {Icon && (
             <span
               className={clsx(
@@ -92,7 +92,7 @@ const Modal: FC<PropsWithChildren<ModalProps>> = ({
           />
           <div
             className={clsx(
-              'flex w-full flex-grow flex-col [-webkit-overflow-scrolling:touch]',
+              'flex h-full w-full flex-grow flex-col [-webkit-overflow-scrolling:touch]',
               {
                 'pr-6': withPadding,
                 'pb-6': withPadding && !withPaddingBottom,


### PR DESCRIPTION
## Description

On mobile, the CTA buttons for all modals should be aligned to the bottom.

## Testing

Check any modals on mobile and ensure the buttons are aligned to the bottom.

* Activate tokens (accessed via userhub)
* Withdraw tokens (accessed via userhub)
* Uninstall extension confirmation
* Re-enable extension confirmation

(Note there is a separate issue for the UserHub icons blocking the close modal button which is out of scope for this PR - #3440)

<img width="519" alt="Screenshot 2024-10-23 at 15 44 38" src="https://github.com/user-attachments/assets/74e014af-3c73-467a-a8d6-bd9f71c6e3ec">

Confirm that modals have not broken on desktop, or that other modals which do not have buttons (such as the activity feed filters) still work as expected.

## Diffs

**Changes** 🏗

* Modal should take up full height on mobile and align buttons to bottom

Resolves #3291 
