### PR TITLE
[Notifications] Fix: Notifications should use correct amount

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/ActionNotification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/ActionNotification.tsx
@@ -8,6 +8,7 @@ import {
   useGetColonyActionQuery,
   useGetUserByAddressQuery,
 } from '~gql';
+import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
 import { TX_SEARCH_PARAM } from '~routes';
 import { type Notification as NotificationInterface } from '~types/notifications.ts';
 import { formatText } from '~utils/intl.ts';
@@ -33,6 +34,7 @@ const ActionNotification: FC<NotificationProps> = ({
   loadingColony,
   notification,
 }) => {
+  const { networkInverseFee } = useNetworkInverseFee();
   const navigate = useNavigate();
 
   const { creator, notificationType, transactionHash } =
@@ -80,6 +82,7 @@ const ActionNotification: FC<NotificationProps> = ({
           },
           metadata: colony.metadata,
         },
+        networkInverseFee,
       }),
     );
   }, [action, colony]);

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureNotification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureNotification.tsx
@@ -9,6 +9,7 @@ import {
   useGetExpenditureQuery,
   ColonyActionType,
 } from '~gql';
+import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
 import { TX_SEARCH_PARAM } from '~routes';
 import { type Notification as NotificationInterface } from '~types/notifications.ts';
 import { formatText } from '~utils/intl.ts';
@@ -34,6 +35,7 @@ const ExpenditureNotification: FC<NotificationProps> = ({
   loadingColony,
   notification,
 }) => {
+  const { networkInverseFee } = useNetworkInverseFee();
   const navigate = useNavigate();
 
   const {
@@ -144,6 +146,7 @@ const ExpenditureNotification: FC<NotificationProps> = ({
           metadata: colony.metadata,
         },
         expenditureData: expenditure ?? undefined,
+        networkInverseFee,
       }),
     );
   }, [action, expenditure, colony]);


### PR DESCRIPTION
## Description

This PR applies the fix introduced in #3307 for the amount in the activity feed and applies it to the notification messages.

Due to the way notification messages are structured, it is very unlikely this would ever actually show up in production as it priorities the custom title, so would only ever show if a custom title was not provided (which is not possible via the UI). However it is such a tiny fix that we will apply it regardless!

## Testing

* Step 1 - Go to `src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/MotionNotificationMessage.tsx` and remove actionTitle from the `secondPart` variable.

```
const secondPart =
      actionTitle || actionMetadataDescription || formatText(MSG.unknownAction);
```

Should become:

```
    const secondPart =
      actionMetadataDescription || formatText(MSG.unknownAction);
```

This will ensure the custom title is not shown.

* Step 2 - Install the reputation weighted voting extension
* Step 3 - Create a simple payment motion
* Step 4 - Stake to support it fully
* Step 5 - Check the notification, note the amount should exactly match the amount entered when creating the motion.

<img width="753" alt="Screenshot 2024-10-23 at 17 25 47" src="https://github.com/user-attachments/assets/2325c220-9112-468b-a98e-b4674b0b77f9">

* Step 6 - Run the following mutation in GraphiQL to change the network fee stored in the database:

```
mutation MyMutation {
  updateCurrentNetworkInverseFee(
    input: {id: "networkInverseFee", inverseFee: "50"}
  ) {
    id
    inverseFee
  }
}
```

* Step 7 - Refresh and check the notification again. The amount should have changed to reflect the change in network fee.

<img width="757" alt="Screenshot 2024-10-23 at 17 25 22" src="https://github.com/user-attachments/assets/4e591d15-a726-4878-a965-08bca3adf276">

* Step 8 - Forward time with `npm run forward-time 1` and finalise the motion.

<img width="707" alt="Screenshot 2024-10-23 at 17 35 01" src="https://github.com/user-attachments/assets/6af40df1-b2f5-4617-b5c5-9ea9e785f543">

* Step 9 - Run another mutation to change the network fee back.

```
mutation MyMutation {
  updateCurrentNetworkInverseFee(
    input: {id: "networkInverseFee", inverseFee: "100"}
  ) {
    id
    inverseFee
  }
}
```

* Step 10 - Refresh and check the notification. The amount change not have changed as the network fee changed **after** the motion was finalized.

<img width="707" alt="Screenshot 2024-10-23 at 17 35 01" src="https://github.com/user-attachments/assets/6af40df1-b2f5-4617-b5c5-9ea9e785f543">


## Diffs

**Changes** 🏗

* `networkInverseFee` is passed to `actionMetadataDescription` for notifications
