### PR TITLE
fix: update UserHub transactions to have correct styles for 720-768px screen

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransactionContent.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransactionContent.tsx
@@ -99,6 +99,7 @@ const GroupedTransactionContent: FC<GroupedTransactionContentProps> = ({
           <NotificationBanner
             status="error"
             callToActionClassName="w-full no-underline"
+            contentClassName="@[600px]/notificationBanner:flex-col"
             callToAction={
               <div className="flex justify-between">
                 <button

--- a/src/components/v5/shared/NotificationBanner/NotificationBanner.tsx
+++ b/src/components/v5/shared/NotificationBanner/NotificationBanner.tsx
@@ -14,6 +14,7 @@ const NotificationBanner: FC<NotificationBannerProps> = ({
   callToAction,
   descriptionClassName,
   callToActionClassName,
+  contentClassName,
 }) => {
   return (
     <div
@@ -40,7 +41,12 @@ const NotificationBanner: FC<NotificationBannerProps> = ({
           })}
         />
       ) : null}
-      <div className="flex flex-1 flex-col items-start gap-2 @[600px]/notificationBanner:flex-row @[600px]/notificationBanner:items-center">
+      <div
+        className={clsx(
+          'flex flex-1 flex-col items-start gap-2 @[600px]/notificationBanner:flex-row @[600px]/notificationBanner:items-center',
+          contentClassName,
+        )}
+      >
         <div className="flex flex-1 flex-col items-start gap-2 text-md break-word">
           {children}
           {description ? (

--- a/src/components/v5/shared/NotificationBanner/types.ts
+++ b/src/components/v5/shared/NotificationBanner/types.ts
@@ -10,4 +10,5 @@ export type NotificationBannerProps = PropsWithChildren<{
   callToAction?: ReactNode;
   descriptionClassName?: string;
   callToActionClassName?: string;
+  contentClassName?: string;
 }>;


### PR DESCRIPTION
## Description
For 720-768px error message was broken: 
![image](https://github.com/user-attachments/assets/657cb0b8-4b35-46f2-839e-3b4d18bbb5eb)

I really hope that my fix will not break anything else, but all I tested now works 😄  

## Testing

* Step 1. Login with MetaMask
* Step 2. Create Simple payment motion
* Step 3. Reject transaction
* Step 4. Open UserHub -> Transactions and ensure that all screens looks good

<img width="447" alt="image" src="https://github.com/user-attachments/assets/27ea1fe6-2b5e-481c-8b39-c6146afbb2ab">
<img width="733" alt="image" src="https://github.com/user-attachments/assets/86e844c6-b826-4c19-bd60-f68cedf62bb1">
<img width="854" alt="image" src="https://github.com/user-attachments/assets/b5734d67-e8f8-4acb-94cc-06f59b9baa7d">
<img width="1380" alt="image" src="https://github.com/user-attachments/assets/844630ee-2c1a-498c-93c2-3ec9d56ac122">

Resolves  #3056
