### PR TITLE
Fix: Voting reputation settings body font color should be text-gray-600

### DIFF
--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/VotingReputationSettings/VotingReputationSettings.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/VotingReputationSettings/VotingReputationSettings.tsx
@@ -64,7 +64,7 @@ const VotingReputationParams: FC<VotingReputationParamsProps> = ({
                     : formatText({ id: 'hours' })}
                 </div>
               </div>
-              <p className="text-sm">{formatText(description)}</p>
+              <p className="text-sm text-gray-600">{formatText(description)}</p>
             </div>
           );
         })}


### PR DESCRIPTION
## Description

Nice simple fix - as the title describes.

## Testing

* Step 1 - Install voting reputation extension
* Step 2 - Enable voting reputation
* Step 3 - Switch to extensions setting tab - check the body font color.

Figma: https://www.figma.com/design/6qONTE1uD9K4yoIbfFzidg/Extensions?node-id=301-36307&t=SK0TZL8h23Z4rmxW-4

<img width="1421" alt="Screenshot 2024-10-24 at 12 52 58" src="https://github.com/user-attachments/assets/c5294285-269d-4ece-a84d-7780a186db07">

<img width="1421" alt="Screenshot 2024-10-24 at 12 52 51" src="https://github.com/user-attachments/assets/3999afa4-2f7c-45a9-a374-c971120ec1da">


## Diffs

**Changes** 🏗

* Extension setting body font is text-gray-600

Resolves #2897
