### PR TITLE
Fix: bridgeXYZMutation to return null on error

### DIFF
--- a/amplify/backend/function/bridgeXYZMutation/src/index.js
+++ b/amplify/backend/function/bridgeXYZMutation/src/index.js
@@ -88,6 +88,6 @@ exports.handler = async (event) => {
     console.error(
       `bridgeXYZMutation handler ${handler.name} failed with error: ${error}`,
     );
-    return { success: false };
+    return null;
   }
 };

--- a/src/redux/sagas/utils/expenditures.ts
+++ b/src/redux/sagas/utils/expenditures.ts
@@ -1,6 +1,6 @@
 import { type AnyColonyClient, type Network, Tokens } from '@colony/colony-js';
 import { BigNumber } from 'ethers';
-import { getAddress } from 'ethers/lib/utils';
+import { getAddress, isAddress } from 'ethers/lib/utils';
 
 import { apolloClient } from '~apollo';
 import { DEV_USDC_ADDRESS, isDev } from '~constants';
@@ -267,7 +267,7 @@ export const adjustRecipientAddress = async (
   const liquidationAddress =
     liquidationAddressData?.bridgeGetUserLiquidationAddress;
 
-  if (!liquidationAddress) {
+  if (!liquidationAddress || !isAddress(liquidationAddress)) {
     return recipientAddress;
   }
 


### PR DESCRIPTION
## Description

Cosmetic-looking change that caused the linked issue when Bridge API went down earlier today. The JSON response got stringified and a payment was attempted to `{ success: false }`.

This PR changes the return value of the bridge mutation to `null` if error is thrown. 

## Testing

To test the fix, you will need to simulate an error in `getUserLiquidationAddress` handler, and make a payment that will trigger liquidation address swapping.

While you could set your native token address as `USDC_LOCAL_ADDRESS` in `.env.local`, go through KYC, add bank details and enable auto offramp, you can also create a file called `diff` with the contents below and apply the patch with `git apply diff`. It will make liquidation address swapping happen for any token and recipient, and throw an error inside the lambda handler.

```git
diff --git a/amplify/backend/function/bridgeXYZMutation/src/handlers/getUserLiquidationAddress.js b/amplify/backend/function/bridgeXYZMutation/src/handlers/getUserLiquidationAddress.js
index af3204bf4..304e83abb 100644
--- a/amplify/backend/function/bridgeXYZMutation/src/handlers/getUserLiquidationAddress.js
+++ b/amplify/backend/function/bridgeXYZMutation/src/handlers/getUserLiquidationAddress.js
@@ -15,6 +15,8 @@ const getUserLiquidationAddressHandler = async (
 ) => {
   const userAddress = event.arguments.userAddress;
 
+  throw new Error('Demo error');
+
   try {
     const overrides = JSON.parse(temp_liquidationAddressOverrides);
     if (overrides[userAddress]) {
diff --git a/src/redux/sagas/utils/expenditures.ts b/src/redux/sagas/utils/expenditures.ts
index adcbcfe67..20c8d4625 100644
--- a/src/redux/sagas/utils/expenditures.ts
+++ b/src/redux/sagas/utils/expenditures.ts
@@ -236,7 +236,7 @@ export const adjustRecipientAddress = async (
 ) => {
   const USDCAddress = isDev ? DEV_USDC_ADDRESS : Tokens[network]?.USDC;
 
-  if (tokenAddress !== USDCAddress) {
+  if (false && tokenAddress !== USDCAddress) {
     return recipientAddress;
   }
 
@@ -251,7 +251,7 @@ export const adjustRecipientAddress = async (
   });
 
   const user = userData?.getUserByAddress?.items[0];
-  if (!user || !user.profile?.isAutoOfframpEnabled) {
+  if (!user || (false && !user.profile?.isAutoOfframpEnabled)) {
     return recipientAddress;
   }
 
```

Next, make a payment (simple or advanced) to `leela`. The payment should go through to her actual wallet address. On `master`, you would get the wrong address error as in the issue.

Resolves #3456 
