### PR TITLE
Fix: Allow separators in bank account number validation

### DIFF
--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsForm/constants.ts
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsForm/constants.ts
@@ -1,11 +1,14 @@
 import { defineMessages } from 'react-intl';
 
-export const IBAN_REGEX =
-  /^([A-Z]{2}[ +\\-]?[0-9]{2})(?=(?:[ +\\-]?[A-Z0-9]){9,30}$)((?:[ +\\-]?[A-Z0-9]{3,5}){2,7})([ +\\-]?[A-Z0-9]{1,3})?$/;
+export const ALPHANUMERIC_WITH_SEPARATORS_REGEX = /^[A-Za-z0-9 -]*$/;
 
-export const BIC_REGEX =
-  // eslint-disable-next-line max-len
-  /^([a-zA-Z]{4})([a-zA-Z]{2})(([2-9a-zA-Z]{1})([0-9a-np-zA-NP-Z]{1}))((([0-9a-wy-zA-WY-Z]{1})([0-9a-zA-Z]{2}))|([xX]{3})?)$/;
+export const SEPARATOR_REGEX = /[ -]/g;
+
+// Strip any separators before comparing against this regex
+// 1.	Two uppercase letters at the start (for the country code).
+// 2.	Two digits immediately following (for the checksum).
+// 3.	11–30 alphanumeric characters after that, allowing for a total length of 15–34 characters.
+export const IBAN_REGEX = /^[A-Z]{2}[0-9]{2}[A-Z0-9]{11,30}$/;
 
 export const displayName =
   'v5.pages.UserCryptoToFiatPage.partials.BankDetailsForm';
@@ -80,14 +83,21 @@ export const BANK_DETAILS_FORM_MSG = defineMessages({
     id: `${displayName}.routingNumberLabel`,
     defaultMessage: 'Routing number',
   },
+  alphanumeric: {
+    id: `${displayName}.alphanumeric`,
+    defaultMessage: 'Please enter only letters and numbers',
+  },
 });
 
 export const BANK_DETAILS_FORM_FIELD_VALUE_LENGTHS = {
   accountNumber: {
-    min: 8,
+    min: 6,
     max: 17,
   },
   routingNumber: {
     length: 9,
+  },
+  swift: {
+    lengths: [8, 11],
   },
 };

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsForm/constants.ts
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsForm/constants.ts
@@ -2,6 +2,8 @@ import { defineMessages } from 'react-intl';
 
 export const ALPHANUMERIC_WITH_SEPARATORS_REGEX = /^[A-Za-z0-9 -]*$/;
 
+export const NUMERIC_WITH_SEPARATORS_REGEX = /^[0-9 -]*$/;
+
 export const SEPARATOR_REGEX = /[ -]/g;
 
 // Strip any separators before comparing against this regex
@@ -86,6 +88,10 @@ export const BANK_DETAILS_FORM_MSG = defineMessages({
   alphanumeric: {
     id: `${displayName}.alphanumeric`,
     defaultMessage: 'Please enter only letters and numbers',
+  },
+  numeric: {
+    id: `${displayName}.numeric`,
+    defaultMessage: 'Please enter only numbers',
   },
 });
 

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsForm/validation.ts
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsForm/validation.ts
@@ -11,6 +11,7 @@ import {
   ALPHANUMERIC_WITH_SEPARATORS_REGEX,
   SEPARATOR_REGEX,
   IBAN_REGEX,
+  NUMERIC_WITH_SEPARATORS_REGEX,
 } from './constants.ts';
 
 export enum BankDetailsFields {
@@ -115,8 +116,8 @@ export const validationSchema = object({
           }),
         )
         .matches(
-          ALPHANUMERIC_WITH_SEPARATORS_REGEX,
-          formatText(BANK_DETAILS_FORM_MSG.alphanumeric),
+          NUMERIC_WITH_SEPARATORS_REGEX,
+          formatText(BANK_DETAILS_FORM_MSG.numeric),
         )
         .test(
           'is-valid-account-number',
@@ -155,8 +156,8 @@ export const validationSchema = object({
           }),
         )
         .matches(
-          ALPHANUMERIC_WITH_SEPARATORS_REGEX,
-          formatText(BANK_DETAILS_FORM_MSG.alphanumeric),
+          NUMERIC_WITH_SEPARATORS_REGEX,
+          formatText(BANK_DETAILS_FORM_MSG.numeric),
         )
         .test(
           'is-valid-routing-number',

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsModal/useBankDetailsFields.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetailsModal/useBankDetailsFields.tsx
@@ -14,6 +14,8 @@ import Toast from '~shared/Extensions/Toast/Toast.tsx';
 import { type BridgeBankAccount } from '~types/graphql.ts';
 import { formatText } from '~utils/intl.ts';
 
+import { SEPARATOR_REGEX } from '../BankDetailsForm/constants.ts';
+
 const displayName = 'v5.pages.UserCryptoToFiatPage.partials.BankDetailsModal';
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -101,8 +103,8 @@ export const useBankDetailsFields = ({
         currency === CURRENCY_VALUES[SupportedCurrencies.Eur]
           ? {
               // eslint-disable-next-line camelcase
-              account_number: iban,
-              bic: swift,
+              account_number: iban.replace(SEPARATOR_REGEX, ''),
+              bic: swift.replace(SEPARATOR_REGEX, ''),
               country,
             }
           : undefined,
@@ -110,9 +112,9 @@ export const useBankDetailsFields = ({
         currency === CURRENCY_VALUES[SupportedCurrencies.Usd]
           ? {
               // eslint-disable-next-line camelcase
-              account_number: accountNumber,
+              account_number: accountNumber.replace(SEPARATOR_REGEX, ''),
               // eslint-disable-next-line camelcase
-              routing_number: routingNumber,
+              routing_number: routingNumber.replace(SEPARATOR_REGEX, ''),
             }
           : undefined,
       address:


### PR DESCRIPTION
## Description

This PR adjusts the validation for the crypto to fiat bank account validation to allow for spaces or hyphens as separators. This will make it easier for users copying their bank details into the forms.

It adds an alphanumeric check to each account number field and will display a specific error message if any non alphanumeric values are entered (ignoring the two valid separators).

The separators are stripped out before validating against regex and when submitting the values to the API.

Please check Arren's comment on the original issue for the exact specs: https://github.com/JoinColony/colonyCDapp/issues/2961#issuecomment-2307001840

## Testing

* Step 1: Edit `src/components/frame/v5/pages/UserCryptoToFiatPage/partials/BankDetails/consts.ts` and replace line 95 with `false` to enable the CTA button and bypass the KYC check.
* Step 2: Navigate to http://localhost:9091/account/crypto-to-fiat
* Step 3: Click the "Add details" button and select USD as the payout currency.
* Step 4: Submit the form so that error validation shows.
* Step 5: Check the account number only allows numeric values, spaces or hyphens and is between 6 and 17 digits once separators are removed.
* Step 6: Check the routing number only allows numeric values, spaces or hyphens and is exactly 9 digits once separators are removed.

<img width="471" alt="Screenshot 2024-10-25 at 09 47 48" src="https://github.com/user-attachments/assets/0993768d-3857-4473-b221-c07f23afeb5e">

<img width="466" alt="Screenshot 2024-10-25 at 09 48 48" src="https://github.com/user-attachments/assets/5025db3e-8ea3-4f7a-91fa-7b2d0a28ba6d">

<img width="466" alt="Screenshot 2024-10-25 at 09 48 01" src="https://github.com/user-attachments/assets/3d67e4d3-4fc1-4596-92cd-a4657a650be5">

* Step 7: Switch the payout currency to EUR.
* Step 8: Check the IBAN only allows alphanumeric values, spaces or hyphens. It should also only allow values that start with 2 uppercase letters, followed by 2 digits. The remainder of the IBAN should be alphanumeric and allow for a total length of 15-34 characters once separators are removed.
* Step 9: Check the SWIFT/BIC only allows alphanumeric values, spaces or hyphens and is either exactly 8 or 11 characters long once separators are removed.

<img width="464" alt="Screenshot 2024-10-25 at 09 48 29" src="https://github.com/user-attachments/assets/5328f7e3-4817-4bc4-8125-73688b75681a">

<img width="470" alt="Screenshot 2024-10-25 at 09 48 37" src="https://github.com/user-attachments/assets/e1fe6f88-47c8-4927-93b6-eadcc530c9d6">

<img width="468" alt="Screenshot 2024-10-25 at 09 48 18" src="https://github.com/user-attachments/assets/40613a11-b820-4a4a-9801-6cef1e9a2cfa">

## Diffs

**Changes** 🏗

* Bank account numbers now allow separators
* Bank account numbers are now validated for alphanumeric values first
* Bank account number length validation adjusted
* Bank account numbers now strip separators when submitting to API

**Deletions** ⚰️

* Removed BIC regex

Resolves #2961
