### PR TITLE
fix: disable 'Accept' incoming funds buttons when other button was clicked

### DIFF
--- a/src/components/frame/v5/pages/FundsPage/context/IncomingFundsLoadingContext.ts
+++ b/src/components/frame/v5/pages/FundsPage/context/IncomingFundsLoadingContext.ts
@@ -1,5 +1,7 @@
 import { createContext, useContext } from 'react';
 
+import noop from '~utils/noop.ts';
+
 interface IncomingFundsLoadingContextValues {
   isAcceptLoading: boolean;
   enableAcceptLoading: () => void;
@@ -9,8 +11,8 @@ interface IncomingFundsLoadingContextValues {
 export const IncomingFundsLoadingContext =
   createContext<IncomingFundsLoadingContextValues>({
     isAcceptLoading: false,
-    enableAcceptLoading: () => {},
-    disableAcceptLoading: () => {},
+    enableAcceptLoading: noop,
+    disableAcceptLoading: noop,
   });
 
 export const useIncomingFundsLoadingContext = () => {

--- a/src/components/frame/v5/pages/FundsPage/context/IncomingFundsLoadingContext.ts
+++ b/src/components/frame/v5/pages/FundsPage/context/IncomingFundsLoadingContext.ts
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react';
+
+interface IncomingFundsLoadingContextValues {
+  isAcceptLoading: boolean;
+  enableAcceptLoading: () => void;
+  disableAcceptLoading: () => void;
+}
+
+export const IncomingFundsLoadingContext =
+  createContext<IncomingFundsLoadingContextValues>({
+    isAcceptLoading: false,
+    enableAcceptLoading: () => {},
+    disableAcceptLoading: () => {},
+  });
+
+export const useIncomingFundsLoadingContext = () => {
+  const context = useContext(IncomingFundsLoadingContext);
+
+  return context;
+};

--- a/src/components/frame/v5/pages/FundsPage/context/IncomingFundsLoadingContextProvider.tsx
+++ b/src/components/frame/v5/pages/FundsPage/context/IncomingFundsLoadingContextProvider.tsx
@@ -1,0 +1,33 @@
+import React, {
+  useCallback,
+  useMemo,
+  useState,
+  type FC,
+  type PropsWithChildren,
+} from 'react';
+
+import { IncomingFundsLoadingContext } from './IncomingFundsLoadingContext.ts';
+
+export const IncomingFundsLoadingContextProvider: FC<PropsWithChildren> = ({
+  children,
+}) => {
+  const [isAcceptLoading, setIsAcceptLoading] = useState(false);
+
+  const enableAcceptLoading = useCallback(() => setIsAcceptLoading(true), []);
+  const disableAcceptLoading = useCallback(() => setIsAcceptLoading(false), []);
+
+  const value = useMemo(
+    () => ({
+      isAcceptLoading,
+      enableAcceptLoading,
+      disableAcceptLoading,
+    }),
+    [isAcceptLoading, enableAcceptLoading, disableAcceptLoading],
+  );
+
+  return (
+    <IncomingFundsLoadingContext.Provider value={value}>
+      {children}
+    </IncomingFundsLoadingContext.Provider>
+  );
+};

--- a/src/components/frame/v5/pages/FundsPage/partials/AcceptButton/AcceptButton.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/AcceptButton/AcceptButton.tsx
@@ -1,6 +1,7 @@
 import React, { type FC, useState } from 'react';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { useIncomingFundsLoadingContext } from '~frame/v5/pages/FundsPage/context/IncomingFundsLoadingContext.ts';
 import { ActionTypes } from '~redux/index.ts';
 import { mergePayload } from '~utils/actions.ts';
 import ActionButton from '~v5/shared/Button/ActionButton.tsx';
@@ -23,6 +24,9 @@ const AcceptButton: FC<AcceptButtonProps> = ({
   } = useColonyContext();
   const [isClaimed, setIsClaimed] = useState(false);
 
+  const { isAcceptLoading, enableAcceptLoading, disableAcceptLoading } =
+    useIncomingFundsLoadingContext();
+
   const transform = mergePayload({
     colonyAddress: colony?.colonyAddress,
     tokenAddresses,
@@ -32,6 +36,11 @@ const AcceptButton: FC<AcceptButtonProps> = ({
     setIsClaimed(true);
     startPollingColonyData(1_000);
     setTimeout(stopPollingColonyData, 10_000);
+    disableAcceptLoading();
+  };
+
+  const getPayload = () => {
+    enableAcceptLoading();
   };
 
   return (
@@ -40,9 +49,13 @@ const AcceptButton: FC<AcceptButtonProps> = ({
       actionType={ActionTypes.CLAIM_TOKEN}
       transform={transform}
       onSuccess={handleClaimSuccess}
-      disabled={disabled || !canInteractWithColony || isClaimed}
+      onError={disableAcceptLoading}
+      disabled={
+        disabled || !canInteractWithColony || isClaimed || isAcceptLoading
+      }
       mode="primarySolid"
       size="small"
+      values={getPayload}
     >
       {children}
     </ActionButton>

--- a/src/components/frame/v5/pages/FundsPage/partials/AcceptButton/AcceptButton.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/AcceptButton/AcceptButton.tsx
@@ -3,7 +3,6 @@ import React, { type FC, useState } from 'react';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useIncomingFundsLoadingContext } from '~frame/v5/pages/FundsPage/context/IncomingFundsLoadingContext.ts';
 import { ActionTypes } from '~redux/index.ts';
-import { mergePayload } from '~utils/actions.ts';
 import ActionButton from '~v5/shared/Button/ActionButton.tsx';
 
 import { type AcceptButtonProps } from './types.ts';
@@ -27,10 +26,15 @@ const AcceptButton: FC<AcceptButtonProps> = ({
   const { isAcceptLoading, enableAcceptLoading, disableAcceptLoading } =
     useIncomingFundsLoadingContext();
 
-  const transform = mergePayload({
-    colonyAddress: colony?.colonyAddress,
-    tokenAddresses,
-  });
+  // Used to set acceptLoading in the context whilst transaction is processed
+  const getPayload = () => {
+    enableAcceptLoading();
+
+    return {
+      colonyAddress: colony?.colonyAddress,
+      tokenAddresses,
+    };
+  };
 
   const handleClaimSuccess = () => {
     setIsClaimed(true);
@@ -39,20 +43,15 @@ const AcceptButton: FC<AcceptButtonProps> = ({
     disableAcceptLoading();
   };
 
-  const getPayload = () => {
-    enableAcceptLoading();
-  };
-
+  const isBtnDisabled =
+    disabled || !canInteractWithColony || isClaimed || isAcceptLoading;
   return (
     <ActionButton
       {...rest}
       actionType={ActionTypes.CLAIM_TOKEN}
-      transform={transform}
       onSuccess={handleClaimSuccess}
       onError={disableAcceptLoading}
-      disabled={
-        disabled || !canInteractWithColony || isClaimed || isAcceptLoading
-      }
+      disabled={isBtnDisabled}
       mode="primarySolid"
       size="small"
       values={getPayload}

--- a/src/components/frame/v5/pages/FundsPage/partials/FundsTable/FundsTable.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/FundsTable/FundsTable.tsx
@@ -5,6 +5,7 @@ import {
 } from '@tanstack/react-table';
 import React, { type FC } from 'react';
 
+import { IncomingFundsLoadingContextProvider } from '~frame/v5/pages/FundsPage/context/IncomingFundsLoadingContextProvider.tsx';
 import { useMobile } from '~hooks';
 import useColonyFundsClaims from '~hooks/useColonyFundsClaims.ts';
 import { formatText } from '~utils/intl.ts';
@@ -32,7 +33,7 @@ const FundsTable: FC = () => {
   );
 
   return (
-    <>
+    <IncomingFundsLoadingContextProvider>
       <TableHeader title={formatText({ id: 'incomingFundsPage.table.title' })}>
         <div className="flex items-center gap-2">
           {!isMobile &&
@@ -107,7 +108,7 @@ const FundsTable: FC = () => {
           )
         }
       />
-    </>
+    </IncomingFundsLoadingContextProvider>
   );
 };
 


### PR DESCRIPTION
## Description


- [x] Disable "Accept" buttons when "Accept all available" is loading
- [x] Disable other "Accept" and "Accept all available" buttons when any "Accept" is loading

## Testing

* Step 1. Login with metamask
* Step 2. Clean Metamask history (Metamask -> Settings -> Advanced -> Clear activity tab data)
* Step 3. Navigate to Balance page
* Step 4. Click Add funds to the Colony and Copy Wallet address
* Step 5. Metamask -> send -> Paste Colony Wallet Address -> Send something to the colony (1 eth or if you choose xDai as Ganache Currency symbol choose xDai)
![send-1-etch](https://github.com/user-attachments/assets/7d507696-cd84-49d3-9b97-31b48eb00c51)

> [!TIP]
> If you don't have ETH to send try to delete Account and Import it again
> If something doesn't work anyway, try to delete Ganache network and install it again

* Step 6. Navigate to Wayne Enterprises
* Step 7. Create simple payment from General to Colony Wallet Address that you copied at Step 4. 
<img width="709" alt="image" src="https://github.com/user-attachments/assets/570b08d1-ce2c-4b62-a6dd-1d4a9d477376">

* Step 8. Navigate back to Planet Express
* Step 9. Navigate to Incoming funds
* Step 10. Try to Accept this funds
* Step 11. Verify that after you click "Accept" or "Accept all available" all other buttons are disabled:
![disabled-accept](https://github.com/user-attachments/assets/8f60b1f0-cc6b-44da-93af-763543ec7241)

> [!NOTE]
> I would recommend going through this flow twice: 1. Approve with the "Accept" button. 2. Approve with the "Accept all available" button. 
> I had another bug after pressing "Approve" in metamask before I started using values={getPayload} for the loading state. So, this is a weak place where something could go wrong.


Resolves #3313
