### PR TITLE
fix: always use roles passed to contract for motions

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=5f3c841b697173776dc666abb6860e1e006f721d
+ENV BLOCK_INGESTOR_HASH=1383395a88c897055b5e886998a3331f5e013454
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=1b94ee2fdd9d2a20014d53cf7550ac2dbd3b8e0c
+ENV BLOCK_INGESTOR_HASH=5f3c841b697173776dc666abb6860e1e006f721d
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/redux/sagas/motions/managePermissionsMotion.ts
+++ b/src/redux/sagas/motions/managePermissionsMotion.ts
@@ -104,7 +104,6 @@ function* managePermissionsMotion({
         }
         case Authority.Own:
         default: {
-          // If assigning the user own permissions and isMultiSig, then pass the colony address
           // If assigning the user own permissions and is not multi-sig, then pass address zero
           altTarget = ADDRESS_ZERO;
           break;


### PR DESCRIPTION
## Description

Basically the solution to this was that instead of always getting the role delta in our block-ingestor handler, we just use what the contracts get called with. If we ever want to display the delta, we can get the user's latest historical roles :shrug: 
It also fixes a bug where all the multisig motions created motions to manage a user's multisig roles instead of whichever authority you chose.

[Block ingestor PR](https://github.com/JoinColony/block-ingestor/pull/289)

## Testing

We need to test if both motions and multi-sig works for updating a member's roles. I'll mix and match multisig and voting reputation just so we cover as many cases as possible without having 20 test cases.
For sanity checks, let's use 2 browsers, `leela` and `amy`.

1. Install the voting reputation extension
2. As `leela` install the multisig extension and give `leela` the Multi-sig owner role.
3. Now let's try this out! Assign `amy` the `Payer` permissions via Multi-sig in `Andromeda`. Finalize the motion and navigate to the members page. 
![image](https://github.com/user-attachments/assets/aca9d185-e222-4a87-9129-2c1875efb63a)
4. Verify that `amy` has the payer role in Andromeda. As an extra check as `amy` try to create a simple payment action from `Andromeda` to anywhere
![image](https://github.com/user-attachments/assets/ffd5fdec-d587-4b49-8086-5fe357f6c5c7)
![image](https://github.com/user-attachments/assets/06751e62-f160-44d6-b090-0a0ee23649b7)
5. Now let's go ahead and create a voting reputation motion to assing `amy` the `Admin` role in `Andromeda`.
![image](https://github.com/user-attachments/assets/f9d2401e-08f1-44bc-90fb-97efa5c1c6b1)
6. When the action gets created, verify that you see the entire role group and not just the new `Architecture` role. 
![image](https://github.com/user-attachments/assets/92c74df6-613b-4ba2-8eb5-ebb1d466406a)
7. Fully support, `npm run forward-time 1` and finalize the motion
![image](https://github.com/user-attachments/assets/c892d7b8-f405-4939-a79b-21ce88074f20)
8. Verify that `amy` received the `Admin` bundle on the members page and try to create an action to remove reputation from somebody in Andromeda
![image](https://github.com/user-attachments/assets/52d52d36-90e5-49ad-8c8b-883205cf5b63)
![image](https://github.com/user-attachments/assets/ef592cd4-c102-4984-826c-9f7b3d5812d1)
9. As `leela` assign `amy` just the `Arbitration` role in `Andromeda` via multi-sig. Verify that the completed action view only has Arbitration checked.
![image](https://github.com/user-attachments/assets/5afc22cf-17ac-4d17-84db-3e666faa8303)
10. Finalize it and verify that she only has that role (also as `amy` try to create a simple payment action, the UI should block it)
![image](https://github.com/user-attachments/assets/f890439b-20ce-4cba-9064-92cfd060ee99)
![image](https://github.com/user-attachments/assets/1bc77913-761e-48eb-b8d7-e8ac70472c45)
![image](https://github.com/user-attachments/assets/672800ff-df0b-4a7a-9947-d09cb2c7eb9e)
11. Now as `leela` create a voting reputation motion to remove all permissions from `amy` in `Andromeda`. Finalize it and verify that `amy` doesn't have any roles anymore.
![image](https://github.com/user-attachments/assets/27b4dff4-0ca3-46b0-9ed1-c43b4f66f7a0)
![image](https://github.com/user-attachments/assets/4d72acd9-7805-4b8b-9f14-ef68c7cacccd)

This should be it, now you can take this :beer:  and do the entire flow but for Multi-sig authority instead of permissions :sweat_smile: I suggest creating a voting reputation motion for multi-sig roles first (that's the only "uncovered" case, setting initial roles via a voting reputation motion).

Additionally, check that when creating a multisig motion to either Remove or award the user some permissions (not multisig authority), the motion doesn't get created with the authority of `Take actions via Multi-Sig`, for this either check the UI or the `rolesAreMultiSig` on the action).

## Diffs

**Changes** 🏗

* `getRolesMapFromHexString` always uses the passed string as the source of truth instead of saving the diff

Resolves #2672
