### PR TITLE
Fix: Hide team filter on incoming funds page

### DIFF
--- a/src/components/common/ColonyFunding/ColonyFunding.tsx
+++ b/src/components/common/ColonyFunding/ColonyFunding.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useSetPageHeadingTitle } from '~context/PageHeadingContext/PageHeadingContext.ts';
 import FundsTable from '~frame/v5/pages/FundsPage/partials/FundsTable/index.ts';
 import { formatText } from '~utils/intl.ts';
-import ContentWithTeamFilter from '~v5/frame/ContentWithTeamFilter/ContentWithTeamFilter.tsx';
+// import ContentWithTeamFilter from '~v5/frame/ContentWithTeamFilter/ContentWithTeamFilter.tsx';
 
 const displayName = 'common.ColonyFunding';
 
@@ -11,9 +11,10 @@ const ColonyFunding = () => {
   useSetPageHeadingTitle(formatText({ id: 'incomingFundsPage.title' }));
 
   return (
-    <ContentWithTeamFilter>
-      <FundsTable />
-    </ContentWithTeamFilter>
+    // @TODO: Uncomment when contracts support incoming funds per team
+    // <ContentWithTeamFilter>
+    <FundsTable />
+    // </ContentWithTeamFilter>
   );
 };
 


### PR DESCRIPTION
## Description

This PR comments out the team filter on the incoming funds page. The contracts are being worked on to allow incoming funds per team so this will be re-enabled at a later point.

## Testing

Navigate to the incoming funds page. Confirm the team filter is not visible.

<img width="1272" alt="Screenshot 2024-10-28 at 14 04 10" src="https://github.com/user-attachments/assets/31303787-5a8e-4490-94db-a7a1f4d772d9">

## Diffs

**Changes** 🏗

* Commented out team filter

Resolves #3476
