### PR TITLE
Fix: Teams Page bottom padding adjustment

### DIFF
--- a/src/components/v5/frame/ColonyHome/ColonyHome.tsx
+++ b/src/components/v5/frame/ColonyHome/ColonyHome.tsx
@@ -41,7 +41,7 @@ const ColonyHome = () => {
           <ReputationChart />
         </div>
       </div>
-      <div className="mb-4 flex flex-grow flex-col rounded-lg border border-gray-200 pb-[1.4375rem] sm:max-h-[37.625rem]">
+      <div className="flex flex-grow flex-col rounded-lg border border-gray-200 pb-[1.4375rem] sm:max-h-[37.625rem]">
         <div className="flex justify-between px-5 pb-[11px] pt-6">
           <h3 className="heading-5">
             {formatText({ id: 'dashboard.recentActivity' })}

--- a/src/components/v5/frame/PageLayout/PageLayout.tsx
+++ b/src/components/v5/frame/PageLayout/PageLayout.tsx
@@ -73,12 +73,9 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
               )}
             >
               <div
-                className={clsx(
-                  'mx-auto h-full max-w-[79.875rem] pb-4 pt-6 md:pt-0',
-                  {
-                    '!pt-0': enableMobileAndDesktopLayoutBreakpoints,
-                  },
-                )}
+                className={clsx('mx-auto max-w-[79.875rem] pb-4 pt-6 md:pt-0', {
+                  '!pt-0': enableMobileAndDesktopLayoutBreakpoints,
+                })}
               >
                 {(pageTitle || isTablet) && (
                   <section


### PR DESCRIPTION
## Description

This PR fixes the bottom padding padding for the Teams page.

<img width="1367" alt="Screenshot 2024-10-29 at 20 33 44" src="https://github.com/user-attachments/assets/a433911d-a1c1-4129-8bda-10e6d59e2092">

During development, I noticed that the Activity table on the Dashboard page has a redundant margin bottom so I removed it as well.

| Before | After |
| ---- | ---- |
| <img width="1075" alt="Screenshot 2024-10-29 at 20 27 30" src="https://github.com/user-attachments/assets/ea12d029-dff2-4ca4-b251-a65ac54250d8"> | <img width="1075" alt="Screenshot 2024-10-29 at 20 27 16" src="https://github.com/user-attachments/assets/d508e5e4-f574-459c-880b-b5971c2a3332"> |

## Testing

1. Go to the `TeamCardList.tsx` file
2. Replace line 15 with this:

```js
// This basically just increases the team cards rendered
{[items, items, items].flat().map(({ key, ...item }) => (
```

3. Visit the Teams page: http://localhost:9091/planex/teams
4. Scroll to the very bottom of the page
5. Verify that the team cards don't hug the bottom part of the browser viewport

**Deletions** ⚰️

* Removed a redundant bottom margin for the Dashboard's Activity Table

Resolves #3489