### PR TITLE
fix: staged payment buttons alignment

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentTable/StagedPaymentTable.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentTable/StagedPaymentTable.tsx
@@ -137,13 +137,15 @@ const useStagedPaymentTableColumns = ({
                   const isClaimed = currentMilestone?.isClaimed;
 
                   return isClaimed ? (
-                    <PillsBase
-                      className={clsx(
-                        'bg-teams-blue-50 text-sm font-medium text-teams-blue-400',
-                      )}
-                    >
-                      {formatText(MSG.released)}
-                    </PillsBase>
+                    <div className="flex items-center justify-end">
+                      <PillsBase
+                        className={clsx(
+                          'bg-teams-blue-50 text-sm font-medium text-teams-blue-400',
+                        )}
+                      >
+                        {formatText(MSG.released)}
+                      </PillsBase>
+                    </div>
                   ) : (
                     <>
                       {isStagedExtensionInstalled ? (

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentTable/partials/ReleaseAllButton/ReleaseAllButton.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentTable/partials/ReleaseAllButton/ReleaseAllButton.tsx
@@ -27,7 +27,7 @@ const ReleaseAllButton: FC<ReleaseAllButtonProps> = ({ items }) => {
   return (
     <button
       type="button"
-      className="w-full text-center text-gray-900 underline transition-colors text-3 hover:text-blue-400"
+      className="w-full text-end text-gray-900 underline transition-colors text-3 hover:text-blue-400"
       onClick={() => {
         setSelectedMilestones(notReleasedMilestones);
         showModal();


### PR DESCRIPTION
## Description

Align buttons to right in staged payments action

## Testing

- Download extension for Staged payment
- Create Staged payment
- Finalize payment

## Diffs

**Changes** 🏗

Before:

![image](https://github.com/user-attachments/assets/5b1f1fbc-e83b-4ca3-9ae0-566a18d9727f)

After:

<img width="673" alt="Screenshot 2024-10-29 at 15 39 52" src="https://github.com/user-attachments/assets/e414339b-70ee-46a3-bf77-6299ee34a6bb">

Resolves - https://github.com/JoinColony/colonyCDapp/issues/3342
