### PR TITLE
Fix: "Upgrade" button on Calmity Banner should be enabled for all users

### DIFF
--- a/src/components/frame/Extensions/layouts/hooks.tsx
+++ b/src/components/frame/Extensions/layouts/hooks.tsx
@@ -13,17 +13,13 @@ import { useLocation } from 'react-router-dom';
 
 import { Action } from '~constants/actions.ts';
 import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
-import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useColonyContractVersion from '~hooks/useColonyContractVersion.ts';
-import useTransformer from '~hooks/useTransformer.ts';
 import {
   COLONY_FOLLOWERS_ROUTE,
   COLONY_MULTISIG_ROUTE,
 } from '~routes/routeConstants.ts';
-import { getAllUserRoles } from '~transformers/index.ts';
-import { canColonyBeUpgraded, hasRoot } from '~utils/checks/index.ts';
-import { extractColonyRoles } from '~utils/colonyRoles.ts';
+import { canColonyBeUpgraded } from '~utils/checks/index.ts';
 import { formatText } from '~utils/intl.ts';
 import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import { type NavigationSidebarItem } from '~v5/frame/NavigationSidebar/partials/NavigationSidebarMainMenu/types.ts';
@@ -45,17 +41,10 @@ import type { UseCalamityBannerInfoReturnType } from './types.ts';
 export const useCalamityBannerInfo = (): UseCalamityBannerInfoReturnType => {
   const { colony } = useColonyContext();
   const { colonyContractVersion } = useColonyContractVersion();
-  const { user, wallet } = useAppContext();
-  const allUserRoles = useTransformer(getAllUserRoles, [
-    extractColonyRoles(colony.roles),
-    wallet?.address || '',
-  ]);
 
   const {
     actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
   } = useActionSidebarContext();
-
-  const canUpgradeColony = user?.profile?.displayName && hasRoot(allUserRoles);
 
   const handleUpgradeColony = useCallback(
     () =>
@@ -78,13 +67,12 @@ export const useCalamityBannerInfo = (): UseCalamityBannerInfoReturnType => {
         buttonProps: {
           onClick: handleUpgradeColony,
           text: formatText({ id: 'button.upgrade' }),
-          disabled: !canUpgradeColony,
         },
         mode: 'info',
         title: formatText({ id: 'calamityBanner.available' }),
       },
     ],
-    [canUpgradeColony, handleUpgradeColony],
+    [handleUpgradeColony],
   );
 
   return {


### PR DESCRIPTION
## Description

This PR ensures the "Upgrade" button on the Calamity Banner is always enabled for all users when a new colony version is available.

## Testing

To save you the hassle of deploying a colony on an older version, we must first update the `canColonyBeUpgraded` function in `src/utils/checks/canColonyBeUpgraded.ts` to return true.

* Step 1 - Connect to a colony as a user with root permissions. Confirm the Calamity Banner is visible and the upgrade button is enabled.

<img width="1728" alt="Screenshot 2024-10-29 at 15 13 47" src="https://github.com/user-attachments/assets/259c52f8-54de-419c-bdc5-7a9dfb17a98e">

* Step 2 - Connect to a colony as a user without root permissions. Confirm the Calamity Banner is visible and the upgrade button is enabled.

## Diffs


**Deletions** ⚰️

* Removed `canUpgradeColony` and related uses from `useCalamityBannerInfo`

Resolves #3340
