### PR TITLE
Fix: Auto-expand accordions to reveal the current route

### DIFF
--- a/src/components/v5/shared/Navigation/Sidebar/partials/SidebarRouteItem/SidebarRouteItem.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/partials/SidebarRouteItem/SidebarRouteItem.tsx
@@ -1,8 +1,8 @@
 import { CaretDown } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import { AnimatePresence, motion } from 'framer-motion';
-import React, { useState } from 'react';
-import { useMatch, useParams } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { useLocation, useMatch, useParams } from 'react-router-dom';
 
 import { usePageLayoutContext } from '~context/PageLayoutContext/PageLayoutContext.ts';
 import { usePageThemeContext } from '~context/PageThemeContext/PageThemeContext.ts';
@@ -29,6 +29,8 @@ const SidebarRouteItem: React.FC<SidebarRouteItemProps> = ({
   isColonyRoute,
 }) => {
   const { colonyName } = useParams();
+
+  const location = useLocation();
 
   const derivedPath = isColonyRoute
     ? `/${colonyName}${path ? `/${path}` : ''}`
@@ -65,6 +67,20 @@ const SidebarRouteItem: React.FC<SidebarRouteItemProps> = ({
       toggleTabletSidebar();
     }
   };
+
+  useEffect(() => {
+    // I don't want to overly complicate this for now.
+    // In the future, if we ever end up having multiple levels of route nesting,
+    // adjust this accordingly via a recursive approach.
+    if (
+      isAccordion &&
+      subItems
+        .map((subItem) => subItem.path)
+        .find((subItemPath) => location.pathname.endsWith(subItemPath))
+    ) {
+      setIsAccordionExpanded(true);
+    }
+  }, [isAccordion, location.pathname, matchingRoute, subItems]);
 
   const shouldHighlightItem = !!matchingRoute && !isAccordion;
 


### PR DESCRIPTION
## Description

When a user is in a child menu item of the Finances area, the mobile navigation isn't expanded by default to show the active page being visited by the user. This causes confusion as nothing shows as being active in the menu and I do not know where I am, since the mobile is full screen.

This PR makes sure that the current page is highlighted.

## Testing

1. Set the view to mobile
2. Visit the Incoming page: http://localhost:9091/planex/incoming
3. Click the Menu button
 
<img width="501" alt="Screenshot 2024-10-30 at 00 28 53" src="https://github.com/user-attachments/assets/60a3cce9-1851-4fad-b611-fb25c3833288">

4. Verify that the Finances accordion is auto-expanded and Finances is highlighted

<img width="501" alt="Screenshot 2024-10-30 at 00 29 23" src="https://github.com/user-attachments/assets/0713225b-b878-4506-99cf-4067a087446c">

5. Please do the same for the Balances page

Resolves #3505 
