### PR TITLE
Fix: lock the body scroll when the tablet Colony Sidebar is active

### DIFF
--- a/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/ColonyPageSidebar.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/ColonyPageSidebar.tsx
@@ -8,6 +8,7 @@ import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSid
 import { usePageLayoutContext } from '~context/PageLayoutContext/PageLayoutContext.ts';
 import { usePageThemeContext } from '~context/PageThemeContext/PageThemeContext.ts';
 import { useTablet } from '~hooks/index.ts';
+import { useLockBodyScroll } from '~hooks/useLockBodyScroll/index.ts';
 import LearnMore from '~shared/Extensions/LearnMore/LearnMore.tsx';
 import Button from '~v5/shared/Button/Button.tsx';
 import Sidebar from '~v5/shared/Navigation/Sidebar/index.ts';
@@ -57,6 +58,8 @@ const ColonyPageSidebar = () => {
     // the Action Form slides into view
     setTimeout(() => setShowTabletSidebar(false), 500);
   };
+
+  useLockBodyScroll(isTablet && showTabletSidebar);
 
   if (isTablet) {
     return (

--- a/src/hooks/useLockBodyScroll/index.ts
+++ b/src/hooks/useLockBodyScroll/index.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+export const useLockBodyScroll = (shouldLock: boolean = true) => {
+  useEffect(() => {
+    const { body } = document;
+
+    // Keep track of the body's overflow style, before attempting to update it
+    const originalStyle = window.getComputedStyle(body).overflow;
+
+    if (shouldLock) {
+      body.style.overflow = 'hidden';
+    } else {
+      // Revert back to the original overflow style when shouldLock is false
+      body.style.overflow = originalStyle;
+    }
+
+    // Cleanup function to restore the original style when the component unmounts
+    return () => {
+      body.style.overflow = originalStyle;
+    };
+  }, [shouldLock]);
+};

--- a/src/hooks/useLockBodyScroll/index.ts
+++ b/src/hooks/useLockBodyScroll/index.ts
@@ -1,5 +1,18 @@
 import { useEffect } from 'react';
 
+/**
+ * This hook locks or unlocks body scroll based on the given boolean flag.
+ * It is a very simplified version of the `useDisableBodyScroll` hook.
+ *
+ * @param {boolean} [shouldLock=true] - Determines whether to lock the body scroll or not. Defaults to true.
+ *
+ * @description
+ * This hook manages the document's body scroll by setting the `overflow` style to `'hidden'` when the
+ * `shouldLock` flag is true and restoring the original overflow style when it's false or on cleanup.
+ *
+ * @note
+ * It is still recommended to use the `useDisableBodyScroll` hook for most use cases.
+ */
 export const useLockBodyScroll = (shouldLock: boolean = true) => {
   useEffect(() => {
     const { body } = document;


### PR DESCRIPTION
## Description

Currently, the scrolling behaviour of our app can be interacted with while the Tablet Colony Sidebar is active, which is not ideal. This PR locks the scroll of the body when the Tablet Colony Sidebar is active.

## Testing

1. Visit a Colony
2. Set your browser to a mobile viewport
3. Expand the Colony Sidebar by clicking the Menu button

<img width="501" alt="Screenshot 2024-10-30 at 00 28 53" src="https://github.com/user-attachments/assets/dd20ebe7-c7ab-4546-b8a8-43e3acecde86">

4. Hover on the top nav and attempt to scroll it
5. Verify that you are unable to
6. To compare, check out to the `master` branch and attempt to scroll it and you will be able to

| This branch | Master branch |
| ---- | ---- |
| ![scrollable NOT](https://github.com/user-attachments/assets/cb078dbb-a4bb-497a-8918-c11dae1a2042) | ![scrollable](https://github.com/user-attachments/assets/42b24eae-bb84-46ed-9df7-cc565d441492) |

**New stuff** ✨

* I added a new hook called `useLockBodyScroll` which is essentially a very stripped down version of our `useDisableBodyScroll` hook. For some reason, I cannot get the `useDisableBodyScroll` to work for my use case and I experimented with making it really basic and simple and it works. _gazes into the distance and questions my existence_

Resolves #3524 