### PR TITLE
Fix: Close the user info modal when the Action Form comes up

### DIFF
--- a/src/components/v5/shared/UserInfoPopover/UserInfoPopover.tsx
+++ b/src/components/v5/shared/UserInfoPopover/UserInfoPopover.tsx
@@ -66,9 +66,11 @@ const UserInfoPopover: FC<UserInfoPopoverProps> = ({
   const openUserPopover = useCallback(() => {
     setIsTooltipVisible(true);
   }, []);
-  const closeUserPopover = useCallback(() => {
+
+  const closeUserInfoPopup = () => {
+    onCloseModal();
     setIsTooltipVisible(false);
-  }, []);
+  };
 
   const onClickHandler = isMobile ? onOpenModal : openUserPopover;
   const onMouseEnterHandler = isMobile ? noop : onOpenModal;
@@ -91,7 +93,7 @@ const UserInfoPopover: FC<UserInfoPopoverProps> = ({
       additionalContent={
         !isVerified ? (
           <UserNotVerified
-            onClick={closeUserPopover}
+            onClick={closeUserInfoPopup}
             walletAddress={walletAddress}
             description={
               <div className="mt-2 break-words pb-2 text-sm font-semibold">


### PR DESCRIPTION
## Description

At the moment, we're only closing the popover User Info popover which is used on Desktop mode. So I'm just simply handling the Modal we use on mobile as well.

## Testing

1. Visit the followers page: http://localhost:9091/planex/members/followers
2. Set the browser to mobile view
3. Click an unverified user i.e. jasmine-jolt
4. Verify that the User Info modal shows up
5. Click the Add as verified member button

<img width="660" alt="Screenshot 2024-10-30 at 02 06 44" src="https://github.com/user-attachments/assets/17862efa-c923-4256-80ea-ab725025e68f">

6. Verify that the Modal is closed when the Action Form comes up

Resolves #3527 