### PR TITLE
Fix: Update contract address copied copy

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/ColonyLinks.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/ColonyLinks.tsx
@@ -98,7 +98,7 @@ const ColonyLinks = () => {
           isSuccess={isColonyAddressCopied}
           tooltipContent={formatText({
             id: isColonyAddressCopied
-              ? 'colony.tooltip.url.copied'
+              ? 'colony.tooltip.colonyAddress.copied'
               : 'colony.tooltip.contractAddress.copy',
           })}
           isCopy


### PR DESCRIPTION
## Description

Wee update to the contract address copy button:

![copied](https://github.com/user-attachments/assets/4708f92b-307c-4ced-ad64-d3e7656c67fc)

## Testing

1. Visit a Colony
2. Click this button
<img width="583" alt="Screenshot 2024-10-30 at 19 57 20" src="https://github.com/user-attachments/assets/e3204578-fbb8-4259-b09f-60f3966ee928">
3. Verify that the tooltip copy changes to "Contract address copied!"

Resolves #3493