### PR TITLE
[Dashboard] Fix: Team switcher should not clip navigation

### DIFF
--- a/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/colonyPageSidebar.styles.ts
+++ b/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/colonyPageSidebar.styles.ts
@@ -6,7 +6,7 @@ export const colonyPageSidebarTabletClass = clsx(
   /** Unfortunately, it's a bit tricky to string interpolate tailwind classes */
   'top-[calc(var(--header-nav-section-height)+var(--top-content-height))]',
   'fixed left-0 !h-[calc(100vh-var(--header-nav-section-height)-var(--top-content-height))] w-full',
-  'z-sidebar flex flex-col justify-between overflow-y-auto bg-base-white p-3 md:bg-gray-900',
+  'z-userNav flex flex-col justify-between overflow-y-auto bg-base-white p-3 md:bg-gray-900',
 );
 
 export const colonyPageSidebarDesktopClass = clsx(


### PR DESCRIPTION
## Description

This PR changes the z-index on the navigation so that the team switcher does not clip. (Thanks @rumzledz for suggesting the fix in the issue).

## Testing

Set the screen size to mobile so that the arrow on the team switcher is visible.

<img width="703" alt="Screenshot 2024-10-30 at 12 07 03" src="https://github.com/user-attachments/assets/6e14d561-1b60-4755-8c85-c2596a18d2c5">


Open the navigation menu, confirm the arrow is not visible.

Master:
![image](https://github.com/user-attachments/assets/93a44c00-7ecc-411d-b689-af5b257987d8)


This branch:
 
<img width="711" alt="Screenshot 2024-10-30 at 12 07 20" src="https://github.com/user-attachments/assets/c332b350-a7bc-4d3d-a9d1-917b293fa0e6">


## Diffs

**Changes** 🏗

* Changed sidebar z-index

Resolves #3504
