### PR TITLE
[Dashboard] Fix: Scrollbar shifts main content

### DIFF
--- a/src/components/v5/frame/PageLayout/PageLayout.tsx
+++ b/src/components/v5/frame/PageLayout/PageLayout.tsx
@@ -66,7 +66,7 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
             </section>
             <section
               className={clsx(
-                'modal-blur h-full w-full overflow-auto px-6 md:p-8 md:pb-0 md:pt-2',
+                'modal-blur h-full w-full overflow-auto px-6 scrollbar-gutter-stable md:p-8 md:pb-0 md:pt-2',
                 {
                   'md:!pt-[1.125rem]': !pageTitle,
                 },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -270,10 +270,13 @@ module.exports = {
         '.no-scrollbar::-webkit-scrollbar': {
           display: 'none',
         },
+        '.scrollbar-gutter-stable': {
+          'scrollbar-gutter': 'stable',
+        },
         '.bold-on-hover': {
           '@apply relative after:w-full after:h-4.5 after:z-base after:block after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:overflow-hidden after:text-gray-700 hover:after:text-gray-900 after:font-medium hover:after:font-semibold after:content-[attr(aria-label)]':
             {},
-        }
+        },
       });
       addComponents({
         '.inner': {


### PR DESCRIPTION
## Description

This PR adds scrollbar-gutter: stable to the main content area. It reserves space for the scrollbar so it will prevent content from jumping around when the scrollbar appears / disappears. It is not fully supported, so we should be aware that this does not resolve this issue for Safari / iOS (https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter).

## Testing

Set the screen size so that there is no scrollbar. Resize so that the scrollbar appears. The content should not jump around.

This branch:
https://github.com/user-attachments/assets/e3b42737-69cd-46a0-92d5-8d3848d0b209

Master:
https://github.com/user-attachments/assets/5d7e8ce7-ad9c-4678-857e-5453722e358e



## Diffs

**New stuff** ✨

* Added `scrollbar-gutter-stable` utility class
* Added new class to main content area

Resolves #3513
