### PR TITLE
Fix: Remove redundant whitespace underneath activity table

### DIFF
--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -114,7 +114,7 @@ const Table = <T,>({
     <div className={className}>
       <table
         className={clsx(
-          'h-px w-full table-fixed',
+          'w-full table-fixed',
           {
             'border-separate border-spacing-0 rounded-lg border border-gray-200':
               showTableBorder,


### PR DESCRIPTION
## Description

| Before | After |
| ---- | ---- |
| ![ios before](https://github.com/user-attachments/assets/8a90d31d-06b7-43ff-be13-0b1d9bb7a8e3) | ![ios after](https://github.com/user-attachments/assets/58907f43-0e16-4851-9053-6c458f8512aa) |

## Testing

> [!NOTE]
> Turns out, you can also replicate this on a Safari browser. Thanks @mmioana 🙏 

1. Open the app on a Safari browser
2. Set it to mobile view
3. Go to a Colony Dashboard
4. Scroll to the very bottom
5. Verify that there is no huge gap between the table and the pagination

<img width="574" alt="Screenshot 2024-10-31 at 18 11 52" src="https://github.com/user-attachments/assets/18976c1a-3edf-447c-9500-f7db27f2bcac">


Resolves #3500 