### PR TITLE
Fix: Activity feed table fixes

### DIFF
--- a/src/components/common/ColonyActionsTable/RecentActivityTable.tsx
+++ b/src/components/common/ColonyActionsTable/RecentActivityTable.tsx
@@ -45,7 +45,6 @@ const RecentActivityTable: FC<ColonyActionsTableProps> = ({
       withNarrowBorder
       alwaysShowPagination={totalActions > 0}
       showTotalPagesNumber={pageCount > 1}
-      tableClassName="flex-auto"
     />
   );
 };

--- a/src/components/common/ColonyActionsTable/RecentActivityTable.tsx
+++ b/src/components/common/ColonyActionsTable/RecentActivityTable.tsx
@@ -45,6 +45,7 @@ const RecentActivityTable: FC<ColonyActionsTableProps> = ({
       withNarrowBorder
       alwaysShowPagination={totalActions > 0}
       showTotalPagesNumber={pageCount > 1}
+      tableClassName="flex-auto"
     />
   );
 };

--- a/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
@@ -83,6 +83,10 @@ export const useActionsTableProps = (
     original: { transactionHash },
   }) => ({
     disabled: loading,
+    dropdownPlacementProps: {
+      withAutoTopPlacement: true,
+      top: 10,
+    },
     items: [
       {
         key: '1',

--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -14,6 +14,7 @@ import { formatText } from '~utils/intl.ts';
 import MeatBallMenu from '~v5/shared/MeatBallMenu/index.ts';
 
 import TablePagination from './partials/TablePagination/index.ts';
+import { TableRowDivider } from './partials/TableRowDivider.tsx';
 import { TableRow } from './partials/VirtualizedRow/VirtualizedRow.tsx';
 import { type TableProps } from './types.ts';
 import { getDefaultRenderCellWrapper, makeMenuColumn } from './utils.tsx';
@@ -420,15 +421,7 @@ const Table = <T,>({
                         /** Unfortunately Safari is not yet that friendly to allow the usage of absolutely positioned (pseudo)-element inside tables
                          * So, for the moment, this is our best shot for showing borders with paddings from the tr margins
                          */
-                        withNarrowBorder && (
-                          <tr className="relative w-full [&:last-of-type]:hidden [&:not(last-child)>#divider-cell>div]:!py-0 [&:not(last-child)>#divider-cell]:!px-0 [&>#divider-cell]:!h-[1px]">
-                            <td colSpan={100} id="divider-cell">
-                              <div className="h-full w-full !py-0 px-4">
-                                <div className="border-b border-gray-100" />
-                              </div>
-                            </td>
-                          </tr>
-                        )
+                        withNarrowBorder && <TableRowDivider />
                       }
                     </React.Fragment>
                   );

--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -112,16 +112,17 @@ const Table = <T,>({
   const hasPagination = pageCount > 1 || canGoToNextPage || canGoToPreviousPage;
   const totalColumnsCount = table.getVisibleFlatColumns().length;
   const shouldShowEmptyContent = emptyContent && data.length === 0;
+  const hasExpandableRows = !!renderSubComponent;
 
   useEffect(() => {
-    if (!isMobile) {
+    if (!isMobile && hasExpandableRows) {
       rows.forEach((row) => {
         if (row.getIsExpanded()) {
           row.toggleExpanded(false);
         }
       });
     }
-  }, [isMobile, rows]);
+  }, [isMobile, hasExpandableRows, rows]);
 
   return (
     <div className={className}>

--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -318,8 +318,6 @@ const Table = <T,>({
                         itemHeight={virtualizedProps?.virtualizedRowHeight || 0}
                         isEnabled={!!virtualizedProps}
                         className={clsx(getRowClassName(row), {
-                          '[&:not(:first-child)]:after:absolute [&:not(:first-child)]:after:left-4 [&:not(:first-child)]:after:top-0 [&:not(:first-child)]:after:w-[calc(100%-2rem)] [&:not(:first-child)]:after:border-b [&:not(:first-child)]:after:border-gray-100':
-                            withNarrowBorder,
                           'translate-z-0 relative [&>tr:first-child>td]:pr-9 [&>tr:last-child>td]:p-0 [&>tr:last-child>th]:p-0':
                             getMenuProps,
                           '[&:not(:last-child)>td]:border-b [&:not(:last-child)>td]:border-gray-100':
@@ -406,6 +404,20 @@ const Table = <T,>({
                           </td>
                         </tr>
                       )}
+                      {
+                        /** Unfortunately Safari is not yet that friendly to allow the usage of absolutely positioned (pseudo)-element inside tables
+                         * So, for the moment, this is our best shot for showing borders with paddings from the tr margins
+                         */
+                        withNarrowBorder && (
+                          <tr className="relative w-full [&:last-of-type]:hidden [&:not(last-child)>#divider-cell>div]:!py-0 [&:not(last-child)>#divider-cell]:!px-0 [&>#divider-cell]:!h-[1px]">
+                            <td colSpan={100} id="divider-cell">
+                              <div className="h-full w-full !py-0 px-4">
+                                <div className="border-b border-gray-100" />
+                              </div>
+                            </td>
+                          </tr>
+                        )
+                      }
                     </React.Fragment>
                   );
                 })

--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -7,8 +7,9 @@ import {
   getExpandedRowModel,
 } from '@tanstack/react-table';
 import clsx from 'clsx';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
+import { useMobile } from '~hooks';
 import { formatText } from '~utils/intl.ts';
 import MeatBallMenu from '~v5/shared/MeatBallMenu/index.ts';
 
@@ -55,6 +56,7 @@ const Table = <T,>({
   ...rest
 }: TableProps<T>) => {
   const helper = useMemo(() => createColumnHelper<T>(), []);
+  const isMobile = useMobile();
 
   const columnsWithMenu = useMemo(
     () => [
@@ -109,6 +111,16 @@ const Table = <T,>({
   const hasPagination = pageCount > 1 || canGoToNextPage || canGoToPreviousPage;
   const totalColumnsCount = table.getVisibleFlatColumns().length;
   const shouldShowEmptyContent = emptyContent && data.length === 0;
+
+  useEffect(() => {
+    if (!isMobile) {
+      rows.forEach((row) => {
+        if (row.getIsExpanded()) {
+          row.toggleExpanded(false);
+        }
+      });
+    }
+  }, [isMobile, rows]);
 
   return (
     <div className={className}>

--- a/src/components/v5/common/Table/partials/TableRowDivider.tsx
+++ b/src/components/v5/common/Table/partials/TableRowDivider.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export const TableRowDivider = () => (
+  <tr className="relative w-full [&:last-of-type]:hidden [&:not(last-child)>#divider-cell>div]:!py-0 [&:not(last-child)>#divider-cell]:!px-0 [&>#divider-cell]:!h-[1px]">
+    <td colSpan={100} id="divider-cell">
+      <div className="h-full w-full !py-0 px-4">
+        <div className="border-b border-gray-100" />
+      </div>
+    </td>
+  </tr>
+);

--- a/src/hooks/useActivityFeed/useActivityFeed.ts
+++ b/src/hooks/useActivityFeed/useActivityFeed.ts
@@ -49,10 +49,11 @@ const useActivityFeed = (
    * It's set one page ahead to prefetch the next page actions
    */
   const requestedActionsCount = pageSize * (pageNumber + 1);
+  const stringifiedFilters = JSON.stringify(filters);
 
   useEffect(() => {
     setPageNumber(1);
-  }, [filters]);
+  }, [stringifiedFilters]);
 
   const { data, fetchMore, loading } = useSearchActionsQuery({
     variables: {


### PR DESCRIPTION
## Description

- This PR aims to solve multiple issues related to the activity table:
- [X] Dashboard pagination resets when requesting new data
- [X] Expanded rows not closing between mobile and desktop viewport changes
- [X] Row dividers not showing up on mobile or Safari
- [X] Actions menu isn’t fully opened on mobile

Please keep in mind I did resist the urge to refactor the `Table` component.

## Testing

TODO: Please test all these scenarios are resolved. For the first issues you can use `Chrome` as on this branch a bug regarding the pagination is still present (fixed by ), for the second issue any browser would do, but for the last 2 issues please use Safari or a mobile simulator - shout if you need help configuring a mobile simulator 😉 

#### Issue 1: Dashboard pagination resets when requesting new data

* Step 1.1. Let us test the pagination no longer resets when requesting new data. In `ColonyHome` please update the `pageSize` to `3` for the `RecentActivityTable` component - thus you'll have more pages of data to test this.
* Step 1.2. Click as fast as possible on the `Next` button to make sure the correct data loads and the pagination is not reset to `1`

https://github.com/user-attachments/assets/2c076ca1-16be-43a7-b769-9242267cf452

#### Issue 2: Expanded rows not closing between mobile and desktop viewport changes

* Step 2.1. Now lets make sure we have a mobile viewport.
* Step 2.2. Expand a few of the rows.
* Step 2.3. Now switch to a desktop view and make sure the expanded content is no longer visible.
* Step 2.4. You can go back to a mobile view and the rows should still be unexpanded


https://github.com/user-attachments/assets/32b5ec52-7924-4ab0-9366-8ecd067bac2d

#### Issue 3: Row dividers not showing up on mobile or Safari

* Step 3.1. Now let's go to `Safari` or a mobile simulator.
* Step 3.2. Check the row dividers are visible.

![Screenshot 2024-10-31 at 17 12 09](https://github.com/user-attachments/assets/87547a79-0556-4848-9925-42dfb9f739f3)

#### Issue 4: Actions menu isn’t fully opened on mobile

* Step 4.1. Again let's use `Safari` or a mobile simulator.
* Step 4.2. Go to one row that is partially visible (preferably at the bottom of the screen)
* Step 4.3. Open up the actions menu and check all options are visible and not cut off.
* Step 4.4. Try opening more options at different table positions and check the menu is visible.
 

https://github.com/user-attachments/assets/8e4f4790-1d01-4a32-ac85-46bd16624995


## Diffs

**New stuff** ✨

* `TableRowDivider` component. Unfortunately this is needed because Safari and `table`, `tr`, `td` etc. elements don't respond well to `absolute` position. 


Resolves #3495
Resolves #3552
Resolves #3487
Resolves #3499 
