### PR TITLE
Fix: Remove Pie Chart's black box background

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/ChartLoadingLayer.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/ChartLoadingLayer.tsx
@@ -9,7 +9,7 @@ const absoluteCenteredClass = tw`absolute left-1/2 top-1/2 z-base -translate-x-1
 export const ChartLoadingLayer = () => {
   return (
     <div className={absoluteCenteredClass}>
-      <div className="relative">
+      <div className="relative overflow-hidden rounded-full bg-transparent">
         <LoadingSkeleton
           className="h-[138px] w-[138px] rounded-full"
           isLoading


### PR DESCRIPTION
## Description

It simply removes Pie Chart's boxy black background:

![loader bg fix](https://github.com/user-attachments/assets/8f3067af-d416-452c-9686-ff75987f9cfd)

## Testing

1. Open the app on a Safari browser
2. Go to a Colony Dashboard
3. Reload the page and just observe the Pie Chart as it loads
4. Verify that it doesn't have a black box background for both light and dark themes:

![image](https://github.com/user-attachments/assets/9db49aef-a1c3-44ea-a0db-1a954f9e916d)
![image](https://github.com/user-attachments/assets/21b8cf97-e309-47d9-ae8c-51073c803353)

Resolves #3570 