### PR TITLE
Fix: Missing permissions banner should not show when reenabling

### DIFF
--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/ExtensionDetailsHeader.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/ExtensionDetailsHeader.tsx
@@ -7,7 +7,7 @@ import { isInstalledExtensionData } from '~utils/extensions.ts';
 import { formatText } from '~utils/intl.ts';
 import ExtensionStatusBadge from '~v5/common/Pills/ExtensionStatusBadge/index.ts';
 
-import PermissionsNeededBanner from '../PermissionsNeededBanner.tsx';
+import ExtensionPermissionsBanner from '../ExtensionPermissionsBanner/ExtensionPermissionsBanner.tsx';
 
 import ActiveInstalls from './ActiveInstalls.tsx';
 import { extensionsBadgeModeMap, extensionsBadgeTextMap } from './consts.ts';
@@ -53,9 +53,10 @@ const ExtensionDetailsHeader: FC = () => {
 
   return (
     <>
-      {isPermissionsBannerVisible && (
-        <PermissionsNeededBanner extensionData={extensionData} />
-      )}
+      <ExtensionPermissionsBanner
+        extensionData={extensionData}
+        isPermissionsBannerVisible={isPermissionsBannerVisible}
+      />
       <div className="flex min-h-10 flex-col flex-wrap justify-between sm:flex-row sm:items-center sm:gap-6">
         <div className="flex w-full flex-col flex-wrap gap-4 sm:flex-row sm:flex-nowrap sm:items-center sm:gap-6">
           <div className="flex flex-col sm:grow sm:flex-row sm:items-center sm:gap-2">

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionPermissionsBanner/ExtensionPermissionsBanner.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionPermissionsBanner/ExtensionPermissionsBanner.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+
+import { type AnyExtensionData } from '~types/extensions.ts';
+
+import PermissionsEnabledBanner from './PermissionsEnabledBanner.tsx';
+import PermissionsNeededBanner from './PermissionsNeededBanner.tsx';
+
+const displayName =
+  'frame.Extensions.ExtensionDetailsPage.ExtensionPermissionsBanner';
+
+interface Props {
+  extensionData: AnyExtensionData;
+  isPermissionsBannerVisible: boolean;
+}
+
+const ExtensionPermissionsBanner = ({
+  extensionData,
+  isPermissionsBannerVisible,
+}: Props) => {
+  const [hasSuccessfullyEnabled, setHasSuccessfullyEnabled] = useState(false);
+
+  if (hasSuccessfullyEnabled) {
+    return <PermissionsEnabledBanner />;
+  }
+
+  if (isPermissionsBannerVisible) {
+    return (
+      <PermissionsNeededBanner
+        extensionData={extensionData}
+        setHasSuccessfullyEnabled={setHasSuccessfullyEnabled}
+      />
+    );
+  }
+
+  return null;
+};
+
+ExtensionPermissionsBanner.displayName = displayName;
+
+export default ExtensionPermissionsBanner;

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionPermissionsBanner/PermissionsEnabledBanner.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionPermissionsBanner/PermissionsEnabledBanner.tsx
@@ -1,0 +1,27 @@
+import { CheckCircle } from '@phosphor-icons/react';
+import React from 'react';
+import { FormattedMessage, defineMessages } from 'react-intl';
+
+import NotificationBanner from '~v5/shared/NotificationBanner/index.ts';
+
+const displayName =
+  'frame.Extensions.ExtensionDetailsPage.PermissionsEnabledBanner';
+
+const MSG = defineMessages({
+  updatedPermission: {
+    id: `${displayName}.updatedPermission`,
+    defaultMessage: 'The required permissions have been updated.',
+  },
+});
+
+const PermissionsEnabledBanner = () => {
+  return (
+    <NotificationBanner icon={CheckCircle} status="success" className="mb-6">
+      <FormattedMessage {...MSG.updatedPermission} />
+    </NotificationBanner>
+  );
+};
+
+PermissionsEnabledBanner.displayName = displayName;
+
+export default PermissionsEnabledBanner;


### PR DESCRIPTION
## Description

This PR fixes an issue where the "Missing permissions" banner would show when re-enabling an extension, even if the extension had previously been assigned permissions.

## Testing

* Step 1 - Switch to the metamask wallet so you can reject specific transactions.
* Step 2 - Navigate to the Multi-Sig extension page.
* Step 3 - Click Install. Accept the "Installation" transaction but reject the "setUserRoles" transaction.
* Step 4 - The "Missing permissions" banner should be visible. Do not interact with it yet.
* Step 5 - Deprecate the extension. The "Missing permissions" banner should disappear.
* Step 6 - Re-enable the extension.
* Step 7 - The "Missing permissions" banner should reappear.
* Step 8 - Click "Enable permissions" on the banner and accept the transaction.
* Step 9 - The "Missing permissions" banner should switch to a green success state.
* Step 10 - Deprecate the extension. The success banner should remain.
* Step 11 - Re-enable the extension. The success banner should still remain.
* Step 12 - Refresh. There should be no permissions banner visible.

https://github.com/user-attachments/assets/9ab1bf6a-46a9-4ce7-8122-139d1102deb6

Further testing:
- Repeat the above steps, refreshing each step of the way to make sure the correct banner shows at the expected times.

## Diffs

**New stuff** ✨

* New stuff goes here

**Changes** 🏗

* Refactored the PermissionsNeededBanner to show the success state correctly

Resolves #3430
Resolves #3337
