### PR TITLE
Fix: Mobile tab arrow alignment update

### DIFF
--- a/src/components/shared/Extensions/Tabs/Tabs.tsx
+++ b/src/components/shared/Extensions/Tabs/Tabs.tsx
@@ -25,10 +25,10 @@ const Tabs: FC<PropsWithChildren<TabsProps>> = ({
         activeTab={activeTab}
         onTabClick={onTabClick}
         tabsUpperContainerClassName={clsx(
-          'before:content-[" "] relative flex w-full items-center p-0 font-semibold before:absolute before:bottom-0 before:left-0 before:block before:h-px before:w-full before:bg-gray-200',
+          'before:content-[" "] relative flex w-full items-start p-0 font-semibold before:absolute before:bottom-0 before:left-0 before:block before:h-px before:w-full before:bg-gray-200',
           upperContainerClassName,
         )}
-        leftNavBtnClassName="absolute top-[50%] translate-y-[-50%] left-0 z-base"
+        leftNavBtnClassName="absolute left-0 z-base"
         rightNavBtnClassName="z-base"
         // @ts-ignore - react-tabs-scrollable has invalid type for this prop
         leftBtnIcon={<CaretLeft size={12} />}


### PR DESCRIPTION
## Description

Just a simple adjustment to how these components are aligned.

| Before | After |
| ---- | ---- |
| <img width="500" alt="Screenshot 2024-10-31 at 22 48 04" src="https://github.com/user-attachments/assets/93fcc79d-7a84-452b-937e-306a83d1ce77"> | <img width="501" alt="Screenshot 2024-10-31 at 22 47 40" src="https://github.com/user-attachments/assets/b97ccbc2-6e06-4c74-a3c7-b8d9a2bc583f"> |

## Testing

1. Visit the account page
2. Set the view to iPhone SE
3. Verify that the arrows are aligned along the same line as the tab copies:

<img width="454" alt="image" src="https://github.com/user-attachments/assets/ee78927f-f2d7-43f2-b363-5f50352fa839">

Resolves #3542