### PR TITLE
Fix: Enable Recent Activity Table Item Redo Functionality

### DIFF
--- a/src/components/common/ColonyActionsTable/ColonyActionsTable.tsx
+++ b/src/components/common/ColonyActionsTable/ColonyActionsTable.tsx
@@ -6,7 +6,7 @@ import Table from '~v5/common/Table/index.ts';
 import TableHeader from '~v5/common/TableHeader/TableHeader.tsx';
 
 import { useActionsTableProps } from './hooks/useActionsTableProps.tsx';
-import { useRedoAction } from './hooks/useRedoAction.ts';
+import { useHandleRedoAction } from './hooks/useHandleRedoAction.ts';
 import ActionsTableFilters from './partials/ActionsTableFilters/index.ts';
 import { type ColonyActionsTableProps } from './types.ts';
 
@@ -22,7 +22,7 @@ const ColonyActionsTable: FC<ColonyActionsTableProps> = ({
     actionProps.setSelectedAction,
   );
 
-  useRedoAction({ actionProps });
+  useHandleRedoAction({ actionProps });
 
   return (
     <>

--- a/src/components/common/ColonyActionsTable/ColonyActionsTable.tsx
+++ b/src/components/common/ColonyActionsTable/ColonyActionsTable.tsx
@@ -1,12 +1,12 @@
-import React, { type FC, useEffect } from 'react';
+import React, { type FC } from 'react';
 
-import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { type ColonyAction } from '~types/graphql.ts';
 import { formatText } from '~utils/intl.ts';
 import Table from '~v5/common/Table/index.ts';
 import TableHeader from '~v5/common/TableHeader/TableHeader.tsx';
 
 import { useActionsTableProps } from './hooks/useActionsTableProps.tsx';
+import { useRedoAction } from './hooks/useRedoAction.ts';
 import ActionsTableFilters from './partials/ActionsTableFilters/index.ts';
 import { type ColonyActionsTableProps } from './types.ts';
 
@@ -21,24 +21,8 @@ const ColonyActionsTable: FC<ColonyActionsTableProps> = ({
     rest,
     actionProps.setSelectedAction,
   );
-  const {
-    actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
-  } = useActionSidebarContext();
 
-  useEffect(() => {
-    if (actionProps.defaultValues && actionProps.selectedAction) {
-      toggleActionSidebarOn({ ...actionProps.defaultValues });
-
-      setTimeout(() => {
-        actionProps.setSelectedAction(undefined);
-      }, 50);
-    }
-  }, [
-    actionProps.defaultValues,
-    toggleActionSidebarOn,
-    actionProps.selectedAction,
-    actionProps,
-  ]);
+  useRedoAction({ actionProps });
 
   return (
     <>

--- a/src/components/common/ColonyActionsTable/RecentActivityTable.tsx
+++ b/src/components/common/ColonyActionsTable/RecentActivityTable.tsx
@@ -6,7 +6,7 @@ import { type ColonyAction } from '~types/graphql.ts';
 import Table from '~v5/common/Table/index.ts';
 
 import { useActionsTableProps } from './hooks/useActionsTableProps.tsx';
-import { useRedoAction } from './hooks/useRedoAction.ts';
+import { useHandleRedoAction } from './hooks/useHandleRedoAction.ts';
 import { type ColonyActionsTableProps } from './types.ts';
 
 const displayName = 'common.RecentActivityTable';
@@ -35,7 +35,7 @@ const RecentActivityTable: FC<ColonyActionsTableProps> = ({
     actionProps.setSelectedAction,
   );
 
-  useRedoAction({ actionProps });
+  useHandleRedoAction({ actionProps });
 
   return (
     <Table<ColonyAction>

--- a/src/components/common/ColonyActionsTable/RecentActivityTable.tsx
+++ b/src/components/common/ColonyActionsTable/RecentActivityTable.tsx
@@ -6,6 +6,7 @@ import { type ColonyAction } from '~types/graphql.ts';
 import Table from '~v5/common/Table/index.ts';
 
 import { useActionsTableProps } from './hooks/useActionsTableProps.tsx';
+import { useRedoAction } from './hooks/useRedoAction.ts';
 import { type ColonyActionsTableProps } from './types.ts';
 
 const displayName = 'common.RecentActivityTable';
@@ -33,6 +34,8 @@ const RecentActivityTable: FC<ColonyActionsTableProps> = ({
     },
     actionProps.setSelectedAction,
   );
+
+  useRedoAction({ actionProps });
 
   return (
     <Table<ColonyAction>

--- a/src/components/common/ColonyActionsTable/hooks/useBuildRedoEnabledActionsMap.ts
+++ b/src/components/common/ColonyActionsTable/hooks/useBuildRedoEnabledActionsMap.ts
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react';
+
+import { ColonyActionType, useGetColonyHistoricRoleRolesLazyQuery } from '~gql';
+import { type ActivityFeedColonyAction } from '~hooks/useActivityFeed/types.ts';
+import { ExtendedColonyActionType } from '~types/actions.ts';
+import { getHistoricRolesDatabaseId } from '~utils/databaseId.ts';
+import { transformActionRolesToColonyRoles } from '~v5/common/CompletedAction/partials/SetUserRoles/utils.ts';
+
+export const useBuildRedoEnabledActionsMap = ({
+  colonyActions = [],
+  colonyActionsLoading,
+}: {
+  colonyActions?: ActivityFeedColonyAction[];
+  colonyActionsLoading: boolean;
+}) => {
+  const [redoEnabledActionsMap, setRedoEnabledActionsMap] = useState<
+    Record<ActivityFeedColonyAction['transactionHash'], boolean>
+  >({});
+
+  const [getHistoricRoles] = useGetColonyHistoricRoleRolesLazyQuery({
+    fetchPolicy: 'cache-and-network',
+  });
+
+  // I'm using simple stringification to help the useEffect hook with shallow comparison and avoid unnecessary rerenders
+  const stringifiedColonyActions = JSON.stringify(colonyActions);
+
+  useEffect(() => {
+    const buildRedoEnabledActionsMap = async () => {
+      const originalColonyActions = JSON.parse(
+        stringifiedColonyActions,
+      ) as typeof colonyActions;
+
+      if (colonyActionsLoading || originalColonyActions.length === 0) {
+        return;
+      }
+
+      const updatedActionsMap: typeof redoEnabledActionsMap = {};
+      const promises: Promise<void>[] = [];
+
+      originalColonyActions.forEach((colonyAction) => {
+        switch (
+          colonyAction.type as ColonyActionType | ExtendedColonyActionType
+        ) {
+          case ColonyActionType.SetUserRoles:
+          case ColonyActionType.SetUserRolesMotion:
+          case ColonyActionType.SetUserRolesMultisig: {
+            const {
+              blockNumber,
+              colonyAddress,
+              fromDomain,
+              recipientAddress,
+              rolesAreMultiSig,
+              roles,
+              motionData,
+              multiSigData,
+            } = colonyAction;
+
+            const promise = async () => {
+              const result = await getHistoricRoles({
+                variables: {
+                  id: getHistoricRolesDatabaseId({
+                    blockNumber,
+                    colonyAddress,
+                    nativeId: fromDomain?.nativeId,
+                    recipientAddress,
+                    isMultiSig: rolesAreMultiSig,
+                  }),
+                },
+              });
+
+              const dbPermissionsNew = transformActionRolesToColonyRoles(
+                result?.data?.getColonyHistoricRole || roles,
+              );
+
+              const isMotion = !!motionData;
+              const isMultiSig = !!multiSigData;
+
+              const shouldShowRedoItem =
+                !!dbPermissionsNew.length ||
+                (isMotion && !motionData?.isFinalized) ||
+                (isMultiSig && !multiSigData?.isExecuted);
+
+              updatedActionsMap[colonyAction.transactionHash] =
+                shouldShowRedoItem;
+            };
+
+            promises.push(promise());
+            break;
+          }
+
+          case ColonyActionType.AddVerifiedMembers:
+          case ColonyActionType.AddVerifiedMembersMotion:
+          case ColonyActionType.AddVerifiedMembersMultisig:
+          case ColonyActionType.CreateDecisionMotion:
+          case ColonyActionType.ColonyEdit:
+          case ColonyActionType.ColonyEditMotion:
+          case ColonyActionType.ColonyEditMultisig:
+          case ColonyActionType.CreateDomain:
+          case ColonyActionType.CreateDomainMotion:
+          case ColonyActionType.CreateDomainMultisig:
+          case ColonyActionType.EditDomain:
+          case ColonyActionType.EditDomainMotion:
+          case ColonyActionType.EditDomainMultisig:
+          case ColonyActionType.RemoveVerifiedMembers:
+          case ColonyActionType.RemoveVerifiedMembersMotion:
+          case ColonyActionType.RemoveVerifiedMembersMultisig:
+          case ColonyActionType.UnlockToken:
+          case ColonyActionType.UnlockTokenMotion:
+          case ColonyActionType.UnlockTokenMultisig:
+          case ColonyActionType.VersionUpgrade:
+          case ColonyActionType.VersionUpgradeMotion:
+          case ColonyActionType.VersionUpgradeMultisig:
+          case ExtendedColonyActionType.UpdateColonyObjective:
+          case ExtendedColonyActionType.UpdateColonyObjectiveMotion:
+          case ExtendedColonyActionType.UpdateColonyObjectiveMultisig:
+            updatedActionsMap[colonyAction.transactionHash] = false;
+            break;
+
+          default:
+            updatedActionsMap[colonyAction.transactionHash] = true;
+        }
+      });
+
+      await Promise.all(promises);
+
+      setRedoEnabledActionsMap(updatedActionsMap);
+    };
+
+    buildRedoEnabledActionsMap();
+  }, [colonyActionsLoading, getHistoricRoles, stringifiedColonyActions]);
+
+  return redoEnabledActionsMap;
+};

--- a/src/components/common/ColonyActionsTable/hooks/useGetMenuProps.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useGetMenuProps.tsx
@@ -1,0 +1,113 @@
+import {
+  ArrowSquareOut,
+  FilePlus,
+  ShareNetwork,
+  Repeat,
+} from '@phosphor-icons/react';
+import React from 'react';
+import { generatePath, useNavigate } from 'react-router-dom';
+
+import { APP_URL, DEFAULT_NETWORK_INFO } from '~constants';
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { type ActivityFeedColonyAction } from '~hooks/useActivityFeed/types.ts';
+import {
+  COLONY_ACTIVITY_ROUTE,
+  COLONY_HOME_ROUTE,
+  TX_SEARCH_PARAM,
+} from '~routes';
+import TransactionLink from '~shared/TransactionLink/index.ts';
+import { formatText } from '~utils/intl.ts';
+import { type TableProps } from '~v5/common/Table/types.ts';
+
+import MeatballMenuCopyItem from '../partials/MeatballMenuCopyItem/index.ts';
+import { type ColonyActionsTableProps } from '../types.ts';
+
+import { useBuildRedoEnabledActionsMap } from './useBuildRedoEnabledActionsMap.ts';
+
+export const useGetMenuProps = ({
+  colonyActionsLoading,
+  setAction,
+  colonyActions,
+}: {
+  colonyActionsLoading: boolean;
+  setAction: ColonyActionsTableProps['actionProps']['setSelectedAction'];
+  colonyActions: ActivityFeedColonyAction[];
+}) => {
+  const navigate = useNavigate();
+
+  const {
+    colony: { name: colonyName },
+  } = useColonyContext();
+
+  const redoEnabledActionsMap = useBuildRedoEnabledActionsMap({
+    colonyActions,
+    colonyActionsLoading,
+  });
+
+  const getMenuProps: TableProps<ActivityFeedColonyAction>['getMenuProps'] = ({
+    original: colonyAction,
+  }) => {
+    const { transactionHash } = colonyAction;
+
+    return {
+      disabled: colonyActionsLoading,
+      items: [
+        {
+          key: '1',
+          label: formatText({ id: 'activityFeedTable.menu.view' }),
+          icon: FilePlus,
+          onClick: () => {
+            navigate(
+              `${window.location.pathname}?${TX_SEARCH_PARAM}=${transactionHash}`,
+              {
+                replace: true,
+              },
+            );
+          },
+        },
+        {
+          key: '2',
+          label: (
+            <TransactionLink hash={transactionHash}>
+              {formatText(
+                { id: 'activityFeedTable.menu.viewOnNetwork' },
+                {
+                  blockExplorerName: DEFAULT_NETWORK_INFO.blockExplorerName,
+                },
+              )}
+            </TransactionLink>
+          ),
+          icon: ArrowSquareOut,
+        },
+        {
+          key: '3',
+          label: formatText({ id: 'activityFeedTable.menu.share' }),
+          renderItemWrapper: (itemWrapperProps, children) => (
+            <MeatballMenuCopyItem
+              textToCopy={`${APP_URL.origin}/${generatePath(COLONY_HOME_ROUTE, {
+                colonyName,
+              })}${COLONY_ACTIVITY_ROUTE}?${TX_SEARCH_PARAM}=${transactionHash}`}
+              {...itemWrapperProps}
+            >
+              {children}
+            </MeatballMenuCopyItem>
+          ),
+          icon: ShareNetwork,
+          onClick: () => false,
+        },
+        ...(redoEnabledActionsMap[colonyAction.transactionHash]
+          ? [
+              {
+                key: '4',
+                label: formatText({ id: 'completedAction.redoAction' }),
+                icon: Repeat,
+                onClick: () => setAction(transactionHash),
+              },
+            ]
+          : []),
+      ],
+    };
+  };
+
+  return getMenuProps;
+};

--- a/src/components/common/ColonyActionsTable/hooks/useHandleRedoAction.ts
+++ b/src/components/common/ColonyActionsTable/hooks/useHandleRedoAction.ts
@@ -4,7 +4,7 @@ import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSid
 
 import { type ColonyActionsTableProps } from '../types.ts';
 
-export const useRedoAction = ({
+export const useHandleRedoAction = ({
   actionProps,
 }: {
   actionProps: ColonyActionsTableProps['actionProps'];

--- a/src/components/common/ColonyActionsTable/hooks/useRedoAction.ts
+++ b/src/components/common/ColonyActionsTable/hooks/useRedoAction.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
+
+import { type ColonyActionsTableProps } from '../types.ts';
+
+export const useRedoAction = ({
+  actionProps,
+}: {
+  actionProps: ColonyActionsTableProps['actionProps'];
+}) => {
+  const {
+    actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
+  } = useActionSidebarContext();
+
+  useEffect(() => {
+    if (actionProps.defaultValues && actionProps.selectedAction) {
+      toggleActionSidebarOn({ ...actionProps.defaultValues });
+
+      setTimeout(() => {
+        actionProps.setSelectedAction(undefined);
+      }, 50);
+    }
+  }, [
+    actionProps.defaultValues,
+    toggleActionSidebarOn,
+    actionProps.selectedAction,
+    actionProps,
+  ]);
+};

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/ManageReputationDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/ManageReputationDescription.tsx
@@ -8,6 +8,7 @@ import useUserByAddress from '~hooks/useUserByAddress.ts';
 import Numeral from '~shared/Numeral/Numeral.tsx';
 import { formatText } from '~utils/intl.ts';
 import { toFinite } from '~utils/lodash.ts';
+import { getSafeStringifiedNumber } from '~utils/numbers.ts';
 import { formatReputationChange } from '~utils/reputation.ts';
 import { splitWalletAddress } from '~utils/splitWalletAddress.ts';
 import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
@@ -63,7 +64,7 @@ const ManageReputationDescription: FC = () => {
           getTokenDecimalsWithFallback(nativeToken.decimals),
         ),
         reputationChangeNumeral: amount ? (
-          <Numeral value={toFinite(amount)} />
+          <Numeral value={toFinite(getSafeStringifiedNumber(amount))} />
         ) : (
           formatText({
             id: 'actionSidebar.metadataDescription.anAmount',

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/hooks.ts
@@ -7,6 +7,7 @@ import { useWatch } from 'react-hook-form';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useUserReputation from '~hooks/useUserReputation.ts';
 import { getInputTextWidth } from '~utils/elements.ts';
+import { getSafeStringifiedNumber } from '~utils/numbers.ts';
 import { calculatePercentageReputation } from '~utils/reputation.ts';
 import {
   getFormattedTokenValue,
@@ -85,7 +86,7 @@ export const useReputationFields = () => {
 
   const amountValueCalculated = BigNumber.from(
     moveDecimal(
-      amount || '0',
+      getSafeStringifiedNumber(amount),
       getTokenDecimalsWithFallback(nativeToken.decimals),
     ),
   ).toString();

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/utils.ts
@@ -8,6 +8,7 @@ import { type ManageReputationMotionPayload } from '~redux/sagas/motions/manageR
 import { DecisionMethod } from '~types/actions.ts';
 import { type Colony } from '~types/graphql.ts';
 import { getMotionPayload } from '~utils/motions.ts';
+import { getSafeStringifiedNumber } from '~utils/numbers.ts';
 import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
 
 import { ModificationOption } from './consts.ts';
@@ -99,6 +100,9 @@ export const moreThanZeroAmountValidation = (
   const { nativeToken } = colony;
 
   return BigNumber.from(
-    moveDecimal(value, getTokenDecimalsWithFallback(nativeToken.decimals)),
+    moveDecimal(
+      getSafeStringifiedNumber(value),
+      getTokenDecimalsWithFallback(nativeToken.decimals),
+    ),
   ).gt(0);
 };

--- a/src/components/v5/common/CompletedAction/partials/ManageReputation/ManageReputation.tsx
+++ b/src/components/v5/common/CompletedAction/partials/ManageReputation/ManageReputation.tsx
@@ -9,6 +9,7 @@ import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { ColonyActionType } from '~gql';
 import Numeral from '~shared/Numeral/Numeral.tsx';
 import { formatText } from '~utils/intl.ts';
+import { getSafeStringifiedNumber } from '~utils/numbers.ts';
 import { formatReputationChange } from '~utils/reputation.ts';
 import { splitWalletAddress } from '~utils/splitWalletAddress.ts';
 import {
@@ -78,7 +79,7 @@ const ManageReputation: FC<ManageReputationProps> = ({ action }) => {
     ColonyActionType.EmitDomainReputationPenaltyMultisig,
   ].includes(action.type);
 
-  const positiveAmountValue = BigNumber.from(amount || '0')
+  const positiveAmountValue = BigNumber.from(getSafeStringifiedNumber(amount))
     .abs()
     .toString();
 

--- a/src/components/v5/common/CompletedAction/partials/SetUserRoles/SetUserRoles.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SetUserRoles/SetUserRoles.tsx
@@ -1,4 +1,3 @@
-import { ColonyRole } from '@colony/colony-js';
 import { ShieldStar, Signature, UserFocus } from '@phosphor-icons/react';
 import React from 'react';
 
@@ -6,12 +5,7 @@ import { ADDRESS_ZERO } from '~constants';
 import { Action } from '~constants/actions.ts';
 import { getRole } from '~constants/permissions.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
-import {
-  ColonyActionType,
-  useGetColonyHistoricRoleRolesQuery,
-  type GetColonyHistoricRoleRolesQuery,
-  type ColonyActionRoles,
-} from '~gql';
+import { ColonyActionType, useGetColonyHistoricRoleRolesQuery } from '~gql';
 import { getUserRolesForDomain } from '~transformers';
 import { Authority } from '~types/authority.ts';
 import { type ColonyAction } from '~types/graphql.ts';
@@ -47,37 +41,13 @@ import {
   TeamFromRow,
 } from '../rows/index.ts';
 
+import { transformActionRolesToColonyRoles } from './utils.ts';
+
 const displayName = 'v5.common.CompletedAction.partials.SetUserRoles';
 
 interface Props {
   action: ColonyAction;
 }
-
-const transformActionRolesToColonyRoles = (
-  roles:
-    | GetColonyHistoricRoleRolesQuery['getColonyHistoricRole']
-    | ColonyActionRoles,
-): ColonyRole[] => {
-  if (!roles) return [];
-
-  const roleKeys = Object.keys(roles);
-
-  const colonyRoles: ColonyRole[] = roleKeys
-    .filter((key) => roles[key])
-    .map((key) => {
-      const match = key.match(/role_(\d+)/); // Extract the role number
-      if (match && match[1]) {
-        const roleIndex = parseInt(match[1], 10);
-        if (roleIndex in ColonyRole) {
-          return roleIndex;
-        }
-      }
-      return null;
-    })
-    .filter((role): role is ColonyRole => role !== null);
-
-  return colonyRoles;
-};
 
 const SetUserRoles = ({ action }: Props) => {
   const {

--- a/src/components/v5/common/CompletedAction/partials/SetUserRoles/utils.ts
+++ b/src/components/v5/common/CompletedAction/partials/SetUserRoles/utils.ts
@@ -1,0 +1,32 @@
+import { ColonyRole } from '@colony/colony-js';
+
+import {
+  type GetColonyHistoricRoleRolesQuery,
+  type ColonyActionRoles,
+} from '~gql';
+
+export const transformActionRolesToColonyRoles = (
+  roles:
+    | GetColonyHistoricRoleRolesQuery['getColonyHistoricRole']
+    | ColonyActionRoles,
+): ColonyRole[] => {
+  if (!roles) return [];
+
+  const roleKeys = Object.keys(roles);
+
+  const colonyRoles: ColonyRole[] = roleKeys
+    .filter((key) => roles[key] !== null)
+    .map((key) => {
+      const match = key.match(/role_(\d+)/); // Extract the role number
+      if (match && match[1]) {
+        const roleIndex = parseInt(match[1], 10);
+        if (roleIndex in ColonyRole) {
+          return roleIndex;
+        }
+      }
+      return null;
+    })
+    .filter((role): role is ColonyRole => role !== null);
+
+  return colonyRoles;
+};

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -52,3 +52,50 @@ export const adjustPercentagesTo100 = (
   // Convert back to percentages with the specified number of decimals
   return roundedValues.map((value) => value / multiplier);
 };
+
+/**
+ * Safely converts a given value to a numeric string. If the input value is `null`, `undefined`,
+ * or an invalid number, a fallback value is used. If the provided fallback value is also invalid,
+ * it defaults to "0".
+ *
+ * @param {string | number | null | undefined} value - The input value to convert.
+ *    If it's a string, commas are removed before validation.
+ * @param {string | number} [fallbackValue='0'] - The fallback value to use if the input value is
+ *    invalid. If this fallback is not a valid number, it defaults to "0".
+ * @returns {string} A numeric string representing the input value or a valid fallback.
+ *
+ * @example
+ * getSafeStringifiedNumber("20,000") // "20000"
+ * getSafeStringifiedNumber("abc", 100) // "100"
+ * getSafeStringifiedNumber(null, "invalid") // "0"
+ * getSafeStringifiedNumber(undefined) // "0"
+ * getSafeStringifiedNumber(NaN, 50) // "50"
+ */
+export const getSafeStringifiedNumber = (
+  value: string | number | null | undefined,
+  fallbackValue: string | number = '0',
+): string => {
+  // Ensure the fallback value is a valid number
+  const safeFallback = !Number.isNaN(Number(fallbackValue))
+    ? String(fallbackValue)
+    : '0';
+
+  if (value === null || value === undefined) {
+    // If value is null or undefined, use the safe fallback
+    return safeFallback;
+  }
+
+  if (typeof value === 'string') {
+    // Remove commas and check if the result is a valid number
+    const numericString = value.replace(/,/g, '');
+    return !Number.isNaN(Number(numericString)) ? numericString : safeFallback;
+  }
+
+  if (typeof value === 'number') {
+    // Check if the number is NaN
+    return Number.isNaN(value) ? safeFallback : String(value);
+  }
+
+  // Default case if the type is unexpected
+  return safeFallback;
+};


### PR DESCRIPTION
## Description

This PR enables the Dashboard page's Activity Table Item Redo Function and aligns it with Activity page's Activity Table.

![Redo action](https://github.com/user-attachments/assets/77ca196b-b556-4ecf-923b-75f8235093f1)

## Testing

> [!NOTE]
> I had to fix the following existing `master` bug and do some refactoring as well. It is unrelated to issue #3551 but you know what, it makes sense to include it in this PR:
>
> @iamsamgibbs  "The only reason I'm rejecting is that not all actions should have the redo option"
> @rdig  "I've tested this with Simple Payments and which work as expected, however, as Sam noted, not all actions require it, so this needs to be enabled on a case by case basis"
>
> I've added a testing section for it 😄 
>
> I also had to handle the Redo flow for Reputation-related actions in the Activity Table items so please test that as well.
>
> I'll find a way to refactor the Completed Actions component as well, so we'll have a single source of truth for knowing which actions are not allowed to have a Redo Action. But it will be in a separate future PR if there's capacity 👌 

### 1. Verify that the Redo action button does what it's intended to do

1. Go to the Dashboard
2. Make a simple payment
3. Once it shows up on the Recent Activity table, click its kebab button
4. Click Redo action
5. Verify that the Action Form comes up and the details are filled in
6. Visit the Activity page http://localhost:9091/planex/activity
7. Look for the same action on the table and redo it
8. Verify that the result is consistent as step 4
 
### 2. Verify that the Redo action is conditionally rendered on a case-by-case basis

1. Go to the Dashboard
2. Create a new Team
3. Add the following cases in `useBuildRedoEnabledActionsMap.ts`, after line 116:

```js
case ColonyActionType.MoveFunds:
```
<img width="469" alt="image" src="https://github.com/user-attachments/assets/2696b5a0-418e-423d-9877-19419372958f">

4. Reload the Dashboard
5. Click the kebab menu for the Create Domain action
6. Verify that you don't see Redo action in the popup menu

<img width="236" alt="image" src="https://github.com/user-attachments/assets/4151736d-b2fd-4c90-96d4-67ddcd81a96a">

7. Click the kebab menu for any Payment action
9. Verify that the Redo action is still present
> [!NOTE]
> The pagination might reset back to page 1 but this is already being fixed by @mmioana in PR: https://github.com/JoinColony/colonyCDapp/pull/3566
10. Move through the Activity table's pages until you find the Transfer Funds action which is done as part of our `create-data` script and click its kebab menu
11. Verify that you don't see Redo action in the popup menu
12. Please repeat steps 1 - 10 for the Actions Table in the Activity page: http://localhost:9091/{colonyName}/activity

### 3. Verify that you can redo Reputation actions and that the app doesn't crash in the process

1. Award 20,000 points for Amy
2. Redo the action via the UserHub Transactions tab
3. Verify that the app does not crash and Manage Reputation form shows up
4. Redo the action via the Activity table
5. Verify that the app does not crash and Manage Reputation form shows up

## Diffs

**New stuff** ✨

* I centralised this "Redo action" behaviour for the Actions Table items in a new hook called `useRedoAction` so it's shared consistently between the Action Tables found with the Dashboard & Activity pages.

Resolves #3551
Resolves #3593