### PR TITLE
Fix: Set the non-mobile Toast width to 390px

### DIFF
--- a/src/components/shared/Extensions/Toast/Toast.css
+++ b/src/components/shared/Extensions/Toast/Toast.css
@@ -7,7 +7,7 @@
 }
 
 .Toastify__toast {
-  @apply relative mb-0 rounded-l-none rounded-r-lg border border-gray-200 bg-base-white p-6 shadow-lg before:absolute before:left-0 before:top-0 before:block before:h-full before:w-[0.375rem] before:content-[''] sm:min-w-[24.375rem];
+  @apply relative mb-0 rounded-l-none rounded-r-lg border border-gray-200 bg-base-white p-6 shadow-lg before:absolute before:left-0 before:top-0 before:block before:h-full before:w-1.5 before:content-[''] sm:w-[24.375rem];
 }
 
 .Toastify__toast-body {


### PR DESCRIPTION
## Description

A wee update to our Toast component's non-mobile container style. We're now setting it width: 390px to adhere to our [Toast's global sizing based on Figma](https://www.figma.com/design/l1dOM5qiQYwF0ElvKDqqjg/Design-System---Colony-v3?node-id=1782-10106&t=nHVBRUN2ELg9KKdd-4).

<img width="477" alt="Screenshot 2024-11-01 at 00 22 12" src="https://github.com/user-attachments/assets/06bbd2d8-7995-465f-9cf5-fa7445530430">

## Testing

1. Set your browser width to 768px
2. Open the `NotificationTypeToggle.tsx` file and add the following param to the `toast.success` function:

```js
{
  autoClose: false, // <-- add me!
},
```
<img width="557" alt="image" src="https://github.com/user-attachments/assets/a44a4d8c-f33c-4851-a391-7fb5a1b303a7">

3. Go to the Preferences page: http://localhost:9091/account/preferences
4. Toggle Payments and Funds
5. Verify that the Toast is 390px in width
6. Go to the Advanced Settings page: http://localhost:9091/account/advanced
7. Toggle Notifications
8. Verify that the Toast is 390px in width

Resolves #3573 