### PR TITLE
Fix: Editing expenditures

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=5e0f7d3fc9fba11cfbdf744e1917e3c489242eb0
+ENV BLOCK_INGESTOR_HASH=6d15a210fdef298f94fc2706548f6b0e06dee829
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/PaymentBuilderRecipientsField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/PaymentBuilderRecipientsField.tsx
@@ -178,6 +178,7 @@ const PaymentBuilderRecipientsField: FC<PaymentBuilderRecipientsFieldProps> = ({
           isFullSize={isMobile}
           onClick={() => {
             fieldArrayMethods.append({
+              // @TODO: Add slotId (find highest existing slotId and add 1)
               recipient: '',
               amount: '',
               tokenAddress: nativeToken?.tokenAddress || '',

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilderEdit/PaymentBuilderEdit.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilderEdit/PaymentBuilderEdit.tsx
@@ -131,6 +131,7 @@ const PaymentBuilderEdit: FC<PaymentBuilderEditProps> = ({ action }) => {
       ),
       tokenAddress: slot.payouts?.[0].tokenAddress,
       delay: convertPeriodToHours(slot.claimDelay || '0'),
+      // slotId: slot.id, // @TODO: Add slotId
     };
   });
 
@@ -189,6 +190,7 @@ const PaymentBuilderEdit: FC<PaymentBuilderEditProps> = ({ action }) => {
         defaultValues={{ payments }}
         onSubmit={(values) => {
           const mappedValues = values.payments.map((payment) => ({
+            // @TODO: Add slotId
             recipientAddress: payment.recipient,
             tokenAddress: payment.tokenAddress,
             claimDelay: convertPeriodToSeconds(

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilderEdit/hooks.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilderEdit/hooks.ts
@@ -2,7 +2,7 @@ import { unformatNumeral } from 'cleave-zen';
 import { BigNumber } from 'ethers';
 import moveDecimal from 'move-decimal-point';
 import { useMemo } from 'react';
-import { array, object, string } from 'yup';
+import { array, number, object, string } from 'yup';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useTokenLockStates from '~hooks/useTokenLockStates.ts';
@@ -33,6 +33,7 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
             .of(
               object()
                 .shape({
+                  slotId: number(),
                   recipient: string()
                     .required(({ path }) => {
                       const index = getLastIndexFromPath(path);

--- a/src/redux/sagas/utils/expenditures.ts
+++ b/src/redux/sagas/utils/expenditures.ts
@@ -178,48 +178,52 @@ export const getResolvedPayouts = (
   payouts: ExpenditurePayoutFieldValue[],
   expenditure: Expenditure,
 ) => {
+  if (!payouts.every((payout) => !!payout.slotId)) {
+    throw new Error('All payouts must have a slotId');
+  }
+
+  if (new Set(payouts.map((payout) => payout.slotId)).size !== payouts.length) {
+    throw new Error('Cannot resolve payouts with duplicate slotIds');
+  }
+
   const resolvedPayouts: ExpenditurePayoutFieldValue[] = [];
 
-  const payoutsWithSlotIds = getPayoutsWithSlotIds(payouts);
+  // Iterate over existing slots to set the new token/amount and remove any existing payouts in different tokens
+  expenditure.slots.forEach((slot) => {
+    const existingPayouts = slot.payouts ?? [];
 
-  payoutsWithSlotIds.forEach((payout) => {
-    // Add payout as specified in the form
-    resolvedPayouts.push(payout);
+    const payoutToSet = payouts.find((payout) => payout.slotId === slot.id);
+    if (payoutToSet) {
+      resolvedPayouts.push(payoutToSet);
+    }
 
-    const existingSlot = expenditure.slots.find(
-      (slot) => slot.id === payout.slotId,
-    );
-
-    // Set the amounts for any existing payouts in different tokens to 0
+    // Remove existing payouts by setting their amounts to 0
     resolvedPayouts.push(
-      ...(existingSlot?.payouts
+      ...(existingPayouts
         ?.filter(
-          (slotPayout) =>
-            slotPayout.tokenAddress !== payout.tokenAddress &&
-            BigNumber.from(slotPayout.amount).gt(0),
+          (existingPayout) =>
+            (!payoutToSet ||
+              existingPayout.tokenAddress !== payoutToSet.tokenAddress) &&
+            BigNumber.from(existingPayout.amount).gt(0),
         )
         .map((slotPayout) => ({
-          slotId: payout.slotId,
-          recipientAddress: payout.recipientAddress,
+          slotId: slot.id,
+          recipientAddress:
+            payoutToSet?.recipientAddress ?? slot.recipientAddress ?? '',
           tokenAddress: slotPayout.tokenAddress,
           amount: '0',
-          claimDelay: payout.claimDelay,
+          claimDelay: payoutToSet?.claimDelay ?? slot.claimDelay ?? '',
         })) ?? []),
     );
   });
 
-  // If there are now less payouts than expenditure slots, we need to remove them by setting their amounts to 0
-  const remainingSlots = expenditure.slots.slice(payouts.length);
-  remainingSlots.forEach((slot) => {
-    slot.payouts?.forEach((payout) => {
-      resolvedPayouts.push({
-        slotId: slot.id,
-        recipientAddress: slot.recipientAddress ?? '',
-        tokenAddress: payout.tokenAddress,
-        amount: '0',
-        claimDelay: slot.claimDelay ?? '0',
-      });
-    });
+  // Add remaining payouts that were not in the existing slots
+  const existingSlotIds = new Set(resolvedPayouts.map((rp) => rp.slotId));
+  const payoutsToAdd = payouts.filter(
+    (payout) => !existingSlotIds.has(payout.slotId),
+  );
+  payoutsToAdd.forEach((payout) => {
+    resolvedPayouts.push(payout);
   });
 
   return resolvedPayouts;


### PR DESCRIPTION
## Description

This PR modifies how `editExpenditure` saga treats the modified payouts. Previously, when editing expenditures, removed payout slots were being recycled for new payouts. For example, if you removed payout #3 and added a new payout, the new one would take slot #3. This led to issues with displaying the list of changes since the UI saw it as "modifying slot #3" rather than "removing one payout and adding another."

It also updates block-ingestor hash to one from [block-ingestor#291](https://github.com/JoinColony/block-ingestor/pull/291), which fixes another edge case with editing expenditures.

