### PR TITLE
Fix: Make the financial card height match the Figma designs

### DIFF
--- a/src/components/v5/common/WidgetCards/WidgetCardsItem.tsx
+++ b/src/components/v5/common/WidgetCards/WidgetCardsItem.tsx
@@ -7,7 +7,7 @@ import { tw } from '~utils/css/index.ts';
 import { WidgetContent } from './partials/WidgetContent.tsx';
 
 const wrapperClassName = tw`
-  flex min-h-[6.5rem]
+  flex max-h-[6.9379rem] min-h-[6.5rem]
   min-w-[15.625rem] select-none flex-col justify-center rounded-lg
   border px-6 py-5 text-left
 `;


### PR DESCRIPTION
## Description

This ensures that the heights are following the [Figma design](https://www.figma.com/design/gac6xVgGNCAge5Bia933dp/Dashboard?node-id=5047-39385&t=aaxvUcV1z11FkHDL-4).

<img width="529" alt="image" src="https://github.com/user-attachments/assets/a0fca02f-3d69-4a85-b8a8-978db5d365f3">

## Testing

1. Visit a Colony Dashboard
2. Inspect the financial cards
3. Verify that their heights are 111px

Resolves #3554 