### PR TITLE
[Permissions] fix: subdomain owner should be an admin

### DIFF
--- a/src/components/frame/v5/pages/MembersPage/utils.ts
+++ b/src/components/frame/v5/pages/MembersPage/utils.ts
@@ -1,4 +1,4 @@
-import { Id } from '@colony/colony-js';
+import { ColonyRole, Id } from '@colony/colony-js';
 
 import {
   getInheritedPermissions,
@@ -58,9 +58,16 @@ const getRoleInfo = ({
     return { role: undefined, isInherited: false };
   }
 
-  const mergedPermissions = [
+  let mergedPermissions = [
     ...new Set([...parentPermissions, ...currentTeamPermissions]),
   ];
+
+  if (!isRootDomain) {
+    mergedPermissions = mergedPermissions.filter(
+      (permission) =>
+        permission !== ColonyRole.Root && permission !== ColonyRole.Recovery,
+    );
+  }
   return {
     role: getRole(mergedPermissions),
     isInherited: inheritedPermissions.length > 0,

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/utils.ts
@@ -176,13 +176,22 @@ export const configureFormRoles = ({
 
   const isMultiSig = authority === Authority.ViaMultiSig;
 
-  const dbInheritedPermissions = getUserRolesForDomain({
+  const isRootDomain = team === Id.RootDomain;
+
+  let dbInheritedPermissions = getUserRolesForDomain({
     colonyRoles,
     userAddress: member,
     domainId: team,
     constraint: 'onlyInheritedRoles',
     isMultiSig,
   });
+
+  if (!isRootDomain) {
+    dbInheritedPermissions = dbInheritedPermissions.filter(
+      (permission) =>
+        permission !== ColonyRole.Root && permission !== ColonyRole.Recovery,
+    );
+  }
 
   const dbPermissionsForDomain = getUserRolesForDomain({
     colonyRoles,


### PR DESCRIPTION
## Description
The owner role from the parent domain should be shown as the "Admin" inherited role for sub-domains. These changes are related to the permission page and the Manage Permissions Motion.

## Testing

Step 1. Assign fry Admin role in Andromeda
Step 2. Assign fry Owner role in general
Step 3. Navigate to the Permissions page with the filter General
Step 4. Verify that fry is under the Owner category
<img width="1196" alt="image" src="https://github.com/user-attachments/assets/cfc95f06-6cb0-4c5f-be71-69606bd18005">

Step 5. Navigate to the Permissions page with the filter Andromeda
Step 6. Check that fry is under the Admin category without inherited pill
<img width="1169" alt="image" src="https://github.com/user-attachments/assets/947838b7-704e-4509-840d-2db318078ce2">

Step 7. Navigate to the Permissions page with the filter Serenity
Step 8. Check that fry is under Admin category with **inherited** pill

<img width="1201" alt="image" src="https://github.com/user-attachments/assets/ff6ebf0c-1d23-4a7c-a36e-acda47d2a078">

Step 9. Create Manage Permissions action with following:
| Field | Value |
| ------ | ------ |
| User | **fry** | 
| Team | **Andromeda** | 
| Authority | **Take actions on their own** | 

Step 10. Verify that Permissions: **Admin** is automatically filled
<img width="680" alt="image" src="https://github.com/user-attachments/assets/47de73e9-1b53-42a3-a95f-5a475e427d10">

Step 11. Change Team to **Serenity** 
Step 12. Verify that Permissions is still **Admin**
<img width="685" alt="image" src="https://github.com/user-attachments/assets/2dab4f30-d9ef-4676-9ee6-203543c0cf80">


Resolves #3397 
