### PR TITLE
Fix/3263 back navigation

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/LegendItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/LegendItem.tsx
@@ -46,8 +46,8 @@ const LegendItem: FC<LegendItemProps> = ({
         <span
           className={clsx('text-xs font-normal text-gray-500', {
             'text-gray-900': isLegendItemActive,
-            // @TODO here we'll need to add if the search param exists once another PR gets merged
-            'cursor-pointer hover:text-gray-900': !!value,
+            'hover:text-gray-900': !!value,
+            'cursor-pointer': !!searchParam,
           })}
         >
           {isTruncated

--- a/src/components/v5/shared/TeamFilter/TeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/TeamFilter.tsx
@@ -20,7 +20,7 @@ const TeamFilter = () => {
   // but only on the pages where we actually use this component
   useEffect(() => {
     if (filteredTeam && !searchParams.get(TEAM_SEARCH_PARAM)) {
-      updateTeamFilter(filteredTeam);
+      updateTeamFilter(filteredTeam, { replace: true });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/context/GlobalFiltersContext/ColonyFiltersContext.ts
+++ b/src/context/GlobalFiltersContext/ColonyFiltersContext.ts
@@ -1,10 +1,11 @@
 import { createContext, useContext } from 'react';
+import { type NavigateOptions } from 'react-router-dom';
 
 import noop from '~utils/noop.ts';
 
 interface ColonyFiltersContextValue {
   filteredTeam: string | null;
-  updateTeamFilter: (domainId: string) => void;
+  updateTeamFilter: (domainId: string, options?: NavigateOptions) => void;
   resetTeamFilter: () => void;
 }
 

--- a/src/context/GlobalFiltersContext/ColonyFiltersContextProvider.tsx
+++ b/src/context/GlobalFiltersContext/ColonyFiltersContextProvider.tsx
@@ -15,20 +15,20 @@ import { ColonyFiltersContext } from './ColonyFiltersContext.ts';
 const ColonyFiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const { colonyName } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
+  const teamSearchParam = searchParams.get(TEAM_SEARCH_PARAM);
 
   const [filteredTeam, setFilteredTeam] = useState<string | null>(
-    searchParams.get(TEAM_SEARCH_PARAM),
+    teamSearchParam,
   );
 
   const [currentColonyName, setCurrentColonyName] = useState(colonyName);
 
   const updateTeamFilter = useCallback(
-    (domainId: string) => {
+    (domainId: string, options) => {
       setFilteredTeam(domainId);
       const newSearchParams = new URLSearchParams(searchParams);
       newSearchParams.set(TEAM_SEARCH_PARAM, domainId);
-      setSearchParams(newSearchParams);
-      setFilteredTeam(domainId);
+      setSearchParams(newSearchParams, options);
     },
     [searchParams, setSearchParams],
   );
@@ -55,6 +55,17 @@ const ColonyFiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
       setCurrentColonyName(colonyName);
     }
   }, [colonyName, currentColonyName]);
+
+  useEffect(() => {
+    /**
+     * If the TEAM_SEARCH_PARAM changed in the meantime and is different than the cached filteredTeam
+     * We want to update the filteredTeam to reflect the search params change
+     */
+    if (teamSearchParam && teamSearchParam !== filteredTeam) {
+      setFilteredTeam(teamSearchParam);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [teamSearchParam]);
 
   return (
     <ColonyFiltersContext.Provider value={value}>


### PR DESCRIPTION
## Description

- This PR addresses handling the proper back navigation, without the initial rendering of a route without the team search parameter being present.

Before

https://github.com/user-attachments/assets/abb027e1-98eb-45b6-9407-a7424214d4cd

Now

https://github.com/user-attachments/assets/15170310-7e34-4783-9daf-87728ebca0e7



## Testing

TODO: Please try to select different teams and navigate across the app. Then check the back navigation is properly behaving.

## Diffs

**Changes** 🏗

* The most notable change is using `updateTeamFilter(filteredTeam, { replace: true });` in the `TeamFilter` component

Resolves #3263 
