### PR TITLE
Fix: CLNY conversion breaks the app

### DIFF
--- a/src/utils/currency/convertFromTokenToCurrency.ts
+++ b/src/utils/currency/convertFromTokenToCurrency.ts
@@ -5,9 +5,10 @@ export const convertFromTokenToCurrency = (
   conversionRate?: number | null,
 ) => {
   const precision = conversionRate ? 1000 : 1;
-  const formattedConversionRate = conversionRate
-    ? Math.floor(conversionRate * precision)
-    : 0;
+  const formattedConversionRate =
+    conversionRate && Number.isFinite(conversionRate)
+      ? Math.floor(conversionRate * precision)
+      : 0;
 
   return BigNumber.from(value ?? 0)
     .mul(formattedConversionRate)

--- a/src/utils/currency/currency.ts
+++ b/src/utils/currency/currency.ts
@@ -1,8 +1,13 @@
 import { Tokens } from '@colony/colony-js';
 
-import { ADDRESS_ZERO, DEFAULT_NETWORK_TOKEN, isDev } from '~constants';
+import {
+  ADDRESS_ZERO,
+  DEFAULT_NETWORK,
+  DEFAULT_NETWORK_TOKEN,
+  isDev,
+} from '~constants';
 import { SupportedCurrencies } from '~gql';
-import { Network } from '~types/network.ts';
+import { ColonyJSNetworkMapping, Network } from '~types/network.ts';
 
 import { coinGeckoMappings } from './config.ts';
 import { getSavedPrice, savePrice } from './memo.ts';
@@ -46,9 +51,13 @@ const fetchPriceFromCoinGecko = async ({
 
 export const getCLNYPriceInUSD = async () => {
   // Returns 1 CLNY in terms of USD, 1 CLNY : x USD
+  const chainId = (DEFAULT_NETWORK as Network) ?? Network.ArbitrumOne;
+  const colonyJSNetwork = ColonyJSNetworkMapping[chainId];
+  const contractAddress =
+    Tokens[colonyJSNetwork]?.CLNY ?? Tokens.ArbitrumOne.CLNY;
   return fetchTokenPriceByAddress({
-    contractAddress: Tokens.Mainnet.CLNY,
-    chainId: Network.Mainnet,
+    contractAddress,
+    chainId,
     conversionDenomination: SupportedCurrencies.Usd,
   });
 };


### PR DESCRIPTION
## Description

- This PR ensures selecting `CLNY` as currency no longer breaks the app. 
- The issue was caused by getting `0` as an exchange rate from CLNY in USD, causing the reverse to be `Infinity`
- Also, updated the `getCLNYPriceInUSD` to use the proper chain id and token address

## Testing

TODO: Select `CLNY` as preferred currency and make sure the app no longer breaks.

![Screenshot 2024-11-05 at 00 52 16](https://github.com/user-attachments/assets/a581c496-7324-461f-9702-d305d8d03b86)

Currently the values for the total cards remain to `0` because of a bug that is resolved in #3614

Resolves #3557 
