### PR TITLE
fix: make colony switcher the same height as sidebar

### DIFF
--- a/src/components/v5/frame/PageLayout/PageLayout.tsx
+++ b/src/components/v5/frame/PageLayout/PageLayout.tsx
@@ -50,7 +50,7 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
         <section ref={topContentContainerRef}>{topContent}</section>
         <div className="flex h-[calc(100vh-var(--top-content-height))] flex-row">
           <section
-            className={clsx('md:py-4 md:pl-4', {
+            className={clsx('relative md:py-4 md:pl-4', {
               'sm:py-4 sm:pl-4': enableMobileAndDesktopLayoutBreakpoints,
             })}
           >

--- a/src/components/v5/shared/Navigation/ColonySwitcher/ColonySwitcher.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/ColonySwitcher.tsx
@@ -38,10 +38,10 @@ const ColonySwitcher: React.FC<ColonySwitcherProps> = ({
 
   const { getTooltipProps, setTooltipRef, setTriggerRef, visible } =
     usePopperTooltip({
-      placement: 'right',
+      placement: 'right-start',
       trigger: 'click',
       interactive: true,
-      offset: offset ?? [-20, 16],
+      offset: offset ?? [-31, 16],
     });
 
   const colonyName =

--- a/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesPopover/JoinedColoniesPopover.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesPopover/JoinedColoniesPopover.tsx
@@ -34,13 +34,13 @@ const JoinedColoniesPopover = ({
       setTooltipRef={setTooltipRef}
       tooltipProps={getTooltipProps}
       classNames={clsx(
-        'bg-white z-top mt-4 max-h-[calc(100vh-32px)] w-[252px] rounded-lg border-gray-200 px-0 pb-4 pt-0 shadow-none',
+        'bg-white z-top mt-4 max-h-[calc(100%-32px)] w-[252px] rounded-lg border-gray-200 px-0 pb-4 pt-0 shadow-none',
         {
           '!bg-gray-100': isDarkMode,
         },
       )}
     >
-      <div className="flex max-h-[calc(536px)] flex-col gap-6 overflow-hidden">
+      <div className="flex flex-col gap-6 overflow-hidden">
         {wallet ? (
           <JoinedColoniesList
             enableMobileAndDesktopLayoutBreakpoints={

--- a/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesPopover/JoinedColoniesPopover.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesPopover/JoinedColoniesPopover.tsx
@@ -34,7 +34,7 @@ const JoinedColoniesPopover = ({
       setTooltipRef={setTooltipRef}
       tooltipProps={getTooltipProps}
       classNames={clsx(
-        'bg-white z-top mt-4 max-h-[calc(100%-32px)] w-[252px] rounded-lg border-gray-200 px-0 pb-4 pt-0 shadow-none',
+        'bg-white !left-[calc(100%+0.4rem)] z-top mt-4 max-h-[calc(100%-32px)] w-[252px] !transform-none rounded-lg border-gray-200 px-0 pb-4 pt-0 shadow-none',
         {
           '!bg-gray-100': isDarkMode,
         },


### PR DESCRIPTION
## Description
Adjust the height of the Colony Switcher to match the sidebar.

<img width="1406" alt="image" src="https://github.com/user-attachments/assets/f4a45aa6-3bfb-4da9-9673-1c655ede11e3">


## Testing
Step 1. Open Planet Express colony
Step 2. Press "Planet Express" to open Colony Switcher
Step 3. Verify that the Colony Switcher appears as expected 😄 :
<img width="762" alt="image" src="https://github.com/user-attachments/assets/e939ca9e-c923-4219-b6b3-309a5651032c">

Step 4. Apply the following .diff file:


> [!TIP]
> Save this code to a .diff file in the root directory, then apply it by running `git apply .diff` in the terminal.

```
diff --git a/src/components/frame/Extensions/layouts/ColonyLayout.tsx b/src/components/frame/Extensions/layouts/ColonyLayout.tsx
index 9dee9daf5..918523ca9 100644
--- a/src/components/frame/Extensions/layouts/ColonyLayout.tsx
+++ b/src/components/frame/Extensions/layouts/ColonyLayout.tsx
@@ -156,9 +156,7 @@ const ColonyLayout: FC<PropsWithChildren> = ({ children }) => {
     <>
       <PageLayout
         topContent={
-          canUpgrade ? (
-            <CalamityBanner items={calamityBannerItems} />
-          ) : undefined
+          true ? <CalamityBanner items={calamityBannerItems} /> : undefined
         }
         headerProps={{
           /** @TODO: Move this inside the Header component */
diff --git a/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesList.tsx b/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesList.tsx
index c2a0edaf0..dc273ca03 100644
--- a/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesList.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesList.tsx
@@ -40,34 +40,49 @@ export const JoinedColoniesList = ({
 
   return hasJoinedColonies ? (
     <div className="flex flex-col gap-1.5 overflow-y-auto px-2 pt-2">
-      {joinedColonies.map(
-        ({ colonyAddress, metadata, name, nativeToken }, index) => {
-          const isActiveColony = colonyContext?.colony.name === name;
+      {[
+        ...joinedColonies,
+        ...joinedColonies,
+        ...joinedColonies,
+        ...joinedColonies,
+        ...joinedColonies,
+        ...joinedColonies,
+        ...joinedColonies,
+        ...joinedColonies,
+        ...joinedColonies,
+        ...joinedColonies,
+        ...joinedColonies,
+        ...joinedColonies,
+        ...joinedColonies,
+        ...joinedColonies,
+        ...joinedColonies,
+        ...joinedColonies,
+      ].map(({ colonyAddress, metadata, name, nativeToken }, index) => {
+        const isActiveColony = colonyContext?.colony.name === name;
 
-          return (
-            <Fragment key={colonyAddress}>
-              <JoinedColonyItem
-                colonyAddress={colonyAddress}
-                metadata={metadata}
-                name={name}
-                onClick={handleColonyClick}
-                tokenSymbol={nativeToken.symbol}
-                isActiveColony={isActiveColony}
-                enableMobileAndDesktopLayoutBreakpoints={
-                  enableMobileAndDesktopLayoutBreakpoints
-                }
+        return (
+          <Fragment key={colonyAddress}>
+            <JoinedColonyItem
+              colonyAddress={colonyAddress}
+              metadata={metadata}
+              name={name}
+              onClick={handleColonyClick}
+              tokenSymbol={nativeToken.symbol}
+              isActiveColony={isActiveColony}
+              enableMobileAndDesktopLayoutBreakpoints={
+                enableMobileAndDesktopLayoutBreakpoints
+              }
+            />
+            {index < joinedColonies.length * 16 - 1 && (
+              <hr
+                className={clsx('mx-4 border-gray-200 md:mx-2', {
+                  'sm:mx-2': enableMobileAndDesktopLayoutBreakpoints,
+                })}
               />
-              {index < joinedColonies.length - 1 && (
-                <hr
-                  className={clsx('mx-4 border-gray-200 md:mx-2', {
-                    'sm:mx-2': enableMobileAndDesktopLayoutBreakpoints,
-                  })}
-                />
-              )}
-            </Fragment>
-          );
-        },
-      )}
+            )}
+          </Fragment>
+        );
+      })}
     </div>
   ) : (
     <div className="p-6 md:px-4 md:pb-0 md:pt-4">

```

Step 5. Reopen the Colony Switcher.
Step 6.Verify the Colony Switcher alignment:
<img width="1409" alt="image" src="https://github.com/user-attachments/assets/d3e10be3-8ed7-4621-ac05-e1e14c262eba">

Step 7. Close the "A new version of the Colony Network is available!" notification.
Step 8. Verify that the tooltip height matches the sidebar:
<img width="1407" alt="image" src="https://github.com/user-attachments/assets/b5846867-49c7-42a0-bc91-181934cc3b38">

> [!NOTE]  
> If the "new version" notification disappears due to localStorage settings, remove the "calamity-banner" entry from localStorage or clear the storage.  🙌 


Resolves #3469
Resolves #3470
