### PR TITLE
test: add e2e tests for 2nd step of create colony flow 

### DIFF
--- a/playwright/utils/create-colony.ts
+++ b/playwright/utils/create-colony.ts
@@ -1,5 +1,7 @@
 import { type Page } from '@playwright/test';
 
+import { fillInputByLabelWithDelay } from './common.ts';
+
 export const generateRandomString = () => {
   return Math.random().toString(36).substring(2, 8);
 };
@@ -73,13 +75,25 @@ export const fillColonyNameStep = async (
     urlFieldValue,
   }: { nameFieldValue: string; urlFieldValue: string },
 ) => {
-  await page.getByLabel(/colony Name/i).fill(nameFieldValue);
+  await fillInputByLabelWithDelay({
+    page,
+    label: /colony name/i,
+    value: nameFieldValue,
+  });
 
-  await page.getByLabel(/custom colony URL/i).fill(urlFieldValue);
+  await fillInputByLabelWithDelay({
+    page,
+    label: /custom colony URL/i,
+    value: urlFieldValue,
+  });
 
   await page
     .getByRole('button', { name: /continue/i })
     .click({ timeout: 10000 });
+
+  await page
+    .getByRole('heading', { name: /creating a new native token/i })
+    .waitFor({ state: 'visible' });
 };
 
 export const fillNativeTokenStepWithExistingToken = async (


### PR DESCRIPTION
## Description


- Added e2e tests for the Create Colony flow / Details step
- Set up playwright eslint plugin


## Testing

**Prerequisites**: The test script simulates user interactions with the local instance of the web app, which means that the BE is expected to be set up and running. For now, backend services should be started manually and the initial test data should be seeded . Therefore, ensure that the development environment is properly set up by following the instructions in the README file

- Start your local dev environment  `npm run dev` 
- Seed the mock data `node scripts/create-data.js` 
- If it's the first time you run e2e tests on your machine - run `npm e2e:install` 

- run `npm run e2e` or `npm run e2e:ui`
- Ensure all tests pass

## Diffs

**New stuff** ✨

- playwright folder is added to the lint script
- added loading of the .env file into playwright environment








