### PR TITLE
Fix: [QA Dashboard] Total funds bug

### DIFF
--- a/amplify/backend/function/fetchDomainBalance/src/api/graphql/operations.js
+++ b/amplify/backend/function/fetchDomainBalance/src/api/graphql/operations.js
@@ -8,6 +8,7 @@ const {
   getDomainExpenditures,
   getColonyExpenditures,
   getColonyFundsClaims,
+  getColonyTokens,
   getToken,
 } = require('./schemas.js');
 
@@ -66,6 +67,24 @@ const getDomains = async (colonyAddress) => {
   });
 
   return result.data.getDomainsByColony?.items;
+};
+
+const getColonyTokensData = async ({ colonyAddress, limit, nextToken }) => {
+  const result = await graphqlRequest(getColonyTokens, {
+    colonyAddress,
+    limit,
+    nextToken,
+  });
+
+  if (!result) {
+    console.warn('Could not find any colony funds claims in db.');
+  }
+
+  return result.data.listColonyTokens;
+};
+
+const getAllColonyTokens = async (colonyAddress) => {
+  return getAllPages(getColonyTokensData, { colonyAddress });
 };
 
 const getIncomingFundsData = async ({ colonyAddress, limit, nextToken }) => {
@@ -224,4 +243,5 @@ module.exports = {
   saveExchangeRate,
   getExchangeRate,
   getTokensDecimalsFor,
+  getAllColonyTokens,
 };

--- a/amplify/backend/function/fetchDomainBalance/src/api/graphql/operations.js
+++ b/amplify/backend/function/fetchDomainBalance/src/api/graphql/operations.js
@@ -14,7 +14,7 @@ const {
 
 const EnvVarsConfig = require('../../config/envVars.js');
 
-const { acceptedColonyActionTypes } = require('../../utils.js');
+const { acceptedColonyActionTypes } = require('../../consts.js');
 
 const graphqlRequest = async (queryOrMutation, variables) => {
   const { apiKey, graphqlURL } = await EnvVarsConfig.getEnvVars();

--- a/amplify/backend/function/fetchDomainBalance/src/api/graphql/schemas.js
+++ b/amplify/backend/function/fetchDomainBalance/src/api/graphql/schemas.js
@@ -225,4 +225,24 @@ module.exports = {
       }
     }
   `,
+  getColonyTokens: /* GraphQL */ `
+    query GetColonyTokens(
+      $colonyAddress: ID!
+      $nextToken: String
+      $limit: Int
+    ) {
+      listColonyTokens(
+        filter: { colonyID: { eq: $colonyAddress } }
+        nextToken: $nextToken
+        limit: $limit
+      ) {
+        items {
+          token {
+            decimals
+            id
+          }
+        }
+      }
+    }
+  `,
 };

--- a/amplify/backend/function/fetchDomainBalance/src/config/coinGeckoConfig.js
+++ b/amplify/backend/function/fetchDomainBalance/src/config/coinGeckoConfig.js
@@ -1,3 +1,4 @@
+const { Network: ColonyJSNetwork } = require('@colony/colony-js');
 const EnvVarsConfig = require('./envVars.js');
 
 const SupportedNetwork = {
@@ -10,6 +11,16 @@ const SupportedNetwork = {
   Amoy: 'amoy',
   ArbitrumOne: 'arbitrumOne',
   ArbitrumSepolia: 'arbitrumSepolia',
+};
+
+const ColonyJSNetworkMapping = {
+  [ColonyJSNetwork.Mainnet]: SupportedNetwork.Mainnet,
+  [ColonyJSNetwork.Goerli]: SupportedNetwork.Goerli,
+  [ColonyJSNetwork.Xdai]: SupportedNetwork.Gnosis,
+  [ColonyJSNetwork.XdaiQa]: SupportedNetwork.GnosisFork,
+  [ColonyJSNetwork.Custom]: SupportedNetwork.Ganache,
+  [ColonyJSNetwork.ArbitrumOne]: SupportedNetwork.ArbitrumOne,
+  [ColonyJSNetwork.ArbitrumSepolia]: SupportedNetwork.ArbitrumSepolia,
 };
 
 // import from amplify backend schema.graphql
@@ -131,8 +142,13 @@ const CoinGeckoConfig = (() => {
 
   return {
     getConfig: async () => {
-      const { network, coinGeckoApiUrl, coinGeckoApiKey } =
-        await EnvVarsConfig.getEnvVars();
+      const {
+        network: colonyJSNetwork,
+        coinGeckoApiUrl,
+        coinGeckoApiKey,
+      } = await EnvVarsConfig.getEnvVars();
+
+      const network = ColonyJSNetworkMapping[colonyJSNetwork];
 
       return {
         DEFAULT_NETWORK_TOKEN: TOKEN_DATA[network],

--- a/amplify/backend/function/fetchDomainBalance/src/config/coinGeckoConfig.js
+++ b/amplify/backend/function/fetchDomainBalance/src/config/coinGeckoConfig.js
@@ -1,114 +1,5 @@
-const { Network: ColonyJSNetwork } = require('@colony/colony-js');
 const EnvVarsConfig = require('./envVars.js');
-
-const SupportedNetwork = {
-  Mainnet: 'mainnet',
-  Goerli: 'goerli',
-  Gnosis: 'gnosis',
-  GnosisFork: 'gnosisFork',
-  Ganache: 'ganache',
-  Polygon: 'polygon',
-  Amoy: 'amoy',
-  ArbitrumOne: 'arbitrumOne',
-  ArbitrumSepolia: 'arbitrumSepolia',
-};
-
-const ColonyJSNetworkMapping = {
-  [ColonyJSNetwork.Mainnet]: SupportedNetwork.Mainnet,
-  [ColonyJSNetwork.Goerli]: SupportedNetwork.Goerli,
-  [ColonyJSNetwork.Xdai]: SupportedNetwork.Gnosis,
-  [ColonyJSNetwork.XdaiQa]: SupportedNetwork.GnosisFork,
-  [ColonyJSNetwork.Custom]: SupportedNetwork.Ganache,
-  [ColonyJSNetwork.ArbitrumOne]: SupportedNetwork.ArbitrumOne,
-  [ColonyJSNetwork.ArbitrumSepolia]: SupportedNetwork.ArbitrumSepolia,
-};
-
-// import from amplify backend schema.graphql
-const SupportedCurrencies = {
-  USD: 'USD',
-  JPY: 'JPY',
-  GBP: 'GBP',
-  EUR: 'EUR',
-  CAD: 'CAD',
-  KRW: 'KRW',
-  INR: 'INR',
-  BRL: 'BRL',
-  ETH: 'ETH',
-  CLNY: 'CLNY',
-};
-
-const XDAI_TOKEN = {
-  /*
-   * Needs to be this exact name, otherwise Metamask marks it as "not valid" when adding it
-   */
-  name: 'xDAI Token', //
-  /*
-   * Needs to be this exact name, otherwise Metamask marks it as "not valid" when adding it
-   */
-  symbol: 'xDAI',
-  decimals: 18,
-};
-
-const ETHER_TOKEN = {
-  name: 'Ether',
-  symbol: 'ETH',
-  decimals: 18,
-};
-
-const GOERLI_TOKEN = {
-  name: 'Goerli Ether',
-  symbol: 'GOETH',
-  decimals: 18,
-};
-
-const POLYGON_TOKEN = {
-  name: 'Matic Token',
-  symbol: 'MATIC',
-  decimals: 18,
-};
-
-const TOKEN_DATA = {
-  [SupportedNetwork.Ganache]: ETHER_TOKEN,
-  [SupportedNetwork.Gnosis]: XDAI_TOKEN,
-  [SupportedNetwork.GnosisFork]: XDAI_TOKEN,
-  [SupportedNetwork.Goerli]: GOERLI_TOKEN,
-  [SupportedNetwork.Mainnet]: ETHER_TOKEN,
-  [SupportedNetwork.Polygon]: POLYGON_TOKEN,
-  [SupportedNetwork.Amoy]: POLYGON_TOKEN,
-  [SupportedNetwork.ArbitrumOne]: ETHER_TOKEN,
-  [SupportedNetwork.ArbitrumSepolia]: ETHER_TOKEN,
-};
-
-const coinGeckoMappings = {
-  // This is a map between our internal reference to a supported currency, and the reference the api uses.
-  // For full list: https://api.coingecko.com/api/v3/simple/supported_vs_currencies
-  currencies: {
-    [SupportedCurrencies.USD]: 'usd',
-    [SupportedCurrencies.JPY]: 'jpy',
-    [SupportedCurrencies.GBP]: 'gbp',
-    [SupportedCurrencies.EUR]: 'eur',
-    [SupportedCurrencies.CAD]: 'cad',
-    [SupportedCurrencies.KRW]: 'krw',
-    [SupportedCurrencies.INR]: 'inr',
-    [SupportedCurrencies.BRL]: 'brl',
-    [SupportedCurrencies.ETH]: 'eth',
-  },
-  chains: {
-    [SupportedNetwork.Amoy]: 'polygon-pos',
-    [SupportedNetwork.ArbitrumOne]: 'arbitrum-one',
-    [SupportedNetwork.ArbitrumSepolia]: 'arbitrum-one',
-    [SupportedNetwork.Ganache]: 'arbitrum-one',
-    [SupportedNetwork.Gnosis]: 'xdai',
-    [SupportedNetwork.GnosisFork]: 'xdai',
-    [SupportedNetwork.Goerli]: 'ethereum',
-    [SupportedNetwork.Mainnet]: 'ethereum',
-    [SupportedNetwork.Polygon]: 'polygon-pos',
-  },
-  networkTokens: {
-    [ETHER_TOKEN.symbol]: 'ethereum',
-    [XDAI_TOKEN.symbol]: 'xdai',
-  },
-};
+const { coinGeckoMappings } = require('../consts.js');
 
 const CoinGeckoConfig = (() => {
   const getCurrencyApiConfig = (apiUrl) => {
@@ -142,18 +33,10 @@ const CoinGeckoConfig = (() => {
 
   return {
     getConfig: async () => {
-      const {
-        network: colonyJSNetwork,
-        coinGeckoApiUrl,
-        coinGeckoApiKey,
-      } = await EnvVarsConfig.getEnvVars();
-
-      const network = ColonyJSNetworkMapping[colonyJSNetwork];
+      const { coinGeckoApiUrl, coinGeckoApiKey } =
+        await EnvVarsConfig.getEnvVars();
 
       return {
-        DEFAULT_NETWORK_TOKEN: TOKEN_DATA[network],
-        SupportedNetwork,
-        SupportedCurrencies,
         mappings: coinGeckoMappings,
         api: getCurrencyApiConfig(coinGeckoApiUrl),
         apiKey: coinGeckoApiKey,

--- a/amplify/backend/function/fetchDomainBalance/src/config/networkConfig.js
+++ b/amplify/backend/function/fetchDomainBalance/src/config/networkConfig.js
@@ -1,0 +1,23 @@
+const EnvVarsConfig = require('./envVars.js');
+
+const {
+  ColonyJSNetworkMapping,
+  TOKEN_DATA,
+  NETWORK_DATA,
+} = require('../consts');
+
+const NetworkConfig = (() => {
+  return {
+    getConfig: async () => {
+      const { network } = await EnvVarsConfig.getEnvVars();
+      const supportedNetwork = ColonyJSNetworkMapping[network];
+
+      return {
+        DEFAULT_NETWORK_TOKEN: TOKEN_DATA[supportedNetwork],
+        DEFAULT_NETWORK_INFO: NETWORK_DATA[supportedNetwork],
+      };
+    },
+  };
+})();
+
+module.exports = NetworkConfig;

--- a/amplify/backend/function/fetchDomainBalance/src/consts.js
+++ b/amplify/backend/function/fetchDomainBalance/src/consts.js
@@ -1,0 +1,233 @@
+const { Network: ColonyJSNetwork } = require('@colony/colony-js');
+
+const SupportedNetwork = {
+  Mainnet: 'mainnet',
+  Goerli: 'goerli',
+  Gnosis: 'gnosis',
+  GnosisFork: 'gnosisFork',
+  Ganache: 'ganache',
+  Polygon: 'polygon',
+  Amoy: 'amoy',
+  ArbitrumOne: 'arbitrumOne',
+  ArbitrumSepolia: 'arbitrumSepolia',
+};
+
+const ColonyJSNetworkMapping = {
+  [ColonyJSNetwork.Mainnet]: SupportedNetwork.Mainnet,
+  [ColonyJSNetwork.Goerli]: SupportedNetwork.Goerli,
+  [ColonyJSNetwork.Xdai]: SupportedNetwork.Gnosis,
+  [ColonyJSNetwork.XdaiQa]: SupportedNetwork.GnosisFork,
+  [ColonyJSNetwork.Custom]: SupportedNetwork.Ganache,
+  [ColonyJSNetwork.ArbitrumOne]: SupportedNetwork.ArbitrumOne,
+  [ColonyJSNetwork.ArbitrumSepolia]: SupportedNetwork.ArbitrumSepolia,
+};
+
+// import from amplify backend schema.graphql
+const SupportedCurrencies = {
+  USD: 'USD',
+  JPY: 'JPY',
+  GBP: 'GBP',
+  EUR: 'EUR',
+  CAD: 'CAD',
+  KRW: 'KRW',
+  INR: 'INR',
+  BRL: 'BRL',
+  ETH: 'ETH',
+  CLNY: 'CLNY',
+};
+
+const XDAI_TOKEN = {
+  /*
+   * Needs to be this exact name, otherwise Metamask marks it as "not valid" when adding it
+   */
+  name: 'xDAI Token', //
+  /*
+   * Needs to be this exact name, otherwise Metamask marks it as "not valid" when adding it
+   */
+  symbol: 'xDAI',
+  decimals: 18,
+};
+
+const ETHER_TOKEN = {
+  name: 'Ether',
+  symbol: 'ETH',
+  decimals: 18,
+};
+
+const GOERLI_TOKEN = {
+  name: 'Goerli Ether',
+  symbol: 'GOETH',
+  decimals: 18,
+};
+
+const POLYGON_TOKEN = {
+  name: 'Matic Token',
+  symbol: 'MATIC',
+  decimals: 18,
+};
+
+const TOKEN_DATA = {
+  [SupportedNetwork.Ganache]: ETHER_TOKEN,
+  [SupportedNetwork.Gnosis]: XDAI_TOKEN,
+  [SupportedNetwork.GnosisFork]: XDAI_TOKEN,
+  [SupportedNetwork.Goerli]: GOERLI_TOKEN,
+  [SupportedNetwork.Mainnet]: ETHER_TOKEN,
+  [SupportedNetwork.Polygon]: POLYGON_TOKEN,
+  [SupportedNetwork.Amoy]: POLYGON_TOKEN,
+  [SupportedNetwork.ArbitrumOne]: ETHER_TOKEN,
+  [SupportedNetwork.ArbitrumSepolia]: ETHER_TOKEN,
+};
+
+const GNOSIS_NETWORK = {
+  name: 'Gnosis Chain',
+  chainId: '100',
+  shortName: 'xDai',
+  displayENSDomain: 'joincolony.colonyxdai',
+  blockExplorerName: 'Gnosisscan',
+  blockExplorerUrl: 'https://gnosis.blockscout.com',
+  tokenExplorerLink: 'https://gnosis.blockscout.com/tokens',
+  contractAddressLink: 'https://gnosis.blockscout.com/address',
+  blockTime: 5,
+};
+
+const ETHEREUM_NETWORK = {
+  name: 'Ethereum',
+  chainId: '1',
+  shortName: 'ETH',
+  blockExplorerName: 'Etherscan',
+  blockExplorerUrl: 'https://etherscan.io',
+  displayENSDomain: 'joincolony.eth',
+  tokenExplorerLink: 'https://etherscan.io/tokens',
+  contractAddressLink: 'https://etherscan.io/address',
+  safeTxService: 'https://safe-transaction-mainnet.safe.global/api',
+  rpcUrl: 'https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
+  apiUri: 'https://api.etherscan.io/api',
+  nativeToken: ETHER_TOKEN,
+  blockTime: 12,
+};
+
+const GOERLI_NETWORK = {
+  name: 'Goerli Testnet',
+  chainId: '5',
+  shortName: 'Goerli',
+  blockExplorerName: 'Etherscan',
+  blockExplorerUrl: 'https://goerli.etherscan.io',
+  displayENSDomain: 'joincolony.eth',
+  tokenExplorerLink: 'https://goerli.etherscan.io/tokens',
+  contractAddressLink: 'https://goerli.etherscan.io/address',
+  nativeToken: GOERLI_TOKEN,
+  blockTime: 5,
+};
+
+const GANACHE_NETWORK = {
+  name: 'Local Ganache Instance',
+  chainId: '265669100',
+  shortName: 'Ganache',
+  blockExplorerName: 'Noexplorer',
+  blockExplorerUrl: 'http://localhost',
+  displayENSDomain: 'joincolony.eth',
+  tokenExplorerLink: 'http://localhost',
+  contractAddressLink: 'http://localhost',
+  nativeToken: ETHER_TOKEN,
+  blockTime: 5,
+};
+
+const POLYGON_NETWORK = {
+  name: 'Polygon Mainnet',
+  chainId: '137',
+  shortName: 'Polygon',
+  blockExplorerName: 'PolygonScan',
+  blockExplorerUrl: 'https://polygonscan.com',
+  tokenExplorerLink: 'https://polygonscan.com/tokens',
+  contractAddressLink: 'https://polygonscan.com/address',
+  displayENSDomain: 'joincolony.matic',
+  blockTime: 3,
+};
+
+const AMOY_NETWORK = {
+  name: 'Polygon Amoy Testnet',
+  chainId: '80002',
+  shortName: 'Amoy',
+  blockExplorerName: 'OKLink',
+  blockExplorerUrl: 'https://www.oklink.com/amoy',
+  tokenExplorerLink: 'https://www.oklink.com/amoy/address',
+  contractAddressLink: 'https://www.oklink.com/amoy/address',
+  displayENSDomain: 'joincolony.matic',
+  blockTime: 3,
+};
+
+const ARBITRUM_NETWORK = {
+  name: 'Arbitrum One',
+  chainId: '42161',
+  shortName: 'Arbitrum',
+  blockExplorerName: 'Arbiscan',
+  blockExplorerUrl: 'https://arbiscan.io',
+  tokenExplorerLink: 'https://arbiscan.io/tokens',
+  contractAddressLink: 'https://arbiscan.io/address',
+  displayENSDomain: 'joincolony.arbitrum',
+  blockTime: 4,
+};
+
+const ARBITRUM_SEPOLIA_NETWORK = {
+  name: 'Arbitrum Sepolia Testnet',
+  chainId: '421614',
+  shortName: 'Arbitrum Sepolia',
+  blockExplorerName: 'Sepolia Arbiscan',
+  blockExplorerUrl: 'https://sepolia.arbiscan.io',
+  tokenExplorerLink: 'https://sepolia.arbiscan.io/tokens',
+  contractAddressLink: 'https://sepolia.arbiscan.io/address',
+  displayENSDomain: 'joincolony.arbitrumsepolia',
+  blockTime: 4,
+};
+
+const NETWORK_DATA = {
+  [SupportedNetwork.Ganache]: GANACHE_NETWORK,
+  [SupportedNetwork.Gnosis]: GNOSIS_NETWORK,
+  [SupportedNetwork.GnosisFork]: GNOSIS_NETWORK,
+  [SupportedNetwork.Goerli]: GOERLI_NETWORK,
+  [SupportedNetwork.Mainnet]: ETHEREUM_NETWORK,
+  [SupportedNetwork.Polygon]: POLYGON_NETWORK,
+  [SupportedNetwork.Amoy]: AMOY_NETWORK,
+  [SupportedNetwork.ArbitrumOne]: ARBITRUM_NETWORK,
+  [SupportedNetwork.ArbitrumSepolia]: ARBITRUM_SEPOLIA_NETWORK,
+};
+
+const coinGeckoMappings = {
+  // This is a map between our internal reference to a supported currency, and the reference the api uses.
+  // For full list: https://api.coingecko.com/api/v3/simple/supported_vs_currencies
+  currencies: {
+    [SupportedCurrencies.USD]: 'usd',
+    [SupportedCurrencies.JPY]: 'jpy',
+    [SupportedCurrencies.GBP]: 'gbp',
+    [SupportedCurrencies.EUR]: 'eur',
+    [SupportedCurrencies.CAD]: 'cad',
+    [SupportedCurrencies.KRW]: 'krw',
+    [SupportedCurrencies.INR]: 'inr',
+    [SupportedCurrencies.BRL]: 'brl',
+    [SupportedCurrencies.ETH]: 'eth',
+  },
+  chains: {
+    [SupportedNetwork.Amoy]: 'polygon-pos',
+    [SupportedNetwork.ArbitrumOne]: 'arbitrum-one',
+    [SupportedNetwork.ArbitrumSepolia]: 'arbitrum-one',
+    [SupportedNetwork.Ganache]: 'arbitrum-one',
+    [SupportedNetwork.Gnosis]: 'xdai',
+    [SupportedNetwork.GnosisFork]: 'xdai',
+    [SupportedNetwork.Goerli]: 'ethereum',
+    [SupportedNetwork.Mainnet]: 'ethereum',
+    [SupportedNetwork.Polygon]: 'polygon-pos',
+  },
+  networkTokens: {
+    [ETHER_TOKEN.symbol]: 'ethereum',
+    [XDAI_TOKEN.symbol]: 'xdai',
+  },
+};
+
+module.exports = {
+  ColonyJSNetworkMapping,
+  SupportedNetwork,
+  SupportedCurrencies,
+  NETWORK_DATA,
+  TOKEN_DATA,
+  coinGeckoMappings,
+};

--- a/amplify/backend/function/fetchDomainBalance/src/consts.js
+++ b/amplify/backend/function/fetchDomainBalance/src/consts.js
@@ -1,5 +1,27 @@
 const { Network: ColonyJSNetwork } = require('@colony/colony-js');
 
+const DEFAULT_TOKEN_DECIMALS = 18;
+
+const TimeframeType = {
+  DAILY: 'DAILY',
+  WEEKLY: 'WEEKLY',
+  MONTHLY: 'MONTHLY',
+  TOTAL: 'TOTAL',
+};
+
+const paymentActionTypes = ['PAYMENT', 'PAYMENT_MOTION', 'PAYMENT_MULTISIG'];
+
+const moveFundsActionTypes = [
+  'MOVE_FUNDS',
+  'MOVE_FUNDS_MOTION',
+  'MOVE_FUNDS_MULTISIG',
+];
+
+const acceptedColonyActionTypes = [
+  ...paymentActionTypes,
+  ...moveFundsActionTypes,
+];
+
 const SupportedNetwork = {
   Mainnet: 'mainnet',
   Goerli: 'goerli',
@@ -224,6 +246,11 @@ const coinGeckoMappings = {
 };
 
 module.exports = {
+  moveFundsActionTypes,
+  paymentActionTypes,
+  acceptedColonyActionTypes,
+  DEFAULT_TOKEN_DECIMALS,
+  TimeframeType,
   ColonyJSNetworkMapping,
   SupportedNetwork,
   SupportedCurrencies,

--- a/amplify/backend/function/fetchDomainBalance/src/index.js
+++ b/amplify/backend/function/fetchDomainBalance/src/index.js
@@ -4,7 +4,7 @@ const {
   BigNumber,
   utils: { Logger },
 } = require('ethers');
-const { getPeriodFor } = require('./utils');
+const { getPeriodFor, shouldFetchNetworkBalance } = require('./utils');
 const {
   getInOutActions,
   getTokensDatesMap,
@@ -13,6 +13,7 @@ const {
 } = require('./services/actions');
 const ExchangeRatesService = require('./services/exchangeRates');
 const { getTotalFiatAmountFor } = require('./services/tokens');
+const { getNetworkTotalBalance } = require('./services/networkBalance');
 Logger.setLogLevel(Logger.levels.ERROR);
 
 // @TODO maybe rename the lambda function
@@ -75,6 +76,22 @@ exports.handler = async (event) => {
 
       timeframeTotalIn = timeframeTotalIn.add(totalInBN);
       timeframeTotalOut = timeframeTotalOut.add(totalOutBN);
+    }
+
+    if (shouldFetchNetworkBalance(timeframeType)) {
+      const total = await getNetworkTotalBalance({
+        colonyAddress,
+        timeframePeriodEndDate,
+        domainId,
+        selectedCurrency,
+        chainId,
+      });
+      return {
+        totalIn: timeframeTotalIn.toString(),
+        totalOut: timeframeTotalOut.toString(),
+        total: total,
+        timeframe: [],
+      };
     }
 
     return {

--- a/amplify/backend/function/fetchDomainBalance/src/package-lock.json
+++ b/amplify/backend/function/fetchDomainBalance/src/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@colony/colony-js": "^0.0.0-snapshot-69cce09-20240724101901",
-        "@colony/events": "0.0.0-snapshot-20240329154314",
+        "@colony/colony-js": "^7.2.0",
+        "@colony/events": "3.0.0",
         "cross-fetch": "^4.0.0",
         "date-fns": "^3.6.0",
         "ethers": "^5.1.3"
@@ -20,30 +20,13 @@
       }
     },
     "node_modules/@colony/colony-js": {
-      "version": "0.0.0-snapshot-75444d7-20240717133215",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-0.0.0-snapshot-75444d7-20240717133215.tgz",
-      "integrity": "sha512-T+9jGgHhuJzchRxV0L9t3nfEDaXKpMhbXnFsWp7AmptXIs9lD9OmUqp0HIoKLzEJXmhqY/lMOG53lOcTYEk+Fg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
+      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
       "dependencies": {
-        "@colony/core": "0.0.0-snapshot-75444d7-20240717133215",
-        "@colony/events": "0.0.0-snapshot-75444d7-20240717133215",
-        "@colony/tokens": "0.0.0-snapshot-75444d7-20240717133215"
-      },
-      "engines": {
-        "node": "^16 || ^18 || ^20",
-        "pnpm": "^8"
-      },
-      "peerDependencies": {
-        "ethers": "^5.1.3"
-      }
-    },
-    "node_modules/@colony/colony-js/node_modules/@colony/events": {
-      "version": "0.0.0-snapshot-75444d7-20240717133215",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-0.0.0-snapshot-75444d7-20240717133215.tgz",
-      "integrity": "sha512-GPLphiP5cCnHUDdTD0zrIvl/OviURdkgPcUygMXqabSjekM91f73kraoUxfYQ9gfWChYaqmbUNle6bToKRZ8Kg==",
-      "dependencies": {
-        "@colony/core": "0.0.0-snapshot-75444d7-20240717133215",
-        "fetch-retry": "^5.0.4",
-        "typia": "^3.8.3"
+        "@colony/core": "^2.3.0",
+        "@colony/events": "^3.0.0",
+        "@colony/tokens": "^0.3.0"
       },
       "engines": {
         "node": "^16 || ^18 || ^20",
@@ -54,9 +37,9 @@
       }
     },
     "node_modules/@colony/core": {
-      "version": "0.0.0-snapshot-75444d7-20240717133215",
-      "resolved": "https://registry.npmjs.org/@colony/core/-/core-0.0.0-snapshot-75444d7-20240717133215.tgz",
-      "integrity": "sha512-TZ+yAa0H0xzk/UjXIkIU8oKKHnmFEGUAWhWwRtb2k1WAhkFXw6Dwoy/q4i3B4AEROh/KbblGnUXgcwa6xcTlNQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@colony/core/-/core-2.3.1.tgz",
+      "integrity": "sha512-TQzdFh+ayJdEh2lR04LyvyPEt1wEo0h/dukUTVY6lY9N8zpUvHZL4JCpyy//fUV1rlly+wQvxoRjcXzHYTguaw==",
       "engines": {
         "node": "^16 || ^18 || ^20",
         "pnpm": "^8"
@@ -66,11 +49,11 @@
       }
     },
     "node_modules/@colony/events": {
-      "version": "0.0.0-snapshot-20240329154314",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-0.0.0-snapshot-20240329154314.tgz",
-      "integrity": "sha512-EFBGsxHN4s44x4eu4LGuxYzFKMVd/bXRnDKz8IkOsN/spx2+qlrfFqDoqZdIA3PcE0npzZJcCg4af3k1O59iXQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-eFM51N75ZXHJ/E5HqAGZa/5btlEhD7Vw5bbkF91fHfF1tsb+TYrb1vVvCKmx2XihzuMRKm1v0iS7VPjFwoTADg==",
       "dependencies": {
-        "@colony/core": "0.0.0-snapshot-20240329154314",
+        "@colony/core": "^2.3.0",
         "fetch-retry": "^5.0.4",
         "typia": "^3.8.3"
       },
@@ -82,22 +65,10 @@
         "ethers": "^5.1.3"
       }
     },
-    "node_modules/@colony/events/node_modules/@colony/core": {
-      "version": "0.0.0-snapshot-20240329154314",
-      "resolved": "https://registry.npmjs.org/@colony/core/-/core-0.0.0-snapshot-20240329154314.tgz",
-      "integrity": "sha512-K9w9bTEj1eKhiH5H0Sm0sIyKC1LU+LI48afuuVWtqm5BemvJBCKv1b74ktgtxMj5tzZy9FiA/tfGUm494pL1iA==",
-      "engines": {
-        "node": "^16 || ^18 || ^20",
-        "pnpm": "^8"
-      },
-      "peerDependencies": {
-        "ethers": "^5.1.3"
-      }
-    },
     "node_modules/@colony/tokens": {
-      "version": "0.0.0-snapshot-75444d7-20240717133215",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.0.0-snapshot-75444d7-20240717133215.tgz",
-      "integrity": "sha512-Tql+gxH5vWtqO0GQ55OtjNV/yZJkI6JKQhoXgZ2ZMhBChlyXIrD1PxYvF8rLBkiLslRlkXycrWqOV/a2D+N2QA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
+      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
       "engines": {
         "node": "^16 || ^18 || ^20",
         "pnpm": "^8"

--- a/amplify/backend/function/fetchDomainBalance/src/package.json
+++ b/amplify/backend/function/fetchDomainBalance/src/package.json
@@ -11,7 +11,7 @@
     "date-fns": "^3.6.0",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.1.3",
-    "@colony/colony-js": "^0.0.0-snapshot-69cce09-20240724101901",
-    "@colony/events": "0.0.0-snapshot-20240329154314"
+    "@colony/colony-js": "^7.2.0",
+    "@colony/events": "3.0.0"
   }
 }

--- a/amplify/backend/function/fetchDomainBalance/src/services/exchangeRates.js
+++ b/amplify/backend/function/fetchDomainBalance/src/services/exchangeRates.js
@@ -1,4 +1,5 @@
 const CoinGeckoConfig = require('../config/coinGeckoConfig');
+const NetworkConfig = require('../config/networkConfig');
 const { getFiatExchangeRate } = require('../api/rest/getFiatExchangeRate');
 const { getTokensList } = require('../api/rest/getTokensList');
 const {
@@ -6,6 +7,7 @@ const {
   saveExchangeRate,
 } = require('../api/graphql/operations');
 const { getStartOfDayFor } = require('../utils');
+const { SupportedCurrencies, SupportedNetwork } = require('../consts');
 
 const { constants: ethersConstants } = require('ethers');
 
@@ -56,8 +58,8 @@ const ExchangeRatesService = (() => {
   };
 
   const getApiTokenIdFromAddress = async ({ tokenAddress, chainId }) => {
-    const { mappings, DEFAULT_NETWORK_TOKEN } =
-      await CoinGeckoConfig.getConfig();
+    const { mappings } = await CoinGeckoConfig.getConfig();
+    const { DEFAULT_NETWORK_TOKEN } = await NetworkConfig.getConfig();
 
     if (tokenAddress === ADDRESS_ZERO) {
       return mappings.networkTokens[DEFAULT_NETWORK_TOKEN.symbol];
@@ -172,9 +174,6 @@ const ExchangeRatesService = (() => {
 
   return {
     getExchangeRates: async (tokens, currency, chainId) => {
-      const { SupportedCurrencies, SupportedNetwork } =
-        await CoinGeckoConfig.getConfig();
-
       const tokensExchangeRate = await Promise.all(
         Object.entries(tokens).map(async ([tokenAddress, dates]) => {
           return getExchangeRatesForToken({

--- a/amplify/backend/function/fetchDomainBalance/src/services/networkBalance.js
+++ b/amplify/backend/function/fetchDomainBalance/src/services/networkBalance.js
@@ -13,49 +13,109 @@ const { getDomains, getAllColonyTokens } = require('../api/graphql/operations');
 const ExchangeRatesService = require('./exchangeRates');
 const { getTotalFiatAmountFor } = require('./tokens');
 const { getTokensDatesMap } = require('./actions');
+const NetworkConfig = require('../config/networkConfig');
 
-const getAverageBlockTime = async ({
-  provider,
-  currentBlockNumber,
-  sampleSize,
-}) => {
-  const currentBlock = await provider.getBlock(currentBlockNumber);
-  const previousBlock = await provider.getBlock(
-    currentBlockNumber - sampleSize,
-  );
-  const timeDifference = currentBlock.timestamp - previousBlock.timestamp;
-  return timeDifference / sampleSize;
+// Helper function to fetch block timestamp in milliseconds
+const getBlockTimestamp = async (provider, blockNumber) => {
+  const block = await provider.getBlock(blockNumber);
+  return block ? block.timestamp * 1000 : null; // convert to milliseconds
 };
 
-const getEstimatedBlockNumber = async ({
-  timeframeEndDate,
-  currentBlockNumber,
-  averageBlockTime,
+// Final check to compare left and right bounds for closest timestamp
+const checkFinalBounds = async ({
+  provider,
+  left,
+  right,
+  targetTimestamp,
+  closestBlock,
+  minTimestampDiff,
 }) => {
-  const currentBlockTimestamp = new Date(
-    currentBlockNumber * 1000,
-  ).toISOString();
-  const numberOfSecondsAgo = getDifferenceInSeconds(
-    currentBlockTimestamp,
-    timeframeEndDate,
-  );
-  const estimatedBlocksDifference = Math.floor(
-    numberOfSecondsAgo / averageBlockTime,
-  );
+  const leftTimestamp = await getBlockTimestamp(provider, left);
+  const rightTimestamp = await getBlockTimestamp(provider, right);
 
-  /**
-   * If estimatedBlocksDifference is negative (due to numberOfSecondsAgo being negative)
-   * It means timeframePeriodEndDate is ahead of current network block time
-   */
-  if (estimatedBlocksDifference < 0) {
-    return currentBlockNumber;
+  if (
+    leftTimestamp !== null &&
+    Math.abs(leftTimestamp - targetTimestamp) < minTimestampDiff
+  ) {
+    closestBlock = left;
   }
-  // @TODO If estimatedBlocksDifference is higher than the existing number of blocks, we need to get the data for the (current or first)? block
-  if (estimatedBlocksDifference > currentBlockNumber) {
-    return currentBlockNumber;
+  if (
+    rightTimestamp !== null &&
+    Math.abs(rightTimestamp - targetTimestamp) < minTimestampDiff
+  ) {
+    closestBlock = right;
   }
 
-  return currentBlockNumber - estimatedBlocksDifference;
+  return closestBlock;
+};
+
+// Finds the closest past block to a target date using binary search
+const findClosestPastBlock = async ({
+  targetDate,
+  averageBlockTime,
+  currentBlockNumber,
+  provider,
+}) => {
+  if (!targetDate) {
+    return currentBlockNumber;
+  }
+  const targetTimestamp = new Date(targetDate).getTime();
+
+  // Step 1: Estimate initial block guess near target timestamp
+  const currentBlockTimestamp = await getBlockTimestamp(
+    provider,
+    currentBlockNumber,
+  );
+  const timeDiffSeconds = (currentBlockTimestamp - targetTimestamp) / 1000;
+  let estimatedBlock =
+    currentBlockNumber - Math.floor(timeDiffSeconds / averageBlockTime);
+
+  // Step 2: Set up binary search bounds
+  let left = Math.max(0, estimatedBlock - 1000);
+  let right = currentBlockNumber;
+  let closestBlock = currentBlockNumber;
+  let minTimestampDiff = Infinity;
+
+  console.log(`Starting binary search between blocks ${left} and ${right}`);
+
+  // Step 3: Perform binary search
+  while (left <= right) {
+    const mid = Math.floor((left + right) / 2);
+    const midTimestamp = await getBlockTimestamp(provider, mid);
+
+    if (midTimestamp === null) {
+      // If the block is missing, skip it and adjust bounds
+      right = mid - 1;
+      continue;
+    }
+
+    const timestampDiff = Math.abs(midTimestamp - targetTimestamp);
+
+    // Update closest block if current mid is closer
+    if (timestampDiff < minTimestampDiff) {
+      closestBlock = mid;
+      minTimestampDiff = timestampDiff;
+    }
+
+    // Adjust search bounds
+    if (midTimestamp < targetTimestamp) {
+      left = mid + 1;
+    } else if (midTimestamp > targetTimestamp) {
+      right = mid - 1;
+    } else {
+      return mid; // Exact match found
+    }
+  }
+
+  // Step 4: Final check between last two bounds to confirm closest timestamp
+  return checkFinalBounds({
+    provider,
+    left,
+    right,
+    targetTimestamp,
+    closestBlock,
+    minTimestampDiff,
+  });
 };
 
 const getTokensWithDefaults = async (colonyAddress) => {
@@ -70,23 +130,39 @@ const fetchBalances = async ({
   tokens,
   colonyClient,
   nativeFundingPotId,
-  estimatedBlockNumber,
+  closestBlock,
 }) => {
   return Promise.all(
     tokens.map(async (token) => {
-      const rewardsPotTotal = await colonyClient.getFundingPotBalance(
-        nativeFundingPotId,
-        token.id,
-        { blockTag: estimatedBlockNumber },
-      );
-      return {
-        amount: rewardsPotTotal,
-        networkFee: 0,
-        token,
-        finalizedDate: getStartOfDayFor(
-          new Date(estimatedBlockNumber * 1000).toISOString(),
-        ),
-      };
+      let rewardsPotTotal;
+      try {
+        rewardsPotTotal = await colonyClient.getFundingPotBalance(
+          nativeFundingPotId,
+          token.id,
+          { blockTag: closestBlock.number },
+        );
+        return {
+          amount: rewardsPotTotal,
+          networkFee: 0,
+          token,
+          finalizedDate: getStartOfDayFor(
+            new Date(closestBlock.timestamp * 1000).toISOString(),
+          ),
+        };
+      } catch {
+        console.warn(
+          `Couldn't retrieve getFundingPotBalance for block ${closestBlock.number}`,
+        );
+
+        return {
+          amount: 0,
+          networkFee: 0,
+          token,
+          finalizedDate: getStartOfDayFor(
+            new Date(closestBlock.timestamp * 1000).toISOString(),
+          ),
+        };
+      }
     }),
   );
 };
@@ -98,6 +174,8 @@ const getNetworkTotalBalance = async ({
   selectedCurrency,
   chainId,
 }) => {
+  const { DEFAULT_NETWORK_INFO } = await NetworkConfig.getConfig();
+  const averageBlockTime = DEFAULT_NETWORK_INFO.blockTime;
   const { network, networkAddress, rpcURL } = await EnvVarsConfig.getEnvVars();
   const provider = new providers.StaticJsonRpcProvider(rpcURL);
   const networkClient = getColonyNetworkClient(network, provider, {
@@ -105,17 +183,14 @@ const getNetworkTotalBalance = async ({
   });
 
   const currentBlockNumber = await provider.getBlockNumber();
-  const averageBlockTime = await getAverageBlockTime({
-    provider,
-    currentBlockNumber,
-    sampleSize: 1000,
-  });
-  const estimatedBlockNumber = await getEstimatedBlockNumber({
-    provider,
-    timeframePeriodEndDate,
-    currentBlockNumber,
+  const closestBlockNumber = await findClosestPastBlock({
+    targetDate: timeframePeriodEndDate,
     averageBlockTime,
+    currentBlockNumber,
+    provider,
   });
+  console.log('Closest block to target date:', closestBlockNumber);
+  const closestBlock = await provider.getBlock(closestBlockNumber);
 
   const colonyClient = await networkClient.getColonyClient(colonyAddress);
   const tokens = await getTokensWithDefaults(colonyAddress);
@@ -130,7 +205,7 @@ const getNetworkTotalBalance = async ({
       tokens,
       colonyClient,
       nativeFundingPotId: domain?.nativeFundingPotId,
-      estimatedBlockNumber,
+      closestBlock,
     });
   } else {
     const allDomainsBalances = await Promise.all(
@@ -139,7 +214,7 @@ const getNetworkTotalBalance = async ({
           tokens,
           colonyClient,
           nativeFundingPotId: domain?.nativeFundingPotId,
-          estimatedBlockNumber,
+          closestBlock,
         }),
       ),
     );

--- a/amplify/backend/function/fetchDomainBalance/src/services/networkBalance.js
+++ b/amplify/backend/function/fetchDomainBalance/src/services/networkBalance.js
@@ -1,0 +1,158 @@
+const { getColonyNetworkClient, Network } = require('@colony/colony-js');
+const {
+  providers,
+  constants: { AddressZero },
+} = require('ethers');
+const EnvVarsConfig = require('../config/envVars');
+const {
+  getDifferenceInSeconds,
+  DEFAULT_TOKEN_DECIMALS,
+  getStartOfDayFor,
+} = require('../utils');
+const { getDomains, getAllColonyTokens } = require('../api/graphql/operations');
+const ExchangeRatesService = require('./exchangeRates');
+const { getTotalFiatAmountFor } = require('./tokens');
+const { getTokensDatesMap } = require('./actions');
+
+const getAverageBlockTime = async ({
+  provider,
+  currentBlockNumber,
+  sampleSize,
+}) => {
+  const currentBlock = await provider.getBlock(currentBlockNumber);
+  const previousBlock = await provider.getBlock(
+    currentBlockNumber - sampleSize,
+  );
+  const timeDifference = currentBlock.timestamp - previousBlock.timestamp;
+  return timeDifference / sampleSize;
+};
+
+const getEstimatedBlockNumber = async ({
+  timeframeEndDate,
+  currentBlockNumber,
+  averageBlockTime,
+}) => {
+  const currentBlockTimestamp = new Date(
+    currentBlockNumber * 1000,
+  ).toISOString();
+  const numberOfSecondsAgo = getDifferenceInSeconds(
+    currentBlockTimestamp,
+    timeframeEndDate,
+  );
+  const estimatedBlocksDifference = Math.floor(
+    numberOfSecondsAgo / averageBlockTime,
+  );
+
+  // If estimatedBlocksDifference is negative, it means timeframePeriodEndDate is ahead of current network block time
+  if (estimatedBlocksDifference < 0) {
+    return currentBlockNumber;
+  }
+  // @TODO If estimatedBlocksDifference is higher than the existing number of blocks, we need to get the data for the (current or first)? block
+  if (estimatedBlocksDifference > currentBlockNumber) {
+    return currentBlockNumber;
+  }
+
+  return currentBlockNumber - estimatedBlocksDifference;
+};
+
+const getTokensWithDefaults = async (colonyAddress) => {
+  const tokensData = await getAllColonyTokens(colonyAddress);
+  return [
+    { id: AddressZero, decimals: DEFAULT_TOKEN_DECIMALS },
+    ...tokensData.map(({ token }) => token),
+  ];
+};
+
+const fetchBalances = async ({
+  tokens,
+  colonyClient,
+  nativeFundingPotId,
+  estimatedBlockNumber,
+}) => {
+  return Promise.all(
+    tokens.map(async (token) => {
+      const rewardsPotTotal = await colonyClient.getFundingPotBalance(
+        nativeFundingPotId,
+        token.id,
+        { blockTag: estimatedBlockNumber },
+      );
+      return {
+        amount: rewardsPotTotal,
+        networkFee: 0,
+        token,
+        finalizedDate: getStartOfDayFor(
+          new Date(estimatedBlockNumber * 1000).toISOString(),
+        ),
+      };
+    }),
+  );
+};
+
+const getNetworkTotalBalance = async ({
+  colonyAddress,
+  domainId,
+  timeframePeriodEndDate,
+  selectedCurrency,
+  chainId,
+}) => {
+  const { network, networkAddress, rpcURL } = await EnvVarsConfig.getEnvVars();
+  const provider = new providers.StaticJsonRpcProvider(rpcURL);
+  const networkClient = getColonyNetworkClient(network, provider, {
+    networkAddress,
+  });
+
+  const currentBlockNumber = await provider.getBlockNumber();
+  const averageBlockTime = await getAverageBlockTime({
+    provider,
+    currentBlockNumber,
+    sampleSize: 1000,
+  });
+  const estimatedBlockNumber = await getEstimatedBlockNumber({
+    provider,
+    timeframePeriodEndDate,
+    currentBlockNumber,
+    averageBlockTime,
+  });
+
+  const colonyClient = await networkClient.getColonyClient(colonyAddress);
+  const tokens = await getTokensWithDefaults(colonyAddress);
+
+  const domains = await getDomains(colonyAddress);
+  let balances = [];
+
+  // If the "All teams" filter is selected, then domain will be undefined
+  if (domainId) {
+    const domain = domains.find((d) => d.id === domainId);
+    balances = await fetchBalances({
+      tokens,
+      colonyClient,
+      nativeFundingPotId: domain?.nativeFundingPotId,
+      estimatedBlockNumber,
+    });
+  } else {
+    const allDomainsBalances = await Promise.all(
+      domains.map(async (domain) =>
+        fetchBalances({
+          tokens,
+          colonyClient,
+          nativeFundingPotId: domain?.nativeFundingPotId,
+          estimatedBlockNumber,
+        }),
+      ),
+    );
+
+    balances = allDomainsBalances.flat();
+  }
+
+  const exchangeRates = await ExchangeRatesService.getExchangeRates(
+    getTokensDatesMap(balances),
+    selectedCurrency,
+    chainId,
+  );
+
+  return getTotalFiatAmountFor(balances, exchangeRates);
+};
+
+module.exports = {
+  getNetworkTotalBalance,
+};

--- a/amplify/backend/function/fetchDomainBalance/src/services/networkBalance.js
+++ b/amplify/backend/function/fetchDomainBalance/src/services/networkBalance.js
@@ -43,7 +43,10 @@ const getEstimatedBlockNumber = async ({
     numberOfSecondsAgo / averageBlockTime,
   );
 
-  // If estimatedBlocksDifference is negative, it means timeframePeriodEndDate is ahead of current network block time
+  /**
+   * If estimatedBlocksDifference is negative (due to numberOfSecondsAgo being negative)
+   * It means timeframePeriodEndDate is ahead of current network block time
+   */
   if (estimatedBlocksDifference < 0) {
     return currentBlockNumber;
   }

--- a/amplify/backend/function/fetchDomainBalance/src/services/networkBalance.js
+++ b/amplify/backend/function/fetchDomainBalance/src/services/networkBalance.js
@@ -4,11 +4,8 @@ const {
   constants: { AddressZero },
 } = require('ethers');
 const EnvVarsConfig = require('../config/envVars');
-const {
-  getDifferenceInSeconds,
-  DEFAULT_TOKEN_DECIMALS,
-  getStartOfDayFor,
-} = require('../utils');
+const { getStartOfDayFor } = require('../utils');
+const { DEFAULT_TOKEN_DECIMALS } = require('../consts');
 const { getDomains, getAllColonyTokens } = require('../api/graphql/operations');
 const ExchangeRatesService = require('./exchangeRates');
 const { getTotalFiatAmountFor } = require('./tokens');

--- a/amplify/backend/function/fetchDomainBalance/src/services/tokens.js
+++ b/amplify/backend/function/fetchDomainBalance/src/services/tokens.js
@@ -1,5 +1,6 @@
 const { BigNumber } = require('ethers');
-const { getStartOfDayFor, DEFAULT_TOKEN_DECIMALS } = require('../utils');
+const { getStartOfDayFor } = require('../utils');
+const { DEFAULT_TOKEN_DECIMALS } = require('../consts');
 const NetworkConfig = require('../config/networkConfig');
 
 const getConvertedTokenAmount = (

--- a/amplify/backend/function/fetchDomainBalance/src/services/tokens.js
+++ b/amplify/backend/function/fetchDomainBalance/src/services/tokens.js
@@ -1,5 +1,5 @@
 const { BigNumber } = require('ethers');
-const { getStartOfDayFor } = require('../utils');
+const { getStartOfDayFor, DEFAULT_TOKEN_DECIMALS } = require('../utils');
 const CoinGeckoConfig = require('../config/coinGeckoConfig');
 
 const getConvertedTokenAmount = (
@@ -27,7 +27,7 @@ const getConvertedTokenAmount = (
   return BigNumber.from(amount)
     .add(formattedNetworkFee) // Add network fee to the initial amount
     .mul(normalizedTokenExchangeRate) // Adjust amount using the normalized exchange rate
-    .mul(BigNumber.from(10).pow(18)) // Scale the result to 10^18 format for consistency
+    .mul(BigNumber.from(10).pow(DEFAULT_TOKEN_DECIMALS)) // Scale the result to 10^18 format for consistency
     .div(tokenScaleFactor) // Undo initial scaling of the amount and network fee
     .div(tokenScaleFactor); // Undo initial scaling of the exchange rate
 };
@@ -40,7 +40,10 @@ const getTotalFiatAmountFor = async (items, exchangeRates) => {
     const tokenId = token.id;
     const date = getStartOfDayFor(finalizedDate);
     const tokenExchangeRate = exchangeRates[tokenId][date];
-    const tokenDecimals = token.decimals ?? DEFAULT_NETWORK_TOKEN.decimals ?? 0;
+    const tokenDecimals =
+      token.decimals ??
+      DEFAULT_NETWORK_TOKEN.decimals ??
+      DEFAULT_TOKEN_DECIMALS;
 
     const convertedTokenValue = getConvertedTokenAmount(
       amount,

--- a/amplify/backend/function/fetchDomainBalance/src/services/tokens.js
+++ b/amplify/backend/function/fetchDomainBalance/src/services/tokens.js
@@ -1,6 +1,6 @@
 const { BigNumber } = require('ethers');
 const { getStartOfDayFor, DEFAULT_TOKEN_DECIMALS } = require('../utils');
-const CoinGeckoConfig = require('../config/coinGeckoConfig');
+const NetworkConfig = require('../config/networkConfig');
 
 const getConvertedTokenAmount = (
   amount,
@@ -33,7 +33,7 @@ const getConvertedTokenAmount = (
 };
 
 const getTotalFiatAmountFor = async (items, exchangeRates) => {
-  const { DEFAULT_NETWORK_TOKEN } = await CoinGeckoConfig.getConfig();
+  const { DEFAULT_NETWORK_TOKEN } = await NetworkConfig.getConfig();
   let totalAmount = BigNumber.from(0);
   for (let item of items) {
     const { amount, networkFee, token, finalizedDate } = item;

--- a/amplify/backend/function/fetchDomainBalance/src/utils.js
+++ b/amplify/backend/function/fetchDomainBalance/src/utils.js
@@ -15,27 +15,7 @@ const {
   isBefore,
 } = require('date-fns');
 
-const DEFAULT_TOKEN_DECIMALS = 18;
-
-const TimeframeType = {
-  DAILY: 'DAILY',
-  WEEKLY: 'WEEKLY',
-  MONTHLY: 'MONTHLY',
-  TOTAL: 'TOTAL',
-};
-
-const paymentActionTypes = ['PAYMENT', 'PAYMENT_MOTION', 'PAYMENT_MULTISIG'];
-
-const moveFundsActionTypes = [
-  'MOVE_FUNDS',
-  'MOVE_FUNDS_MOTION',
-  'MOVE_FUNDS_MULTISIG',
-];
-
-const acceptedColonyActionTypes = [
-  ...paymentActionTypes,
-  ...moveFundsActionTypes,
-];
+const { TimeframeType, paymentActionTypes } = require('./consts');
 
 const getActionFinalizedDate = (action) => {
   if (action.isMotion && action.motionData) {
@@ -272,8 +252,6 @@ const shouldFetchNetworkBalance = (timeframeType) =>
   timeframeType === TimeframeType.TOTAL;
 
 module.exports = {
-  DEFAULT_TOKEN_DECIMALS,
-  acceptedColonyActionTypes,
   getDifferenceInSeconds,
   getPeriodFormat,
   getPeriodFor,

--- a/amplify/backend/function/fetchDomainBalance/src/utils.js
+++ b/amplify/backend/function/fetchDomainBalance/src/utils.js
@@ -1,4 +1,5 @@
 const {
+  differenceInSeconds,
   startOfDay,
   subDays,
   startOfWeek,
@@ -13,6 +14,8 @@ const {
   isAfter,
   isBefore,
 } = require('date-fns');
+
+const DEFAULT_TOKEN_DECIMALS = 18;
 
 const TimeframeType = {
   DAILY: 'DAILY',
@@ -194,7 +197,7 @@ const getFormattedActions = (actions, domainId) => {
   return actions
     .filter((action) => !action.initiatorExtension?.id)
     .map((action) => getActionWithFinalizedDate(action))
-    .filter((action) => !action.finalizedDate)
+    .filter((action) => !!action.finalizedDate)
     .map((action) => {
       let amount = action.amount;
       let networkFee = action.networkFee;
@@ -255,8 +258,23 @@ const getFormattedExpenditures = (expenditures, domainId, tokensDecimals) => {
   return formattedExpenditures;
 };
 
+const getDifferenceInSeconds = (startDateTimestamp, endDateTimestamp) => {
+  const endDate = endDateTimestamp ? new Date(endDateTimestamp) : new Date();
+
+  const startDate = startDateTimestamp
+    ? new Date(startDateTimestamp)
+    : new Date();
+
+  return differenceInSeconds(startDate, endDate, { roundingMethod: 'ceil' });
+};
+
+const shouldFetchNetworkBalance = (timeframeType) =>
+  timeframeType === TimeframeType.TOTAL;
+
 module.exports = {
+  DEFAULT_TOKEN_DECIMALS,
   acceptedColonyActionTypes,
+  getDifferenceInSeconds,
   getPeriodFormat,
   getPeriodFor,
   getFormattedIncomingFunds,
@@ -270,4 +288,5 @@ module.exports = {
   getStartOfDayFor,
   isAfter,
   isBefore,
+  shouldFetchNetworkBalance,
 };

--- a/docker/colony-cdapp-dev-env-network
+++ b/docker/colony-cdapp-dev-env-network
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV NETWORK_HASH=291c8ad437f0a898e51c737ca0a3272d50be01af
+ENV NETWORK_HASH=cb8c967b4b99d1ceb8988a284130751a753fdedd
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]


### PR DESCRIPTION
## Description

- Given the incoming funds entries are not available for prior to May 2024 - previously when an incoming funds action was claimed, the entry got deleted, we need to change a bit our approach to the balances. So, in order to get our data right, at least for the overall amounts shown in the Total cards we need to make use of the actual network balance at colony level or domain level. This PR addresses that ✨ 

## Testing

TODO: Let's test the changes in this PR retrieve the correct total balance for a domain, for `All teams` and also the caching.

* Step 1. First things first, run your dev environment
* Step 2. Run the `create-data` script
* Step 3. Visit http://localhost:9091/planex check the `All teams` or `General` `Total` card correctly reflects the `Income` - `Payments`
![Screenshot 2024-11-04 at 17 08 30](https://github.com/user-attachments/assets/42d24ce2-f34a-4c98-8c7d-b20daaa3b288)

* Step 4. Now select `Andromeda` and check again the difference is correct.
![Screenshot 2024-11-04 at 17 08 34](https://github.com/user-attachments/assets/fe6895e4-0538-4464-8c25-6ee41ee02684)

* Step 5. Please replace
`const closestBlock = await provider.getBlock(closestBlockNumber);`
with 
`const closestBlock = await provider.getBlock(closestBlockNumber || currentBlockNumber);`
in `amplify/backend/function/fetchDomainBalance/src/services/networkBalance.js`

> [!IMPORTANT]
> This is needed because when we start our local dev env, the first block will have the current timestamp, so if we try to cache data from the past for the `Total` timeframe type, there will be no block having that timestamp and it will fallback to `0`

* Step 6. For ease of testing let's already cache the balance values
```
query MyQuery {
  cacheAllDomainBalance {
    success
  }
}
```
* Step 7. You can run the following query to check the `Total` cache has been properly updated
```
query MyQuery {
  listCacheTotalBalances(
    filter: {
      timeframeType: {eq: TOTAL}, 
      domainId: {eq: "<DOMAIN_ID>"} # or use <COLONY_ADDRESS>_2
    }
  ) {
    items {
      colonyAddress
      timeframeType
      timeframePeriod
      totalUSDC
      domainId
      totalUSDCIn
      totalUSDCOut
      date
    }
  }
}
```
* Step 8. Make sure to refresh the app as the new cached values have not yet been fetched
* Step 9. Now let's create a `Simple payment` with `Permissions`
![Screenshot 2024-11-04 at 17 09 48](https://github.com/user-attachments/assets/94a2fe79-3dd7-41fb-b7a6-13137441edd6)

* Step 10. Check the `Total`, the trend for `Total`, `Income` and `Payments` properly update
![Screenshot 2024-11-04 at 17 10 18](https://github.com/user-attachments/assets/cc583a90-d9af-481c-bf95-abe8e7d5396e)

## Important
Locally it's a bit tricky to properly test the `findClosestPastBlock` for a given date, and even cache the `Total` funds trends only because with the latest network hash change, the first block should be at the current date.

However, let's do some magic ✨ 

Now run the following query
```
query MyQuery {
  getDomainBalance(
    input: {
      colonyAddress: "<COLONY_ADDRESS>", 
      timeframePeriod: 1, 
      timeframeType: TOTAL, 
      timeframePeriodEndDate: "<DATE_HERE>" # put a date here with at least one extra day compared to the current date
      domainId: "<DOMAIN_ID>" # you can either remove this or use <COLONY_ADDRESS>_<TEAM_NUMBER>
  }) {
    total
    totalIn
    totalOut
  }
}

```
And see if in the logs you get 
`Closest block to target date: 1025` - the number should update based on the used date and the existing block in the network

Last, but not least - and forever grateful you made it so far - please don't let these testing steps hinder your creativity. 

Also, if you want to test the cache values for the `Income`/`Payments` sections you can check [this PR](https://github.com/JoinColony/colonyCDapp/pull/3080)

## Diffs

**Changes** 🏗

* Make use of `colonyClient.getFundingPotBalance` for `TimeframeType.TOTAL`

## TODO

- [ ] We don't get all relevant timeframe keys if we were to change our timeframePeriod query input - this will be solved in another PR as it doesn't impact the data that we currently use in the UI

Contributes to [#3555](https://github.com/JoinColony/colonyCDapp/issues/3555)
