### PR TITLE
Fix: Prevent shifting of other team filter copies

### DIFF
--- a/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
@@ -53,10 +53,10 @@ const TeamItem: FC<TeamItemProps> = ({
       type="button"
       aria-label={label}
       className={clsx(
-        'box-border inline-flex h-full w-full items-center justify-center border-y border-solid bg-base-white px-4 py-2 text-sm text-transparent bold-on-hover',
+        'box-border inline-flex h-full w-full items-center justify-center border-y border-solid bg-base-white px-4 py-2 text-sm font-medium text-transparent bold-on-hover',
         selected ? teamColor : null,
         {
-          'border-gray-200 font-medium hover:bg-gray-50': !selected,
+          'border-gray-200 hover:bg-gray-50': !selected,
           'border-l border-transparent after:font-semibold after:text-base-white hover:after:text-base-white':
             selected,
           'border-r': hasDelimiter,


### PR DESCRIPTION
## Description

I guess the best way to explain this fix is we're currently faking the semibold effect via the `after` pseudo-element to prevent the font weight change from affecting the rest of the layout. The problem is that `font-medium` is only being applied for team items that are not selected. So when a team item is selected, this `font-medium` doesn't get applied and it's causing the rest of the layout to sort of "shift".

So I'm just applying the `font-medium` style as the base style for these team items regardless if they're selected or not which should keep the layout in tact. When a team item does get selected, our "fake" semibold effect gets applied which doesn't affect our layout.

![prevent-shift](https://github.com/user-attachments/assets/79d225e3-0e69-4f64-b725-cf4dd6b4036a)

## Testing

1. Visit a Colony Dashboard and make sure there's at least 2 subdomains in there
2. Keep on clicking the first subdomain on the Team Filter
3. Verify that the layout of the Team Filter component doesn't "shift"
4. Verify this on mobile view as well please

Resolves #3564 