### PR TITLE
Fix: Userhub styling adjustments

### DIFF
--- a/src/components/common/Extensions/UserHub/UserHub.tsx
+++ b/src/components/common/Extensions/UserHub/UserHub.tsx
@@ -100,7 +100,7 @@ const UserHub: FC<Props> = ({
           <>
             <div>
               <TitleLabel
-                className="pb-5"
+                className="pb-3"
                 text={formatText(MSG.titleColonyOverview)}
               />
               <ul className="-ml-4 flex w-[calc(100%+2rem)] flex-col">
@@ -127,13 +127,13 @@ const UserHub: FC<Props> = ({
                           'font-medium': selectedTab === id,
                         })}
                       >
-                        <span className="relative mr-2 flex shrink-0">
+                        <span className="relative mr-2.5 flex shrink-0">
                           {id === UserHubTab.Notifications && (
                             <NotificationsEnabledWrapper>
                               <UnreadNotifications />
                             </NotificationsEnabledWrapper>
                           )}
-                          <Icon size={14} />
+                          <Icon size={16} />
                         </span>
                         {formatText(label)}
                       </div>

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
@@ -78,9 +78,12 @@ const NotificationsTab = ({ closeUserHub }: { closeUserHub: () => void }) => {
         )}
       </div>
       <div
-        className={clsx('flex flex-col justify-center pt-4 sm:justify-normal', {
-          'h-full sm:h-auto': isEmpty,
-        })}
+        className={clsx(
+          'flex flex-col justify-center pt-0.5 sm:justify-normal',
+          {
+            'h-full sm:h-auto': isEmpty,
+          },
+        )}
       >
         {isEmpty ? (
           <>

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/NotificationWrapper.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/NotificationWrapper.tsx
@@ -60,10 +60,11 @@ const NotificationWrapper: FC<NotificationWrapperProps> = ({
             colony?.metadata?.avatar || colony?.metadata?.thumbnail || undefined
           }
           colonyName={colony?.name || formatText(MSG.unknownColony)}
-          className={
-            loadingColony ? 'overflow-hidden rounded-full skeleton' : undefined
-          }
+          className={clsx('mt-1', {
+            'overflow-hidden rounded-full skeleton': loadingColony,
+          })}
         />
+
         <div
           className={clsx('w-full flex-col', {
             skeleton: loadingColony,


### PR DESCRIPTION
## Description

Just some styling updates to follow the Figma designs:

1. Our fonts have a default line height which causes them to have extra vertical spacing. On Figma, you'll find that the Avatar has compensated for this by having a top spacing of 4px from the container. So I just added it:

![avatar alignment](https://github.com/user-attachments/assets/6b7b1540-9dca-44dd-8737-6b854fdd2bd4)

2. Then made a little style update for the UserHub tabs to sort of align the Balance icon's top edge with the notification title's top edge as shown in #3578 

![image](https://github.com/user-attachments/assets/3b513fbe-d6ca-4e6c-9a48-5566ba75f116)

So yeah, here's the result:

<img width="686" alt="image" src="https://github.com/user-attachments/assets/fdaf277c-90a8-426a-8994-0f027ff54247">

## Testing

1. Create a Simple Payment
2. Wait for the notification to arrive
3. Open the UserHub
4. Go to the Notifications tab
5. Verify that the issue raised on #3678 is addressed by referring to these designs: https://www.figma.com/design/l1dOM5qiQYwF0ElvKDqqjg/Design-System---Colony-v3?node-id=1782-51509&t=9BgEXHLnQiK6dmp0-4

Resolves #3578