### PR TITLE
Fix: Split payment should not send multiple notifications

### DIFF
--- a/amplify/backend/api/colonycdapp/schema/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema/schema.graphql
@@ -3887,6 +3887,10 @@ type Expenditure @model {
   Address of StakedExpenditure extension which created the expenditure, if applicable
   """
   stakedExpenditureAddress: ID
+  """
+  Only used for Split Payments, used to prevent sending multiple payment notifications
+  """
+  splitPaymentPayoutClaimedNotificationSent: Boolean
 }
 
 """

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=1383395a88c897055b5e886998a3331f5e013454
+ENV BLOCK_INGESTOR_HASH=d2c9d9ee531640abe8e561cc7a06cfd662de18b3
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -1707,6 +1707,7 @@ export type CreateExpenditureInput = {
   nativeId: Scalars['Int'];
   ownerAddress: Scalars['ID'];
   slots: Array<ExpenditureSlotInput>;
+  splitPaymentPayoutClaimedNotificationSent?: InputMaybe<Scalars['Boolean']>;
   stagedExpenditureAddress?: InputMaybe<Scalars['ID']>;
   stakedExpenditureAddress?: InputMaybe<Scalars['ID']>;
   status: ExpenditureStatus;
@@ -2358,6 +2359,8 @@ export type Expenditure = {
   ownerAddress: Scalars['ID'];
   /** Array containing expenditure slots */
   slots: Array<ExpenditureSlot>;
+  /** Indicates whether the splitPaymentClaimedNotification has been sent to prevent sending multiple notifications */
+  splitPaymentPayoutClaimedNotificationSent?: Maybe<Scalars['Boolean']>;
   /** Address of StagedExpenditure extension which set the expenditure as staged, if applicable */
   stagedExpenditureAddress?: Maybe<Scalars['ID']>;
   /** Address of StakedExpenditure extension which created the expenditure, if applicable */
@@ -3591,6 +3594,7 @@ export type ModelExpenditureConditionInput = {
   not?: InputMaybe<ModelExpenditureConditionInput>;
   or?: InputMaybe<Array<InputMaybe<ModelExpenditureConditionInput>>>;
   ownerAddress?: InputMaybe<ModelIdInput>;
+  splitPaymentPayoutClaimedNotificationSent?: InputMaybe<ModelBooleanInput>;
   stagedExpenditureAddress?: InputMaybe<ModelIdInput>;
   stakedExpenditureAddress?: InputMaybe<ModelIdInput>;
   status?: InputMaybe<ModelExpenditureStatusInput>;
@@ -3618,6 +3622,7 @@ export type ModelExpenditureFilterInput = {
   not?: InputMaybe<ModelExpenditureFilterInput>;
   or?: InputMaybe<Array<InputMaybe<ModelExpenditureFilterInput>>>;
   ownerAddress?: InputMaybe<ModelIdInput>;
+  splitPaymentPayoutClaimedNotificationSent?: InputMaybe<ModelBooleanInput>;
   stagedExpenditureAddress?: InputMaybe<ModelIdInput>;
   stakedExpenditureAddress?: InputMaybe<ModelIdInput>;
   status?: InputMaybe<ModelExpenditureStatusInput>;
@@ -4475,6 +4480,7 @@ export type ModelSubscriptionExpenditureFilterInput = {
   nativeId?: InputMaybe<ModelSubscriptionIntInput>;
   or?: InputMaybe<Array<InputMaybe<ModelSubscriptionExpenditureFilterInput>>>;
   ownerAddress?: InputMaybe<ModelSubscriptionIdInput>;
+  splitPaymentPayoutClaimedNotificationSent?: InputMaybe<ModelSubscriptionBooleanInput>;
   stagedExpenditureAddress?: InputMaybe<ModelSubscriptionIdInput>;
   stakedExpenditureAddress?: InputMaybe<ModelSubscriptionIdInput>;
   status?: InputMaybe<ModelSubscriptionStringInput>;
@@ -9736,6 +9742,7 @@ export type UpdateExpenditureInput = {
   nativeId?: InputMaybe<Scalars['Int']>;
   ownerAddress?: InputMaybe<Scalars['ID']>;
   slots?: InputMaybe<Array<ExpenditureSlotInput>>;
+  splitPaymentPayoutClaimedNotificationSent?: InputMaybe<Scalars['Boolean']>;
   stagedExpenditureAddress?: InputMaybe<Scalars['ID']>;
   stakedExpenditureAddress?: InputMaybe<Scalars['ID']>;
   status?: InputMaybe<ExpenditureStatus>;


### PR DESCRIPTION
## Description

[See block-ingestor PR](https://github.com/JoinColony/block-ingestor/pull/292)

Previously when a split payment is released, a notification would be sent for each recipient resulting in multiple notifications being sent to all users.

This PR adds a flag to the expenditure model to avoid sending multiple notifications for each split payment payout claimed event.

## Testing

* Step 1 - Create a split payment action with multiple recipients

<img width="718" alt="Screenshot 2024-11-04 at 16 08 55" src="https://github.com/user-attachments/assets/77bb2a62-06d1-4c82-920c-a4cc097a3a00">

* Step 2 - Proceed through all the steps and release the payment
* Step 3 - Check you only receive 1 payment notification

<img width="771" alt="Screenshot 2024-11-04 at 16 09 55" src="https://github.com/user-attachments/assets/86738448-1d0e-4925-a072-21a67362f3c3">

## Diffs

**Changes** 🏗

* Added new `splitPaymentPayoutClaimedNotificationSent` flag to expenditure model
* Made changes to payoutClaimed handler to only send notification on first split payment payout claim

Resolves #3574
