### PR TITLE
Fix: Add action sidebar overflow

### DIFF
--- a/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
@@ -314,7 +314,7 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
       </div>
       {isLoading && <ActionSidebarLoadingSkeleton />}
       <div
-        className={clsx('flex flex-grow', {
+        className={clsx('flex flex-grow overflow-y-auto', {
           hidden: isLoading,
         })}
       >


### PR DESCRIPTION
## Description

This adds a vertical overflow for the action sidebar content

![sidebar overflow](https://github.com/user-attachments/assets/05089490-3bc9-46c5-978f-7c414dd320f8)

## Testing

1. Go to a Colony
2. On the left sidebar, click Manage Colony
3. Verify that:
  - the action sidebar content isn't overflowing
  - the action sidebar content's hidden components can be viewed via scrolling
4. Click Edit Colony Details
5. Make sure that the content is scrollable if the Colony Description text area causes the rest of the form contents to go out of view 

Resolves #3620 