### PR TITLE
Fix: Prevent stale response data from useGetColonyForNotificationQuery

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Notification.tsx
@@ -43,6 +43,7 @@ const Notification: FC<NotificationProps> = ({
         address: colonyAddress || '',
       },
       skip: !colonyAddress || !notificationType,
+      fetchPolicy: 'cache-and-network',
     });
 
   const notificationColony = colonyData?.getColonyByAddress?.items[0];

--- a/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
@@ -314,7 +314,7 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
       </div>
       {isLoading && <ActionSidebarLoadingSkeleton />}
       <div
-        className={clsx('flex flex-grow', {
+        className={clsx('flex flex-grow overflow-y-auto', {
           hidden: isLoading,
         })}
       >


### PR DESCRIPTION
## Description

I updated `useGetColonyForNotificationQuery`'s fetch policy to cache-and-network to ensure data freshness. 

![fetchpolicy](https://github.com/user-attachments/assets/7968699b-83dd-48ef-bff5-38b62ddebcad)

## Testing

1. Edit the Colony's name and logo
2. ⚠️  **IMPORTANT** Don't refresh the page
3. Complete a transfer fund action via Permissions
4. ⚠️ **IMPORTANT** Don't refresh the page
5. Wait for the notification to come through
6. Verify that the latest Colony name and logo are shown

Resolves #3576 