### PR TITLE
Fix: Prevent crash when redoing the Manage Reputation action

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/hooks.ts
@@ -7,6 +7,7 @@ import { useWatch } from 'react-hook-form';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useUserReputation from '~hooks/useUserReputation.ts';
 import { getInputTextWidth } from '~utils/elements.ts';
+import { getSafeStringifiedNumber } from '~utils/numbers.ts';
 import { calculatePercentageReputation } from '~utils/reputation.ts';
 import {
   getFormattedTokenValue,
@@ -85,7 +86,7 @@ export const useReputationFields = () => {
 
   const amountValueCalculated = BigNumber.from(
     moveDecimal(
-      amount || '0',
+      getSafeStringifiedNumber(amount),
       getTokenDecimalsWithFallback(nativeToken.decimals),
     ),
   ).toString();

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/utils.ts
@@ -8,6 +8,7 @@ import { type ManageReputationMotionPayload } from '~redux/sagas/motions/manageR
 import { DecisionMethod } from '~types/actions.ts';
 import { type Colony } from '~types/graphql.ts';
 import { getMotionPayload } from '~utils/motions.ts';
+import { getSafeStringifiedNumber } from '~utils/numbers.ts';
 import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
 
 import { ModificationOption } from './consts.ts';
@@ -99,6 +100,9 @@ export const moreThanZeroAmountValidation = (
   const { nativeToken } = colony;
 
   return BigNumber.from(
-    moveDecimal(value, getTokenDecimalsWithFallback(nativeToken.decimals)),
+    moveDecimal(
+      getSafeStringifiedNumber(value),
+      getTokenDecimalsWithFallback(nativeToken.decimals),
+    ),
   ).gt(0);
 };

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -52,3 +52,50 @@ export const adjustPercentagesTo100 = (
   // Convert back to percentages with the specified number of decimals
   return roundedValues.map((value) => value / multiplier);
 };
+
+/**
+ * Safely converts a given value to a numeric string. If the input value is `null`, `undefined`,
+ * or an invalid number, a fallback value is used. If the provided fallback value is also invalid,
+ * it defaults to "0".
+ *
+ * @param {string | number | null | undefined} value - The input value to convert.
+ *    If it's a string, commas are removed before validation.
+ * @param {string | number} [fallbackValue='0'] - The fallback value to use if the input value is
+ *    invalid. If this fallback is not a valid number, it defaults to "0".
+ * @returns {string} A numeric string representing the input value or a valid fallback.
+ *
+ * @example
+ * getSafeStringifiedNumber("20,000") // "20000"
+ * getSafeStringifiedNumber("abc", 100) // "100"
+ * getSafeStringifiedNumber(null, "invalid") // "0"
+ * getSafeStringifiedNumber(undefined) // "0"
+ * getSafeStringifiedNumber(NaN, 50) // "50"
+ */
+export const getSafeStringifiedNumber = (
+  value: string | number | null | undefined,
+  fallbackValue: string | number = '0',
+): string => {
+  // Ensure the fallback value is a valid number
+  const safeFallback = !Number.isNaN(Number(fallbackValue))
+    ? String(fallbackValue)
+    : '0';
+
+  if (value === null || value === undefined) {
+    // If value is null or undefined, use the safe fallback
+    return safeFallback;
+  }
+
+  if (typeof value === 'string') {
+    // Remove commas and check if the result is a valid number
+    const numericString = value.replace(/,/g, '');
+    return !Number.isNaN(Number(numericString)) ? numericString : safeFallback;
+  }
+
+  if (typeof value === 'number') {
+    // Check if the number is NaN
+    return Number.isNaN(value) ? safeFallback : String(value);
+  }
+
+  // Default case if the type is unexpected
+  return safeFallback;
+};


### PR DESCRIPTION
## Description

Added a `getSafeStringifiedNumber` function to sanitise numeric input strings by removing commas and ensuring numeric validity before conversion. This addresses issues with BigNumber.from throwing errors on values like "20,000", which contain commas.

![bignumber-fix](https://github.com/user-attachments/assets/7333a4b1-2078-4dac-a7ef-37e2ef4889ad)

## Testing

1. Award 20,000 points for Amy
2. Redo the action via the UserHub Transactions tab
3. Verify that the app does not crash and Manage Reputation form shows up
4. Verify that you don't see the following error on the console

<img width="601" alt="Screenshot 2024-11-05 at 03 23 07" src="https://github.com/user-attachments/assets/d36cc503-d931-470b-8e0d-6994e1f46efd">

Resolves #3593 