### PR TITLE
Fix: Prevent crash when the Advanced Payment's Completed Action Component mounts

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/CompletedExpenditureContent/CompletedExpenditureContent.tsx
+++ b/src/components/v5/common/CompletedAction/partials/CompletedExpenditureContent/CompletedExpenditureContent.tsx
@@ -88,8 +88,9 @@ const CompletedExpenditureContent: FC<CompletedExpenditureContentProps> = ({
   const tokensCount = getTokensNumber(expenditure);
   const stagedPaymentTokenSymbol =
     tokensCount === 1 &&
-    allTokens.find(({ token }) => token.tokenAddress === stages[0].tokenAddress)
-      ?.token.symbol;
+    allTokens.find(
+      ({ token }) => token.tokenAddress === stages[0]?.tokenAddress,
+    )?.token.symbol;
 
   return (
     <>


### PR DESCRIPTION
## Description

Just needed to add a null guard for the payouts array item to make sure we're not referencing a property from undefined.

## Testing

1. Create an Advanced Payment
2. Verify that the app doesn't crash as soon as the Advanced Payment Completed Action Component mounts

Resolves #3626