### PR TITLE
Fix: Enable the Advanced Payment form's staking submission logic

### DIFF
--- a/src/components/shared/Fields/Form/ActionForm.tsx
+++ b/src/components/shared/Fields/Form/ActionForm.tsx
@@ -1,4 +1,7 @@
-import React, { type ButtonHTMLAttributes } from 'react';
+import React, {
+  type MouseEventHandler,
+  type ButtonHTMLAttributes,
+} from 'react';
 import { type FieldValues, type UseFormReturn } from 'react-hook-form';
 
 import { authenticateWallet } from '~auth';
@@ -56,7 +59,7 @@ export interface ActionFormProps<
     type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
 
     /** Function called when the form's primary button type is set to "button" */
-    onClick?: () => void;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
   };
 }
 

--- a/src/components/v5/common/ActionSidebar/partials/ActionButtons.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionButtons.tsx
@@ -34,7 +34,6 @@ const displayName = 'v5.common.ActionSidebar.partials.ActionButtons';
 const ActionButtons: FC<ActionButtonsProps> = ({
   isActionDisabled,
   primaryButton,
-  onSubmitClick,
 }) => {
   const isMobile = useMobile();
   const { colony } = useColonyContext();
@@ -85,9 +84,7 @@ const ActionButtons: FC<ActionButtonsProps> = ({
     return undefined;
   });
 
-  const primaryButtonType = onSubmitClick
-    ? 'button'
-    : primaryButton?.type ?? 'submit';
+  const primaryButtonType = primaryButton?.type ?? 'submit';
 
   return (
     <div
@@ -126,8 +123,10 @@ const ActionButtons: FC<ActionButtonsProps> = ({
             text={submitText}
             isFullSize={isMobile}
             type={primaryButtonType}
-            onClick={() =>
-              primaryButton?.type === 'button' && primaryButton?.onClick?.()
+            onClick={
+              primaryButtonType === 'button'
+                ? primaryButton?.onClick
+                : undefined
             }
           />
         )}

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -24,7 +24,6 @@ import {
   DESCRIPTION_FIELD_NAME,
   TITLE_FIELD_NAME,
 } from '~v5/common/ActionSidebar/consts.ts';
-import { actionsWithStakingDecisionMethod } from '~v5/common/ActionSidebar/hooks/permissions/consts.ts';
 import useHasActionPermissions from '~v5/common/ActionSidebar/hooks/permissions/useHasActionPermissions.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import useActionFormProps from '~v5/common/ActionSidebar/hooks/useActionFormProps.ts';
@@ -34,7 +33,6 @@ import NotificationBanner from '~v5/shared/NotificationBanner/NotificationBanner
 
 import ActionButtons from '../ActionButtons.tsx';
 import ActionSidebarDescription from '../ActionSidebarDescription/ActionSidebarDescription.tsx';
-import CreateStakedExpenditureModal from '../CreateStakedExpenditureModal/CreateStakedExpenditureModal.tsx';
 import RemoveDraftModal from '../RemoveDraftModal/RemoveDraftModal.tsx';
 
 import { useGetFormActionErrors } from './hooks.ts';
@@ -76,11 +74,9 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
   const {
     formState: {
       errors: { this: customError },
-      isValid,
     },
     getValues,
     reset,
-    trigger,
   } = useFormContext();
 
   const formValues = getValues();
@@ -109,21 +105,9 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
     { toggleOn: showRemoveDraftModal, toggleOff: hideRemoveDraftModal },
   ] = useToggle();
 
-  const [
-    isCreateStakedExpenditureModalVisible,
-    {
-      toggleOn: showCreateStakedExpenditureModal,
-      toggleOff: hideCreateStakedExpenditureModal,
-    },
-  ] = useToggle();
-
   const draftAgreement = useSelector(
     getDraftDecisionFromStore(user?.walletAddress || '', colony.colonyAddress),
   );
-
-  const shouldShowCreateStakedExpenditureModal =
-    actionsWithStakingDecisionMethod.includes(actionType) &&
-    decisionMethod === DecisionMethod.Staking;
 
   useEffect(() => {
     if (
@@ -218,17 +202,6 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
         <div className="mt-auto">
           <ActionButtons
             isActionDisabled={isSubmitDisabled}
-            onSubmitClick={
-              shouldShowCreateStakedExpenditureModal
-                ? async () => {
-                    await trigger();
-
-                    if (isValid) {
-                      showCreateStakedExpenditureModal();
-                    }
-                  }
-                : undefined
-            }
             primaryButton={primaryButton}
           />
         </div>
@@ -254,14 +227,6 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
             });
             hideRemoveDraftModal();
           }}
-        />
-      )}
-      {shouldShowCreateStakedExpenditureModal && (
-        <CreateStakedExpenditureModal
-          actionType={actionType}
-          isOpen={isCreateStakedExpenditureModalVisible}
-          onClose={hideCreateStakedExpenditureModal}
-          formValues={formValues}
         />
       )}
     </>

--- a/src/components/v5/common/ActionSidebar/partials/CreateStakedExpenditureModal/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/CreateStakedExpenditureModal/hooks.tsx
@@ -1,0 +1,57 @@
+import React, { useCallback } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { type Action } from '~constants/actions.ts';
+import useToggle from '~hooks/useToggle/index.ts';
+import { DecisionMethod } from '~types/actions.ts';
+import { actionsWithStakingDecisionMethod } from '~v5/common/ActionSidebar/hooks/permissions/consts.ts';
+
+import CreateStakedExpenditureModal from './CreateStakedExpenditureModal.tsx';
+
+export const useShowCreateStakedExpenditureModal = (actionType: Action) => {
+  const [
+    isStakedExpenditureModalVisible,
+    { toggleOn: showStakedExpenditureModal, toggleOff },
+  ] = useToggle();
+
+  const {
+    watch,
+    formState: { isValid },
+  } = useFormContext();
+
+  const stringifiedWatchValues = JSON.stringify(watch());
+
+  const shouldShowStakedExpenditureModal =
+    actionsWithStakingDecisionMethod.includes(actionType) &&
+    watch().decisionMethod === DecisionMethod.Staking &&
+    isValid;
+
+  const renderStakedExpenditureModal = useCallback(() => {
+    const originalWatchValues = JSON.parse(stringifiedWatchValues);
+
+    if (shouldShowStakedExpenditureModal && isStakedExpenditureModalVisible) {
+      return (
+        <CreateStakedExpenditureModal
+          actionType={actionType}
+          isOpen={isStakedExpenditureModalVisible}
+          onClose={toggleOff}
+          formValues={originalWatchValues}
+        />
+      );
+    }
+
+    return null;
+  }, [
+    actionType,
+    isStakedExpenditureModalVisible,
+    shouldShowStakedExpenditureModal,
+    stringifiedWatchValues,
+    toggleOff,
+  ]);
+
+  return {
+    showStakedExpenditureModal,
+    renderStakedExpenditureModal,
+    shouldShowStakedExpenditureModal,
+  };
+};

--- a/src/components/v5/common/ActionSidebar/partials/CreateStakedExpenditureModal/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/CreateStakedExpenditureModal/hooks.tsx
@@ -29,18 +29,16 @@ export const useShowCreateStakedExpenditureModal = (actionType: Action) => {
   const renderStakedExpenditureModal = useCallback(() => {
     const originalWatchValues = JSON.parse(stringifiedWatchValues);
 
-    if (shouldShowStakedExpenditureModal && isStakedExpenditureModalVisible) {
-      return (
-        <CreateStakedExpenditureModal
-          actionType={actionType}
-          isOpen={isStakedExpenditureModalVisible}
-          onClose={toggleOff}
-          formValues={originalWatchValues}
-        />
-      );
-    }
-
-    return null;
+    return (
+      <CreateStakedExpenditureModal
+        actionType={actionType}
+        isOpen={
+          shouldShowStakedExpenditureModal && isStakedExpenditureModalVisible
+        }
+        onClose={toggleOff}
+        formValues={originalWatchValues}
+      />
+    );
   }, [
     actionType,
     isStakedExpenditureModalVisible,

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/PaymentBuilderForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/PaymentBuilderForm.tsx
@@ -18,7 +18,7 @@ import PaymentBuilderRecipientsField from './partials/PaymentBuilderRecipientsFi
 const displayName = 'v5.common.ActionSidebar.partials.PaymentBuilderForm';
 
 const PaymentBuilderForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
-  usePaymentBuilder(getFormOptions);
+  const { renderStakedExpenditureModal } = usePaymentBuilder(getFormOptions);
   const hasNoDecisionMethods = useHasNoDecisionMethods();
 
   const createdInFilterFn = useFilterCreatedInField('from');
@@ -49,6 +49,7 @@ const PaymentBuilderForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       <CreatedIn filterOptionsFn={createdInFilterFn} />
       <Description />
       <PaymentBuilderRecipientsField name="payments" />
+      {renderStakedExpenditureModal()}
     </>
   );
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/hooks.ts
@@ -6,6 +6,7 @@ import { useMemo } from 'react';
 import { type DeepPartial } from 'utility-types';
 import { array, type InferType, number, object, string } from 'yup';
 
+import { Action } from '~constants/actions.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
 import useTokenLockStates from '~hooks/useTokenLockStates.ts';
@@ -18,6 +19,7 @@ import { shouldPreventPaymentsWithTokenInColony } from '~utils/tokens.ts';
 import { amountGreaterThanZeroValidation } from '~utils/validation/amountGreaterThanZeroValidation.ts';
 import { ACTION_BASE_VALIDATION_SCHEMA } from '~v5/common/ActionSidebar/consts.ts';
 import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { useShowCreateStakedExpenditureModal } from '~v5/common/ActionSidebar/partials/CreateStakedExpenditureModal/hooks.tsx';
 import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { CLAIM_DELAY_MAX_VALUE } from './partials/ClaimDelayField/consts.ts';
@@ -184,6 +186,12 @@ export const usePaymentBuilder = (
   const { networkInverseFee = '0' } = useNetworkInverseFee();
   const validationSchema = useValidationSchema(networkInverseFee);
 
+  const {
+    renderStakedExpenditureModal,
+    showStakedExpenditureModal,
+    shouldShowStakedExpenditureModal,
+  } = useShowCreateStakedExpenditureModal(Action.PaymentBuilder);
+
   useActionFormBaseHook({
     validationSchema,
     defaultValues: useMemo<DeepPartial<PaymentBuilderFormValues>>(
@@ -211,5 +219,11 @@ export const usePaymentBuilder = (
     transform: mapPayload((payload: PaymentBuilderFormValues) => {
       return getPaymentBuilderPayload(colony, payload, networkInverseFee);
     }),
+    primaryButton: {
+      type: shouldShowStakedExpenditureModal ? 'button' : 'submit',
+      onClick: showStakedExpenditureModal,
+    },
   });
+
+  return { renderStakedExpenditureModal };
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/SplitPaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/SplitPaymentForm.tsx
@@ -23,7 +23,8 @@ import SplitPaymentRecipientsField from './partials/SplitPaymentRecipientsField/
 const displayName = 'v5.common.ActionSidebar.partials.SplitPaymentForm';
 
 const SplitPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
-  const { currentToken, distributionMethod } = useSplitPayment(getFormOptions);
+  const { currentToken, distributionMethod, renderStakedExpenditureModal } =
+    useSplitPayment(getFormOptions);
   const hasNoDecisionMethods = useHasNoDecisionMethods();
 
   const { watch, trigger } = useFormContext();
@@ -112,6 +113,7 @@ const SplitPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
           disabled={hasNoDecisionMethods}
         />
       )}
+      {renderStakedExpenditureModal()}
     </>
   );
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/hooks.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { array, type InferType, number, object, string } from 'yup';
 
+import { Action } from '~constants/actions.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { SplitPaymentDistributionType } from '~gql';
 import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
@@ -21,6 +22,7 @@ import {
   DECISION_METHOD_FIELD_NAME,
 } from '~v5/common/ActionSidebar/consts.ts';
 import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { useShowCreateStakedExpenditureModal } from '~v5/common/ActionSidebar/partials/CreateStakedExpenditureModal/hooks.tsx';
 import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { getSplitPaymentPayload } from './utils.ts';
@@ -238,6 +240,12 @@ export const useSplitPayment = (
   const validationSchema = useValidationSchema();
   const { networkInverseFee = '0' } = useNetworkInverseFee();
 
+  const {
+    renderStakedExpenditureModal,
+    showStakedExpenditureModal,
+    shouldShowStakedExpenditureModal,
+  } = useShowCreateStakedExpenditureModal(Action.SplitPayment);
+
   useActionFormBaseHook({
     validationSchema,
     defaultValues: useMemo(
@@ -261,10 +269,15 @@ export const useSplitPayment = (
     transform: mapPayload((payload: SplitPaymentFormValues) =>
       getSplitPaymentPayload(colony, payload, networkInverseFee),
     ),
+    primaryButton: {
+      type: shouldShowStakedExpenditureModal ? 'button' : 'submit',
+      onClick: showStakedExpenditureModal,
+    },
   });
 
   return {
     currentToken,
     distributionMethod,
+    renderStakedExpenditureModal,
   };
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/StagedPaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/StagedPaymentForm.tsx
@@ -24,7 +24,9 @@ const displayName = 'v5.common.ActionSidebar.partials.StagedPaymentForm';
 
 const StagedPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
   const hasNoDecisionMethods = useHasNoDecisionMethods();
-  useStagePayment(getFormOptions);
+
+  const { renderStakedExpenditureModal } = useStagePayment(getFormOptions);
+
   const decisionMethodFilterFn = createUnsupportedDecisionMethodFilter([
     DecisionMethod.MultiSig,
     DecisionMethod.Reputation,
@@ -65,6 +67,7 @@ const StagedPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       <CreatedIn />
       <Description />
       <StagedPaymentRecipientsField name="stages" />
+      {renderStakedExpenditureModal()}
     </>
   );
 };

--- a/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/hooks.ts
@@ -4,6 +4,7 @@ import { type DeepPartial } from 'utility-types';
 import { type InferType, array, number, object, string } from 'yup';
 
 import { MAX_MILESTONE_LENGTH } from '~constants';
+import { Action } from '~constants/actions.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { usePaymentBuilderContext } from '~context/PaymentBuilderContext/PaymentBuilderContext.ts';
 import { ExpenditureType } from '~gql';
@@ -24,6 +25,7 @@ import {
   FROM_FIELD_NAME,
 } from '~v5/common/ActionSidebar/consts.ts';
 import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
+import { useShowCreateStakedExpenditureModal } from '~v5/common/ActionSidebar/partials/CreateStakedExpenditureModal/hooks.tsx';
 import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
 import { allTokensAmountValidation } from '../PaymentBuilderForm/utils.ts';
@@ -163,6 +165,9 @@ export const useStagePayment = (
   const validationSchema = useValidationSchema(networkInverseFee);
   const { setExpectedExpenditureType } = usePaymentBuilderContext();
 
+  const { renderStakedExpenditureModal, showStakedExpenditureModal } =
+    useShowCreateStakedExpenditureModal(Action.StagedPayment);
+
   useActionFormBaseHook({
     validationSchema,
     defaultValues: useMemo<DeepPartial<StagedPaymentFormValues>>(
@@ -189,5 +194,13 @@ export const useStagePayment = (
     transform: mapPayload((payload: StagedPaymentFormValues) => {
       return getStagedPaymentPayload(colony, payload, networkInverseFee);
     }),
+    primaryButton: {
+      type: 'button',
+      onClick: showStakedExpenditureModal,
+    },
   });
+
+  return {
+    renderStakedExpenditureModal,
+  };
 };


### PR DESCRIPTION
## Description

I found some time to refactor the `ActionSidebarContent`. I took out expenditure staking-specific logic and handled it in their respective forms instead.

I create a new hook called `useShowCreateStakedExpenditureModal` which encapsulates logic for showing/hiding the expenditure modal. Basically, we're meant to show this modal for the following actions if the decision method is set to `DecisionMethod.Staking`:

```js
export const actionsWithStakingDecisionMethod = [
  Action.PaymentBuilder,
  Action.StagedPayment,
  Action.SplitPayment,
];
```

<img width="528" alt="image" src="https://github.com/user-attachments/assets/5e54ce93-3d34-415d-a29d-c8c5e288591b">

For future reference, you can control the Action Form's primary button type and onClick props via the `useActionFormBaseHook` hook i.e.

```js
useActionFormBaseHook({
  ...otherOptions,
  primaryButton: { <<-- This one! 😄 
    type: shouldShowStakedExpenditureModal ? 'button' : 'submit',
    onClick: showStakedExpenditureModal,
  },
});
``` 

## Testing

1. Bring up the Advanced Payment form
2. Set the decision method to Staking
3. Fill in all other required fields
4. Submit the form
5. Verify that the Staking Expenditure Modal shows up

Resolves #3628