### PR TITLE
Fix: Update external links mobile styles

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/GroupedActionWrapper/GroupedActionWrapper.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/GroupedActionWrapper/GroupedActionWrapper.tsx
@@ -9,7 +9,7 @@ export const GroupedActionWrapper: FC<
   PropsWithChildren<GroupedActionWrapperProps>
 > = ({ title, description, children }) => {
   return (
-    <div className="overflow-auto px-6 py-8 pr-8">
+    <div className="w-full overflow-auto px-6 py-8 pr-8">
       <h2 className="pb-2 heading-3">{title}</h2>
       <p className="pb-8 text-md text-gray-600">{description}</p>
       {children}

--- a/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/SocialLinksTable.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/EditColonyDetailsForm/partials/SocialLinksTable/SocialLinksTable.tsx
@@ -77,6 +77,7 @@ const SocialLinksTable: FC<SocialLinksTableProps> = ({ name }) => {
               readonly || hasNoDecisionMethods ? undefined : getMenuProps
             }
             verticalLayout={isMobile}
+            withBorder={false}
           />
         </>
       )}

--- a/src/components/v5/common/CompletedAction/partials/rows/SocialLinksTable.tsx
+++ b/src/components/v5/common/CompletedAction/partials/rows/SocialLinksTable.tsx
@@ -30,12 +30,13 @@ const SocialLinksTable = ({ socialLinks }: Props) => {
             {formatText({ id: 'editColony.socialLinks.table.title' })}
           </h5>
           <Table<SocialLinksTableModel>
-            sizeUnit="%"
-            meatBallMenuSize={10}
+            sizeUnit={isMobile ? undefined : '%'}
+            meatBallMenuSize={isMobile ? undefined : 10}
             getRowId={({ key }) => key}
             columns={columns}
             data={data}
             verticalLayout={isMobile}
+            withBorder={false}
           />
         </>
       )}

--- a/src/hooks/useSocialLinksTableColumns.tsx
+++ b/src/hooks/useSocialLinksTableColumns.tsx
@@ -2,6 +2,7 @@ import { createColumnHelper, type ColumnDef } from '@tanstack/react-table';
 import clsx from 'clsx';
 import React, { useMemo } from 'react';
 
+import { useMobile } from '~hooks';
 import { type SocialLinksTableModel } from '~types/colony.ts';
 import { formatText } from '~utils/intl.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
@@ -16,6 +17,8 @@ export const useSocialLinksTableColumns = (): ColumnDef<
   );
 
   const hasNoDecisionMethods = useHasNoDecisionMethods();
+
+  const isMobile = useMobile();
 
   const columns: ColumnDef<SocialLinksTableModel, string>[] = useMemo(
     () => [
@@ -36,7 +39,7 @@ export const useSocialLinksTableColumns = (): ColumnDef<
             {getValue()}
           </span>
         ),
-        size: 23,
+        size: isMobile ? 118 : 23,
       }),
       columnHelper.accessor('link', {
         enableSorting: false,
@@ -61,7 +64,7 @@ export const useSocialLinksTableColumns = (): ColumnDef<
         size: 67,
       }),
     ],
-    [columnHelper, hasNoDecisionMethods],
+    [columnHelper, hasNoDecisionMethods, isMobile],
   );
 
   return columns;


### PR DESCRIPTION
## Description

I just updated the mobile styles of the table so that the `th` contents are properly contained within the `th` components. I also removed the dividers and I based this from the Figma designs:

**Mobile:** [Mobile Figma URL](https://www.figma.com/design/l1dOM5qiQYwF0ElvKDqqjg/Design-System---Colony-v3?node-id=1782-156523&t=qaKy19kp8aAlTYrP-4)

**Non-mobile:** [Mobile Figma URL](https://www.figma.com/design/l1dOM5qiQYwF0ElvKDqqjg/Design-System---Colony-v3?node-id=1782-156462&t=qaKy19kp8aAlTYrP-4)

<img width="405" alt="image" src="https://github.com/user-attachments/assets/9801ee1a-12a0-41b5-a56f-7cd38486df85">

## Testing

1. Open the EditColony Details form
2. Set your view to mobile
3. Verify that the UI matches the designs

Resolves #3488 