### PR TITLE
Fix: Overlapping timeframe keys

### DIFF
--- a/amplify/backend/function/fetchDomainBalance/src/services/actions.js
+++ b/amplify/backend/function/fetchDomainBalance/src/services/actions.js
@@ -10,7 +10,7 @@ const {
   getFormattedIncomingFunds,
   getFormattedExpenditures,
   getTokenAddressesFromExpenditures,
-  getPeriodFormat,
+  getFullPeriodFormat,
   getPeriodFor,
   isAfter,
   isBefore,
@@ -94,8 +94,12 @@ const groupBalanceByPeriod = (
 
   // Initialise the balance for each period item within the timeframe
   for (let periodIndex = 0; periodIndex < timeframePeriod; periodIndex++) {
-    const periodStartDate = getPeriodFor(periodIndex, timeframeType, timeframePeriodEndDate);
-    const formattedPeriod = getPeriodFormat(periodStartDate, timeframeType);
+    const periodStartDate = getPeriodFor(
+      periodIndex,
+      timeframeType,
+      timeframePeriodEndDate,
+    );
+    const formattedPeriod = getFullPeriodFormat(periodStartDate, timeframeType);
 
     if (!balance[formattedPeriod]) {
       balance[formattedPeriod] = getDefaultDomainBalance();
@@ -103,7 +107,7 @@ const groupBalanceByPeriod = (
   }
   // Add each action to its corresponding balance period in/out operation
   actions.forEach((action) => {
-    const period = getPeriodFormat(action.finalizedDate, timeframeType);
+    const period = getFullPeriodFormat(action.finalizedDate, timeframeType);
 
     // If we are at colony level and the action has a type
     // The action is among the acceptedColonyActionTypes and must be an outgoing source of funds

--- a/amplify/backend/function/fetchDomainBalance/src/utils.js
+++ b/amplify/backend/function/fetchDomainBalance/src/utils.js
@@ -99,6 +99,35 @@ const subtractDaysFor = (numberOfDays, timeframePeriodEndDate) => {
   return startOfDay(new Date(subDays(now, numberOfDays)));
 };
 
+const getFullPeriodFormat = (date, timeframeType) => {
+  if (!date || timeframeType === TimeframeType.TOTAL) {
+    return '0';
+  }
+
+  let formattingPattern = ``;
+
+  switch (timeframeType) {
+    case TimeframeType.DAILY: {
+      formattingPattern = 'dd-MM-yyyy';
+      break;
+    }
+    case TimeframeType.WEEKLY: {
+      formattingPattern = `ww'W'-yyyy`;
+      break;
+    }
+    case TimeframeType.MONTHLY: {
+      formattingPattern = '01-MM-yyyy';
+      break;
+    }
+    default: {
+      formattingPattern = '01-01-yyyy';
+      break;
+    }
+  }
+
+  return format(new Date(date), formattingPattern);
+};
+
 const getPeriodFormat = (date, timeframeType) => {
   if (!date || timeframeType === TimeframeType.TOTAL) {
     return '0';
@@ -254,6 +283,7 @@ const shouldFetchNetworkBalance = (timeframeType) =>
 module.exports = {
   getDifferenceInSeconds,
   getPeriodFormat,
+  getFullPeriodFormat,
   getPeriodFor,
   getFormattedIncomingFunds,
   getFormattedActions,

--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/utils.ts
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/utils.ts
@@ -1,4 +1,4 @@
-import { format, setMonth } from 'date-fns';
+import { format, parse, setMonth, setWeek, startOfWeek } from 'date-fns';
 import numbro from 'numbro';
 
 import { convertToDecimal } from '~utils/convertToDecimal.ts';
@@ -14,6 +14,23 @@ export const getMonthShortName = (month: string) => {
   const now = Date.now();
 
   return format(new Date(setMonth(now, parsedMonth)), 'MMM');
+};
+
+export const parseTimeframeKey = (key: string = '') => {
+  let parsedDate = new Date();
+  if (/^\d{2}-\d{2}-\d{4}$/.test(key)) {
+    parsedDate = parse(key, 'dd-MM-yyyy', new Date());
+  } else if (/^\d{2}W-\d{4}$/.test(key)) {
+    const [weekString, yearString] = key.split('W-');
+    const year = parseInt(yearString, 10);
+    const week = parseInt(weekString, 10);
+    const startOfYearDate = new Date(year, 0, 1);
+    parsedDate = startOfWeek(setWeek(startOfYearDate, week), {
+      weekStartsOn: 1,
+    });
+  }
+
+  return format(parsedDate, 'MM');
 };
 
 export const getFallbackData = () => {

--- a/src/context/TotalInOutBalanceChartContext/TotalInOutBalanceChartContextProvider.tsx
+++ b/src/context/TotalInOutBalanceChartContext/TotalInOutBalanceChartContextProvider.tsx
@@ -13,7 +13,10 @@ import {
   useGetDomainBalanceQuery,
 } from '~gql';
 import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
-import { sortByLabel } from '~v5/frame/ColonyHome/partials/TotalInOutBalance/utils.ts';
+import {
+  sortByLabel,
+  parseTimeframeKey,
+} from '~v5/frame/ColonyHome/partials/TotalInOutBalance/utils.ts';
 
 import { useColonyContext } from '../ColonyContext/ColonyContext.ts';
 
@@ -79,7 +82,7 @@ const TotalInOutBalanceChartContextProvider: FC<PropsWithChildren> = ({
   const value = useMemo(() => {
     const timeframeBalanceArray = domainBalanceData?.timeframe
       ?.map((timeframeBalance) => ({
-        label: timeframeBalance?.key,
+        label: parseTimeframeKey(timeframeBalance?.key),
         in: convertAmount(timeframeBalance?.value?.totalIn ?? '0'),
         out: convertAmount(timeframeBalance?.value?.totalOut ?? '0'),
       }))


### PR DESCRIPTION
## Description

- This PR addresses the bug related to overlapping timeframe keys. 
- Given for the moment we query data only for the `last 4 months` (which is less than the actual number of months in a year), the issue was not immediately visible.

## Testing

TODO: Let's test the retrieved data contains the full date keys and the changes didn't impact the `Total in and out` chart

* Step 1. First make sure you have started your dev env and have data in your colony
* Step 2. Visit http://localhost:9091/planex and make sure the chart has data to display for the current month

![Screenshot 2024-11-05 at 16 33 55](https://github.com/user-attachments/assets/2954997e-527f-4a27-958c-03ce8ea72592)

* Step 3. Now let us run some queries
* Step 4. Go to http://localhost:20002/ and run the following query
```
query MyQuery {
  getDomainBalance(
    input: {
      colonyAddress: "<COLONY_ADDRESS_HERE>", 
      timeframePeriod: 4, 
      timeframeType: WEEKLY
    }
  ) {
    timeframe {
      key
      value {
        total
        totalIn
        totalOut
      }
    }
  }
}
```
![Screenshot 2024-11-05 at 16 35 36](https://github.com/user-attachments/assets/93ddc0e7-bfa2-4df0-8eea-038e5e393ede)

* Step 5. Now please use different `timeframePeriod` and `timeframeType` values (ideally timeframePeriod > 12 if you use `Monthly` timeframeType or timeframePeriod > 31 for `Daily`)

> [!IMPORTANT]
> With the latest changes to fetch data directly from the network for the `Total` timeframeType, the `timeframe` array should be empty


## Diffs

**New stuff** ✨

* `getFullPeriodFormat` to retrieve the whole needed date for a timeframe entry
* `parseTimeframeKey` to parse the timeframe key before using it for the chart data

Contributes to #3555
