### PR TITLE
Fix: Correctly show the expected Action Form content

### DIFF
--- a/src/components/shared/Fields/Form/Form.tsx
+++ b/src/components/shared/Fields/Form/Form.tsx
@@ -129,6 +129,20 @@ const Form = <FormData extends FieldValues>({
     [handleSubmit, onSubmit, formHelpers, onError],
   );
 
+  // Separate concern for handling defaultValues updates
+  useEffect(() => {
+    const initializeForm = async () => {
+      const resolvedDefaultValues =
+        typeof defaultValues === 'function'
+          ? await defaultValues()
+          : defaultValues;
+
+      formHelpers.reset(resolvedDefaultValues);
+    };
+
+    initializeForm();
+  }, [defaultValues, formHelpers]);
+
   return (
     <AdditionalFormOptionsContextProvider value={{ readonly }}>
       <FormProvider {...formHelpers}>

--- a/src/components/v5/common/ActionSidebar/hooks/useActionFormProps.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useActionFormProps.ts
@@ -1,5 +1,5 @@
 import { noop } from 'lodash';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { type Action } from '~constants/actions.ts';
@@ -32,6 +32,17 @@ const useActionFormProps = (
   });
   const { colony } = useColonyContext();
   const [searchParams, setSearchParams] = useSearchParams();
+
+  // This ensures that actionFormProps always receives the freshest defaultValues updates
+  useEffect(() => {
+    if (defaultValues) {
+      setActionFormProps((state) => ({
+        ...state,
+        actionType: defaultValues.actionType,
+        defaultValues,
+      }));
+    }
+  }, [defaultValues]);
 
   const getFormOptions = useCallback<ActionFormBaseProps['getFormOptions']>(
     async (formOptions, form) => {
@@ -82,7 +93,7 @@ const useActionFormProps = (
           readonly: isReadonly,
           ...formOptions.options,
         },
-        defaultValues: formOptionsWithDefaults,
+        defaultValues: actionFormProps.defaultValues,
       });
 
       if (prevActionTypeRef.current === actionType) {
@@ -99,6 +110,7 @@ const useActionFormProps = (
       defaultValues,
       colony.nativeToken.tokenAddress,
       isReadonly,
+      actionFormProps.defaultValues,
       searchParams,
       setSearchParams,
     ],

--- a/src/context/ActionSidebarContext/ActionSidebarContextProvider.tsx
+++ b/src/context/ActionSidebarContext/ActionSidebarContextProvider.tsx
@@ -2,7 +2,6 @@ import React, {
   type FC,
   type PropsWithChildren,
   useCallback,
-  useEffect,
   useMemo,
   useState,
 } from 'react';
@@ -77,12 +76,6 @@ const ActionSidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
     removeTxParamOnClose();
     return undefined;
   });
-
-  useEffect(() => {
-    if (!isActionSidebarOpen) {
-      setActionSidebarInitialValues(undefined);
-    }
-  }, [isActionSidebarOpen]);
 
   const toggleOn = useCallback(
     (initialValues) => {


### PR DESCRIPTION
## Description

There was a weird race condition being caused by a `useEffect` inside `ActionSidebarContextProvider`. It was resetting a state which ended up clearing the current action which we're using to conditionally render either the GroupedTransactionContent or the actual Action Form.

![race-condition](https://github.com/user-attachments/assets/44859247-3559-45bf-9e56-5e2763019bef)

There was also an issue wherein if you're already on an action-specific form i.e. Simple payment, clicking the "Create agreement" button on the Sidebar doesn't do anything. I fixed those up to make sure that the actionType correctly propagates, which should hopefully make the form update correctly depending on what action has been set.

![action-form-updates](https://github.com/user-attachments/assets/72a346e5-1333-4f15-bcff-3613a9402da0)

## Testing

1. Click the Manage Colony Sidebar button
2. Verify that you see the Manage Group Content
3. Click the Make Payment Sidebar button
4. Verify that you see the Payments Group Content
5. Click Simple Payment
6. Wait for the Simple Payment form to be initialised
7. Click the Create Agreement Sidebar button
8. Verify that the form gets correctly updated to Create Agreement
9. Click the Manage Colony Sidebar button
10. Verify that you see the Manage Group Content
11. Click Mint Tokens
12. Click the Make Payment Sidebar button 
13. Verify that you see the Payments Group Content

Resolves #3482 