### PR TITLE
Fix: Locked token validation should properly refresh

### DIFF
--- a/src/hooks/useTokenLockStates.ts
+++ b/src/hooks/useTokenLockStates.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useGetColonyTokenLockedStateLazyQuery } from '~gql';
@@ -10,7 +10,7 @@ const useTokenLockStates = (): Record<string, boolean> => {
   const [getColonyTokenLockedState] = useGetColonyTokenLockedStateLazyQuery();
   const [tokenLockStatesMap, setTokenLockStatesMap] = useState({});
 
-  const fetchTokenStates = useCallback(async () => {
+  const fetchTokenStates = async () => {
     if (!tokens) {
       return;
     }
@@ -39,11 +39,11 @@ const useTokenLockStates = (): Record<string, boolean> => {
     });
 
     setTokenLockStatesMap(newTokenLockStatesMap);
-  }, [getColonyTokenLockedState, tokens]);
+  };
 
   useEffect(() => {
     fetchTokenStates();
-  }, [fetchTokenStates]);
+  }, []);
 
   return tokenLockStatesMap;
 };


### PR DESCRIPTION
## Description

This PR removes useCallback from `fetchTokenStates` and instead calls it on initial render to ensure the latest token lock state is used.

## Explanation if you're interested

Bit of an edge case here. The `fetchTokenStates` function previously used `useCallback` and is only called when either the `getColonyTokenLockedState` or `tokens` passed from the colony context change.

When a token is unlocked, the `tokens` array passed from the colony context doesn't actually change as the locked status is not stored on the token model. This means the `fetchTokenStates` `useCallback` is not re-run as there are no changes. As a result, if a user has the app opened, and a token's locked status is changed by another user, this change will not be reflected in the token select component / validation until the user refreshes the entire app.

This PR removes the `useCallback` and changes the `useEffect` in `useTokenLockStates` to call `fetchTokenStates` when it is first rendered to fetch the fresh token locked state.

## Testing

For testing, open two tabs, one in the Planex colony and one in the Wayne colony both as the Leela wallet. Do not refresh at any point during these steps.

* Step 1 - Planex tab: Go to the incoming funds page and claim the incoming GGG tokens.
* Step 2 - Planex tab: Create a Simple Payment action. Switch the token to GGG. Note the validation error:

<img width="684" alt="Screenshot 2024-11-05 at 15 53 48" src="https://github.com/user-attachments/assets/7cf43345-ad0c-40f5-918e-2ffcbf052a98">

* Step 3 - Planex tab: Close the action sidebar
* Step 4 - Wayne tab: Create an unlock tokens action.

<img width="681" alt="Screenshot 2024-11-05 at 15 54 06" src="https://github.com/user-attachments/assets/9979ce7d-f44b-4f0d-8213-4ec56096c58c">

* Step 5 - Planex tab: Create a Simple Payment action. Switch the token to GGG. There should be no validation error:

<img width="678" alt="Screenshot 2024-11-05 at 15 54 20" src="https://github.com/user-attachments/assets/bb159082-328e-40ad-a939-35ae0ee4819c">

## Diffs

**Changes** 🏗

* `fetchTokenStates` is called on initial render

Resolves #3403
