### PR TITLE
Fix: Dismiss lingering tooltips when the page is scrolled

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/ColonyLinks.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/ColonyLinks.tsx
@@ -157,7 +157,7 @@ const ColonyLinks = () => {
           tooltipContent={getCopyVariant({
             uncopied: 'colony.tooltip.colonyAddress.copy',
             copied: 'colony.tooltip.url.copied',
-            isCopied: isColonyAddressCopied,
+            isCopied: isShareUrlCopied,
             isMobile,
           })}
           isCopy

--- a/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/helpers.ts
+++ b/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/helpers.ts
@@ -1,4 +1,5 @@
 import { type ExternalLink } from '~gql';
+import { formatText } from '~utils/intl.ts';
 import { COLONY_LINK_CONFIG } from '~v5/shared/SocialLinks/colonyLinks.ts';
 
 export const sortExternalLinks = (
@@ -10,4 +11,26 @@ export const sortExternalLinks = (
     (link1, link2) =>
       linksPriority.indexOf(link1.name) - linksPriority.indexOf(link2.name),
   );
+};
+
+export const getCopyVariant = ({
+  copied,
+  uncopied,
+  isCopied,
+  isMobile,
+}: {
+  uncopied: string;
+  copied: string;
+  isCopied: boolean;
+  isMobile: boolean;
+}) => {
+  let tooltipMessage = uncopied;
+
+  if (isMobile || isCopied) {
+    tooltipMessage = copied;
+  }
+
+  return formatText({
+    id: tooltipMessage,
+  });
 };

--- a/src/components/v5/frame/PageLayout/PageLayout.tsx
+++ b/src/components/v5/frame/PageLayout/PageLayout.tsx
@@ -65,6 +65,7 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
               {headerProps ? <PageHeader {...headerProps} /> : header}
             </section>
             <section
+              id="main-content-container"
               className={clsx(
                 'modal-blur h-full w-full overflow-auto px-6 scrollbar-gutter-stable md:p-8 md:pb-0 md:pt-2',
                 {

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -1,27 +1,31 @@
 import copyToClipboard from 'copy-to-clipboard';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 const useCopyToClipboard = (copyTimeOut = 2000) => {
   const [isCopied, setCopied] = useState(false);
 
+  const timeout = useRef<ReturnType<typeof setTimeout>>();
+
   const handleClipboardCopy = (dataToCopy: string) => {
+    clearTimeout(timeout.current); // Clear any existing timeout
     setCopied(true);
     copyToClipboard(dataToCopy);
+    timeout.current = setTimeout(() => setCopied(false), copyTimeOut);
   };
 
+  const resetCopiedState = useCallback(() => {
+    clearTimeout(timeout.current);
+    setCopied(false);
+  }, []);
+
   useEffect(() => {
-    let timeout;
-    if (isCopied) {
-      timeout = setTimeout(() => setCopied(false), copyTimeOut);
-    }
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [copyTimeOut, isCopied]);
+    return resetCopiedState; // Cleanup on unmount
+  }, [resetCopiedState]);
 
   return {
     isCopied,
     handleClipboardCopy,
+    resetCopiedState,
   };
 };
 

--- a/src/hooks/useOnElementScroll.tsx
+++ b/src/hooks/useOnElementScroll.tsx
@@ -1,0 +1,47 @@
+import { noop } from 'lodash';
+import { useEffect } from 'react';
+
+/**
+ * Hook to run a callback function when a specific element is scrolled.
+ *
+ * @param {string} scrollableElementId - The ID of the element to listen for scroll events.
+ * @param {() => void} callback - The function to run on each scroll.
+ * @param {boolean} [shouldExecute=true] - Whether to set up the scroll listener.
+ *
+ * @example
+ * useOnElementScroll({
+ *   scrollableElementId: 'content',
+ *   callback: () => console.log('Scrolled!'),
+ *   shouldExecute: true,
+ * });
+ */
+export const useOnElementScroll = ({
+  scrollableElementId,
+  callback,
+  shouldExecute = true,
+}: {
+  scrollableElementId: string;
+  callback: () => void;
+  shouldExecute?: boolean;
+}) => {
+  useEffect(() => {
+    if (!shouldExecute) {
+      return noop;
+    }
+
+    const scrollElement = document.getElementById(scrollableElementId);
+
+    if (!scrollElement) {
+      console.error(`Element with ID '${scrollableElementId}' not found`);
+      return noop;
+    }
+
+    const handleScroll = () => callback();
+
+    scrollElement.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      scrollElement?.removeEventListener('scroll', handleScroll);
+    };
+  }, [callback, scrollableElementId, shouldExecute]);
+};

--- a/src/hooks/useOnElementScroll.tsx
+++ b/src/hooks/useOnElementScroll.tsx
@@ -1,4 +1,5 @@
 import { noop } from 'lodash';
+import throttle from 'lodash/throttle';
 import { useEffect } from 'react';
 
 /**
@@ -7,6 +8,7 @@ import { useEffect } from 'react';
  * @param {string} scrollableElementId - The ID of the element to listen for scroll events.
  * @param {() => void} callback - The function to run on each scroll.
  * @param {boolean} [shouldExecute=true] - Whether to set up the scroll listener.
+ * @param {number} [scrollThrottle=100] - Throttle delay for the scroll event handler.
  *
  * @example
  * useOnElementScroll({
@@ -19,10 +21,12 @@ export const useOnElementScroll = ({
   scrollableElementId,
   callback,
   shouldExecute = true,
+  scrollThrottle = 100,
 }: {
   scrollableElementId: string;
   callback: () => void;
   shouldExecute?: boolean;
+  scrollThrottle?: number;
 }) => {
   useEffect(() => {
     if (!shouldExecute) {
@@ -38,7 +42,13 @@ export const useOnElementScroll = ({
 
     const handleScroll = () => callback();
 
-    scrollElement.addEventListener('scroll', handleScroll, { passive: true });
+    scrollElement.addEventListener(
+      'scroll',
+      throttle(handleScroll, scrollThrottle),
+      {
+        passive: true,
+      },
+    );
 
     return () => {
       scrollElement?.removeEventListener('scroll', handleScroll);


### PR DESCRIPTION
## Description

TLDR: The `trigger` and `isOpen` props were clashing and led to situations whereby the tooltip still lingers even if we don't want it to. As a workaround, I had to manually detect hover states for the Tooltip's children and conditionally update the `isOpen` prop ✌️ 

| Production | Current Master | This Branch |
| ---- | ---- | --- |
| ![Production](https://github.com/user-attachments/assets/261eb9a0-83d2-4bfe-8f34-ef06a62991da) | ![master](https://github.com/user-attachments/assets/8a25ca3d-248e-4fac-a728-ac35c1080496) | ![my branch](https://github.com/user-attachments/assets/5676e880-9ddc-4998-a7f2-6510bf1498ed) |

This is how it behaves on mobile now, on this branch:

![mobile-tooltip](https://github.com/user-attachments/assets/02fb2d2c-a002-41e0-9cec-b95b304c7b3a)

## Testing

1. Hover on the Copy Contract Address button
2. Click it
3. Scroll the page
4. Verify that its tooltip is not visible
5. Do the same for the Share button please

## Diffs

**New stuff** ✨

A new hook called `useOnElementScroll` which executes a function when the page is scrolled:

```js
useOnElementScroll({
  scrollableElementId: 'scrollable-element',
  callback: () => console.log('Scrolled!'),
});
```

I also had to slightly tweak the `useCopyToClipboard` hook.

Resolves #3486 