### PR TITLE
Fix: Do not clear the required default form values on form mount

### DIFF
--- a/src/components/shared/Fields/Form/Form.tsx
+++ b/src/components/shared/Fields/Form/Form.tsx
@@ -98,6 +98,7 @@ const Form = <FormData extends FieldValues>({
     handleSubmit,
     watch,
     reset,
+    getValues,
     formState: { isSubmitting },
   } = formHelpers;
   const values = watch();
@@ -137,11 +138,14 @@ const Form = <FormData extends FieldValues>({
           ? await defaultValues()
           : defaultValues;
 
-      formHelpers.reset(resolvedDefaultValues);
+      const currentValues = getValues();
+      const mergedValues = { ...currentValues, ...resolvedDefaultValues };
+
+      reset(mergedValues, { keepDirtyValues: true });
     };
 
     initializeForm();
-  }, [defaultValues, formHelpers]);
+  }, [defaultValues, reset, getValues]);
 
   return (
     <AdditionalFormOptionsContextProvider value={{ readonly }}>

--- a/src/components/v5/common/ActionSidebar/hooks/useActionFormProps.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useActionFormProps.ts
@@ -38,8 +38,10 @@ const useActionFormProps = (
     if (defaultValues) {
       setActionFormProps((state) => ({
         ...state,
-        actionType: defaultValues.actionType,
-        defaultValues,
+        defaultValues: {
+          ...state.defaultValues,
+          ...defaultValues,
+        },
       }));
     }
   }, [defaultValues]);
@@ -93,7 +95,7 @@ const useActionFormProps = (
           readonly: isReadonly,
           ...formOptions.options,
         },
-        defaultValues: actionFormProps.defaultValues,
+        defaultValues: formOptionsWithDefaults,
       });
 
       if (prevActionTypeRef.current === actionType) {
@@ -110,7 +112,6 @@ const useActionFormProps = (
       defaultValues,
       colony.nativeToken.tokenAddress,
       isReadonly,
-      actionFormProps.defaultValues,
       searchParams,
       setSearchParams,
     ],


### PR DESCRIPTION
## Description

There's a bit of code that resets the default values for any given form whenever a form mounts. In issue #3656, the reason why it says "Not enough tokens" is because the "selectedToken" field value for the Simple Payment form is being cleared on mount. This makes the `hasEnoughFundsValidation()` function trigger the form error because it pretty cannot calculate your funds correctly.

<img width="694" alt="image" src="https://github.com/user-attachments/assets/9c3e6ffd-a10d-4534-9e04-ad730ea83cd7">

This was also causing the issue which Raul raised about the Mint Tokens form -- it's because `selectedToken` is undefined at this point -- it got cleared on mount.

<img width="696" alt="image" src="https://github.com/user-attachments/assets/c9ba0857-3afd-48ae-9831-e29f14ad08a3">

For the create domain action, it complains about the `createdIn` field, and same issue, it's because it got cleared on mount.

<img width="694" alt="image" src="https://github.com/user-attachments/assets/51022b11-45ea-433b-b052-c391620ac60b">

But these changes should make all of those go away and unblock testing on QA 🙏 

| Minting tokens | Creating domains | Simple payments |
| ---- | ---- | ---- |
| ![form-mint](https://github.com/user-attachments/assets/64508dc8-9a3c-49df-8f79-6990b516863d) | ![domains](https://github.com/user-attachments/assets/b99e4a45-6ce1-48ac-8fce-ba5ddfd102df) | ![form-simple-payment](https://github.com/user-attachments/assets/fa51a978-cf44-4108-987c-e148b569fce7) |

## Testing

1. Ensure you actually have some CREDS
2. Open the Simple Payment form
3. Enter a Token amount
4. Verify that you don't see the "Not enough tokens" error message
5. Change the Action type field to "Advanced Payments"
6. Enter an amount in the token value field
7. Verify that you don't see the "Not enough tokens" error message
8. Please test creating domains & minting tokens as well

Resolves #3656 
Resolves #3664