### PR TITLE
Fix: Fixes for fetchDomainBalance lambda edge cases

### DIFF
--- a/amplify/backend/function/fetchDomainBalance/src/config/networkConfig.js
+++ b/amplify/backend/function/fetchDomainBalance/src/config/networkConfig.js
@@ -1,4 +1,5 @@
 const EnvVarsConfig = require('./envVars.js');
+const { SupportedNetwork } = require('../consts.js');
 
 const {
   ColonyJSNetworkMapping,
@@ -10,11 +11,14 @@ const NetworkConfig = (() => {
   return {
     getConfig: async () => {
       const { network } = await EnvVarsConfig.getEnvVars();
-      const supportedNetwork = ColonyJSNetworkMapping[network];
+      const supportedNetwork = ColonyJSNetworkMapping[network] || network;
 
       return {
-        DEFAULT_NETWORK_TOKEN: TOKEN_DATA[supportedNetwork],
-        DEFAULT_NETWORK_INFO: NETWORK_DATA[supportedNetwork],
+        DEFAULT_NETWORK_TOKEN:
+          TOKEN_DATA[supportedNetwork] ?? TOKEN_DATA[SupportedNetwork.Ganache],
+        DEFAULT_NETWORK_INFO:
+          NETWORK_DATA[supportedNetwork] ??
+          NETWORK_DATA[SupportedNetwork.Ganache],
       };
     },
   };

--- a/amplify/backend/function/fetchDomainBalance/src/index.js
+++ b/amplify/backend/function/fetchDomainBalance/src/index.js
@@ -32,10 +32,30 @@ exports.handler = async (event) => {
       timeframeType,
       timeframePeriodEndDate,
     } = event.arguments?.input || {};
+
+    /**
+     * We want to early return if there is no positive period for which to compute values
+     */
+    if (timeframePeriod <= 0) {
+      return {
+        totalIn: 0,
+        totalOut: 0,
+        total: 0,
+        timeframe: [],
+      };
+    }
+
     const periodForTimeframe = getPeriodFor(
       timeframePeriod,
       timeframeType,
       timeframePeriodEndDate,
+    );
+
+    console.log(
+      `Date for ${timeframePeriod} timeframe, ` +
+        `${timeframeType} type, and ` +
+        `${timeframePeriodEndDate} end date: ` +
+        `${periodForTimeframe}`,
     );
 
     const inOutActions = await getInOutActions(colonyAddress, domainId);

--- a/amplify/backend/function/fetchDomainBalance/src/services/actions.js
+++ b/amplify/backend/function/fetchDomainBalance/src/services/actions.js
@@ -40,7 +40,9 @@ const getInOutActions = async (colonyAddress, domainId) => {
     ...getFormattedIncomingFunds(incomingFunds, domainId),
     ...getFormattedActions(actions, domainId),
     ...getFormattedExpenditures(filteredExpenditures, domainId, tokensDecimals),
-  ];
+  ].filter(
+    (action) => !!action.token && (!!action.amount || !!action.networkFee),
+  );
 };
 
 const getTokensDatesMap = (actions) => {
@@ -108,6 +110,11 @@ const groupBalanceByPeriod = (
   // Add each action to its corresponding balance period in/out operation
   actions.forEach((action) => {
     const period = getFullPeriodFormat(action.finalizedDate, timeframeType);
+
+    if (!balance[period]) {
+      console.warn(`No balance entry configured for period ${period}`);
+      return;
+    }
 
     // If we are at colony level and the action has a type
     // The action is among the acceptedColonyActionTypes and must be an outgoing source of funds

--- a/amplify/backend/function/fetchDomainBalance/src/utils.js
+++ b/amplify/backend/function/fetchDomainBalance/src/utils.js
@@ -69,17 +69,17 @@ const subtractYearsFor = (numberOfYears, timeframePeriodEndDate) => {
   const now = timeframePeriodEndDate
     ? new Date(timeframePeriodEndDate)
     : new Date();
-  return startOfDay(
-    new Date(startOfYear(new Date(subYears(now, numberOfYears)))),
-  );
+  const timeOffset = numberOfYears > 0 ? numberOfYears - 1 : 0;
+  return startOfDay(new Date(startOfYear(new Date(subYears(now, timeOffset)))));
 };
 
 const subtractMonthsFor = (numberOfMonths, timeframePeriodEndDate) => {
   const now = timeframePeriodEndDate
     ? new Date(timeframePeriodEndDate)
     : new Date();
+  const timeOffset = numberOfMonths > 0 ? numberOfMonths - 1 : 0;
   return startOfDay(
-    new Date(startOfMonth(new Date(subMonths(now, numberOfMonths)))),
+    new Date(startOfMonth(new Date(subMonths(now, timeOffset)))),
   );
 };
 
@@ -87,16 +87,16 @@ const subtractWeeksFor = (numberOfWeeks, timeframePeriodEndDate) => {
   const now = timeframePeriodEndDate
     ? new Date(timeframePeriodEndDate)
     : new Date();
-  return startOfDay(
-    new Date(startOfWeek(new Date(subWeeks(now, numberOfWeeks)))),
-  );
+  const timeOffset = numberOfWeeks > 0 ? numberOfWeeks - 1 : 0;
+  return startOfDay(new Date(startOfWeek(new Date(subWeeks(now, timeOffset)))));
 };
 
 const subtractDaysFor = (numberOfDays, timeframePeriodEndDate) => {
   const now = timeframePeriodEndDate
     ? new Date(timeframePeriodEndDate)
     : new Date();
-  return startOfDay(new Date(subDays(now, numberOfDays)));
+  const timeOffset = numberOfDays > 0 ? numberOfDays - 1 : 0;
+  return startOfDay(new Date(subDays(now, timeOffset)));
 };
 
 const getFullPeriodFormat = (date, timeframeType) => {


### PR DESCRIPTION
## Description

- This PR aims to solve the following issues identified on QA
- [X] Cover case for action without token in `getTotalFiatAmountFor` - for this I have actually added a filter for the actions before reaching this step as it doesn't make sense to include the actions that don't have a `token` and an `amount`/`networkFee`
- [X] Use directly the network value for getting the default network token and network info in `NetworkConfig` - actually for this one I added a fallback to the `network` env var if the colony js mapping does not exist
- [X] Cover case for grouping actions by period, but the computed action period was not included in the initial setup - this was happening due to wrongly computing the start date of a period, including one extra `day`/`month`/`week`/`year`

## Testing

TODO: Please test the fetchDomainBalance lambda and check these edge cases are covered. 
Don't know how to easily do this on `DEV` without actually changing directly into code the used values as in for eg. adding a `null` token or using `arbitrumOne` as a value for the `network` env var etc. So let's do this 🦾 

> [!IMPORTANT]
> To check the values returned or logged in a lambda, you need to always run the `getDomainBalance` query and then check the `amplify` logs

Step 1. Let's make sure the query runs as expected first
```
query MyQuery {
  getDomainBalance(
    input: {
      colonyAddress: "<COLONY_ADDRESS_HERE>", 
      timeframePeriod: 1, 
      timeframeType: MONTHLY
    }
  ) {
    total
    totalIn
    totalOut
  }
}
```

Step 2. Now let's try to break it by using a negative or 0 `timeframePeriod`
```
query MyQuery {
  getDomainBalance(
    input: {
      colonyAddress: "<COLONY_ADDRESS_HERE>", 
      timeframePeriod: -10, 
      timeframeType: MONTHLY
    }
  ) {
    total
    totalIn
    totalOut
  }
}
```

Step 3. For the next queries please change back the `timeframePeriod` to a value `> 0`

Step 4. Go to `amplify/backend/function/fetchDomainBalance/src/config/envVars.js` and replace 
`let network = Network.Custom;` with 
`let network = 'arbitrumOne'`

Step 5. Now in `amplify/backend/function/fetchDomainBalance/src/config/networkConfig.js` check the `DEFAULT_NETWORK_TOKEN` and `DEFAULT_NETWORK_INFO`

Step 6. Go to `amplify/backend/function/fetchDomainBalance/src/utils.js` go to `getFormattedActions` and replace the code with 
```
const getFormattedActions = (actions, domainId) => {
  // Separating the actions created as extension support
  let extensionSupportActions = actions.filter(
    (action) => !!action.initiatorExtension?.id,
  );

  return actions
    .filter((action) => !action.initiatorExtension?.id)
    .map((action) => getActionWithFinalizedDate(action))
    .filter((action) => !!action.finalizedDate)
    .map((action) => {
      let amount = action.amount;
      let networkFee = action.networkFee;

      /**
       * If there is no domain selected (aka we are at colony level) and the action type is not among payments, we'll consider the amount to be '0'
       * Though we might need to reconsider this when transferring funds between colonies
       */
      if (!domainId && !paymentActionTypes.includes(action.type)) {
        amount = '0';
      }

      const attachedAction = extensionSupportActions.find(
        (extensionSupportAction) =>
          extensionSupportAction.rootHash === action.rootHash,
      );

      if (attachedAction) {
        networkFee = attachedAction.networkFee;
      }

      return {
        ...action,
        token: null,
        amount,
        networkFee,
      };
    });
};
```

Step 7. Go to `amplify/backend/function/fetchDomainBalance/src/index.js` and check `inOutActions` don't contain the regular actions (`Simple payments` or `Transfer funds`)

Resolves #3658
