### PR TITLE
Feat: Improve failed auth handling

### DIFF
--- a/src/apollo/utils.ts
+++ b/src/apollo/utils.ts
@@ -1,31 +1,19 @@
+import { backOff } from 'exponential-backoff';
+
 import { authenticateWalletWithRetry } from '~auth';
 
 export async function mutateWithAuthRetry(
   mutationFn: () => Promise<any>,
   maxRetries = 3,
 ) {
-  let attempts = 0;
-  let result: any;
-  while (attempts < maxRetries) {
-    attempts += 1;
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      result = await mutationFn();
-      return result;
-    } catch (error) {
-      if (attempts >= maxRetries) {
-        throw error;
-      }
-
-      // Re-attempt authentication on 403 status
+  return backOff(() => mutationFn(), {
+    numOfAttempts: maxRetries,
+    retry: async (error) => {
+      console.error(error);
       if (error.networkError?.statusCode === 403) {
-        // eslint-disable-next-line no-await-in-loop
         await authenticateWalletWithRetry();
       }
-
-      console.error(`Attempt ${attempts} failed, retrying...`, error);
-    }
-  }
-
-  return result;
+      return true;
+    },
+  });
 }

--- a/src/apollo/utils.ts
+++ b/src/apollo/utils.ts
@@ -1,0 +1,31 @@
+import { authenticateWalletWithRetry } from '~auth';
+
+export async function mutateWithAuthRetry(
+  mutationFn: () => Promise<any>,
+  maxRetries = 3,
+) {
+  let attempts = 0;
+  let result: any;
+  while (attempts < maxRetries) {
+    attempts += 1;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      result = await mutationFn();
+      return result;
+    } catch (error) {
+      if (attempts >= maxRetries) {
+        throw error;
+      }
+
+      // Re-attempt authentication on 403 status
+      if (error.networkError?.statusCode === 403) {
+        // eslint-disable-next-line no-await-in-loop
+        await authenticateWalletWithRetry();
+      }
+
+      console.error(`Attempt ${attempts} failed, retrying...`, error);
+    }
+  }
+
+  return result;
+}

--- a/src/components/shared/Fields/Form/ActionForm.tsx
+++ b/src/components/shared/Fields/Form/ActionForm.tsx
@@ -1,7 +1,7 @@
 import React, { type ButtonHTMLAttributes } from 'react';
 import { type FieldValues, type UseFormReturn } from 'react-hook-form';
 
-import { authenticateWallet } from '~auth';
+import { authenticateWalletWithRetry } from '~auth';
 import useAsyncFunction from '~hooks/useAsyncFunction.ts';
 import { type ActionTypes, type ActionTypeString } from '~redux/index.ts';
 import { type ActionTransformFnType, getFormAction } from '~utils/actions.ts';
@@ -81,7 +81,7 @@ const ActionForm = <V extends Record<string, any>>({
   const handleSubmit: CustomSubmitHandler<V> = async (values, formHelpers) => {
     try {
       // Force re-auth check to account for loss of auth/connection after the session has been started
-      await authenticateWallet();
+      await authenticateWalletWithRetry();
       const res = await asyncFunction(values);
       onSuccess?.(values, formHelpers, res);
     } catch (e) {

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/types.ts
@@ -9,6 +9,7 @@ export interface ActionSidebarFormContentProps extends ActionFormBaseProps {
   transactionId?: string;
   isExpenditure?: boolean;
   actionFormProps: Omit<ActionFormProps, 'children' | 'actionType'>;
+  showApolloNetworkError?: boolean;
 }
 
 export interface ActionSidebarContentProps {

--- a/src/redux/sagas/colony/colonyCreate.ts
+++ b/src/redux/sagas/colony/colonyCreate.ts
@@ -12,6 +12,7 @@ import { /* BigNumber */ utils } from 'ethers';
 import { poll } from 'ethers/lib/utils';
 import { all, call, put } from 'redux-saga/effects';
 
+import { mutateWithAuthRetry } from '~apollo/utils.ts';
 import {
   ADDRESS_ZERO,
   DEFAULT_TOKEN_DECIMALS,
@@ -238,23 +239,25 @@ function* colonyCreate({
     /**
      * Save colony metadata to the db
      */
-    yield apolloClient.mutate<
-      CreateColonyEtherealMetadataMutation,
-      CreateColonyEtherealMetadataMutationVariables
-    >({
-      mutation: CreateColonyEtherealMetadataDocument,
-      variables: {
-        input: {
-          colonyName: givenColonyName,
-          colonyDisplayName: displayName,
-          tokenAvatar,
-          tokenThumbnail,
-          initiatorAddress: walletAddress,
-          transactionHash: colonyCreationTransactionHash,
-          inviteCode, // temporary, while in private beta
+    yield mutateWithAuthRetry(() =>
+      apolloClient.mutate<
+        CreateColonyEtherealMetadataMutation,
+        CreateColonyEtherealMetadataMutationVariables
+      >({
+        mutation: CreateColonyEtherealMetadataDocument,
+        variables: {
+          input: {
+            colonyName: givenColonyName,
+            colonyDisplayName: displayName,
+            tokenAvatar,
+            tokenThumbnail,
+            initiatorAddress: walletAddress,
+            transactionHash: colonyCreationTransactionHash,
+            inviteCode, // temporary, while in private beta
+          },
         },
-      },
-    });
+      }),
+    );
 
     const {
       payload: { eventData },

--- a/src/redux/sagas/expenditures/createStreamingPayment.ts
+++ b/src/redux/sagas/expenditures/createStreamingPayment.ts
@@ -7,6 +7,7 @@ import {
 import { BigNumber } from 'ethers';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
+import { mutateWithAuthRetry } from '~apollo/utils.ts';
 import { ContextModule, getContext } from '~context/index.ts';
 import {
   CreateStreamingPaymentMetadataDocument,
@@ -182,22 +183,24 @@ function* createStreamingPaymentAction({
       streamingPaymentsClient.getNumStreamingPayments,
     );
 
-    yield apolloClient.mutate<
-      CreateStreamingPaymentMetadataMutation,
-      CreateStreamingPaymentMetadataMutationVariables
-    >({
-      mutation: CreateStreamingPaymentMetadataDocument,
-      variables: {
-        input: {
-          id: getExpenditureDatabaseId(
-            colonyAddress,
-            toNumber(streamingPaymentId),
-          ),
-          endCondition,
-          limitAmount,
+    yield mutateWithAuthRetry(() =>
+      apolloClient.mutate<
+        CreateStreamingPaymentMetadataMutation,
+        CreateStreamingPaymentMetadataMutationVariables
+      >({
+        mutation: CreateStreamingPaymentMetadataDocument,
+        variables: {
+          input: {
+            id: getExpenditureDatabaseId(
+              colonyAddress,
+              toNumber(streamingPaymentId),
+            ),
+            endCondition,
+            limitAmount,
+          },
         },
-      },
-    });
+      }),
+    );
 
     yield put<AllActions>({
       type: ActionTypes.STREAMING_PAYMENT_CREATE_SUCCESS,

--- a/src/redux/sagas/motions/createDecisionMotion.ts
+++ b/src/redux/sagas/motions/createDecisionMotion.ts
@@ -5,6 +5,7 @@ import {
 } from '@colony/colony-js';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
+import { mutateWithAuthRetry } from '~apollo/utils.ts';
 import { ACTION_DECISION_MOTION_CODE, ADDRESS_ZERO } from '~constants/index.ts';
 import { ContextModule, getContext } from '~context/index.ts';
 import {
@@ -132,24 +133,26 @@ function* createDecisionMotion({
       ActionTypes.TRANSACTION_ERROR,
     ]);
 
-    yield apolloClient.mutate<
-      CreateColonyDecisionMutation,
-      CreateColonyDecisionMutationVariables
-    >({
-      mutation: CreateColonyDecisionDocument,
-      variables: {
-        input: {
-          id: getColonyDecisionId(colonyAddress, txHash),
-          actionId: txHash,
-          colonyAddress,
-          description,
-          title,
-          motionDomainId,
-          walletAddress,
-          showInDecisionsList: false,
+    yield mutateWithAuthRetry(() =>
+      apolloClient.mutate<
+        CreateColonyDecisionMutation,
+        CreateColonyDecisionMutationVariables
+      >({
+        mutation: CreateColonyDecisionDocument,
+        variables: {
+          input: {
+            id: getColonyDecisionId(colonyAddress, txHash),
+            actionId: txHash,
+            colonyAddress,
+            description,
+            title,
+            motionDomainId,
+            walletAddress,
+            showInDecisionsList: false,
+          },
         },
-      },
-    });
+      }),
+    );
 
     // yield transactionSetPending(annotateMotion.id);
 

--- a/src/redux/sagas/motions/domains/utils/handleDomainMetadata.ts
+++ b/src/redux/sagas/motions/domains/utils/handleDomainMetadata.ts
@@ -1,10 +1,12 @@
 import { type ApolloClient } from '@apollo/client';
 
+import { mutateWithAuthRetry } from '~apollo/utils.ts';
 import {
   type CreateDomainMetadataMutation,
   type CreateDomainMetadataMutationVariables,
   CreateDomainMetadataDocument,
   DomainColor,
+  type DomainMetadataFragment,
 } from '~gql';
 import { type ActionTypes } from '~redux/actionTypes.ts';
 import {
@@ -37,42 +39,48 @@ export function* handleDomainMetadata({
   customActionTitle,
 }: Params) {
   if (isCreateDomain) {
-    yield apolloClient.mutate<
-      CreateDomainMetadataMutation,
-      CreateDomainMetadataMutationVariables
-    >({
-      mutation: CreateDomainMetadataDocument,
-      variables: {
-        input: {
-          id: getPendingMetadataDatabaseId(colonyAddress, txHash),
-          name: domainName,
-          color: domainColor || DomainColor.LightPink,
-          description: domainPurpose || '',
+    yield mutateWithAuthRetry(() =>
+      apolloClient.mutate<
+        CreateDomainMetadataMutation,
+        CreateDomainMetadataMutationVariables
+      >({
+        mutation: CreateDomainMetadataDocument,
+        variables: {
+          input: {
+            id: getPendingMetadataDatabaseId(colonyAddress, txHash),
+            name: domainName,
+            color: domainColor || DomainColor.LightPink,
+            description: domainPurpose || '',
+          },
         },
-      },
-    });
+      }),
+    );
   } else if (domain?.metadata) {
-    yield apolloClient.mutate<
-      CreateDomainMetadataMutation,
-      CreateDomainMetadataMutationVariables
-    >({
-      mutation: CreateDomainMetadataDocument,
-      variables: {
-        input: {
-          id: getPendingMetadataDatabaseId(colonyAddress, txHash),
-          name: domainName,
-          color: domainColor || domain.metadata.color,
-          description: domainPurpose || domain.metadata.description,
-          changelog: getUpdatedDomainMetadataChangelog({
-            transactionHash: txHash,
-            metadata: domain.metadata,
-            newName: domainName,
-            newColor: domainColor,
-            newDescription: domainPurpose,
-          }),
+    const domainMetadata = domain.metadata as DomainMetadataFragment;
+
+    yield mutateWithAuthRetry(() =>
+      apolloClient.mutate<
+        CreateDomainMetadataMutation,
+        CreateDomainMetadataMutationVariables
+      >({
+        mutation: CreateDomainMetadataDocument,
+        variables: {
+          input: {
+            id: getPendingMetadataDatabaseId(colonyAddress, txHash),
+            name: domainName,
+            color: domainColor || domainMetadata.color,
+            description: domainPurpose || domainMetadata.description,
+            changelog: getUpdatedDomainMetadataChangelog({
+              transactionHash: txHash,
+              metadata: domainMetadata,
+              newName: domainName,
+              newColor: domainColor,
+              newDescription: domainPurpose,
+            }),
+          },
         },
-      },
-    });
+      }),
+    );
   }
 
   yield createActionMetadataInDB(txHash, customActionTitle);

--- a/src/redux/sagas/motions/editColonyMotion.ts
+++ b/src/redux/sagas/motions/editColonyMotion.ts
@@ -2,10 +2,12 @@ import { Id, getChildIndex, ClientType } from '@colony/colony-js';
 import { BigNumber } from 'ethers';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
+import { mutateWithAuthRetry } from '~apollo/utils.ts';
 import { PERMISSIONS_NEEDED_FOR_ACTION } from '~constants/actions.ts';
 import { ADDRESS_ZERO } from '~constants/index.ts';
 import { ContextModule, getContext } from '~context/index.ts';
 import {
+  type ColonyMetadataFragment,
   CreateColonyMetadataDocument,
   type CreateColonyMetadataMutation,
   type CreateColonyMetadataMutationVariables,
@@ -34,7 +36,7 @@ import {
 
 function* editColonyMotion({
   payload: {
-    colony: { colonyAddress, metadata },
+    colony: { colonyAddress },
     colony,
     colonyDisplayName,
     colonyAvatarImage,
@@ -233,48 +235,53 @@ function* editColonyMotion({
       },
     } = yield waitForTxResult(createMotion.channel);
 
+    const colonyMetadata = colony.metadata as ColonyMetadataFragment;
+
     /*
      * Save the pending colony metadata in the database
      */
     if (colony.metadata) {
-      yield apolloClient.mutate<
-        CreateColonyMetadataMutation,
-        CreateColonyMetadataMutationVariables
-      >({
-        mutation: CreateColonyMetadataDocument,
-        variables: {
-          input: {
-            id: getPendingMetadataDatabaseId(colonyAddress, txHash),
-            displayName: colonyDisplayName ?? colony.metadata.displayName,
-            avatar: colonyAvatarImage ?? colony.metadata.avatar,
-            thumbnail: colonyThumbnail ?? colony.metadata.thumbnail,
-            description: colonyDescription ?? colony.metadata.description,
-            externalLinks: colonyExternalLinks ?? colony.metadata.externalLinks,
-            // We only need a single entry here, as we'll be appending it to the colony's metadata
-            // changelog if the motion succeeds.
-            changelog: [
-              {
-                transactionHash: txHash,
-                newDisplayName:
-                  colonyDisplayName ?? colony.metadata.displayName,
-                oldDisplayName: colony.metadata.displayName,
-                hasAvatarChanged:
-                  colonyAvatarImage === undefined
-                    ? false
-                    : colonyAvatarImage !== colony.metadata.avatar,
-                hasDescriptionChanged:
-                  metadata?.description !== colonyDescription,
-                haveExternalLinksChanged: !isEqual(
-                  metadata?.externalLinks,
-                  colonyExternalLinks,
-                ),
-                newSafes: colony.metadata.safes,
-                oldSafes: colony.metadata.safes,
-              },
-            ],
+      yield mutateWithAuthRetry(() =>
+        apolloClient.mutate<
+          CreateColonyMetadataMutation,
+          CreateColonyMetadataMutationVariables
+        >({
+          mutation: CreateColonyMetadataDocument,
+          variables: {
+            input: {
+              id: getPendingMetadataDatabaseId(colonyAddress, txHash),
+              displayName: colonyDisplayName ?? colonyMetadata.displayName,
+              avatar: colonyAvatarImage ?? colonyMetadata.avatar,
+              thumbnail: colonyThumbnail ?? colonyMetadata.thumbnail,
+              description: colonyDescription ?? colonyMetadata.description,
+              externalLinks:
+                colonyExternalLinks ?? colonyMetadata.externalLinks,
+              // We only need a single entry here, as we'll be appending it to the colony's metadata
+              // changelog if the motion succeeds.
+              changelog: [
+                {
+                  transactionHash: txHash,
+                  newDisplayName:
+                    colonyDisplayName ?? colonyMetadata.displayName,
+                  oldDisplayName: colonyMetadata.displayName,
+                  hasAvatarChanged:
+                    colonyAvatarImage === undefined
+                      ? false
+                      : colonyAvatarImage !== colonyMetadata.avatar,
+                  hasDescriptionChanged:
+                    colonyMetadata?.description !== colonyDescription,
+                  haveExternalLinksChanged: !isEqual(
+                    colonyMetadata?.externalLinks,
+                    colonyExternalLinks,
+                  ),
+                  newSafes: colonyMetadata.safes,
+                  oldSafes: colonyMetadata.safes,
+                },
+              ],
+            },
           },
-        },
-      });
+        }),
+      );
     }
 
     yield createActionMetadataInDB(txHash, customActionTitle);

--- a/src/redux/sagas/utils/annotations.ts
+++ b/src/redux/sagas/utils/annotations.ts
@@ -1,5 +1,6 @@
 import { call } from 'redux-saga/effects';
 
+import { mutateWithAuthRetry } from '~apollo/utils.ts';
 import { ContextModule, getContext } from '~context/index.ts';
 import {
   CreateAnnotationDocument,
@@ -32,20 +33,22 @@ export const uploadAnnotationToDb = async ({
 }) => {
   const apolloClient = getContext(ContextModule.ApolloClient);
 
-  await apolloClient.mutate<
-    CreateAnnotationMutation,
-    CreateAnnotationMutationVariables
-  >({
-    mutation: CreateAnnotationDocument,
-    variables: {
-      input: {
-        message,
-        id: annotationId,
-        actionId,
-        ipfsHash,
+  await mutateWithAuthRetry(() =>
+    apolloClient.mutate<
+      CreateAnnotationMutation,
+      CreateAnnotationMutationVariables
+    >({
+      mutation: CreateAnnotationDocument,
+      variables: {
+        input: {
+          message,
+          id: annotationId,
+          actionId,
+          ipfsHash,
+        },
       },
-    },
-  });
+    }),
+  );
 };
 
 export function* uploadAnnotation({

--- a/src/redux/sagas/utils/createActionMetadata.ts
+++ b/src/redux/sagas/utils/createActionMetadata.ts
@@ -1,3 +1,4 @@
+import { mutateWithAuthRetry } from '~apollo/utils.ts';
 import { ContextModule, getContext } from '~context/index.ts';
 import {
   type CreateColonyActionMetadataMutation,
@@ -8,16 +9,18 @@ import {
 export function* createActionMetadataInDB(txHash: string, customTitle: string) {
   const apolloClient = getContext(ContextModule.ApolloClient);
 
-  yield apolloClient.mutate<
-    CreateColonyActionMetadataMutation,
-    CreateColonyActionMetadataMutationVariables
-  >({
-    mutation: CreateColonyActionMetadataDocument,
-    variables: {
-      input: {
-        id: txHash,
-        customTitle,
+  yield mutateWithAuthRetry(() =>
+    apolloClient.mutate<
+      CreateColonyActionMetadataMutation,
+      CreateColonyActionMetadataMutationVariables
+    >({
+      mutation: CreateColonyActionMetadataDocument,
+      variables: {
+        input: {
+          id: txHash,
+          customTitle,
+        },
       },
-    },
-  });
+    }),
+  );
 }

--- a/src/redux/sagas/utils/expenditures.ts
+++ b/src/redux/sagas/utils/expenditures.ts
@@ -3,6 +3,7 @@ import { BigNumber } from 'ethers';
 import { getAddress, isAddress } from 'ethers/lib/utils';
 
 import { apolloClient } from '~apollo';
+import { mutateWithAuthRetry } from '~apollo/utils.ts';
 import { DEV_USDC_ADDRESS, isDev } from '~constants';
 import {
   CreateExpenditureMetadataDocument,
@@ -83,25 +84,27 @@ export function* saveExpenditureMetadata({
   numberOfTokens,
   distributionType,
 }: SaveExpenditureMetadataParams) {
-  yield apolloClient.mutate<
-    CreateExpenditureMetadataMutation,
-    CreateExpenditureMetadataMutationVariables
-  >({
-    mutation: CreateExpenditureMetadataDocument,
-    variables: {
-      input: {
-        id: getExpenditureDatabaseId(colonyAddress, expenditureId),
-        fundFromDomainNativeId: fundFromDomainId,
-        stages: stages?.map((stage, index) => ({
-          name: stage.name,
-          slotId: index + 1,
-        })),
-        expectedNumberOfPayouts: numberOfPayouts,
-        expectedNumberOfTokens: numberOfTokens,
-        distributionType,
+  yield mutateWithAuthRetry(() =>
+    apolloClient.mutate<
+      CreateExpenditureMetadataMutation,
+      CreateExpenditureMetadataMutationVariables
+    >({
+      mutation: CreateExpenditureMetadataDocument,
+      variables: {
+        input: {
+          id: getExpenditureDatabaseId(colonyAddress, expenditureId),
+          fundFromDomainNativeId: fundFromDomainId,
+          stages: stages?.map((stage, index) => ({
+            name: stage.name,
+            slotId: index + 1,
+          })),
+          expectedNumberOfPayouts: numberOfPayouts,
+          expectedNumberOfTokens: numberOfTokens,
+          distributionType,
+        },
       },
-    },
-  });
+    }),
+  );
 }
 
 export const getPayoutsWithSlotIds = (


### PR DESCRIPTION
## Description

This PR attempts to improve the way we handle failed mutations. There are few instances on QA and Production where actions were failing due to apollo 403 errors, the transaction would still succeed but the form would not proceed to the completed action screen due to the failed apollo calls. This meant the form could be resubmitted over and over resulting in multiple transactions.

It is likely these issues are caused by auth proxy rejecting the mutation. This can happen if auth proxy restarted after the saga has started running as the user will no longer be authenticated.

This PR attempts to improve this experiencing by adding a retry with re-authentication mechanism to all mutations and authentication attempts. If auth proxy rejects the mutation it will prompt the user to sign in again with metamask and reattempt the mutation. If the mutation still fails after this, the form will show an error message and the submit button will be disabled. This is a real edge case scenario and hopefully will never actually be seen in production.

## Testing

This is going to be a bit of a pain to test I'm afraid and involves running a deliberately broken version of auth proxy locally to facilitate testing.

* Step 1 - Spin up the dev environment as usual and run the create-data script.
* Step 2 - Clear your metamask activity and nonce data by opening the metamask extension, going to settings, advanced and then clicking the "Clear activity tab data" button.
* Step 3 - Connect your metamask wallet and open the Planex colony.
* Step 4 - In docker, stop the auth container.
* Step 5 - We need to run the auth proxy locally, clone down the repository (https://github.com/JoinColony/colonyCDappAuthProxy) and run `npm install` if you have never used it before.
* Step 6 - Switch to the `tmp/3669-testing` branch on auth proxy. I've made some changes here which will cause the following calls to occasionally fail (this obviously won't be merged in and is just for the sake of testing the changes here): createTransaction, updateTransaction, createDomainMetadata. The authentication check and handler functions will also occasionally fail. The updateDomainMetadata call will always fail.
* Step 7 - Run `npm run dev` on the auth proxy.

From this point on, if your wallet is disconnected and you end up getting kicked out of the colony, it may take a couple of attempts to reconnect the wallet. This is due to the auth proxy changes. I've not added retries to the main wallet connect authentication as we haven't had issues raised in this area.

* Step 8 - Okay, back on the Planex colony! Create a new team action and submit the form. Due to the auth proxy changes, we are expecting some of the calls to fail. The CDapp changes introduced in this PR allow us to reattempt these calls and we will be prompted to sign in with metamask when this happens. Whenever a metamask pop up appears, accept the transactions and sign in prompts. Eventually you should make it through.

https://github.com/user-attachments/assets/38da06c1-8678-4862-a198-ccaa3b0ed6e1

Compared to master, there is no automatic retry mechanism so the submit button will simply get stuck on "Pending" when a call fails.

* Step 9 - Now let's try an "Edit team" action. Submit the form. Due to the auth proxy changes we are expecting this one to fail completely. Accept your way through the metamask prompts until it gets to the metadata mutation which should fail. An error message should appear and the submit button should be disabled to prevent the user from reattempting the transaction. (Note: If the transaction itself fails, the UserHub will open to show the transaction error and the form itself will not show the new apollo error message.)

https://github.com/user-attachments/assets/8c019c4a-641b-401a-8388-ce3e0ac1e954

<img width="676" alt="Screenshot 2024-11-13 at 11 58 06" src="https://github.com/user-attachments/assets/dd23c2ff-357d-4c0e-be02-6705d56c0e09">

* Step 10 - Feel free to try out some other actions, they should all work similarly to the create team action.

### Further testing

* Step 11 - Kill your local auth proxy instance, and restart the auth container in docker.

* Step 12 - Okay we're back to a bit more of a normal environment now. Try running a bunch of actions and check nothing has broken. Test this with both the metamask wallet and the dev wallet.

## Diffs

**New stuff** ✨

* Added `mutateWithAuthRetry` function
* Added `authenticateWalletWithRetry` function

**Changes** 🏗

* Action form calls `authenticateWalletWithRetry` instead of `authenticateWallet` before calling saga
* Action form now shows an error on the frontend when there is an apollo error.
* All instances of `apolloClient.mutate` are now wrapped in `mutateWithAuthRetry`

## TODO

- [ ] Delete the `tmp/3669-testing` branch on auth proxy once this is merged
- [ ] Remove the transaction retry mechanism to come in a later PR

Resolves #3523
Contributes to #3510