### PR TITLE
Fix: Prevent the loading view to render more than once on page load

### DIFF
--- a/src/routes/ColonyRoute.tsx
+++ b/src/routes/ColonyRoute.tsx
@@ -50,7 +50,6 @@ const ColonyRoute = () => {
       name: colonyName,
     },
     fetchPolicy: 'network-only',
-    nextFetchPolicy: 'cache-first',
   });
 
   const { user, userLoading, walletConnecting } = useAppContext();


### PR DESCRIPTION
## Description

> [!NOTE]
> I appreciate that this may be more of a band-aid solution.
> Justification is that, this hook sits on a top-level component and it only ever makes a network request again when the `colonyName` changes i.e. when you switch Colonies and `colonyName` is plucked directly from the URL via `useParams()` so it should remain constant whilst you're browsing the same Colony.

The issue is that the following options are causing the hook to make the request twice:

```js
fetchPolicy: 'network-only',
nextFetchPolicy: 'cache-only', // <<-- This one
```

Which then causes this component to render twice:

```js
if (
  walletConnecting ||
  isColonyLoading ||
  userLoading ||
  isContributorLoading
) {
  return <LoadingTemplate loadingText={MSG.loadingText} />;
}
```

## Testing

1. Directly visit a colony: http://localhost:9091/planex/
2. Verify that the following loader only shows up once:

<img width="1361" alt="image" src="https://github.com/user-attachments/assets/8d28a893-d8db-4ff4-a0a3-9e315efa2a2b">

Resolves #3662