### PR TITLE
Fix: Advanced payments crashing due to unsafe array access

### DIFF
--- a/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
+++ b/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
@@ -79,7 +79,7 @@ const useGetRecipientData = (
   } = actionData || {};
   const safeRecipient = safeTransaction?.transactions?.items[0]?.recipient;
   const stagedPaymentRecipientAddress =
-    expenditure?.slots[0].recipientAddress || '';
+    expenditure?.slots[0]?.recipientAddress || '';
   const stagedPaymentRecipient = useUserByAddress(
     stagedPaymentRecipientAddress,
   );
@@ -421,8 +421,8 @@ export const useMapColonyActionToExpectedFormat = ({
         decimals={getTokenDecimalsWithFallback(
           getSelectedToken(
             colony,
-            !!expenditureData?.slots?.length &&
-              !!expenditureData?.slots[0].payouts?.length
+            !!expenditureData?.slots.length &&
+              !!expenditureData.slots[0].payouts?.length
               ? expenditureData.slots[0].payouts[0].tokenAddress
               : '',
           )?.decimals,


### PR DESCRIPTION
## Description

This small PR fixes unsafe array access when generating action description.

I came across a case where a newly created expenditure gets returned from the DB, but it does not yet have any slots (block-ingestor has not processed them yet). In such a scenario, the entire app would crash due to it trying to read the recipient of the first slot.

It would also be possible to run into this issue when an empty expenditure is created, such as in #3302 or through direct contract interaction (it is possible to create an expenditure with 0 slots).

## Testing

Create a couple of advanced payments and confirm the app does not crash.

Resolves #3677 
