### PR TITLE
est: add e2e tests for final step of create colony flow 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,6 +51,7 @@ module.exports = {
       extends: 'plugin:playwright/recommended',
       rules: {
         'no-await-in-loop': 'off',
+        'playwright/no-conditional-expect': 'off',
       },
     },
   ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,7 @@ dotenv.config({ path: path.resolve(__dirname, '.env') });
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
+  fullyParallel: true,
   testDir: './playwright/e2e',
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,

--- a/playwright/e2e/create-colony.spec.ts
+++ b/playwright/e2e/create-colony.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
 
 import {
-  acceptCookieConsentBanner,
   fillInputByLabelWithDelay,
+  setCookieConsent,
 } from '../utils/common.ts';
 import {
   fillColonyNameStep,
@@ -19,15 +19,15 @@ import {
 test.describe('Create Colony flow', () => {
   const colonyName = 'testcolonyname';
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
+    await setCookieConsent(context, baseURL);
     const colonyUrl = await generateCreateColonyUrl();
 
     await page.goto(colonyUrl);
 
     await selectWalletAndUserProfile(page);
-
-    await acceptCookieConsentBanner(page);
   });
+
   test.describe('Details step', () => {
     test('Should render Details step correctly', async ({ page }) => {
       // Heading of the step and form is shown
@@ -565,7 +565,6 @@ test.describe('Create Colony flow', () => {
     test('Should create a colony and navigate to the newly created colony URL', async ({
       page,
     }) => {
-      test.slow();
       const colonyURL = generateRandomString();
       await fillColonyNameStep(page, {
         nameFieldValue: colonyName,
@@ -610,17 +609,14 @@ test.describe('Create Colony flow', () => {
 
       // eslint-disable-next-line playwright/no-conditional-in-test
       if (isInviteBlockPresent) {
-        // eslint-disable-next-line playwright/no-conditional-expect
         await expect(
           colonyCreateDialog.getByRole('button', { name: /copy/i }),
         ).toBeVisible();
 
-        // eslint-disable-next-line playwright/no-conditional-expect
         await expect(
           colonyCreateDialog.getByText(/\/create-colony\/.*/),
         ).toBeVisible();
 
-        // eslint-disable-next-line playwright/no-conditional-expect
         await expect(
           colonyCreateDialog.getByRole('heading', {
             name: /Invite a person to create a Colony/i,

--- a/playwright/e2e/create-colony.spec.ts
+++ b/playwright/e2e/create-colony.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '../utils/common.ts';
 import {
   fillColonyNameStep,
+  fillNativeTokenStepWithExistingToken,
   generateRandomString,
   selectWalletAndUserProfile,
 } from '../utils/create-colony.ts';
@@ -460,6 +461,172 @@ test.describe('Create Colony flow', () => {
           page.getByRole('button', { name: /continue/i }),
         ).toBeEnabled();
       });
+    });
+  });
+
+  test.describe('Confirmation step', () => {
+    let existingToken: string;
+    test.beforeAll(async () => {
+      existingToken = await fetchFirstValidTokenAddress();
+    });
+    test('Should render Confirmation step as expected', async ({ page }) => {
+      await fillColonyNameStep(page, {
+        nameFieldValue: colonyName,
+        urlFieldValue: generateRandomString(),
+      });
+      await fillNativeTokenStepWithExistingToken(page, existingToken);
+      // Heading of the Step
+      await expect(
+        page.getByText(/Confirm your Colony’s details/i),
+      ).toBeVisible();
+      // Subheading
+      await expect(
+        page.getByText(
+          /Check to ensure your Colony’s details are correct as they can not be changed later/i,
+        ),
+      ).toBeVisible();
+
+      const colonyNameCard = page.getByTestId('colony-details-card');
+      const colonyTokenCard = page.getByTestId('colony-token-card');
+
+      await expect(colonyNameCard.getByText('testcolonyname')).toBeVisible();
+
+      await expect(
+        colonyNameCard.getByRole('button', { name: 'Edit' }),
+      ).toBeEnabled();
+
+      await expect(
+        colonyTokenCard.getByText('DAI for Local Development'),
+      ).toBeVisible();
+
+      await expect(
+        colonyTokenCard.getByRole('button', { name: 'Edit' }),
+      ).toBeEnabled();
+
+      await expect(
+        page.getByRole('button', { name: 'Back', exact: true }),
+      ).toBeVisible();
+
+      await expect(
+        page.getByRole('img', {
+          name: /Avatar of token DAI for Local Development/i,
+        }),
+      ).toBeVisible();
+
+      await expect(
+        page.getByRole('button', { name: /continue/i }),
+      ).toBeEnabled();
+    });
+
+    test('Should navigate to Details step when Edit colony details is clicked', async ({
+      page,
+    }) => {
+      const customColonyURL = generateRandomString();
+      await fillColonyNameStep(page, {
+        nameFieldValue: colonyName,
+        urlFieldValue: customColonyURL,
+      });
+
+      await fillNativeTokenStepWithExistingToken(page, existingToken);
+
+      await page
+        .getByTestId('colony-details-card')
+        .getByRole('button', { name: 'Edit' })
+        .click();
+
+      await expect(page.getByLabel(/Colony name/i)).toBeVisible();
+      await expect(page.getByLabel(/Colony name/i)).toHaveValue(colonyName);
+      await expect(page.getByLabel(/Custom Colony URL/i)).toBeVisible();
+      await expect(page.getByLabel(/Custom Colony URL/i)).toHaveValue(
+        customColonyURL,
+      );
+    });
+
+    test('Should navigate to Native token step when Edit token is clicked', async ({
+      page,
+    }) => {
+      await fillColonyNameStep(page, {
+        nameFieldValue: colonyName,
+        urlFieldValue: generateRandomString(),
+      });
+      await fillNativeTokenStepWithExistingToken(page, existingToken);
+
+      await page
+        .getByTestId('colony-token-card')
+        .getByRole('button', { name: 'Edit' })
+        .click();
+
+      await expect(page.getByLabel(/Existing token address/i)).toBeVisible();
+      await expect(page.getByLabel(/Existing token address/i)).toHaveValue(
+        existingToken,
+      );
+    });
+
+    test('Should create a colony and navigate to the newly created colony URL', async ({
+      page,
+    }) => {
+      test.slow();
+      const colonyURL = generateRandomString();
+      await fillColonyNameStep(page, {
+        nameFieldValue: colonyName,
+        urlFieldValue: colonyURL,
+      });
+      await fillNativeTokenStepWithExistingToken(page, existingToken);
+
+      await page.getByRole('button', { name: /continue/i }).click();
+
+      await expect(
+        page
+          .getByTestId('onboarding-heading')
+          .filter({ hasText: /Complete setup/i }),
+      ).toBeVisible();
+      await expect(
+        page.getByTestId('onboarding-subheading').filter({
+          hasText:
+            /Deploying to the blockchain requires you to sign a transaction in your wallet for each step/i,
+        }),
+      ).toBeVisible();
+
+      // Expect the transition to the newly created colony URL
+      await page.waitForURL(colonyURL);
+
+      // Expect the Colony Created dialog to be visible
+      const colonyCreateDialog = page
+        .getByRole('dialog')
+        .filter({ hasText: /Congratulations/i });
+      await expect(colonyCreateDialog).toBeVisible({ timeout: 10000 });
+
+      await expect(
+        colonyCreateDialog.getByRole('button', {
+          name: /explore your colony/i,
+        }),
+      ).toBeVisible();
+      // This section is not shown on first time creation of a colony by a given user
+      const isInviteBlockPresent = await colonyCreateDialog
+        .getByRole('heading', {
+          name: /Invite a person to create a Colony/i,
+        })
+        .isVisible();
+
+      // eslint-disable-next-line playwright/no-conditional-in-test
+      if (isInviteBlockPresent) {
+        // eslint-disable-next-line playwright/no-conditional-expect
+        await expect(
+          colonyCreateDialog.getByRole('button', { name: /copy/i }),
+        ).toBeVisible();
+
+        // eslint-disable-next-line playwright/no-conditional-expect
+        await expect(
+          colonyCreateDialog.getByText(/\/create-colony\/.*/),
+        ).toBeVisible();
+
+        // eslint-disable-next-line playwright/no-conditional-expect
+        await expect(
+          colonyCreateDialog.getByRole('heading', {
+            name: /Invite a person to create a Colony/i,
+          }),
+        ).toBeVisible();
+      }
     });
   });
 });

--- a/playwright/utils/common.ts
+++ b/playwright/utils/common.ts
@@ -1,4 +1,4 @@
-import { type Page } from '@playwright/test';
+import { type BrowserContext, type Page } from '@playwright/test';
 
 export const acceptCookieConsentBanner = async (page: Page) => {
   // Check if the cookie banner is present on the page
@@ -11,6 +11,27 @@ export const acceptCookieConsentBanner = async (page: Page) => {
 
     await acceptButton.click();
   }
+};
+
+const cookieNames = [
+  'cookies-analytics',
+  'cookies-marketing',
+  'cookies-prefernces',
+  'cookies-functional',
+];
+
+export const setCookieConsent = async (
+  context: BrowserContext,
+  baseUrl: string = '',
+) => {
+  await context.addCookies(
+    cookieNames.map((cookie) => ({
+      name: cookie,
+      value: 'true',
+      url: baseUrl,
+      expires: Date.now() / 1000 + 60 * 60 * 24 * 365,
+    })),
+  );
 };
 
 export const fillInputByLabelWithDelay = async ({
@@ -27,5 +48,5 @@ export const fillInputByLabelWithDelay = async ({
   // eslint-disable-next-line playwright/no-wait-for-timeout
   await page.waitForTimeout(timeout);
 
-  await page.getByLabel(label).pressSequentially(value, { delay: 100 });
+  await page.getByLabel(label).fill(value);
 };

--- a/playwright/utils/create-colony.ts
+++ b/playwright/utils/create-colony.ts
@@ -103,6 +103,10 @@ export const fillNativeTokenStepWithExistingToken = async (
   await page.getByLabel(/Use an existing token/i).check();
   await page.getByRole('button', { name: /continue/i }).click();
 
-  await page.getByLabel(/Existing token address/i).fill(token);
+  await fillInputByLabelWithDelay({
+    page,
+    label: /Existing token address/i,
+    value: token,
+  });
   await page.getByRole('button', { name: /continue/i }).click();
 };

--- a/playwright/utils/create-colony.ts
+++ b/playwright/utils/create-colony.ts
@@ -6,45 +6,7 @@ export const generateRandomString = () => {
   return Math.random().toString(36).substring(2, 8);
 };
 
-const generateRandomUsername = () => {
-  return `user_${generateRandomString()}`;
-};
-
-const generateRandomEmail = () => {
-  return `test_${generateRandomString()}@example.com`;
-};
-
-const fillUserProfile = async (page: Page) => {
-  const username = generateRandomUsername();
-  const email = generateRandomEmail();
-
-  await page.getByLabel(/Email address/i).fill(email);
-  await page.getByLabel(/username/i).fill(username);
-
-  await page.getByRole('button', { name: /continue/i }).click();
-};
-
 export const selectWalletAndUserProfile = async (page: Page) => {
-  let isUserConnected = false;
-
-  await page.route('**/graphql', async (route, request) => {
-    const postData = request.postDataJSON(); // Get the request body as JSON
-    if (postData.operationName === 'GetUserByAddress') {
-      // Fetch original response.
-      const response = await route.fetch();
-
-      const jsonResponse = await response.json();
-
-      // Check if the user exists and has a profile
-      const items = jsonResponse.data?.getUserByAddress?.items;
-      if (items && items.length > 0) {
-        isUserConnected = !!items[0]?.profile?.displayName;
-      }
-    }
-
-    route.continue();
-  });
-
   await page
     .getByRole('button', { name: /connect wallet/i })
     .first()
@@ -61,10 +23,6 @@ export const selectWalletAndUserProfile = async (page: Page) => {
 
   if (loadingIndicatorVisible) {
     await loadingIndicator.waitFor({ state: 'hidden' });
-  }
-
-  if (!isUserConnected) {
-    await fillUserProfile(page);
   }
 };
 

--- a/playwright/utils/graphqlHelpers.ts
+++ b/playwright/utils/graphqlHelpers.ts
@@ -1,8 +1,76 @@
-import { request } from '@playwright/test';
+import { backOff } from 'exponential-backoff';
 
 const API_KEY = 'da2-fakeApiId123456';
 const GRAPHQL_URI =
   process.env.AWS_APPSYNC_GRAPHQL_URL || 'http://localhost:20002/graphql';
+
+interface FetchOptions {
+  maxAttempts?: number;
+  timeout?: number;
+  initialDelay?: number;
+  maxDelay?: number;
+}
+
+export async function fetchWithRetry(
+  url: string,
+  options: RequestInit & FetchOptions = {},
+) {
+  const {
+    maxAttempts = 2,
+    timeout = 15000,
+    initialDelay = 1000,
+    maxDelay = 5000,
+    ...fetchOptions
+  } = options;
+
+  return backOff(
+    async () => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+      try {
+        const response = await fetch(url, {
+          ...fetchOptions,
+          signal: controller.signal,
+          headers: {
+            'Content-Type': 'application/json',
+            ...fetchOptions.headers,
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        return await response.json();
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    },
+    {
+      numOfAttempts: maxAttempts,
+      startingDelay: initialDelay,
+      maxDelay,
+      timeMultiple: 2,
+    },
+  );
+}
+
+async function graphqlRequest<T = any>(
+  query: string,
+  variables?: Record<string, any>,
+): Promise<T> {
+  return fetchWithRetry(GRAPHQL_URI, {
+    method: 'POST',
+    headers: {
+      'x-api-key': API_KEY,
+    },
+    body: JSON.stringify({
+      query,
+      variables,
+    }),
+  });
+}
 
 export async function generateCreateColonyUrl() {
   const CREATE_PRIVATE_BETA_INVITE_CODE = `
@@ -13,28 +81,13 @@ export async function generateCreateColonyUrl() {
       }
     `;
 
-  const requestContext = await request.newContext({
-    baseURL: GRAPHQL_URI,
-    extraHTTPHeaders: {
-      'x-api-key': API_KEY,
-    },
+  const response = await graphqlRequest(CREATE_PRIVATE_BETA_INVITE_CODE, {
+    input: { shareableInvites: 99 },
   });
 
-  const response = await requestContext.post(GRAPHQL_URI, {
-    data: {
-      query: CREATE_PRIVATE_BETA_INVITE_CODE,
-      variables: {
-        input: { shareableInvites: 99 },
-      },
-    },
-  });
-
-  const responseBody = await response.json();
-  const inviteCodeId = responseBody.data.createPrivateBetaInviteCode.id;
-
-  return `/create-colony/${inviteCodeId}`;
+  return `/create-colony/${response.data.createPrivateBetaInviteCode.id}`;
 }
-// The query is used to fetch a list of pre-seeded verified tokens from the db, and extract the first token address that can be used in the tests
+
 export async function fetchFirstValidTokenAddress() {
   const LIST_COLONY_TOKENS_QUERY = `
     query ListColonyTokens {
@@ -46,24 +99,8 @@ export async function fetchFirstValidTokenAddress() {
     }
   `;
 
-  const requestContext = await request.newContext({
-    baseURL: GRAPHQL_URI,
-    extraHTTPHeaders: {
-      'x-api-key': API_KEY,
-    },
-  });
-
-  const response = await requestContext.post(GRAPHQL_URI, {
-    data: {
-      query: LIST_COLONY_TOKENS_QUERY,
-    },
-  });
-
-  const responseBody = await response.json();
-
-  const tokenAddress = responseBody.data.listTokens.items[0].id;
-
-  return tokenAddress;
+  const response = await graphqlRequest(LIST_COLONY_TOKENS_QUERY);
+  return response.data.listTokens.items[0].id;
 }
 
 export async function getColonyAddressByName(name: string = 'planex') {
@@ -77,20 +114,6 @@ export async function getColonyAddressByName(name: string = 'planex') {
     }
   `;
 
-  const requestContext = await request.newContext({
-    baseURL: GRAPHQL_URI,
-    extraHTTPHeaders: {
-      'x-api-key': API_KEY,
-    },
-  });
-
-  const response = await requestContext.post(GRAPHQL_URI, {
-    data: {
-      query: QUERY,
-    },
-  });
-
-  const responseBody = await response.json();
-
-  return responseBody.data.getColonyByName.items[0].id;
+  const response = await graphqlRequest(QUERY);
+  return response.data.getColonyByName.items[0].id;
 }


### PR DESCRIPTION
## Description


- added e2e tests for the Create Colony flow
- enabled parallelization for tests of a single file
- use `fill` instead of `pressSequentially` to speed up the tests a bit


## Testing

**Prerequisites**: The test script simulates user interactions with the local instance of the web app, which means that the BE is expected to be set up and running. For now, backend services should be started manually and the initial test data should be seeded . Therefore, ensure that the development environment is properly set up by following the instructions in the README file

- Start your local dev environment  `npm run dev` 
- Seed the mock data `node scripts/create-data.js` 
- If it's the first time you run e2e tests on your machine - run `npm e2e:install` 

- run `npm run e2e` or `npm run e2e:ui`
- Ensure all tests pass (the 'should reject invalid colony name' test may intermittently fail due to the input validation issue described in #3565)

## Diffs

**New stuff** ✨









