### PR TITLE
fix: add only numeric values and remove tokens validation

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
@@ -72,8 +72,8 @@ const AmountField: FC<AmountFieldProps> = ({
     tokenAddressController.value,
   );
 
-  const [value, setValue] = useState<string | undefined>(
-    field.value ? formatNumeral(field.value, formattingOptions) : undefined,
+  const [value, setValue] = useState<string>(
+    field.value ? formatNumeral(field.value, formattingOptions) : '',
   );
 
   const handleFieldChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/components/v5/common/ActionSidebar/partials/forms/StreamingPaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/StreamingPaymentForm/hooks.ts
@@ -16,7 +16,6 @@ import getLastIndexFromPath from '~utils/getLastIndexFromPath.ts';
 import { formatText } from '~utils/intl.ts';
 import { amountGreaterThanValidation } from '~utils/validation/amountGreaterThanValidation.ts';
 import { amountGreaterThanZeroValidation } from '~utils/validation/amountGreaterThanZeroValidation.ts';
-import { hasEnoughFundsValidation } from '~utils/validation/hasEnoughFundsValidation.ts';
 import { ACTION_BASE_VALIDATION_SCHEMA } from '~v5/common/ActionSidebar/consts.ts';
 import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts';
 import { AmountPerInterval } from '~v5/common/ActionSidebar/partials/AmountPerPeriodRow/types.ts';
@@ -51,18 +50,6 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
               },
               (value, context) =>
                 amountGreaterThanZeroValidation({ value, context, colony }),
-            )
-            .test(
-              'enough-tokens',
-              formatText({ id: 'errors.amount.notEnoughTokens' }) || '',
-              (value, context) =>
-                hasEnoughFundsValidation({
-                  value,
-                  context,
-                  domainId: fromDomainId,
-                  colony,
-                  networkInverseFee,
-                }),
             ),
           tokenAddress: string().address().required(),
           limitTokenAddress: string().address(),


### PR DESCRIPTION
## Description

Remove validation for checking tokens amount.

## Testing

- Create new streaming payments action
- Input amount higher than available tokens

## Diffs

**Changes** 🏗

remove validation for checking tokens

Before:

![Screenshot 2024-11-08 at 17 19 50](https://github.com/user-attachments/assets/1772a462-7e5a-46c9-bdc6-83f5b89bc5a4)

After:

![Screenshot 2024-11-12 at 12 30 34](https://github.com/user-attachments/assets/d30920bf-8827-41c9-b723-d64a7e3877eb)

Resolves  [#31415](https://github.com/JoinColony/colonyCDapp/issues/3647)
