### PR TITLE
Fix: Dynamically set the Manage Permissions form Authority field

### DIFF
--- a/src/components/v5/common/ActionSidebar/hooks/useGetActionData.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useGetActionData.ts
@@ -334,7 +334,9 @@ const useGetActionData = (transactionId: string | undefined) => {
         return {
           [ACTION_TYPE_FIELD_NAME]: Action.ManagePermissions,
           member: recipientAddress,
-          authority: Authority.Own,
+          authority: action.rolesAreMultiSig
+            ? Authority.ViaMultiSig
+            : Authority.Own,
           role,
           team: fromDomain?.nativeId,
           permissions:


### PR DESCRIPTION
## Description

The Authority field value was being hardcoded for the Manage Permissions action and this was because at the time this was written, we didn't have any other values for the Authority field. So this PR just makes it dynamic.

![authority-fix](https://github.com/user-attachments/assets/df9e1090-de22-40e2-b4d5-845169874da2)

## Testing

1. Install the multi-sig extension
2. Bring up the Manage Permissions form
3. Set the Authority field to "Take actions via Multi-Sig"
4. Fill in the rest of the required fields
5. Submit the form
6. Visit the Dashboard page
7. Redo the action from the Recent Activity table
8. Verify that the Authority field is set to "Take actions via Multi-Sig"
9. Visit the activity page
10. Redo the action from the Latest Activity table
11. Verify that the Authority field is set to "Take actions via Multi-Sig"

Resolves #3699 