### PR TITLE
Fix: Add disabled styling to multi-sig setting selects

### DIFF
--- a/src/components/v5/common/Fields/Select/Select.module.css
+++ b/src/components/v5/common/Fields/Select/Select.module.css
@@ -14,6 +14,14 @@
   @apply bg-transparent text-gray-300;
 }
 
+.wrapper :global(.select__control--is-disabled .select__single-value) {
+  @apply text-gray-300;
+}
+
+.wrapper :global(.select__control--is-disabled .select__indicator) {
+  @apply text-gray-300;
+}
+
 .wrapper :global(.select__placeholder) {
   @apply font-normal text-gray-400;
 }


### PR DESCRIPTION
## Description

This PR adds disabled styling to the selects on the multi-sig extension settings page. (The inputs were already disabled, just missing the styling.)

## Testing

* Step 1 - Login as a user with permissions to install extensions (Leela)
* Step 2 - Install the multi-sig extension and check the inputs are enabled on the extension settings page

<img width="1728" alt="Screenshot 2024-11-14 at 10 09 55" src="https://github.com/user-attachments/assets/350fb5e5-433d-43c0-9a48-16e081bab6e2">

* Step 3 - Switch to a user who does not have permissions to update extensions (Amy / Fry)
* Step 4 - Navigate to the extension settings page and check the inputs are disabled and the select styling is as expected

<img width="1365" alt="Screenshot 2024-11-14 at 10 10 06" src="https://github.com/user-attachments/assets/bf8329fe-73d0-448a-98ad-90c5f916d73f">


## Diffs

**New stuff** ✨

* Added disabled styling to select inputs

Resolves #3227
