### PR TITLE
test: e2e tests for manage account page

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typecheck": "tsc --noEmit",
     "frontend": "ulimit -n 2048 && vite",
     "frontend:safe": "SAFE_ENABLED=true ulimit -n 2048 && vite",
+    "preview": "ulimit -n 2048 && NODE_ENV=development npm run build && npx import-meta-env -x .env && vite preview --port=9091",
     "build": "vite build",
     "hardhat": "docker exec -e DISABLE_DOCKER=true -it network bash -c \". /root/.nvm/nvm.sh && cd colonyNetwork && npx hardhat console --network localhost\"",
     "hardhat:cmd": "./scripts/hardhat-cmd.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "typecheck": "tsc --noEmit",
     "frontend": "ulimit -n 2048 && vite",
     "frontend:safe": "SAFE_ENABLED=true ulimit -n 2048 && vite",
-    "preview": "ulimit -n 2048 && NODE_ENV=development npm run build && npx import-meta-env -x .env && vite preview --port=9091",
+    "preview": "NODE_ENV=development npm run build && npx import-meta-env -x .env && vite preview --port=9091",
     "build": "vite build",
     "hardhat": "docker exec -e DISABLE_DOCKER=true -it network bash -c \". /root/.nvm/nvm.sh && cd colonyNetwork && npx hardhat console --network localhost\"",
     "hardhat:cmd": "./scripts/hardhat-cmd.js",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'npm run preview',
+    timeout: 90000,
     url: 'http://localhost:9091',
     reuseExistingServer: !process.env.CI,
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'], permissions: ['clipboard-read'] },
     },
 
     {
@@ -42,13 +42,13 @@ export default defineConfig({
 
     {
       name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
+      use: { ...devices['Desktop Safari'], permissions: ['clipboard-read'] },
     },
   ],
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run frontend',
+    command: 'npm run preview',
     url: 'http://localhost:9091',
     reuseExistingServer: !process.env.CI,
   },

--- a/playwright/e2e/create-colony.spec.ts
+++ b/playwright/e2e/create-colony.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import {
-  fillInputWithDelay,
+  fillInput,
   selectWallet,
   setCookieConsent,
   generateRandomString,
@@ -71,13 +71,13 @@ test.describe('Create Colony flow', () => {
       ).toBeDisabled();
 
       // Fill in colony name and custom URL
-      await fillInputWithDelay({
+      await fillInput({
         page,
         label: /colony name/i,
         value: colonyName,
       });
 
-      await fillInputWithDelay({
+      await fillInput({
         page,
         label: /custom colony URL/i,
         value: generateRandomString(),
@@ -118,7 +118,7 @@ test.describe('Create Colony flow', () => {
         }
       });
 
-      await fillInputWithDelay({
+      await fillInput({
         page,
         label: /custom colony URL/i,
         value: 'takenurl',
@@ -131,7 +131,7 @@ test.describe('Create Colony flow', () => {
 
     test('Should reject invalid colony name', async ({ page }) => {
       // More than 20 characters
-      await fillInputWithDelay({
+      await fillInput({
         page,
         label: /colony name/i,
         value: 'A'.repeat(21),
@@ -142,7 +142,7 @@ test.describe('Create Colony flow', () => {
 
     test("Should reject invalid custom colony URL's", async ({ page }) => {
       await test.step('Invalid value', async () => {
-        await fillInputWithDelay({
+        await fillInput({
           page,
           label: /custom colony URL/i,
           value: 'invalid name',
@@ -154,7 +154,7 @@ test.describe('Create Colony flow', () => {
       await test.step('Contains invalid character', async () => {
         await page.getByLabel(/custom colony URL/i).clear();
 
-        await fillInputWithDelay({
+        await fillInput({
           page,
           label: /custom colony URL/i,
           value: '/invalid',
@@ -166,7 +166,7 @@ test.describe('Create Colony flow', () => {
       await test.step('More than 20 characters', async () => {
         await page.getByLabel(/custom colony URL/i).clear();
 
-        await fillInputWithDelay({
+        await fillInput({
           page,
           label: /custom colony URL/i,
           value: 'a'.repeat(21),
@@ -178,7 +178,7 @@ test.describe('Create Colony flow', () => {
       await test.step('Reserved keyword', async () => {
         await page.getByLabel(/custom colony URL/i).clear();
 
-        await fillInputWithDelay({
+        await fillInput({
           page,
           label: /custom colony URL/i,
           value: 'account',
@@ -236,13 +236,13 @@ test.describe('Create Colony flow', () => {
 
       await expect(page.getByLabel(/Use an existing token/i)).not.toBeChecked();
 
-      await fillInputWithDelay({
+      await fillInput({
         page,
         label: /token name/i,
         value: tokenName,
       });
 
-      await fillInputWithDelay({
+      await fillInput({
         page,
         label: /token symbol/i,
         value: tokenSymbol,
@@ -320,7 +320,7 @@ test.describe('Create Colony flow', () => {
       await expect(page.getByLabel(/Create a new token/i)).not.toBeChecked();
 
       await test.step('Should not accept incorrectly formatted token address', async () => {
-        await fillInputWithDelay({
+        await fillInput({
           page,
           label: /existing token address/i,
           value: invalidToken,
@@ -337,7 +337,7 @@ test.describe('Create Colony flow', () => {
 
         await page.getByLabel(/Existing token address/i).clear();
 
-        await fillInputWithDelay({
+        await fillInput({
           page,
           label: /existing token address/i,
           value: userAddress,
@@ -365,7 +365,7 @@ test.describe('Create Colony flow', () => {
 
         await page.getByLabel(/existing token address/i).clear();
 
-        await fillInputWithDelay({
+        await fillInput({
           page,
           label: /existing token address/i,
           value: addressZero,
@@ -389,7 +389,7 @@ test.describe('Create Colony flow', () => {
 
         await page.getByLabel(/existing token address/i).clear();
 
-        await fillInputWithDelay({
+        await fillInput({
           page,
           label: /existing token address/i,
           value: colonyAddress,
@@ -417,7 +417,7 @@ test.describe('Create Colony flow', () => {
 
         await page.getByLabel(/existing token address/i).clear();
 
-        await fillInputWithDelay({
+        await fillInput({
           page,
           label: /existing token address/i,
           value: notExistingToken,
@@ -444,7 +444,7 @@ test.describe('Create Colony flow', () => {
 
         await page.getByLabel(/existing token address/i).clear();
 
-        await fillInputWithDelay({
+        await fillInput({
           page,
           label: /existing token address/i,
           value: existingToken,

--- a/playwright/e2e/create-colony.spec.ts
+++ b/playwright/e2e/create-colony.spec.ts
@@ -319,7 +319,7 @@ test.describe('Create Colony flow', () => {
 
       await expect(page.getByLabel(/Create a new token/i)).not.toBeChecked();
 
-      await test.step('Should not accept incorrectly formated token address', async () => {
+      await test.step('Should not accept incorrectly formatted token address', async () => {
         await fillInputWithDelay({
           page,
           label: /existing token address/i,
@@ -332,7 +332,7 @@ test.describe('Create Colony flow', () => {
         ).toBeDisabled();
       });
 
-      await test.step('Should not accept correctly formated, but a User address', async () => {
+      await test.step('Should not accept correctly formatted, but a User address', async () => {
         const userAddress = '0x3a965407cEd5E62C5aD71dE491Ce7B23DA5331A4';
 
         await page.getByLabel(/Existing token address/i).clear();
@@ -384,7 +384,7 @@ test.describe('Create Colony flow', () => {
         ).toBeDisabled();
       });
 
-      await test.step('Should not accept correctly formated, but a colony address', async () => {
+      await test.step('Should not accept correctly formatted, but a colony address', async () => {
         const colonyAddress = await getColonyAddressByName();
 
         await page.getByLabel(/existing token address/i).clear();
@@ -411,7 +411,7 @@ test.describe('Create Colony flow', () => {
         ).toBeDisabled();
       });
 
-      await test.step('Should not accept correctly formated, but not existing token address', async () => {
+      await test.step('Should not accept correctly formatted, but not existing token address', async () => {
         // This mocked address passes client side validation but fails on BE side
         const notExistingToken = '0x6b175474e89094c44da98b954eedeac495271d0f';
 
@@ -439,7 +439,7 @@ test.describe('Create Colony flow', () => {
         ).toBeDisabled();
       });
 
-      await test.step('Should accept correctly formated, and existing token address', async () => {
+      await test.step('Should accept correctly formatted, and existing token address', async () => {
         const existingToken = await fetchFirstValidTokenAddress();
 
         await page.getByLabel(/existing token address/i).clear();

--- a/playwright/e2e/create-colony.spec.ts
+++ b/playwright/e2e/create-colony.spec.ts
@@ -1,14 +1,14 @@
 import { expect, test } from '@playwright/test';
 
 import {
-  fillInputByLabelWithDelay,
+  fillInputWithDelay,
+  selectWallet,
   setCookieConsent,
+  generateRandomString,
 } from '../utils/common.ts';
 import {
   fillColonyNameStep,
   fillNativeTokenStepWithExistingToken,
-  generateRandomString,
-  selectWalletAndUserProfile,
 } from '../utils/create-colony.ts';
 import {
   fetchFirstValidTokenAddress,
@@ -25,7 +25,7 @@ test.describe('Create Colony flow', () => {
 
     await page.goto(colonyUrl);
 
-    await selectWalletAndUserProfile(page);
+    await selectWallet(page, /dev wallet 1$/i);
   });
 
   test.describe('Details step', () => {
@@ -71,13 +71,13 @@ test.describe('Create Colony flow', () => {
       ).toBeDisabled();
 
       // Fill in colony name and custom URL
-      await fillInputByLabelWithDelay({
+      await fillInputWithDelay({
         page,
         label: /colony name/i,
         value: colonyName,
       });
 
-      await fillInputByLabelWithDelay({
+      await fillInputWithDelay({
         page,
         label: /custom colony URL/i,
         value: generateRandomString(),
@@ -118,7 +118,7 @@ test.describe('Create Colony flow', () => {
         }
       });
 
-      await fillInputByLabelWithDelay({
+      await fillInputWithDelay({
         page,
         label: /custom colony URL/i,
         value: 'takenurl',
@@ -131,7 +131,7 @@ test.describe('Create Colony flow', () => {
 
     test('Should reject invalid colony name', async ({ page }) => {
       // More than 20 characters
-      await fillInputByLabelWithDelay({
+      await fillInputWithDelay({
         page,
         label: /colony name/i,
         value: 'A'.repeat(21),
@@ -142,7 +142,7 @@ test.describe('Create Colony flow', () => {
 
     test("Should reject invalid custom colony URL's", async ({ page }) => {
       await test.step('Invalid value', async () => {
-        await fillInputByLabelWithDelay({
+        await fillInputWithDelay({
           page,
           label: /custom colony URL/i,
           value: 'invalid name',
@@ -154,7 +154,7 @@ test.describe('Create Colony flow', () => {
       await test.step('Contains invalid character', async () => {
         await page.getByLabel(/custom colony URL/i).clear();
 
-        await fillInputByLabelWithDelay({
+        await fillInputWithDelay({
           page,
           label: /custom colony URL/i,
           value: '/invalid',
@@ -166,7 +166,7 @@ test.describe('Create Colony flow', () => {
       await test.step('More than 20 characters', async () => {
         await page.getByLabel(/custom colony URL/i).clear();
 
-        await fillInputByLabelWithDelay({
+        await fillInputWithDelay({
           page,
           label: /custom colony URL/i,
           value: 'a'.repeat(21),
@@ -178,7 +178,7 @@ test.describe('Create Colony flow', () => {
       await test.step('Reserved keyword', async () => {
         await page.getByLabel(/custom colony URL/i).clear();
 
-        await fillInputByLabelWithDelay({
+        await fillInputWithDelay({
           page,
           label: /custom colony URL/i,
           value: 'account',
@@ -236,13 +236,13 @@ test.describe('Create Colony flow', () => {
 
       await expect(page.getByLabel(/Use an existing token/i)).not.toBeChecked();
 
-      await fillInputByLabelWithDelay({
+      await fillInputWithDelay({
         page,
         label: /token name/i,
         value: tokenName,
       });
 
-      await fillInputByLabelWithDelay({
+      await fillInputWithDelay({
         page,
         label: /token symbol/i,
         value: tokenSymbol,
@@ -320,7 +320,7 @@ test.describe('Create Colony flow', () => {
       await expect(page.getByLabel(/Create a new token/i)).not.toBeChecked();
 
       await test.step('Should not accept incorrectly formated token address', async () => {
-        await fillInputByLabelWithDelay({
+        await fillInputWithDelay({
           page,
           label: /existing token address/i,
           value: invalidToken,
@@ -337,7 +337,7 @@ test.describe('Create Colony flow', () => {
 
         await page.getByLabel(/Existing token address/i).clear();
 
-        await fillInputByLabelWithDelay({
+        await fillInputWithDelay({
           page,
           label: /existing token address/i,
           value: userAddress,
@@ -365,7 +365,7 @@ test.describe('Create Colony flow', () => {
 
         await page.getByLabel(/existing token address/i).clear();
 
-        await fillInputByLabelWithDelay({
+        await fillInputWithDelay({
           page,
           label: /existing token address/i,
           value: addressZero,
@@ -389,7 +389,7 @@ test.describe('Create Colony flow', () => {
 
         await page.getByLabel(/existing token address/i).clear();
 
-        await fillInputByLabelWithDelay({
+        await fillInputWithDelay({
           page,
           label: /existing token address/i,
           value: colonyAddress,
@@ -417,7 +417,7 @@ test.describe('Create Colony flow', () => {
 
         await page.getByLabel(/existing token address/i).clear();
 
-        await fillInputByLabelWithDelay({
+        await fillInputWithDelay({
           page,
           label: /existing token address/i,
           value: notExistingToken,
@@ -444,7 +444,7 @@ test.describe('Create Colony flow', () => {
 
         await page.getByLabel(/existing token address/i).clear();
 
-        await fillInputByLabelWithDelay({
+        await fillInputWithDelay({
           page,
           label: /existing token address/i,
           value: existingToken,

--- a/playwright/e2e/manage-account-advanced-settings.spec.ts
+++ b/playwright/e2e/manage-account-advanced-settings.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test';
+
+import { selectWallet, setCookieConsent } from '../utils/common.ts';
+
+test.describe('Advanced Settings section', () => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
+    await setCookieConsent(context, baseURL);
+
+    await page.goto('/');
+
+    await selectWallet(page);
+
+    await page.getByTestId('user-navigation-hamburger').click();
+
+    await page.getByTestId('user-menu').waitFor({ state: 'visible' });
+
+    await page
+      .getByTestId('user-menu')
+      .getByRole('link', { name: /manage account/i })
+      .click();
+
+    await page.waitForURL('/account/profile');
+    await page
+      .getByTestId('account-page-sidebar')
+      .getByLabel('/account/preferences')
+      .click();
+
+    await page.waitForURL('/account/preferences');
+  });
+
+  test('Metatransactions toggle', async ({ page }) => {
+    await page
+      .getByTestId('account-page-sidebar')
+      .getByLabel('/account/advanced')
+      .click();
+
+    await page.getByTestId('metatransactions-toggle').click();
+
+    await expect(
+      page
+        .getByRole('alert')
+        .filter({
+          hasText:
+            /(colony will pay your gas fee|you will pay your own gas fee)/i,
+        })
+        .last(),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole('heading', { name: 'Advanced settings', level: 3 }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole('heading', { name: 'Colony pays my gas fees' }),
+    ).toBeVisible();
+
+    await page.getByTestId('settings-row-tooltip').hover();
+
+    await expect(page.getByText(/disabling this option means/i)).toBeVisible();
+  });
+});

--- a/playwright/e2e/manage-account-preferences.spec.ts
+++ b/playwright/e2e/manage-account-preferences.spec.ts
@@ -1,0 +1,211 @@
+/* eslint-disable playwright/no-conditional-in-test */
+import { expect, test } from '@playwright/test';
+
+import {
+  selectWallet,
+  setCookieConsent,
+  generateRandomEmail,
+  fillInput,
+} from '../utils/common.ts';
+
+test.describe('Preferences section', () => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
+    await setCookieConsent(context, baseURL);
+
+    await page.goto('/');
+
+    await selectWallet(page);
+
+    await page.getByTestId('user-navigation-hamburger').click();
+
+    await page.getByTestId('user-menu').waitFor({ state: 'visible' });
+
+    await page
+      .getByTestId('user-menu')
+      .getByRole('link', { name: /manage account/i })
+      .click();
+
+    await page.waitForURL('/account/profile');
+    await page
+      .getByTestId('account-page-sidebar')
+      .getByLabel('/account/preferences')
+      .click();
+
+    await page.waitForURL('/account/preferences');
+  });
+
+  test('Email field', async ({ page }) => {
+    await expect(page.getByText(/^Email address$/)).toBeVisible();
+
+    await expect(page.getByText(/Update your email address/)).toBeVisible();
+    const emailValue = await page
+      .getByTestId('preferences-email-value')
+      .innerText();
+    await expect(page.getByTestId('preferences-email-value')).toBeVisible();
+
+    await page.getByRole('button', { name: /update email/i }).click();
+
+    await page
+      .getByRole('button', { name: /update email/i })
+      .waitFor({ state: 'hidden' });
+
+    await expect(page.getByTestId('preferences-email-value')).toBeHidden();
+
+    await expect(
+      page.getByRole('button', { name: /save changes/i }),
+    ).toBeVisible();
+
+    const emailInput = page.locator('[name="email"]');
+    await expect(emailInput).toHaveValue(emailValue);
+
+    await page.getByRole('button', { name: /cancel/i }).click();
+
+    await expect(page.getByTestId('preferences-email-value')).toBeVisible();
+    await expect(emailInput).toBeHidden();
+
+    await test.step('Should not accept existing email', async () => {
+      await page.getByRole('button', { name: /update email/i }).click();
+
+      await emailInput.waitFor({ state: 'visible' });
+      await emailInput.clear();
+      await fillInput({
+        page,
+        selector: '[name="email"]',
+        value: emailValue,
+      });
+
+      await page.getByRole('button', { name: /save changes/i }).click();
+
+      await expect(
+        page
+          .getByTestId('form-error')
+          .filter({ hasText: /email already registered/i }),
+      ).toBeVisible();
+
+      await page.getByRole('button', { name: /cancel/i }).click();
+    });
+
+    await test.step('Shows an error message when the email is invalid', async () => {
+      await page.getByRole('button', { name: /update email/i }).click();
+
+      await fillInput({
+        page,
+        selector: '[name="email"]',
+        value: 'invalid-email',
+      });
+
+      await page.getByRole('button', { name: /save changes/i }).click();
+
+      await expect(page.getByTestId('form-error')).toBeVisible();
+
+      await page.getByRole('button', { name: /cancel/i }).click();
+    });
+
+    await test.step('Should accept a valid email', async () => {
+      const email = generateRandomEmail();
+
+      await page.getByRole('button', { name: /update email/i }).click();
+
+      await fillInput({
+        page,
+        selector: '[name="email"]',
+        value: email,
+      });
+
+      await page.getByRole('button', { name: /save changes/i }).click();
+
+      await expect(
+        page
+          .getByRole('alert')
+          .filter({ hasText: /action completed successfully/i })
+          .last(),
+      ).toBeVisible();
+
+      await expect(page.getByTestId('preferences-email-value')).toHaveText(
+        email,
+      );
+    });
+  });
+
+  test('Wallet information', async ({ page }) => {
+    await page.getByRole('button', { name: /copy address/i }).click();
+
+    const clipboardText: string = await page.evaluate(
+      'navigator.clipboard.readText()',
+    );
+
+    await expect(page.getByText(clipboardText, { exact: true })).toBeVisible();
+  });
+
+  test('Notification preferences', async ({ page }) => {
+    await expect(
+      page.getByRole('heading', { name: 'Notification preferences' }),
+    ).toBeVisible();
+
+    const notificationsDisabled = await page
+      .getByText(/Notifications are disabled/)
+      .isVisible();
+
+    if (notificationsDisabled) {
+      // Enable notifications
+      await page.getByRole('link', { name: /advanced settings/i }).click();
+
+      await page.waitForURL('/account/advanced');
+
+      const notificationsSection = page.getByTestId('notifications-section');
+      await expect(
+        notificationsSection.getByText(/Manage services/i),
+      ).toBeVisible();
+
+      await expect(
+        notificationsSection.getByRole('heading', { name: /Notifications/i }),
+      ).toBeVisible();
+
+      await expect(
+        notificationsSection.getByText(
+          /Enables in-app and external notifications for activity in colonies you’ve joined/i,
+        ),
+      ).toBeVisible();
+
+      await page.getByTestId('notifications-toggle').click();
+
+      const alert = page.getByRole('alert');
+
+      await expect(alert).toBeVisible();
+
+      await expect(
+        alert.getByText(/You will now receive notifications/i),
+      ).toBeVisible();
+      await page.goBack();
+      await page.waitForURL('/account/preferences');
+    }
+
+    await expect(page.getByText(/Payments and funds/)).toBeVisible();
+
+    await expect(page.getByRole('heading', { name: /Mention/ })).toBeVisible();
+
+    await expect(
+      page.getByRole('heading', { name: /Operations and admin/i }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByTestId('payment-notifications-toggle'),
+    ).toBeVisible();
+
+    await expect(
+      page.getByTestId('mention-notifications-toggle'),
+    ).toBeVisible();
+
+    await expect(
+      page.getByTestId('mention-notifications-toggle'),
+    ).toBeVisible();
+
+    await page.goto('/account/advanced');
+
+    if (await page.getByText('Loading...').isVisible()) {
+      await page.getByText('Loading...').waitFor({ state: 'hidden' });
+    }
+
+    await page.getByTestId('notifications-toggle').click();
+  });
+});

--- a/playwright/e2e/manage-account-profile.spec.ts
+++ b/playwright/e2e/manage-account-profile.spec.ts
@@ -1,12 +1,7 @@
 /* eslint-disable playwright/no-conditional-in-test */
 import { expect, test } from '@playwright/test';
 
-import {
-  selectWallet,
-  setCookieConsent,
-  generateRandomEmail,
-  fillInput,
-} from '../utils/common.ts';
+import { selectWallet, setCookieConsent, fillInput } from '../utils/common.ts';
 
 const validImagePath = 'playwright/fixtures/images/jaya-the-beast_400KB.png';
 const invalidImagePath = 'playwright/fixtures/images/cat-image-new-1_3_MB.png';
@@ -48,7 +43,7 @@ test.describe('Manage Account', () => {
       const displayNameInput = page.locator('[name="displayName"]');
 
       // Should be pre-filled with the user's display name
-      await expect(displayNameInput.inputValue()).toBeTruthy();
+      await expect(displayNameInput).toHaveValue(/.+/);
 
       await displayNameInput.hover();
 
@@ -177,7 +172,7 @@ test.describe('Manage Account', () => {
       await expect(page.getByText('Your website is optional')).toBeVisible();
       await expect(websiteInput).toBeEnabled();
       // Verify that the website field is pre-filled with the user's website
-      await expect(websiteInput.inputValue()).toBeTruthy();
+      await expect(websiteInput).toHaveValue(/.+/);
 
       await test.step('Shows an error message when the website is invalid', async () => {
         await fillInput({
@@ -319,231 +314,6 @@ test.describe('Manage Account', () => {
         await expect(locationInput).toHaveValue(location);
         await expect(toast).toBeHidden();
       });
-    });
-  });
-
-  test.describe('Preferences section', () => {
-    test.beforeEach(async ({ page }) => {
-      await page
-        .getByTestId('account-page-sidebar')
-        .getByLabel('/account/preferences')
-        .click();
-
-      await page.waitForURL('/account/preferences');
-    });
-
-    test('Email field', async ({ page }) => {
-      await expect(page.getByText(/^Email address$/)).toBeVisible();
-
-      await expect(page.getByText(/Update your email address/)).toBeVisible();
-      const emailValue = await page
-        .getByTestId('preferences-email-value')
-        .innerText();
-      await expect(page.getByTestId('preferences-email-value')).toBeVisible();
-
-      await page.getByRole('button', { name: /update email/i }).click();
-
-      await page
-        .getByRole('button', { name: /update email/i })
-        .waitFor({ state: 'hidden' });
-
-      await expect(page.getByTestId('preferences-email-value')).toBeHidden();
-
-      await expect(
-        page.getByRole('button', { name: /save changes/i }),
-      ).toBeVisible();
-
-      const emailInput = page.locator('[name="email"]');
-      await expect(emailInput).toHaveValue(emailValue);
-
-      await page.getByRole('button', { name: /cancel/i }).click();
-
-      await expect(page.getByTestId('preferences-email-value')).toBeVisible();
-      await expect(emailInput).toBeHidden();
-
-      await test.step('Should not accept existing email', async () => {
-        await page.getByRole('button', { name: /update email/i }).click();
-
-        await emailInput.waitFor({ state: 'visible' });
-        await emailInput.clear();
-        await fillInput({
-          page,
-          selector: '[name="email"]',
-          value: emailValue,
-        });
-
-        await page.getByRole('button', { name: /save changes/i }).click();
-
-        await expect(
-          page
-            .getByTestId('form-error')
-            .filter({ hasText: /email already registered/i }),
-        ).toBeVisible();
-
-        await page.getByRole('button', { name: /cancel/i }).click();
-      });
-
-      await test.step('Shows an error message when the email is invalid', async () => {
-        await page.getByRole('button', { name: /update email/i }).click();
-
-        await fillInput({
-          page,
-          selector: '[name="email"]',
-          value: 'invalid-email',
-        });
-
-        await page.getByRole('button', { name: /save changes/i }).click();
-
-        await expect(page.getByTestId('form-error')).toBeVisible();
-
-        await page.getByRole('button', { name: /cancel/i }).click();
-      });
-
-      await test.step('Should accept a valid email', async () => {
-        const email = generateRandomEmail();
-
-        await page.getByRole('button', { name: /update email/i }).click();
-
-        await fillInput({
-          page,
-          selector: '[name="email"]',
-          value: email,
-        });
-
-        await page.getByRole('button', { name: /save changes/i }).click();
-
-        await expect(
-          page
-            .getByRole('alert')
-            .filter({ hasText: /action completed successfully/i })
-            .last(),
-        ).toBeVisible();
-
-        await expect(page.getByTestId('preferences-email-value')).toHaveText(
-          email,
-        );
-      });
-    });
-
-    test('Wallet information', async ({ page }) => {
-      await page.getByRole('button', { name: /copy address/i }).click();
-
-      const clipboardText: string = await page.evaluate(
-        'navigator.clipboard.readText()',
-      );
-
-      await expect(
-        page.getByText(clipboardText, { exact: true }),
-      ).toBeVisible();
-    });
-
-    test('Notification preferences', async ({ page }) => {
-      await expect(
-        page.getByRole('heading', { name: 'Notification preferences' }),
-      ).toBeVisible();
-
-      const notificationsDisabled = await page
-        .getByText(/Notifications are disabled/)
-        .isVisible();
-
-      if (notificationsDisabled) {
-        // Enable notifications
-        await page.getByRole('link', { name: /advanced settings/i }).click();
-
-        await page.waitForURL('/account/advanced');
-
-        const notificationsSection = page.getByTestId('notifications-section');
-        await expect(
-          notificationsSection.getByText(/Manage services/i),
-        ).toBeVisible();
-
-        await expect(
-          notificationsSection.getByRole('heading', { name: /Notifications/i }),
-        ).toBeVisible();
-
-        await expect(
-          notificationsSection.getByText(
-            /Enables in-app and external notifications for activity in colonies you’ve joined/i,
-          ),
-        ).toBeVisible();
-
-        await page.getByTestId('notifications-toggle').click();
-
-        const alert = page.getByRole('alert');
-
-        await expect(alert).toBeVisible();
-
-        await expect(
-          alert.getByText(/You will now receive notifications/i),
-        ).toBeVisible();
-        await page.goBack();
-        await page.waitForURL('/account/preferences');
-      }
-
-      await expect(page.getByText(/Payments and funds/)).toBeVisible();
-
-      await expect(
-        page.getByRole('heading', { name: /Mention/ }),
-      ).toBeVisible();
-
-      await expect(
-        page.getByRole('heading', { name: /Operations and admin/i }),
-      ).toBeVisible();
-
-      await expect(
-        page.getByTestId('payment-notifications-toggle'),
-      ).toBeVisible();
-
-      await expect(
-        page.getByTestId('mention-notifications-toggle'),
-      ).toBeVisible();
-
-      await expect(
-        page.getByTestId('mention-notifications-toggle'),
-      ).toBeVisible();
-
-      await page.goto('/account/advanced');
-
-      if (await page.getByText('Loading...').isVisible()) {
-        await page.getByText('Loading...').waitFor({ state: 'hidden' });
-      }
-
-      await page.getByTestId('notifications-toggle').click();
-    });
-  });
-
-  test.describe('Advanced Settings section', () => {
-    test('Metatransactions toggle', async ({ page }) => {
-      await page
-        .getByTestId('account-page-sidebar')
-        .getByLabel('/account/advanced')
-        .click();
-
-      await page.getByTestId('metatransactions-toggle').click();
-
-      await expect(
-        page
-          .getByRole('alert')
-          .filter({
-            hasText:
-              /(colony will pay your gas fee|you will pay your own gas fee)/i,
-          })
-          .last(),
-      ).toBeVisible();
-
-      await expect(
-        page.getByRole('heading', { name: 'Advanced settings', level: 3 }),
-      ).toBeVisible();
-
-      await expect(
-        page.getByRole('heading', { name: 'Colony pays my gas fees' }),
-      ).toBeVisible();
-
-      await page.getByTestId('settings-row-tooltip').hover();
-
-      await expect(
-        page.getByText(/disabling this option means/i),
-      ).toBeVisible();
     });
   });
 });

--- a/playwright/e2e/manage-account.spec.ts
+++ b/playwright/e2e/manage-account.spec.ts
@@ -19,17 +19,24 @@ test.describe('Manage Account', () => {
 
     await selectWallet(page);
 
-    await page.goto('/account/profile');
+    await page.getByTestId('user-navigation-hamburger').click();
+
+    await page
+      .getByText(/manage account/i)
+      .first()
+      .waitFor({ state: 'visible' });
+
+    await page.getByTestId('user-menu').waitFor({ state: 'visible' });
+
+    await page
+      .getByTestId('user-menu')
+      .getByRole('link', { name: /manage account/i })
+      .click();
+
+    await page.waitForURL('/account/profile');
   });
 
   test.describe('Profile section', () => {
-    test.beforeEach(async ({ page }) => {
-      await page
-        .getByTestId('account-page-sidebar')
-        .getByLabel('/account/profile')
-        .click();
-    });
-
     test('Username field', async ({ page }) => {
       await expect(
         page.getByRole('heading', { name: 'Profile', level: 3 }),
@@ -56,10 +63,17 @@ test.describe('Manage Account', () => {
     });
 
     test('Avatar', async ({ page }) => {
+      const toast = page
+        .getByRole('alert')
+        .filter({ hasText: /profile image changed successfully/i })
+        .last();
       await test.step('Removing Avatar', async () => {
         const removeAvatarButton = page.getByRole('button', {
           name: 'Remove avatar',
         });
+        const avatarUploader = page.getByTestId('avatar-uploader');
+        const avatar = page.getByTestId('user-profile-avatar');
+        const avatarInHeader = page.getByTestId('header-avatar');
 
         if (!(await removeAvatarButton.isVisible())) {
           // Upload a valid image
@@ -71,9 +85,7 @@ test.describe('Manage Account', () => {
 
           await removeAvatarButton.waitFor({ state: 'visible' });
         }
-        const avatarUploader = page.getByTestId('avatar-uploader');
-        const avatar = page.getByTestId('user-profile-avatar');
-        const avatarInHeader = page.getByTestId('header-avatar');
+
         //  Avatar in the profile form and header should be the same
         await expect(page.getByTestId('user-profile-avatar')).toHaveAttribute(
           'src',
@@ -88,12 +100,7 @@ test.describe('Manage Account', () => {
         // Remove the avatar
         await removeAvatarButton.click();
 
-        await expect(
-          page
-            .getByRole('alert')
-            .filter({ hasText: /profile image changed successfully/i })
-            .last(),
-        ).toBeVisible();
+        await expect(toast).toBeVisible();
 
         await removeAvatarButton.waitFor({ state: 'hidden' });
 
@@ -138,12 +145,7 @@ test.describe('Manage Account', () => {
 
         await expect(avatar).toHaveAttribute('src', /data:/);
 
-        await expect(
-          page
-            .getByRole('alert')
-            .filter({ hasText: /profile image changed successfully/i })
-            .last(),
-        ).toBeVisible();
+        await expect(toast).toBeVisible();
 
         // Upload an invalid image
         await page.getByRole('button', { name: /change avatar/i }).click();
@@ -168,6 +170,10 @@ test.describe('Manage Account', () => {
 
     test('Website field', async ({ page }) => {
       const websiteInput = page.locator('[name="website"]');
+      const toast = page
+        .getByRole('alert')
+        .filter({ hasText: /action completed successfully/i })
+        .last();
 
       const saveChangesButton = page.getByRole('button', {
         name: 'Save changes',
@@ -203,19 +209,9 @@ test.describe('Manage Account', () => {
         });
 
         await saveChangesButton.click();
-        await expect(
-          page
-            .getByRole('alert')
-            .filter({ hasText: /action completed successfully/i })
-            .last(),
-        ).toBeVisible();
+        await expect(toast).toBeVisible();
         await expect(websiteInput).toHaveValue('');
-        await expect(
-          page
-            .getByRole('alert')
-            .filter({ hasText: /action completed successfully/i })
-            .last(),
-        ).toBeHidden();
+        await expect(toast).toBeHidden();
       });
 
       await test.step('Accepts a valid website', async () => {
@@ -228,20 +224,9 @@ test.describe('Manage Account', () => {
         });
         await saveChangesButton.click();
 
-        await expect(
-          page
-            .getByRole('alert')
-            .filter({ hasText: /action completed successfully/i })
-            .last(),
-        ).toBeVisible();
+        await expect(toast).toBeVisible();
 
-        await expect(websiteInput).toHaveValue(`${website}/`);
-        await expect(
-          page
-            .getByRole('alert')
-            .filter({ hasText: /action completed successfully/i })
-            .last(),
-        ).toBeHidden();
+        await expect(toast).toBeHidden();
       });
     });
 
@@ -254,6 +239,10 @@ test.describe('Manage Account', () => {
       ).toBeVisible();
 
       const bioInput = page.locator('[name="bio"]');
+      const toast = page
+        .getByRole('alert')
+        .filter({ hasText: /action completed successfully/i })
+        .last();
 
       await test.step('Shows an error message when the bio is too long', async () => {
         // eslint-disable-next-line playwright/no-wait-for-timeout
@@ -274,19 +263,9 @@ test.describe('Manage Account', () => {
 
         await page.getByRole('button', { name: /save changes/i }).click();
 
-        await expect(
-          page
-            .getByRole('alert')
-            .filter({ hasText: /action completed successfully/i })
-            .last(),
-        ).toBeVisible();
+        await expect(toast).toBeVisible();
 
-        await expect(
-          page
-            .getByRole('alert')
-            .filter({ hasText: /action completed successfully/i })
-            .last(),
-        ).toBeHidden();
+        await expect(toast).toBeHidden();
       });
 
       await test.step('Accepts a valid value', async () => {
@@ -301,18 +280,15 @@ test.describe('Manage Account', () => {
 
         await page.getByRole('button', { name: /save changes/i }).click();
 
-        await expect(
-          page
-            .getByRole('alert')
-            .filter({ hasText: /action completed successfully/i })
-            .last(),
-        ).toBeVisible();
-
-        await expect(bioInput).toHaveValue(text);
+        await expect(toast).toBeVisible();
       });
     });
 
     test('Location field', async ({ page }) => {
+      const toast = page
+        .getByRole('alert')
+        .filter({ hasText: /action completed successfully/i })
+        .last();
       await expect(page.getByText(/Location/)).toBeVisible();
       await expect(
         page.getByText(
@@ -325,23 +301,11 @@ test.describe('Manage Account', () => {
       await test.step('The field is not required', async () => {
         await locationInput.clear();
 
-        // eslint-disable-next-line playwright/no-wait-for-timeout
-        await page.waitForTimeout(1000);
         await page.getByRole('button', { name: /save changes/i }).click();
 
-        await expect(
-          page
-            .getByRole('alert')
-            .filter({ hasText: /action completed successfully/i })
-            .last(),
-        ).toBeVisible();
+        await expect(toast).toBeVisible();
 
-        await expect(
-          page
-            .getByRole('alert')
-            .filter({ hasText: /action completed successfully/i })
-            .last(),
-        ).toBeHidden();
+        await expect(toast).toBeHidden();
       });
 
       await test.step('Accepts a valid value', async () => {
@@ -356,20 +320,10 @@ test.describe('Manage Account', () => {
 
         await page.getByRole('button', { name: /save changes/i }).click();
 
-        await expect(
-          page
-            .getByRole('alert')
-            .filter({ hasText: /action completed successfully/i })
-            .last(),
-        ).toBeVisible();
+        await expect(toast).toBeVisible();
 
         await expect(locationInput).toHaveValue(location);
-        await expect(
-          page
-            .getByRole('alert')
-            .filter({ hasText: /action completed successfully/i })
-            .last(),
-        ).toBeHidden();
+        await expect(toast).toBeHidden();
       });
     });
   });
@@ -380,7 +334,10 @@ test.describe('Manage Account', () => {
         .getByTestId('account-page-sidebar')
         .getByLabel('/account/preferences')
         .click();
+
+      await page.waitForURL('/account/preferences');
     });
+
     test('Email field', async ({ page }) => {
       await expect(page.getByText(/^Email address$/)).toBeVisible();
 
@@ -552,6 +509,10 @@ test.describe('Manage Account', () => {
       ).toBeVisible();
 
       await page.goto('/account/advanced');
+
+      if (await page.getByText('Loading...').isVisible()) {
+        await page.getByText('Loading...').waitFor({ state: 'hidden' });
+      }
 
       await page.getByTestId('notifications-toggle').click();
     });

--- a/playwright/e2e/manage-account.spec.ts
+++ b/playwright/e2e/manage-account.spec.ts
@@ -5,7 +5,7 @@ import {
   selectWallet,
   setCookieConsent,
   generateRandomEmail,
-  fillInputWithDelay,
+  fillInput,
 } from '../utils/common.ts';
 
 const validImagePath = 'playwright/fixtures/images/jaya-the-beast_400KB.png';
@@ -53,7 +53,7 @@ test.describe('Manage Account', () => {
       const displayNameInput = page.locator('[name="displayName"]');
 
       // Should be pre-filled with the user's display name
-      await expect(displayNameInput.inputValue).toBeTruthy();
+      await expect(displayNameInput.inputValue()).toBeTruthy();
 
       await displayNameInput.hover();
 
@@ -100,7 +100,7 @@ test.describe('Manage Account', () => {
         // Remove the avatar
         await removeAvatarButton.click();
 
-        await expect(toast).toBeVisible();
+        await toast.waitFor({ state: 'visible' });
 
         await removeAvatarButton.waitFor({ state: 'hidden' });
 
@@ -181,12 +181,11 @@ test.describe('Manage Account', () => {
       await expect(page.getByText('Website', { exact: true })).toBeVisible();
       await expect(page.getByText('Your website is optional')).toBeVisible();
       await expect(websiteInput).toBeEnabled();
-
       // Verify that the website field is pre-filled with the user's website
-      await expect(websiteInput.inputValue).toBeTruthy();
+      await expect(websiteInput.inputValue()).toBeTruthy();
 
       await test.step('Shows an error message when the website is invalid', async () => {
-        await fillInputWithDelay({
+        await fillInput({
           page,
           selector: '[name="website"]',
           value: 'invalid-website',
@@ -202,7 +201,7 @@ test.describe('Manage Account', () => {
 
       await test.step('The field is not required', async () => {
         await websiteInput.clear();
-        await fillInputWithDelay({
+        await fillInput({
           page,
           selector: '[name="website"]',
           value: '',
@@ -217,7 +216,7 @@ test.describe('Manage Account', () => {
       await test.step('Accepts a valid website', async () => {
         const website = 'https://colony.io';
 
-        await fillInputWithDelay({
+        await fillInput({
           page,
           selector: '[name="website"]',
           value: website,
@@ -272,7 +271,7 @@ test.describe('Manage Account', () => {
         const text = 'This is my bio';
 
         await bioInput.clear();
-        await fillInputWithDelay({
+        await fillInput({
           page,
           selector: '[name="bio"]',
           value: text,
@@ -312,7 +311,7 @@ test.describe('Manage Account', () => {
         const location = 'New York';
 
         await locationInput.clear();
-        await fillInputWithDelay({
+        await fillInput({
           page,
           selector: '[name="location"]',
           value: location,
@@ -372,7 +371,7 @@ test.describe('Manage Account', () => {
 
         await emailInput.waitFor({ state: 'visible' });
         await emailInput.clear();
-        await fillInputWithDelay({
+        await fillInput({
           page,
           selector: '[name="email"]',
           value: emailValue,
@@ -392,7 +391,7 @@ test.describe('Manage Account', () => {
       await test.step('Shows an error message when the email is invalid', async () => {
         await page.getByRole('button', { name: /update email/i }).click();
 
-        await fillInputWithDelay({
+        await fillInput({
           page,
           selector: '[name="email"]',
           value: 'invalid-email',
@@ -410,7 +409,7 @@ test.describe('Manage Account', () => {
 
         await page.getByRole('button', { name: /update email/i }).click();
 
-        await fillInputWithDelay({
+        await fillInput({
           page,
           selector: '[name="email"]',
           value: email,

--- a/playwright/e2e/manage-account.spec.ts
+++ b/playwright/e2e/manage-account.spec.ts
@@ -1,0 +1,594 @@
+/* eslint-disable playwright/no-conditional-in-test */
+import { expect, test } from '@playwright/test';
+
+import {
+  selectWallet,
+  setCookieConsent,
+  generateRandomEmail,
+  fillInputWithDelay,
+} from '../utils/common.ts';
+
+const validImagePath = 'playwright/fixtures/images/jaya-the-beast_400KB.png';
+const invalidImagePath = 'playwright/fixtures/images/cat-image-new-1_3_MB.png';
+
+test.describe('Manage Account', () => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
+    await setCookieConsent(context, baseURL);
+
+    await page.goto('/');
+
+    await selectWallet(page);
+
+    await page.goto('/account/profile');
+  });
+
+  test.describe('Profile section', () => {
+    test.beforeEach(async ({ page }) => {
+      await page
+        .getByTestId('account-page-sidebar')
+        .getByLabel('/account/profile')
+        .click();
+    });
+
+    test('Username field', async ({ page }) => {
+      await expect(
+        page.getByRole('heading', { name: 'Profile', level: 3 }),
+      ).toBeVisible();
+
+      await expect(
+        page.getByRole('heading', { name: 'Your Colony profile', level: 4 }),
+      ).toBeVisible();
+
+      await expect(
+        page.getByText(/You can change your username every 90 days/i),
+      ).toBeVisible();
+
+      const displayNameInput = page.locator('[name="displayName"]');
+
+      // Should be pre-filled with the user's display name
+      await expect(displayNameInput.inputValue).toBeTruthy();
+
+      await displayNameInput.hover();
+
+      await expect(
+        page.getByText(/You can change your username again in /i),
+      ).toBeVisible();
+    });
+
+    test('Avatar', async ({ page }) => {
+      await test.step('Removing Avatar', async () => {
+        const removeAvatarButton = page.getByRole('button', {
+          name: 'Remove avatar',
+        });
+
+        if (!(await removeAvatarButton.isVisible())) {
+          // Upload a valid image
+          const uploadInput = page.locator('input[type="file"]');
+
+          await page.getByRole('button', { name: 'Change avatar' }).click();
+
+          await uploadInput.setInputFiles(validImagePath);
+
+          await removeAvatarButton.waitFor({ state: 'visible' });
+        }
+        const avatarUploader = page.getByTestId('avatar-uploader');
+        const avatar = page.getByTestId('user-profile-avatar');
+        const avatarInHeader = page.getByTestId('header-avatar');
+        //  Avatar in the profile form and header should be the same
+        await expect(page.getByTestId('user-profile-avatar')).toHaveAttribute(
+          'src',
+          (await page
+            .getByTestId('header-avatar')
+            .getAttribute('src')) as string,
+        );
+
+        // Verify that the avatar uploader is visible
+        await expect(avatarUploader).toBeVisible();
+
+        // Remove the avatar
+        await removeAvatarButton.click();
+
+        await expect(
+          page
+            .getByRole('alert')
+            .filter({ hasText: /profile image changed successfully/i })
+            .last(),
+        ).toBeVisible();
+
+        await removeAvatarButton.waitFor({ state: 'hidden' });
+
+        const updatedAvatarSrc = await avatar.getAttribute('src');
+        const updatedAvatarInHeaderSrc =
+          await avatarInHeader.getAttribute('src');
+
+        await expect(updatedAvatarSrc?.startsWith('data:')).toBeTruthy();
+        await expect(
+          updatedAvatarInHeaderSrc?.startsWith('data:'),
+        ).toBeTruthy();
+        // Avatars in the profile and header should be the same
+        await expect(page.getByTestId('user-profile-avatar')).toHaveAttribute(
+          'src',
+          (await page
+            .getByTestId('header-avatar')
+            .getAttribute('src')) as string,
+        );
+
+        await expect(removeAvatarButton).toBeHidden();
+      });
+
+      await test.step('Uploading avatar', async () => {
+        const avatarUploader = page.getByTestId('avatar-uploader');
+        const avatar = page.getByTestId('user-profile-avatar');
+
+        await expect(avatarUploader).toBeVisible();
+
+        await expect(avatar).toBeVisible();
+        await expect(avatar).toHaveAttribute('src', /data:/);
+
+        // Upload a valid image
+        const uploadInput = page.locator('input[type="file"]');
+
+        await page.getByRole('button', { name: 'Change avatar' }).click();
+
+        await page.getByRole('button', { name: 'Click to upload' }).waitFor({
+          state: 'visible',
+        });
+
+        await uploadInput.setInputFiles(validImagePath);
+
+        await expect(avatar).toHaveAttribute('src', /data:/);
+
+        await expect(
+          page
+            .getByRole('alert')
+            .filter({ hasText: /profile image changed successfully/i })
+            .last(),
+        ).toBeVisible();
+
+        // Upload an invalid image
+        await page.getByRole('button', { name: /change avatar/i }).click();
+        await uploadInput.setInputFiles(invalidImagePath);
+
+        // Verify that the error message is displayed
+        await expect(
+          page.getByText(/File size is too large, it should not exceed 1MB/i),
+        ).toBeVisible();
+
+        await expect(
+          page.getByRole('button', { name: 'Try again' }),
+        ).toBeVisible();
+
+        await expect(page.getByTestId('file-remove')).toBeVisible();
+
+        await expect(
+          page.getByRole('button', { name: 'Click to upload' }),
+        ).toBeHidden();
+      });
+    });
+
+    test('Website field', async ({ page }) => {
+      const websiteInput = page.locator('[name="website"]');
+
+      const saveChangesButton = page.getByRole('button', {
+        name: 'Save changes',
+      });
+      await expect(page.getByText('Website', { exact: true })).toBeVisible();
+      await expect(page.getByText('Your website is optional')).toBeVisible();
+      await expect(websiteInput).toBeEnabled();
+
+      // Verify that the website field is pre-filled with the user's website
+      await expect(websiteInput.inputValue).toBeTruthy();
+
+      await test.step('Shows an error message when the website is invalid', async () => {
+        await fillInputWithDelay({
+          page,
+          selector: '[name="website"]',
+          value: 'invalid-website',
+        });
+        await saveChangesButton.click();
+
+        await expect(
+          page
+            .getByTestId('form-error')
+            .filter({ hasText: /Enter a valid URL/i }),
+        ).toBeVisible();
+      });
+
+      await test.step('The field is not required', async () => {
+        await websiteInput.clear();
+        await fillInputWithDelay({
+          page,
+          selector: '[name="website"]',
+          value: '',
+        });
+
+        await saveChangesButton.click();
+        await expect(
+          page
+            .getByRole('alert')
+            .filter({ hasText: /action completed successfully/i })
+            .last(),
+        ).toBeVisible();
+        await expect(websiteInput).toHaveValue('');
+        await expect(
+          page
+            .getByRole('alert')
+            .filter({ hasText: /action completed successfully/i })
+            .last(),
+        ).toBeHidden();
+      });
+
+      await test.step('Accepts a valid website', async () => {
+        const website = 'https://colony.io';
+
+        await fillInputWithDelay({
+          page,
+          selector: '[name="website"]',
+          value: website,
+        });
+        await saveChangesButton.click();
+
+        await expect(
+          page
+            .getByRole('alert')
+            .filter({ hasText: /action completed successfully/i })
+            .last(),
+        ).toBeVisible();
+
+        await expect(websiteInput).toHaveValue(`${website}/`);
+        await expect(
+          page
+            .getByRole('alert')
+            .filter({ hasText: /action completed successfully/i })
+            .last(),
+        ).toBeHidden();
+      });
+    });
+
+    test('Your Bio field', async ({ page }) => {
+      await expect(page.getByText(/^Your bio$/)).toBeVisible();
+      await expect(
+        page.getByText(
+          /Your bio is optional and shows on your Colony profile in under 200 characters/,
+        ),
+      ).toBeVisible();
+
+      const bioInput = page.locator('[name="bio"]');
+
+      await test.step('Shows an error message when the bio is too long', async () => {
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await page.waitForTimeout(500);
+        await bioInput.fill('a'.repeat(201));
+
+        await page.getByRole('button', { name: /save changes/i }).click();
+
+        await expect(
+          page
+            .getByTestId('form-error')
+            .filter({ hasText: /Too many characters/i }),
+        ).toBeVisible();
+      });
+
+      await test.step('The field is not required', async () => {
+        await bioInput.clear();
+
+        await page.getByRole('button', { name: /save changes/i }).click();
+
+        await expect(
+          page
+            .getByRole('alert')
+            .filter({ hasText: /action completed successfully/i })
+            .last(),
+        ).toBeVisible();
+
+        await expect(
+          page
+            .getByRole('alert')
+            .filter({ hasText: /action completed successfully/i })
+            .last(),
+        ).toBeHidden();
+      });
+
+      await test.step('Accepts a valid value', async () => {
+        const text = 'This is my bio';
+
+        await bioInput.clear();
+        await fillInputWithDelay({
+          page,
+          selector: '[name="bio"]',
+          value: text,
+        });
+
+        await page.getByRole('button', { name: /save changes/i }).click();
+
+        await expect(
+          page
+            .getByRole('alert')
+            .filter({ hasText: /action completed successfully/i })
+            .last(),
+        ).toBeVisible();
+
+        await expect(bioInput).toHaveValue(text);
+      });
+    });
+
+    test('Location field', async ({ page }) => {
+      await expect(page.getByText(/Location/)).toBeVisible();
+      await expect(
+        page.getByText(
+          /Your location is optional and only shown on your Colony profile/,
+        ),
+      ).toBeVisible();
+
+      const locationInput = page.locator('[name="location"]');
+
+      await test.step('The field is not required', async () => {
+        await locationInput.clear();
+
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await page.waitForTimeout(1000);
+        await page.getByRole('button', { name: /save changes/i }).click();
+
+        await expect(
+          page
+            .getByRole('alert')
+            .filter({ hasText: /action completed successfully/i })
+            .last(),
+        ).toBeVisible();
+
+        await expect(
+          page
+            .getByRole('alert')
+            .filter({ hasText: /action completed successfully/i })
+            .last(),
+        ).toBeHidden();
+      });
+
+      await test.step('Accepts a valid value', async () => {
+        const location = 'New York';
+
+        await locationInput.clear();
+        await fillInputWithDelay({
+          page,
+          selector: '[name="location"]',
+          value: location,
+        });
+
+        await page.getByRole('button', { name: /save changes/i }).click();
+
+        await expect(
+          page
+            .getByRole('alert')
+            .filter({ hasText: /action completed successfully/i })
+            .last(),
+        ).toBeVisible();
+
+        await expect(locationInput).toHaveValue(location);
+        await expect(
+          page
+            .getByRole('alert')
+            .filter({ hasText: /action completed successfully/i })
+            .last(),
+        ).toBeHidden();
+      });
+    });
+  });
+
+  test.describe('Preferences section', () => {
+    test.beforeEach(async ({ page }) => {
+      await page
+        .getByTestId('account-page-sidebar')
+        .getByLabel('/account/preferences')
+        .click();
+    });
+    test('Email field', async ({ page }) => {
+      await expect(page.getByText(/^Email address$/)).toBeVisible();
+
+      await expect(page.getByText(/Update your email address/)).toBeVisible();
+      const emailValue = await page
+        .getByTestId('preferences-email-value')
+        .innerText();
+      await expect(page.getByTestId('preferences-email-value')).toBeVisible();
+
+      await page.getByRole('button', { name: /update email/i }).click();
+
+      await page
+        .getByRole('button', { name: /update email/i })
+        .waitFor({ state: 'hidden' });
+
+      await expect(page.getByTestId('preferences-email-value')).toBeHidden();
+
+      await expect(
+        page.getByRole('button', { name: /save changes/i }),
+      ).toBeVisible();
+
+      const emailInput = page.locator('[name="email"]');
+      await expect(emailInput).toHaveValue(emailValue);
+
+      await page.getByRole('button', { name: /cancel/i }).click();
+
+      await expect(page.getByTestId('preferences-email-value')).toBeVisible();
+      await expect(emailInput).toBeHidden();
+
+      await test.step('Should not accept existing email', async () => {
+        await page.getByRole('button', { name: /update email/i }).click();
+
+        await emailInput.waitFor({ state: 'visible' });
+        await emailInput.clear();
+        await fillInputWithDelay({
+          page,
+          selector: '[name="email"]',
+          value: emailValue,
+        });
+
+        await page.getByRole('button', { name: /save changes/i }).click();
+
+        await expect(
+          page
+            .getByTestId('form-error')
+            .filter({ hasText: /email already registered/i }),
+        ).toBeVisible();
+
+        await page.getByRole('button', { name: /cancel/i }).click();
+      });
+
+      await test.step('Shows an error message when the email is invalid', async () => {
+        await page.getByRole('button', { name: /update email/i }).click();
+
+        await fillInputWithDelay({
+          page,
+          selector: '[name="email"]',
+          value: 'invalid-email',
+        });
+
+        await page.getByRole('button', { name: /save changes/i }).click();
+
+        await expect(page.getByTestId('form-error')).toBeVisible();
+
+        await page.getByRole('button', { name: /cancel/i }).click();
+      });
+
+      await test.step('Should accept a valid email', async () => {
+        const email = generateRandomEmail();
+
+        await page.getByRole('button', { name: /update email/i }).click();
+
+        await fillInputWithDelay({
+          page,
+          selector: '[name="email"]',
+          value: email,
+        });
+
+        await page.getByRole('button', { name: /save changes/i }).click();
+
+        await expect(
+          page
+            .getByRole('alert')
+            .filter({ hasText: /action completed successfully/i })
+            .last(),
+        ).toBeVisible();
+
+        await expect(page.getByTestId('preferences-email-value')).toHaveText(
+          email,
+        );
+      });
+    });
+
+    test('Wallet information', async ({ page }) => {
+      await page.getByRole('button', { name: /copy address/i }).click();
+
+      const clipboardText: string = await page.evaluate(
+        'navigator.clipboard.readText()',
+      );
+
+      await expect(
+        page.getByText(clipboardText, { exact: true }),
+      ).toBeVisible();
+    });
+
+    test('Notification preferences', async ({ page }) => {
+      await expect(
+        page.getByRole('heading', { name: 'Notification preferences' }),
+      ).toBeVisible();
+
+      const notificationsDisabled = await page
+        .getByText(/Notifications are disabled/)
+        .isVisible();
+
+      if (notificationsDisabled) {
+        // Enable notifications
+        await page.getByRole('link', { name: /advanced settings/i }).click();
+
+        await page.waitForURL('/account/advanced');
+
+        const notificationsSection = page.getByTestId('notifications-section');
+        await expect(
+          notificationsSection.getByText(/Manage services/i),
+        ).toBeVisible();
+
+        await expect(
+          notificationsSection.getByRole('heading', { name: /Notifications/i }),
+        ).toBeVisible();
+
+        await expect(
+          notificationsSection.getByText(
+            /Enables in-app and external notifications for activity in colonies you’ve joined/i,
+          ),
+        ).toBeVisible();
+
+        await page.getByTestId('notifications-toggle').click();
+
+        const alert = page.getByRole('alert');
+
+        await expect(alert).toBeVisible();
+
+        await expect(
+          alert.getByText(/You will now receive notifications/i),
+        ).toBeVisible();
+        await page.goBack();
+        await page.waitForURL('/account/preferences');
+      }
+
+      await expect(page.getByText(/Payments and funds/)).toBeVisible();
+
+      await expect(
+        page.getByRole('heading', { name: /Mention/ }),
+      ).toBeVisible();
+
+      await expect(
+        page.getByRole('heading', { name: /Operations and admin/i }),
+      ).toBeVisible();
+
+      await expect(
+        page.getByTestId('payment-notifications-toggle'),
+      ).toBeVisible();
+
+      await expect(
+        page.getByTestId('mention-notifications-toggle'),
+      ).toBeVisible();
+
+      await expect(
+        page.getByTestId('mention-notifications-toggle'),
+      ).toBeVisible();
+
+      await page.goto('/account/advanced');
+
+      await page.getByTestId('notifications-toggle').click();
+    });
+  });
+
+  test.describe('Advanced Settings section', () => {
+    test('Metatransactions toggle', async ({ page }) => {
+      await page
+        .getByTestId('account-page-sidebar')
+        .getByLabel('/account/advanced')
+        .click();
+
+      await page.getByTestId('metatransactions-toggle').click();
+
+      await expect(
+        page
+          .getByRole('alert')
+          .filter({
+            hasText:
+              /(colony will pay your gas fee|you will pay your own gas fee)/i,
+          })
+          .last(),
+      ).toBeVisible();
+
+      await expect(
+        page.getByRole('heading', { name: 'Advanced settings', level: 3 }),
+      ).toBeVisible();
+
+      await expect(
+        page.getByRole('heading', { name: 'Colony pays my gas fees' }),
+      ).toBeVisible();
+
+      await page.getByTestId('settings-row-tooltip').hover();
+
+      await expect(
+        page.getByText(/disabling this option means/i),
+      ).toBeVisible();
+    });
+  });
+});

--- a/playwright/e2e/manage-account.spec.ts
+++ b/playwright/e2e/manage-account.spec.ts
@@ -21,11 +21,6 @@ test.describe('Manage Account', () => {
 
     await page.getByTestId('user-navigation-hamburger').click();
 
-    await page
-      .getByText(/manage account/i)
-      .first()
-      .waitFor({ state: 'visible' });
-
     await page.getByTestId('user-menu').waitFor({ state: 'visible' });
 
     await page

--- a/playwright/utils/common.ts
+++ b/playwright/utils/common.ts
@@ -34,25 +34,22 @@ export const setCookieConsent = async (
   );
 };
 
-export const fillInputWithDelay = async ({
+export const fillInput = async ({
   page,
   label,
   selector,
   value,
-  // timeout = 500,
 }: {
   page: Page;
   label?: string | RegExp;
   selector?: string;
   value: string;
-  timeout?: number;
 }) => {
   if (!label && !selector) {
     throw new Error('You must provide either a label or a selector');
   }
   const input = label ? page.getByLabel(label) : page.locator(selector!);
 
-  // await page.waitForTimeout(timeout);
   await input.fill(value);
   await expect(input).toHaveValue(value);
 };
@@ -65,7 +62,7 @@ export const generateRandomEmail = () => {
   return `${generateRandomString()}@example.com`;
 };
 
-const customTimeout = parseInt(process.env.E2E_TIMEOUT || '3000', 10); // Allow to run with different timeout, defaults to 2000ms
+const customTimeout = parseInt(process.env.E2E_TIMEOUT || '3000', 10); // Allow to run with different timeout, defaults to 3000ms
 
 export const selectWallet = async (
   page: Page,

--- a/playwright/utils/common.ts
+++ b/playwright/utils/common.ts
@@ -65,7 +65,7 @@ export const generateRandomEmail = () => {
   return `${generateRandomString()}@example.com`;
 };
 
-const customTimeout = parseInt(process.env.E2E_TIMEOUT || '2000', 10); // Allow to run with different timeout, defaults to 2000ms
+const customTimeout = parseInt(process.env.E2E_TIMEOUT || '3000', 10); // Allow to run with different timeout, defaults to 2000ms
 
 export const selectWallet = async (
   page: Page,

--- a/playwright/utils/common.ts
+++ b/playwright/utils/common.ts
@@ -16,7 +16,7 @@ export const acceptCookieConsentBanner = async (page: Page) => {
 const cookieNames = [
   'cookies-analytics',
   'cookies-marketing',
-  'cookies-prefernces',
+  'cookies-preferences',
   'cookies-functional',
 ];
 
@@ -39,7 +39,7 @@ export const fillInputWithDelay = async ({
   label,
   selector,
   value,
-  timeout = 500,
+  // timeout = 500,
 }: {
   page: Page;
   label?: string | RegExp;
@@ -51,8 +51,8 @@ export const fillInputWithDelay = async ({
     throw new Error('You must provide either a label or a selector');
   }
   const input = label ? page.getByLabel(label) : page.locator(selector!);
-  // eslint-disable-next-line playwright/no-wait-for-timeout
-  await page.waitForTimeout(timeout);
+
+  // await page.waitForTimeout(timeout);
   await input.fill(value);
   await expect(input).toHaveValue(value);
 };
@@ -64,6 +64,8 @@ export const generateRandomString = () => {
 export const generateRandomEmail = () => {
   return `${generateRandomString()}@example.com`;
 };
+
+const customTimeout = parseInt(process.env.E2E_TIMEOUT || '2000', 10); // Allow to run with different timeout, defaults to 2000ms
 
 export const selectWallet = async (
   page: Page,
@@ -86,4 +88,11 @@ export const selectWallet = async (
   if (loadingIndicatorVisible) {
     await loadingIndicator.waitFor({ state: 'hidden' });
   }
+  // Using waitForTimeout as a temporary workaround,
+  // to ensure all input fields and buttons are fully interactive.
+  // Otherwise tests might randomply fail
+  // due to elements not being fully ready for actions.
+  // Look for a better signal to wait for.
+  // eslint-disable-next-line playwright/no-wait-for-timeout
+  await page.waitForTimeout(customTimeout);
 };

--- a/playwright/utils/common.ts
+++ b/playwright/utils/common.ts
@@ -1,4 +1,4 @@
-import { type BrowserContext, type Page } from '@playwright/test';
+import { expect, type BrowserContext, type Page } from '@playwright/test';
 
 export const acceptCookieConsentBanner = async (page: Page) => {
   // Check if the cookie banner is present on the page
@@ -34,19 +34,56 @@ export const setCookieConsent = async (
   );
 };
 
-export const fillInputByLabelWithDelay = async ({
+export const fillInputWithDelay = async ({
   page,
   label,
+  selector,
   value,
   timeout = 500,
 }: {
   page: Page;
-  label: string | RegExp;
+  label?: string | RegExp;
+  selector?: string;
   value: string;
   timeout?: number;
 }) => {
+  if (!label && !selector) {
+    throw new Error('You must provide either a label or a selector');
+  }
+  const input = label ? page.getByLabel(label) : page.locator(selector!);
   // eslint-disable-next-line playwright/no-wait-for-timeout
   await page.waitForTimeout(timeout);
+  await input.fill(value);
+  await expect(input).toHaveValue(value);
+};
 
-  await page.getByLabel(label).fill(value);
+export const generateRandomString = () => {
+  return Math.random().toString(36).substring(2, 8);
+};
+
+export const generateRandomEmail = () => {
+  return `${generateRandomString()}@example.com`;
+};
+
+export const selectWallet = async (
+  page: Page,
+  wallet: string | RegExp = /dev wallet 2/i,
+) => {
+  await page
+    .getByRole('button', { name: /connect wallet/i })
+    .first()
+    .click();
+
+  await page.getByLabel(/I agree to/i).click();
+
+  await page.getByText(wallet).click();
+
+  await page.getByText(/Local Ganache Instance/i).waitFor({ state: 'visible' });
+
+  const loadingIndicator = page.getByText(/Checking your access.../i);
+  const loadingIndicatorVisible = await loadingIndicator.isVisible();
+
+  if (loadingIndicatorVisible) {
+    await loadingIndicator.waitFor({ state: 'hidden' });
+  }
 };

--- a/playwright/utils/create-colony.ts
+++ b/playwright/utils/create-colony.ts
@@ -1,6 +1,6 @@
 import { type Page } from '@playwright/test';
 
-import { fillInputWithDelay } from './common.ts';
+import { fillInput } from './common.ts';
 
 export const fillColonyNameStep = async (
   page: Page,
@@ -9,13 +9,13 @@ export const fillColonyNameStep = async (
     urlFieldValue,
   }: { nameFieldValue: string; urlFieldValue: string },
 ) => {
-  await fillInputWithDelay({
+  await fillInput({
     page,
     label: /colony name/i,
     value: nameFieldValue,
   });
 
-  await fillInputWithDelay({
+  await fillInput({
     page,
     label: /custom colony URL/i,
     value: urlFieldValue,
@@ -37,7 +37,7 @@ export const fillNativeTokenStepWithExistingToken = async (
   await page.getByLabel(/Use an existing token/i).check();
   await page.getByRole('button', { name: /continue/i }).click();
 
-  await fillInputWithDelay({
+  await fillInput({
     page,
     label: /Existing token address/i,
     value: token,

--- a/playwright/utils/create-colony.ts
+++ b/playwright/utils/create-colony.ts
@@ -1,30 +1,6 @@
 import { type Page } from '@playwright/test';
 
-import { fillInputByLabelWithDelay } from './common.ts';
-
-export const generateRandomString = () => {
-  return Math.random().toString(36).substring(2, 8);
-};
-
-export const selectWalletAndUserProfile = async (page: Page) => {
-  await page
-    .getByRole('button', { name: /connect wallet/i })
-    .first()
-    .click();
-
-  await page.getByLabel(/I agree to/i).click();
-
-  await page.getByText(/dev wallet 2/i).click();
-
-  await page.getByText(/Local Ganache Instance/i).waitFor({ state: 'visible' });
-
-  const loadingIndicator = page.getByText(/Checking your access.../i);
-  const loadingIndicatorVisible = await loadingIndicator.isVisible();
-
-  if (loadingIndicatorVisible) {
-    await loadingIndicator.waitFor({ state: 'hidden' });
-  }
-};
+import { fillInputWithDelay } from './common.ts';
 
 export const fillColonyNameStep = async (
   page: Page,
@@ -33,13 +9,13 @@ export const fillColonyNameStep = async (
     urlFieldValue,
   }: { nameFieldValue: string; urlFieldValue: string },
 ) => {
-  await fillInputByLabelWithDelay({
+  await fillInputWithDelay({
     page,
     label: /colony name/i,
     value: nameFieldValue,
   });
 
-  await fillInputByLabelWithDelay({
+  await fillInputWithDelay({
     page,
     label: /custom colony URL/i,
     value: urlFieldValue,
@@ -61,7 +37,7 @@ export const fillNativeTokenStepWithExistingToken = async (
   await page.getByLabel(/Use an existing token/i).check();
   await page.getByRole('button', { name: /continue/i }).click();
 
-  await fillInputByLabelWithDelay({
+  await fillInputWithDelay({
     page,
     label: /Existing token address/i,
     value: token,

--- a/src/components/common/Extensions/UserNavigation/UserNavigation.tsx
+++ b/src/components/common/Extensions/UserNavigation/UserNavigation.tsx
@@ -108,6 +108,7 @@ const UserNavigation: FC<UserNavigationProps> = ({
         iconSize={isMobile ? 18 : 16}
         setTriggerRef={setTriggerRef}
         onClick={onUserMenuButtonClick}
+        data-testid="user-navigation-hamburger"
       />
       {visible && (
         <UserMenu

--- a/src/components/common/Extensions/UserNavigation/partials/HeaderAvatar/HeaderAvatar.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/HeaderAvatar/HeaderAvatar.tsx
@@ -26,6 +26,7 @@ const HeaderAvatar = () => {
         userName={userName}
         userAddress={wallet.address}
         size={isMobile ? 18 : 16}
+        testId="header-avatar"
       />
       {!isMobile && (
         <p className="ml-1 truncate text-sm font-medium">{userName}</p>

--- a/src/components/common/Extensions/UserNavigation/partials/UserMenu/UserMenu.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserMenu/UserMenu.tsx
@@ -77,6 +77,7 @@ const UserMenu: FC<UserMenuProps> = ({
       )}
     >
       <div
+        data-testid="user-menu"
         className={clsx('transition-transform', {
           '-translate-x-0': !activeSubmenu,
           'absolute -translate-x-[100vw]': activeSubmenu,

--- a/src/components/frame/v5/pages/UserAdvancedPage/partials/MetatransactionsSection/partials/MetatransactionsToggle.tsx
+++ b/src/components/frame/v5/pages/UserAdvancedPage/partials/MetatransactionsSection/partials/MetatransactionsToggle.tsx
@@ -55,6 +55,7 @@ const MetatransactionsToggle = () => {
 
   return (
     <Switch
+      testId="metatransactions-toggle"
       checked={areMetaTxEnabled}
       disabled={loading}
       onChange={async () => {

--- a/src/components/frame/v5/pages/UserAdvancedPage/partials/NotificationsSection/NotificationsSection.tsx
+++ b/src/components/frame/v5/pages/UserAdvancedPage/partials/NotificationsSection/NotificationsSection.tsx
@@ -40,18 +40,22 @@ const MSG = defineMessages({
   },
 });
 
+const toggleButton = (
+  <NotificationTypeToggle
+    testId="notifications-toggle"
+    notificationType="notificationsDisabled"
+    toastTextEnabled={formatText(MSG.toastNotificationsEnabled)}
+    toastTextDisabled={formatText(MSG.toastNotificationsDisabled)}
+  />
+);
+
 // @TODO if we get more items in this "section" split the sections up and rename this
 const NotificationsSection = () => {
-  const toggleButton = (
-    <NotificationTypeToggle
-      notificationType="notificationsDisabled"
-      toastTextEnabled={formatText(MSG.toastNotificationsEnabled)}
-      toastTextDisabled={formatText(MSG.toastNotificationsDisabled)}
-    />
-  );
-
   return (
-    <SettingsRow.Container className="border-none">
+    <SettingsRow.Container
+      className="border-none"
+      testId="notifications-section"
+    >
       <SettingsRow.Content>
         <div className="flex items-center gap-1.5">
           <SettingsRow.Title>{formatText(MSG.sectionTitle)}</SettingsRow.Title>

--- a/src/components/frame/v5/pages/UserAdvancedPage/partials/NotificationsSection/NotificationsSection.tsx
+++ b/src/components/frame/v5/pages/UserAdvancedPage/partials/NotificationsSection/NotificationsSection.tsx
@@ -39,18 +39,17 @@ const MSG = defineMessages({
     defaultMessage: 'You will no longer receive notifications.',
   },
 });
-
-const toggleButton = (
-  <NotificationTypeToggle
-    testId="notifications-toggle"
-    notificationType="notificationsDisabled"
-    toastTextEnabled={formatText(MSG.toastNotificationsEnabled)}
-    toastTextDisabled={formatText(MSG.toastNotificationsDisabled)}
-  />
-);
-
 // @TODO if we get more items in this "section" split the sections up and rename this
 const NotificationsSection = () => {
+  const toggleButton = (
+    <NotificationTypeToggle
+      testId="notifications-toggle"
+      notificationType="notificationsDisabled"
+      toastTextEnabled={formatText(MSG.toastNotificationsEnabled)}
+      toastTextDisabled={formatText(MSG.toastNotificationsDisabled)}
+    />
+  );
+
   return (
     <SettingsRow.Container
       className="border-none"

--- a/src/components/frame/v5/pages/UserPreferencesPage/partials/AdminNotifications.tsx
+++ b/src/components/frame/v5/pages/UserPreferencesPage/partials/AdminNotifications.tsx
@@ -28,16 +28,16 @@ const MSG = defineMessages({
   },
 });
 
-const toggleButton = (
-  <NotificationTypeToggle
-    testId="admin-notifications-toggle"
-    toastTextEnabled={formatText(MSG.toastAdminNotificationsEnabled)}
-    toastTextDisabled={formatText(MSG.toastAdminNotificationsDisabled)}
-    notificationType="adminNotificationsDisabled"
-  />
-);
-
 const AdminNotifications = () => {
+  const toggleButton = (
+    <NotificationTypeToggle
+      testId="admin-notifications-toggle"
+      toastTextEnabled={formatText(MSG.toastAdminNotificationsEnabled)}
+      toastTextDisabled={formatText(MSG.toastAdminNotificationsDisabled)}
+      notificationType="adminNotificationsDisabled"
+    />
+  );
+
   return (
     <SettingsRow.Content rightContent={toggleButton}>
       <SettingsRow.Subtitle>{formatText(MSG.adminTitle)}</SettingsRow.Subtitle>

--- a/src/components/frame/v5/pages/UserPreferencesPage/partials/AdminNotifications.tsx
+++ b/src/components/frame/v5/pages/UserPreferencesPage/partials/AdminNotifications.tsx
@@ -28,15 +28,16 @@ const MSG = defineMessages({
   },
 });
 
-const AdminNotifications = () => {
-  const toggleButton = (
-    <NotificationTypeToggle
-      toastTextEnabled={formatText(MSG.toastAdminNotificationsEnabled)}
-      toastTextDisabled={formatText(MSG.toastAdminNotificationsDisabled)}
-      notificationType="adminNotificationsDisabled"
-    />
-  );
+const toggleButton = (
+  <NotificationTypeToggle
+    testId="admin-notifications-toggle"
+    toastTextEnabled={formatText(MSG.toastAdminNotificationsEnabled)}
+    toastTextDisabled={formatText(MSG.toastAdminNotificationsDisabled)}
+    notificationType="adminNotificationsDisabled"
+  />
+);
 
+const AdminNotifications = () => {
   return (
     <SettingsRow.Content rightContent={toggleButton}>
       <SettingsRow.Subtitle>{formatText(MSG.adminTitle)}</SettingsRow.Subtitle>

--- a/src/components/frame/v5/pages/UserPreferencesPage/partials/EmailSection/EmailSection.tsx
+++ b/src/components/frame/v5/pages/UserPreferencesPage/partials/EmailSection/EmailSection.tsx
@@ -86,7 +86,9 @@ const EmailSection = () => {
     if (!isEmailInputVisible) {
       return (
         <div className="flex w-full flex-col gap-4 md:w-fit md:flex-row md:items-center md:justify-end md:gap-6">
-          <span className="text-md">{emailValue}</span>
+          <span className="text-md" data-testid="preferences-email-value">
+            {emailValue}
+          </span>
           <Button
             mode="primarySolid"
             text={{ id: 'button.updateEmail' }}

--- a/src/components/frame/v5/pages/UserPreferencesPage/partials/MentionNotifications.tsx
+++ b/src/components/frame/v5/pages/UserPreferencesPage/partials/MentionNotifications.tsx
@@ -30,16 +30,16 @@ const MSG = defineMessages({
   },
 });
 
-const toggleButton = (
-  <NotificationTypeToggle
-    testId="mention-notifications-toggle"
-    notificationType="mentionNotificationsDisabled"
-    toastTextEnabled={formatText(MSG.toastMentionNotificationsEnabled)}
-    toastTextDisabled={formatText(MSG.toastMentionNotificationsDisabled)}
-  />
-);
-
 const MentionNotifications = () => {
+  const toggleButton = (
+    <NotificationTypeToggle
+      testId="mention-notifications-toggle"
+      notificationType="mentionNotificationsDisabled"
+      toastTextEnabled={formatText(MSG.toastMentionNotificationsEnabled)}
+      toastTextDisabled={formatText(MSG.toastMentionNotificationsDisabled)}
+    />
+  );
+
   return (
     <SettingsRow.Content rightContent={toggleButton}>
       <SettingsRow.Subtitle>

--- a/src/components/frame/v5/pages/UserPreferencesPage/partials/MentionNotifications.tsx
+++ b/src/components/frame/v5/pages/UserPreferencesPage/partials/MentionNotifications.tsx
@@ -30,15 +30,16 @@ const MSG = defineMessages({
   },
 });
 
-const MentionNotifications = () => {
-  const toggleButton = (
-    <NotificationTypeToggle
-      notificationType="mentionNotificationsDisabled"
-      toastTextEnabled={formatText(MSG.toastMentionNotificationsEnabled)}
-      toastTextDisabled={formatText(MSG.toastMentionNotificationsDisabled)}
-    />
-  );
+const toggleButton = (
+  <NotificationTypeToggle
+    testId="mention-notifications-toggle"
+    notificationType="mentionNotificationsDisabled"
+    toastTextEnabled={formatText(MSG.toastMentionNotificationsEnabled)}
+    toastTextDisabled={formatText(MSG.toastMentionNotificationsDisabled)}
+  />
+);
 
+const MentionNotifications = () => {
   return (
     <SettingsRow.Content rightContent={toggleButton}>
       <SettingsRow.Subtitle>

--- a/src/components/frame/v5/pages/UserPreferencesPage/partials/PaymentNotifications.tsx
+++ b/src/components/frame/v5/pages/UserPreferencesPage/partials/PaymentNotifications.tsx
@@ -30,15 +30,16 @@ const MSG = defineMessages({
   },
 });
 
-const PaymentNotifications = () => {
-  const toggleButton = (
-    <NotificationTypeToggle
-      notificationType="paymentNotificationsDisabled"
-      toastTextEnabled={formatText(MSG.toastPaymentNotificationsEnabled)}
-      toastTextDisabled={formatText(MSG.toastPaymentNotificationsDisabled)}
-    />
-  );
+const toggleButton = (
+  <NotificationTypeToggle
+    testId="payment-notifications-toggle"
+    notificationType="paymentNotificationsDisabled"
+    toastTextEnabled={formatText(MSG.toastPaymentNotificationsEnabled)}
+    toastTextDisabled={formatText(MSG.toastPaymentNotificationsDisabled)}
+  />
+);
 
+const PaymentNotifications = () => {
   return (
     <SettingsRow.Content rightContent={toggleButton}>
       <SettingsRow.Subtitle>

--- a/src/components/frame/v5/pages/UserPreferencesPage/partials/PaymentNotifications.tsx
+++ b/src/components/frame/v5/pages/UserPreferencesPage/partials/PaymentNotifications.tsx
@@ -30,16 +30,16 @@ const MSG = defineMessages({
   },
 });
 
-const toggleButton = (
-  <NotificationTypeToggle
-    testId="payment-notifications-toggle"
-    notificationType="paymentNotificationsDisabled"
-    toastTextEnabled={formatText(MSG.toastPaymentNotificationsEnabled)}
-    toastTextDisabled={formatText(MSG.toastPaymentNotificationsDisabled)}
-  />
-);
-
 const PaymentNotifications = () => {
+  const toggleButton = (
+    <NotificationTypeToggle
+      testId="payment-notifications-toggle"
+      notificationType="paymentNotificationsDisabled"
+      toastTextEnabled={formatText(MSG.toastPaymentNotificationsEnabled)}
+      toastTextDisabled={formatText(MSG.toastPaymentNotificationsDisabled)}
+    />
+  );
+
   return (
     <SettingsRow.Content rightContent={toggleButton}>
       <SettingsRow.Subtitle>

--- a/src/components/frame/v5/pages/UserProfilePage/partials/UserAccountForm/hooks.tsx
+++ b/src/components/frame/v5/pages/UserProfilePage/partials/UserAccountForm/hooks.tsx
@@ -161,6 +161,7 @@ export const useUserProfilePageForm = () => {
                 size={60}
                 src={avatarUrl ?? undefined}
                 address={wallet.address}
+                testId="user-profile-avatar"
               />
             ) : (
               <div />
@@ -170,6 +171,7 @@ export const useUserProfilePageForm = () => {
             uploaderText,
             SuccessComponent: IconSuccessContent,
             uploaderShownByDefault: false,
+            testId: 'avatar-uploader',
           },
         },
       ],

--- a/src/components/shared/Extensions/Tooltip/Tooltip.tsx
+++ b/src/components/shared/Extensions/Tooltip/Tooltip.tsx
@@ -25,6 +25,7 @@ const Tooltip: FC<PropsWithChildren<TooltipProps>> = ({
   isSuccess = false,
   isError = false,
   isFullWidthContent,
+  testId,
   className,
   contentWrapperClassName,
   selectTriggerRef = (v) => v,
@@ -60,6 +61,7 @@ const Tooltip: FC<PropsWithChildren<TooltipProps>> = ({
         ref={(ref) => {
           setTriggerRef(selectTriggerRef(ref));
         }}
+        data-testid={testId}
       >
         {children}
       </div>

--- a/src/components/shared/Extensions/Tooltip/types.ts
+++ b/src/components/shared/Extensions/Tooltip/types.ts
@@ -17,5 +17,6 @@ export interface TooltipProps {
   isFullWidthContent?: boolean;
   className?: string;
   contentWrapperClassName?: string;
+  testId?: string;
   selectTriggerRef?: (ref: HTMLElement | null) => HTMLElement | null;
 }

--- a/src/components/v5/common/AvatarUploader/AvatarUploader.tsx
+++ b/src/components/v5/common/AvatarUploader/AvatarUploader.tsx
@@ -32,6 +32,7 @@ const AvatarUploader: FC<AvatarUploaderProps & UseAvatarUploaderProps> = ({
   SuccessComponent,
   uploaderText,
   uploaderShownByDefault = true,
+  testId,
 }) => {
   const {
     uploadAvatarError,
@@ -72,7 +73,7 @@ const AvatarUploader: FC<AvatarUploaderProps & UseAvatarUploaderProps> = ({
   }, [uploadProgress, uploaderShownByDefault]);
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-4" data-testid={testId}>
       <div className="flex flex-row items-start gap-4">
         <div className="flex-shrink-0">
           {isLoading ? (

--- a/src/components/v5/common/AvatarUploader/types.ts
+++ b/src/components/v5/common/AvatarUploader/types.ts
@@ -51,6 +51,7 @@ export interface AvatarUploaderProps {
   SuccessComponent?: React.FC<SuccessContentProps>;
   uploaderText?: string;
   uploaderShownByDefault?: boolean;
+  testId?: string;
 }
 
 export interface DefaultContentProps extends Pick<ErrorContentProps, 'open'> {

--- a/src/components/v5/common/Fields/Switch/Switch.tsx
+++ b/src/components/v5/common/Fields/Switch/Switch.tsx
@@ -8,7 +8,10 @@ import { type SwitchProps } from './types.ts';
 const displayName = 'v5.common.Fields.Switch';
 
 const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(
-  ({ id, disabled: disabledProp, readOnly, className, ...rest }, ref) => {
+  (
+    { id, disabled: disabledProp, readOnly, testId, className, ...rest },
+    ref,
+  ) => {
     const generatedId = useId();
     const { isDarkMode } = usePageThemeContext();
     const disabled = disabledProp || readOnly;
@@ -20,6 +23,7 @@ const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(
           'pointer-events-none': disabled,
           'cursor-pointer': !disabled,
         })}
+        data-testid={testId}
       >
         <input
           ref={ref}

--- a/src/components/v5/common/Fields/Switch/types.ts
+++ b/src/components/v5/common/Fields/Switch/types.ts
@@ -1,4 +1,6 @@
-export type SwitchProps = React.InputHTMLAttributes<HTMLInputElement>;
+export type SwitchProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  testId?: string;
+};
 
 export interface FormSwitchProps
   extends Omit<SwitchProps, 'onChange' | 'value'> {

--- a/src/components/v5/common/NotificationTypeToggle/NotificationTypeToggle.tsx
+++ b/src/components/v5/common/NotificationTypeToggle/NotificationTypeToggle.tsx
@@ -17,12 +17,14 @@ interface NotificationTypeToggleProps {
     | 'notificationsDisabled'
     | 'mentionNotificationsDisabled'
     | 'paymentNotificationsDisabled';
+  testId?: string;
 }
 
 const NotificationTypeToggle: FC<NotificationTypeToggleProps> = ({
   notificationType,
   toastTextDisabled,
   toastTextEnabled,
+  testId,
 }) => {
   const { user, updateUser } = useAppContext();
   const [isNotificationTypeDisabled, setIsNotificationTypeDisabled] = useState(
@@ -67,6 +69,7 @@ const NotificationTypeToggle: FC<NotificationTypeToggleProps> = ({
       onChange={async () => {
         await handleUpdateNotificationTypeMuted(!isNotificationTypeDisabled);
       }}
+      testId={testId}
     />
   );
 };

--- a/src/components/v5/common/SettingsRow/SettingsRowContainer.tsx
+++ b/src/components/v5/common/SettingsRow/SettingsRowContainer.tsx
@@ -5,14 +5,17 @@ const displayName = 'v5.common.SettingsRow.Container';
 
 interface SettingsRowContainerProps extends PropsWithChildren {
   className?: string;
+  testId?: string;
 }
 
 const SettingsRowContainer: FC<SettingsRowContainerProps> = ({
   children,
   className,
+  testId,
 }) => {
   return (
     <div
+      data-testid={testId}
       className={clsx(
         'flex w-full flex-col items-start gap-6 border-b border-gray-200 pb-6',
         className,

--- a/src/components/v5/common/SettingsRow/SettingsRowTooltip.tsx
+++ b/src/components/v5/common/SettingsRow/SettingsRowTooltip.tsx
@@ -9,7 +9,7 @@ interface SettingsRowTooltipProps extends PropsWithChildren {}
 
 const SettingsRowTooltip: FC<SettingsRowTooltipProps> = ({ children }) => {
   return (
-    <Tooltip tooltipContent={children}>
+    <Tooltip tooltipContent={children} testId="settings-row-tooltip">
       <span className="flex text-gray-400">
         <Info size={18} />
       </span>

--- a/src/components/v5/shared/Avatar/Avatar.tsx
+++ b/src/components/v5/shared/Avatar/Avatar.tsx
@@ -21,6 +21,7 @@ export interface AvatarProps {
   alt?: string;
   address: string;
   size: number;
+  testId?: string;
 }
 
 export const Avatar: FC<AvatarProps> = ({
@@ -29,11 +30,13 @@ export const Avatar: FC<AvatarProps> = ({
   className,
   size,
   src,
+  testId,
 }) => {
   const source = src ?? getIcon(address.toLowerCase());
 
   return (
     <img
+      data-testid={testId}
       className={clsx('rounded-full', className)}
       src={source}
       alt={alt ?? formatText(MSG.defaultAlt, { address })}

--- a/src/components/v5/shared/Navigation/Sidebar/Sidebar.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/Sidebar.tsx
@@ -23,6 +23,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
       className,
       headerClassName,
       footerClassName,
+      testId,
       children,
     },
     ref,
@@ -40,6 +41,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
           },
           className,
         )}
+        data-testid={testId}
       >
         {showColonySwitcher && (
           <section

--- a/src/components/v5/shared/Navigation/Sidebar/sidebars/AccountPageSidebar/AccountPageSidebar.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/sidebars/AccountPageSidebar/AccountPageSidebar.tsx
@@ -32,6 +32,7 @@ export const AccountPageSidebar = () => {
       headerClassName="mb-[27px]"
       colonySwitcherProps={{ showColonySwitcherText: true }}
       feedbackButtonProps={{ widgetPlacement: { horizontalPadding: 240 } }}
+      testId="account-page-sidebar"
     >
       <section className="flex flex-col gap-0.5">
         <SidebarRouteItem

--- a/src/components/v5/shared/Navigation/Sidebar/types.ts
+++ b/src/components/v5/shared/Navigation/Sidebar/types.ts
@@ -13,4 +13,5 @@ export interface SidebarProps extends PropsWithChildren {
   footerClassName?: string;
   colonySwitcherProps?: ColonySwitcherProps;
   feedbackButtonProps?: FeedbackButtonProps;
+  testId?: string;
 }

--- a/src/components/v5/shared/UserAvatar/UserAvatar.tsx
+++ b/src/components/v5/shared/UserAvatar/UserAvatar.tsx
@@ -20,6 +20,7 @@ interface UserAvatarProps {
   userAddress: string;
   userAvatarSrc?: string;
   userName?: string;
+  testId?: string;
 }
 
 export const UserAvatar: FC<UserAvatarProps> = ({
@@ -28,6 +29,7 @@ export const UserAvatar: FC<UserAvatarProps> = ({
   userAddress,
   userAvatarSrc,
   userName,
+  testId,
 }) => {
   return (
     <Avatar
@@ -36,6 +38,7 @@ export const UserAvatar: FC<UserAvatarProps> = ({
       alt={formatText(MSG.defaultAlt, { name: userName ?? userAddress })}
       src={userAvatarSrc}
       address={userAddress}
+      testId={testId}
     />
   );
 };


### PR DESCRIPTION
## Description

- Added e2e tests for the Manage Account page. 
- Added a package.json script to run the app in the preview mode  (using `vite preview`) 

## Testing



* Step 1. Spin up the dev environment and seed the test data (`npm run dev ` and then `node scripts/create-data.js`)
* Step 2. Remove your local playwright trace files `rm -rf playwright-report/` (from the root of the project )
* Step 3. Run `npm run preview` to build and start the frontend in preview mode
* Step 4. Run the tests in a separate terminal `npm run e2e`
* Step 5. The tests should pass ( if any failures - please send me .zip files from /playwright-report/data directory)



## TODO

- [ ] Write tests to cover changing the displayName  value in ManageAccount. (Need a reliable method to simulate the 90-day restriction on edits for this field)


