### PR TITLE
fix: expand text after click

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/rows/Description.tsx
+++ b/src/components/v5/common/CompletedAction/partials/rows/Description.tsx
@@ -28,6 +28,10 @@ const DescriptionRow = ({ description }: DescriptionRowProps) => {
 
   const isExpandButtonVisible = !isExpanded && isDescriptionClamped;
 
+  const onClickText = () => {
+    if (!isExpanded) setIsExpanded(true);
+  };
+
   return (
     <div
       className={clsx('mt-4 flex items-start text-md text-gray-900', {
@@ -59,9 +63,13 @@ const DescriptionRow = ({ description }: DescriptionRowProps) => {
       </div>
       <div
         className={clsx('flex items-start', {
-          'h-10 flex-1': !isExpanded,
-          'mt-4 w-full flex-col': isExpanded,
+          'h-10 flex-1 cursor-pointer': !isExpanded,
+          'mt-4 w-full cursor-default flex-col': isExpanded,
         })}
+        onClick={onClickText}
+        onKeyDown={onClickText}
+        role="button"
+        tabIndex={0}
       >
         <RichTextDisplay
           content={description}


### PR DESCRIPTION
## Description

Expand text after click

## Testing

- Create any action with long description
- Open action and click text

## Diffs

**New stuff** ✨

Before:

[expand-description.webm](https://github.com/user-attachments/assets/d126583e-8ecc-465f-bda6-683e99f99a0c)


After:


https://github.com/user-attachments/assets/6ef2783a-97b6-476a-9782-5f36b69cf919


Main issue https://github.com/JoinColony/colonyCDapp/issues/3681
