### PR TITLE
fix: fund expenditure via motion permission proofs and domains

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/FundingModal.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/FundingModal.tsx
@@ -267,10 +267,10 @@ const FundingModal: FC<FundingModalProps> = ({
 
       const motionPayload: ExpenditureFundMotionPayload = {
         ...commonPayload,
-        colony,
-        motionDomainId: Id.RootDomain,
-        fromDomainFundingPotId: Id.RootDomain,
-        fromDomainId: Id.RootDomain,
+        motionDomainId: Id.RootDomain, // @TODO wire this up in the future
+        colonyAddress: colony.colonyAddress,
+        expenditure,
+        fromDomainFundingPotId: selectedTeam.nativeFundingPotId,
       };
 
       const payload: FundExpenditurePayload = {

--- a/src/redux/sagas/motions/expenditures/fundExpenditureMotion.ts
+++ b/src/redux/sagas/motions/expenditures/fundExpenditureMotion.ts
@@ -1,94 +1,105 @@
-import {
-  ClientType,
-  Id,
-  getChildIndex,
-  getPermissionProofs,
-  getPotDomain,
-} from '@colony/colony-js';
-import { constants } from 'ethers';
-import { call, put, takeEvery } from 'redux-saga/effects';
+import { ClientType, Extension, getPotDomain } from '@colony/colony-js';
+import { BigNumber, constants, type BigNumberish } from 'ethers';
+import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
-import { ADDRESS_ZERO, APP_URL } from '~constants/index.ts';
+import { ADDRESS_ZERO } from '~constants/index.ts';
 import { FUND_EXPENDITURE_REQUIRED_ROLE } from '~constants/permissions.ts';
 import { ActionTypes } from '~redux/actionTypes.ts';
 import {
-  createGroupTransaction,
+  createTransaction,
   createTransactionChannels,
   waitForTxResult,
 } from '~redux/sagas/transactions/index.ts';
 import { getExpenditureBalancesByTokenAddress } from '~redux/sagas/utils/expenditures.ts';
 import {
-  createInvalidParamsError,
   getColonyManager,
+  getMoveFundsActionDomain,
+  getMoveFundsPermissionProofs,
+  getPermissionProofsLocal,
   initiateTransaction,
+  putError,
+  takeFrom,
+  uploadAnnotation,
 } from '~redux/sagas/utils/index.ts';
 import { type Action } from '~redux/types/index.ts';
 
 function* fundExpenditureMotion({
   payload: {
-    colony: { colonyAddress },
+    colonyAddress,
     expenditure,
     fromDomainFundingPotId,
+    colonyDomains,
+    colonyRoles,
+    annotationMessage,
     motionDomainId,
-    fromDomainId,
-    /* annotationMessage */
   },
-  meta: { setTxHash, id },
   meta,
 }: Action<ActionTypes.MOTION_EXPENDITURE_FUND>) {
-  const { createMotion /* annotationMessage */ } = yield call(
+  const { createMotion, annotateMotion } = yield call(
     createTransactionChannels,
-    id,
+    meta.id,
     ['createMotion', 'annotateMotion'],
   );
 
   try {
-    const sagaName = fundExpenditureMotion.name;
-
-    if (
-      !fromDomainId ||
-      !colonyAddress ||
-      !expenditure ||
-      !fromDomainFundingPotId ||
-      !motionDomainId
-    ) {
-      const paramDescription =
-        (!fromDomainId &&
-          'The domain id the expenditure is being funded from') ||
-        (!colonyAddress && 'Colony address') ||
-        (!expenditure && 'The expenditure being funded') ||
-        (!fromDomainFundingPotId &&
-          'The domain funding pot id from which the expenditure will be funded') ||
-        (!motionDomainId &&
-          'The id of the domain the motion is taking place in');
-      throw createInvalidParamsError(sagaName, paramDescription as string);
-    }
-
+    const balances = getExpenditureBalancesByTokenAddress(expenditure);
     const { nativeFundingPotId: expenditureFundingPotId } = expenditure;
 
     const colonyManager = yield call(getColonyManager);
-    const colonyClient = yield call(
-      [colonyManager, colonyManager.getClient],
+    const colonyClient = yield colonyManager.getClient(
       ClientType.ColonyClient,
       colonyAddress,
     );
-    const votingReputationClient = yield call(
-      [colonyManager, colonyManager.getClient],
-      ClientType.VotingReputationClient,
-      colonyAddress,
+    const votingReputationClient = yield colonyClient.getExtensionClient(
+      Extension.VotingReputation,
     );
 
-    const childSkillIndex = yield call(
-      getChildIndex,
-      colonyClient.networkClient,
+    const fromDomainId: BigNumberish = yield getPotDomain(
       colonyClient,
-      motionDomainId,
+      fromDomainFundingPotId,
+    );
+    const expenditurePotDomainId: BigNumberish = yield call(
+      getPotDomain,
+      colonyClient,
+      expenditureFundingPotId,
+    );
+
+    // this will basically just run motionDomainId through inheritance validation
+    const actionDomainId = getMoveFundsActionDomain({
+      actionDomainId: motionDomainId,
       fromDomainId,
+      toDomainId: expenditurePotDomainId,
+    });
+
+    const requiredRoles = [FUND_EXPENDITURE_REQUIRED_ROLE];
+
+    const { fromChildSkillIndex, toChildSkillIndex } = yield call(
+      getMoveFundsPermissionProofs,
+      {
+        actionDomainId,
+        toDomainId: expenditurePotDomainId,
+        fromDomainId,
+        colonyDomains,
+        colonyAddress,
+      },
+    );
+
+    const [votRepPermissionDomainId, votRepChildSkillIndex] = yield call(
+      getPermissionProofsLocal,
+      {
+        networkClient: colonyClient.networkClient,
+        colonyRoles,
+        colonyDomains,
+        requiredDomainId: Number(actionDomainId),
+        requiredColonyRoles: requiredRoles,
+        permissionAddress: votingReputationClient.address,
+        isMultiSig: false,
+      },
     );
 
     const { skillId } = yield call(
       [colonyClient, colonyClient.getDomain],
-      Id.RootDomain,
+      actionDomainId,
     );
 
     const { key, value, branchMask, siblings } = yield call(
@@ -97,41 +108,14 @@ function* fundExpenditureMotion({
       ADDRESS_ZERO,
     );
 
-    const balances = getExpenditureBalancesByTokenAddress(expenditure);
-    const requiredRoles = [FUND_EXPENDITURE_REQUIRED_ROLE];
-
-    const [fromPermissionDomainId, fromChildSkillIndex] = yield call(
-      getPermissionProofs,
-      colonyClient.networkClient,
-      colonyClient,
-      fromDomainId,
-      requiredRoles,
-      votingReputationClient.address,
-    );
-
-    const expenditurePotDomain = yield call(
-      getPotDomain,
-      colonyClient,
-      expenditureFundingPotId,
-    );
-
-    const [, toChildSkillIndex] = yield call(
-      getPermissionProofs,
-      colonyClient.networkClient,
-      colonyClient,
-      expenditurePotDomain,
-      requiredRoles,
-      votingReputationClient.address,
-    );
-
     const encodedFundingPotActions = [...balances.entries()].map(
-      ([tokenAddress, amount]) =>
-        colonyClient.interface.encodeFunctionData(
+      ([tokenAddress, amount]) => {
+        return colonyClient.interface.encodeFunctionData(
           'moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)',
           [
-            fromPermissionDomainId,
-            constants.MaxUint256,
-            fromPermissionDomainId,
+            votRepPermissionDomainId,
+            votRepChildSkillIndex,
+            BigNumber.from(actionDomainId),
             fromChildSkillIndex,
             toChildSkillIndex,
             fromDomainFundingPotId,
@@ -139,7 +123,8 @@ function* fundExpenditureMotion({
             amount,
             tokenAddress,
           ],
-        ),
+        );
+      },
     );
 
     const encodedMulticallAction = colonyClient.interface.encodeFunctionData(
@@ -149,72 +134,79 @@ function* fundExpenditureMotion({
 
     const batchKey = 'createMotion';
 
-    yield createGroupTransaction({
-      channel: createMotion,
-      batchKey,
-      meta,
-      config: {
-        context: ClientType.VotingReputationClient,
-        methodName: 'createMotion',
+    yield fork(createTransaction, createMotion.id, {
+      context: ClientType.VotingReputationClient,
+      methodName: 'createMotion',
+      params: [
+        actionDomainId,
+        constants.MaxUint256,
+        ADDRESS_ZERO,
+        encodedMulticallAction,
+        key,
+        value,
+        branchMask,
+        siblings,
+      ],
+      identifier: colonyAddress,
+      group: {
+        key: batchKey,
+        id: meta.id,
+        index: 0,
+      },
+      ready: false,
+    });
+
+    if (annotationMessage) {
+      yield fork(createTransaction, annotateMotion.id, {
+        context: ClientType.ColonyClient,
+        methodName: 'annotateTransaction',
         identifier: colonyAddress,
-        params: [
-          motionDomainId,
-          childSkillIndex,
-          ADDRESS_ZERO,
-          encodedMulticallAction,
-          key,
-          value,
-          branchMask,
-          siblings,
-        ],
         group: {
           key: batchKey,
           id: meta.id,
           index: 1,
         },
-      },
-    });
+        ready: false,
+      });
+    }
+
+    yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_CREATED);
+    if (annotationMessage) {
+      yield takeFrom(annotateMotion.channel, ActionTypes.TRANSACTION_CREATED);
+    }
 
     yield initiateTransaction(createMotion.id);
 
     const {
-      type,
       payload: {
         receipt: { transactionHash: txHash },
       },
     } = yield call(waitForTxResult, createMotion.channel);
 
-    setTxHash?.(txHash);
-
-    if (type === ActionTypes.TRANSACTION_SUCCEEDED) {
-      yield put<Action<ActionTypes.MOTION_EXPENDITURE_FUND_SUCCESS>>({
-        type: ActionTypes.MOTION_EXPENDITURE_FUND_SUCCESS,
-        meta,
+    if (annotationMessage) {
+      yield uploadAnnotation({
+        txChannel: annotateMotion,
+        message: annotationMessage,
+        txHash,
       });
-
-      // @TODO: Remove during advanced payments UI wiring
-      // eslint-disable-next-line no-console
-      console.log(
-        `Fund Expenditure Motion URL: ${APP_URL}${window.location.pathname.slice(
-          1,
-        )}?tx=${txHash}`,
-      );
     }
-  } catch (e) {
-    console.error(e);
-    yield put<Action<ActionTypes.MOTION_EXPENDITURE_FUND_ERROR>>({
-      type: ActionTypes.MOTION_EXPENDITURE_FUND_ERROR,
-      payload: {
-        name: ActionTypes.MOTION_EXPENDITURE_FUND_ERROR,
-        message: JSON.stringify(e),
-      },
+
+    yield put<Action<ActionTypes.MOTION_EXPENDITURE_FUND_SUCCESS>>({
+      type: ActionTypes.MOTION_EXPENDITURE_FUND_SUCCESS,
       meta,
-      error: true,
     });
+  } catch (error) {
+    return yield putError(
+      ActionTypes.MOTION_EXPENDITURE_FUND_ERROR,
+      error,
+      meta,
+    );
   } finally {
     createMotion.channel.close();
+    annotateMotion.channel.close();
   }
-  // @todo add annotation logic post-rebase on master
+
+  return null;
 }
 
 export default function* fundExpenditureMotionSaga() {

--- a/src/redux/types/actions/motion.ts
+++ b/src/redux/types/actions/motion.ts
@@ -40,14 +40,9 @@ export enum RootMotionMethodNames {
   UnlockToken = 'unlockToken',
 }
 
-export type ExpenditureFundMotionPayload = Omit<
-  ExpenditureFundPayload,
-  'colonyAddress'
-> & {
-  fromDomainId: number;
+export interface ExpenditureFundMotionPayload extends ExpenditureFundPayload {
   motionDomainId: number;
-  colony: Colony;
-};
+}
 
 export type StakedExpenditureCancelMotionPayload =
   CancelStakedExpenditurePayload & {


### PR DESCRIPTION
## Description

This PR reimplements the fund expenditure via voting reputation saga so it uses the new helpers and it adds support for changing the funding motion created in domain.

## Testing

1. Install the voting reputation extension
2. Create an advanced payment as `leela` sending some funds to some recipients from `General`
![image](https://github.com/user-attachments/assets/836c01fd-b1cd-449f-bf1e-d380496b0a6d)
3. Get to the funding step and fund it via Reputation
![image](https://github.com/user-attachments/assets/fef72505-61db-4d09-b30b-9c263eb8c43b)
4. Fully support the motion, run `npm run forward-time 1` and try to finalize it. Then release it and verify that the funds were sent (`leela` had 396 at start, now she has 398 so hooray!)
![image](https://github.com/user-attachments/assets/1269dcbc-2d0b-4b27-937b-b2c6f02088c2)
![image](https://github.com/user-attachments/assets/c211454a-6189-471b-adf8-4987f1d23378)

ALright so funding from general works which is all fine, now let's check out 2 more cases

1. Create an advanced payment as `leela` sending some funds to some recipients from `Andromeda`
![image](https://github.com/user-attachments/assets/f01ef10f-4ad6-4699-9ea0-02a70ba6b515)
2. Get to the funding phase and choose `Reputation` as the decision method
![image](https://github.com/user-attachments/assets/c41a0ca7-a1c3-4ff9-8993-e5955e1ce0a3)
3. Fully support it, run `npm run forward-time 1` and refresh the page. Finalize the motion, release the payment and verify that the changes are applied (for example check if Andromeda's funds were drained).

Now open the `FundingModal` file and change line 270
![image](https://github.com/user-attachments/assets/485592dc-c934-44ed-a138-2f8594016341)
to `motionDomainId: selectedTeam.nativeId,`

1. Create an advanced payment as `leela` sending some funds to some recipients from `Andromeda`
![image](https://github.com/user-attachments/assets/d60863e8-4cb8-4492-910d-5065d3c5c70f)
2. Get to the funding step and choose `Reputation` as the decision method.
![image](https://github.com/user-attachments/assets/b349c041-0742-4b62-a984-0bd39338bde1)
3. Verify that the motion gets created (we can't really check that it's been created in `Andromeda` in the UI) in Andromeda, by running this query
```
query MyQuery {
  getColonyAction(
    id: "0x8ec51ae8a1bf0d18500e6f29b737965f36ef522f0fb2fb32825f22eca886de29"
  ) {
    expenditure {
      nativeDomainId
      actions {
        items {
          isMotion
          motionDomainId
          motionData {
            nativeMotionDomainId
          }
        }
      }
    }
  }
}
```
and verify that the `nativeMotionDomainId` is 2 (ignore the blue blocks, it was testing time :D )
![image](https://github.com/user-attachments/assets/c2742750-2854-46a2-8e34-e6dbe28f95d3)
4. Fully support it, `npm run forward-time 1` and finalize it then release the payment. Verify that the funds were moved.

As an additional sanity check, install the multisig extension, set the threshold to 1, create an advanced payment and fund it via multisig.

## Diffs

**Changes** 🏗

* `fundExpenditureMotion` now uses the new helpers and supports creating the motion in a different domain than root

Resolves #3705
