### PR TITLE
RESERVED_ROUTES check for create new colony is only done on the front end

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=d2c9d9ee531640abe8e561cc7a06cfd662de18b3
+ENV BLOCK_INGESTOR_HASH=7d91f791e1e7aefe0c8c0e3495f4d012fa9bb54f
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -64,6 +64,7 @@ import {
   COLONY_MULTISIG_ROUTE,
   COLONY_AGREEMENTS_ROUTE,
   USER_CRYPTO_TO_FIAT_ROUTE,
+  RESERVED_ROUTES,
   // ACTIONS_PAGE_ROUTE,
   // UNWRAP_TOKEN_ROUTE,
   // CLAIM_TOKEN_ROUTE,
@@ -118,6 +119,11 @@ const Routes = () => {
           path={CREATE_COLONY_ROUTE}
           element={<OnboardingPage flow={Flow.Colony} />}
         />
+
+        {/* If a reserved route has not been used by this point, redirect to NotFoundRoute */}
+        {[...RESERVED_ROUTES].map((route) => (
+          <Route path={route} element={<NotFoundRoute />} />
+        ))}
 
         {/* Colony routes */}
         <Route path={COLONY_HOME_ROUTE} element={<ColonyRoute />}>

--- a/src/routes/routeConstants.ts
+++ b/src/routes/routeConstants.ts
@@ -61,6 +61,8 @@ export const CRYPTO_TO_FIAT_VERIFICATION_SEARCH_PARAM = 'verification';
 
 // Note all base routes begin with a '/'
 
+// Make sure this is kept up to date with the same set in the block-ingestor
+// src/constants.ts
 export const RESERVED_ROUTES = new Set([
   NOT_FOUND_ROUTE,
   METACOLONY_HOME_ROUTE,


### PR DESCRIPTION
## Description

See block-ingestor counterpart

This PR adds a RESERVED_ROUTES check to the block-ingestor and will prevent a colony from being created if the name matches a reserved route.

It also adds an extra safety fallback that if any unused reserved route will now redirect to a 404 before checking for any colony pages, so even if a colony is somehow created using a reserved route, it will fail to load.

## Testing

* Step 1 - This has a new block-ingestor hash, so boot up from scratch I'm afraid.
* Step 2 - Change the `isValidName` function in: `src/components/common/Onboarding/wizardSteps/CreateColony/validation.ts` to this:

```
function isValidName(name: string) {
  return name ? new RegExp(COLONY_NAME_REGEX).test(name) : true;
}
```

This will remove the reserved routes check from the frontend and allow us to test these extra checks.

* Step 3 - Run the `node scripts/create-colony-url.js` script.
* Step 4 - Try creating a colony using one of the names from the reserved routes list: `src/routes/routeConstants.ts`

The app should hang at the final stage of the setup as the block-ingestor rejects it. We don't need to handle this nicely as the validation will prevent the form getting to this state.

<img width="1728" alt="Screenshot 2024-11-15 at 13 48 42" src="https://github.com/user-attachments/assets/7c03893b-b57a-48ab-a820-9ca1c0753199">

* Step 5 - Refresh to start the colony creation flow over again.
* Step 6 - Kill the block-ingestor docker container, and run the block-ingestor on master (this will remove the block-ingestor check that has been added in this PR).
* Step 7 - Try creating a colony using one of the names from the reserved routes list: `src/routes/routeConstants.ts`

This time at the end of the colony creation flow, you should be redirected to a 404. The colony will still have been accepted by the block-ingestor and created in the database, but now the route check will redirect it to a 404 even though the colony exists. The colony will also show under the colony switcher, if you try to select it, you will be redirected to the 404.

## Diffs

**Changes** 🏗

* Unused reserved routes will now redirect to 404.
* Block-ingestor now prevents creating colonies with a reserved route as the name.

Resolves #3406
