### PR TITLE
Fix: Previous steps in colony creation should not be clickable

### DIFF
--- a/src/components/common/Onboarding/Wizard/MobileWizardHeader.tsx
+++ b/src/components/common/Onboarding/Wizard/MobileWizardHeader.tsx
@@ -52,6 +52,7 @@ const MobileWizardHeader = ({ currentStep, wizardSteps }: WizardProps) => {
       <Stepper
         activeStepKey={activeStepKey}
         items={steps.filter((step) => !!step)}
+        disablePreviousSteps
       />
     </div>
   );

--- a/src/components/v5/shared/Stepper/Stepper.tsx
+++ b/src/components/v5/shared/Stepper/Stepper.tsx
@@ -18,6 +18,7 @@ function Stepper<TKey extends React.Key>({
   activeStepKey,
   setActiveStepKey,
   items,
+  disablePreviousSteps = false,
 }: StepperProps<TKey>): JSX.Element | null {
   const activeItemIndex = items.findIndex(({ key }) => key === activeStepKey);
   const [hiddenItem, setHiddenItem] = useState<TKey | undefined>(undefined);
@@ -118,7 +119,10 @@ function Stepper<TKey extends React.Key>({
               } = heading;
               const isNextStepOptional = items[index + 1]?.isOptional;
               const isNextStepSkipped = items[index + 1]?.isSkipped;
-              const itemDisabled = index > activeItemIndex || isSkipped;
+              const itemDisabled =
+                isSkipped ||
+                index > activeItemIndex ||
+                (index < activeItemIndex && disablePreviousSteps);
 
               return !isHidden ? (
                 <motion.li

--- a/src/components/v5/shared/Stepper/types.ts
+++ b/src/components/v5/shared/Stepper/types.ts
@@ -15,4 +15,5 @@ export interface StepperProps<TKey> {
   items: StepperItem<TKey>[];
   activeStepKey: TKey;
   setActiveStepKey?: (key: TKey) => void;
+  disablePreviousSteps?: boolean;
 }


### PR DESCRIPTION
## Description

The previous steps in the colony creation stepper are to show progress only, they should not be clickable. This PR adds a Stepper prop to disable previous steps.

## Testing

* Step 1 - Run: `node scripts/create-colony-url.js`
* Step 2 - Progress the create colony flow to the confirmation step

## Diffs

**New stuff** ✨

* New stuff goes here

**Changes** 🏗

* Changes go here

**Deletions** ⚰️

* Deletions go here

## TODO

- [ ] Add TODOs

(Resolves | Contributes to) #31415
