### PR TITLE
Fix: Optimise token sums calculation for multi-row advanced payments

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/hooks.ts
@@ -26,7 +26,7 @@ import {
   getPaymentBuilderPayload,
 } from './utils.ts';
 
-export const useValidationSchema = (networkInverseFee: string | undefined) => {
+export const useValidationSchema = () => {
   const { colony } = useColonyContext();
   const colonyTokens = useMemo(
     () =>
@@ -41,6 +41,11 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
     () =>
       object()
         .shape({
+          /**
+           * Stores a map of the sums for each token present on the form
+           * @internal
+           */
+          _tokenSums: object(),
           from: number().required(
             formatText({ id: 'errors.fundFrom.required' }),
           ),
@@ -90,7 +95,6 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
                         value,
                         context,
                         colony,
-                        networkInverseFee,
                       }),
                     ),
                   tokenAddress: string()
@@ -168,7 +172,7 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
         )
         .defined()
         .concat(ACTION_BASE_VALIDATION_SCHEMA),
-    [colony, colonyTokens, networkInverseFee, tokenLockStatesMap],
+    [colony, colonyTokens, tokenLockStatesMap],
   );
 };
 
@@ -182,7 +186,7 @@ export const usePaymentBuilder = (
   const { colony } = useColonyContext();
   const { nativeToken } = colony;
   const { networkInverseFee = '0' } = useNetworkInverseFee();
-  const validationSchema = useValidationSchema(networkInverseFee);
+  const validationSchema = useValidationSchema();
 
   useActionFormBaseHook({
     validationSchema,

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/PaymentBuilderRecipientsField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/PaymentBuilderRecipientsField.tsx
@@ -17,6 +17,7 @@ import { type ExpenditurePayoutFieldValue } from '~types/expenditures.ts';
 import { formatText } from '~utils/intl.ts';
 import { convertEnotationToNumber } from '~utils/numbers.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
+import { useBuildTokenSumsMap } from '~v5/common/ActionSidebar/partials/forms/shared/hooks/useBuildTokenSumsMap.ts';
 import Table from '~v5/common/Table/index.ts';
 import Button from '~v5/shared/Button/Button.tsx';
 
@@ -45,6 +46,8 @@ const PaymentBuilderRecipientsField: FC<PaymentBuilderRecipientsFieldProps> = ({
     name,
   });
   const hasNoDecisionMethods = useHasNoDecisionMethods();
+
+  useBuildTokenSumsMap();
 
   useEffect(() => {
     if (paymentsFromFile) {

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/utils.ts
@@ -1,6 +1,5 @@
 import { Id } from '@colony/colony-js';
 import { unformatNumeral } from 'cleave-zen';
-import { BigNumber } from 'ethers';
 import { type TestContext } from 'yup';
 
 import { DEFAULT_TOKEN_DECIMALS } from '~constants';
@@ -11,12 +10,7 @@ import { findDomainByNativeId } from '~utils/domains.ts';
 import { convertPeriodToSeconds } from '~utils/extensions.ts';
 import getLastIndexFromPath from '~utils/getLastIndexFromPath.ts';
 import { formatText } from '~utils/intl.ts';
-import { groupBy } from '~utils/lodash.ts';
-import {
-  calculateFee,
-  getBalanceForTokenAndDomain,
-  getTokenDecimalsWithFallback,
-} from '~utils/tokens.ts';
+import { getBalanceForTokenAndDomain } from '~utils/tokens.ts';
 
 import { type PaymentBuilderFormValues } from './hooks.ts';
 
@@ -60,14 +54,12 @@ interface AllTokensAmountValidationParams {
   value: string | null | undefined;
   context: TestContext<{ formValues?: any }>;
   colony: Colony;
-  networkInverseFee: string | undefined;
 }
 
 export const allTokensAmountValidation = ({
   value,
   context,
   colony,
-  networkInverseFee,
 }: AllTokensAmountValidationParams) => {
   if (!value) {
     return false;
@@ -79,50 +71,12 @@ export const allTokensAmountValidation = ({
     path,
   } = context;
   const { formValues } = formContext || {};
-  const { payments, from, stages } = formValues || {};
+  const { from, _tokenSums } = formValues || {};
   const { tokenAddress: fieldTokenAddress } = parent || {};
 
   if (!fieldTokenAddress) {
     return false;
   }
-
-  const groupedTokens = groupBy(
-    payments || stages,
-    (payment) => payment.tokenAddress,
-  );
-
-  const token = colony.tokens?.items
-    .filter(notNull)
-    .find(
-      ({ token: { tokenAddress } }) => tokenAddress === fieldTokenAddress,
-    )?.token;
-
-  const tokenAmountSum = groupedTokens[fieldTokenAddress].reduce(
-    (acc, payment) => {
-      const { amount } = payment;
-
-      if (!amount) {
-        return acc;
-      }
-
-      const tokenDecimals = getTokenDecimalsWithFallback(token?.decimals);
-
-      const { totalToPay } = calculateFee(
-        amount,
-        networkInverseFee ?? '0',
-        tokenDecimals,
-      );
-
-      return acc.add(totalToPay);
-    },
-    BigNumber.from('0'),
-  );
-
-  const tokenBalance = getBalanceForTokenAndDomain(
-    colony.balances,
-    fieldTokenAddress,
-    from || Id.RootDomain,
-  );
 
   const index = getLastIndexFromPath(path);
 
@@ -134,6 +88,12 @@ export const allTokensAmountValidation = ({
       path,
     });
   }
+
+  const token = colony.tokens?.items
+    .filter(notNull)
+    .find(
+      ({ token: { tokenAddress } }) => tokenAddress === fieldTokenAddress,
+    )?.token;
 
   if (!token) {
     return context.createError({
@@ -149,7 +109,15 @@ export const allTokensAmountValidation = ({
     });
   }
 
-  if (!tokenAmountSum.lte(tokenBalance)) {
+  const tokenAmountSum = _tokenSums[fieldTokenAddress];
+
+  const tokenBalance = getBalanceForTokenAndDomain(
+    colony.balances,
+    fieldTokenAddress,
+    from || Id.RootDomain,
+  );
+
+  if (!tokenAmountSum?.lte(tokenBalance)) {
     return context.createError({
       message: formatText(
         {

--- a/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/hooks.ts
@@ -30,7 +30,7 @@ import { allTokensAmountValidation } from '../PaymentBuilderForm/utils.ts';
 
 import { getStagedPaymentPayload } from './utils.ts';
 
-export const useValidationSchema = (networkInverseFee: string | undefined) => {
+export const useValidationSchema = () => {
   const { colony } = useColonyContext();
   const colonyTokens = useMemo(
     () =>
@@ -115,7 +115,6 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
                         value,
                         context,
                         colony,
-                        networkInverseFee,
                       }),
                     ),
                   [TOKEN_FIELD_NAME]: string().required(),
@@ -146,7 +145,7 @@ export const useValidationSchema = (networkInverseFee: string | undefined) => {
         )
         .defined()
         .concat(ACTION_BASE_VALIDATION_SCHEMA),
-    [colony, colonyTokens, networkInverseFee],
+    [colony, colonyTokens],
   );
 };
 
@@ -160,7 +159,7 @@ export const useStagePayment = (
   const { colony } = useColonyContext();
   const { nativeToken } = colony;
   const { networkInverseFee = '0' } = useNetworkInverseFee();
-  const validationSchema = useValidationSchema(networkInverseFee);
+  const validationSchema = useValidationSchema();
   const { setExpectedExpenditureType } = usePaymentBuilderContext();
 
   useActionFormBaseHook({

--- a/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/partials/StagedPaymentRecipientsField/StagedPaymentRecipientField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/partials/StagedPaymentRecipientsField/StagedPaymentRecipientField.tsx
@@ -7,6 +7,7 @@ import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useMobile, useTablet } from '~hooks';
 import { formatText } from '~utils/intl.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
+import { useBuildTokenSumsMap } from '~v5/common/ActionSidebar/partials/forms/shared/hooks/useBuildTokenSumsMap.ts';
 import Table from '~v5/common/Table/Table.tsx';
 import Button from '~v5/shared/Button/Button.tsx';
 
@@ -30,6 +31,8 @@ const StagedPaymentRecipientsField: FC<StagedPaymentRecipientsFieldProps> = ({
   const { fields, append, insert, remove } = useFieldArray({
     name,
   });
+
+  useBuildTokenSumsMap();
 
   const data: StagedPaymentRecipientsTableModel[] = fields.map(({ id }) => ({
     key: id,

--- a/src/components/v5/common/ActionSidebar/partials/forms/shared/hooks/useBuildTokenSumsMap.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/shared/hooks/useBuildTokenSumsMap.ts
@@ -1,0 +1,62 @@
+import { BigNumber } from 'ethers';
+import { useEffect } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
+import { groupBy } from '~utils/lodash.ts';
+import { calculateFee, getTokenDecimalsWithFallback } from '~utils/tokens.ts';
+
+export const useBuildTokenSumsMap = () => {
+  const {
+    colony: { tokens },
+  } = useColonyContext();
+
+  const { setValue } = useFormContext();
+
+  const { networkInverseFee = '0' } = useNetworkInverseFee();
+
+  const payments = useWatch({ name: 'payments' });
+  const stages = useWatch({ name: 'stages' });
+
+  useEffect(() => {
+    if (tokens?.items?.length) {
+      const groupedTokens = groupBy(
+        payments || stages,
+        (payment) => payment.tokenAddress,
+      );
+
+      const tokenSums = tokens.items.reduce((accumulator, item) => {
+        if (!item?.token) return accumulator;
+
+        const { tokenAddress, decimals } = item.token;
+        const tokenGroup = groupedTokens[tokenAddress];
+
+        if (tokenGroup) {
+          const tokenDecimals = getTokenDecimalsWithFallback(decimals);
+
+          const tokenAmountSum = tokenGroup.reduce((acc, payment) => {
+            if (!payment?.amount) return acc;
+
+            const { totalToPay } = calculateFee(
+              payment.amount,
+              networkInverseFee ?? '0',
+              tokenDecimals,
+            );
+
+            return acc.add(totalToPay);
+          }, BigNumber.from('0'));
+
+          return {
+            ...accumulator,
+            [tokenAddress]: tokenAmountSum,
+          };
+        }
+
+        return accumulator;
+      }, {});
+
+      setValue('_tokenSums', tokenSums);
+    }
+  }, [networkInverseFee, payments, setValue, stages, tokens?.items]);
+};

--- a/src/components/v5/common/Table/partials/VirtualizedRow/VirtualizedRow.tsx
+++ b/src/components/v5/common/Table/partials/VirtualizedRow/VirtualizedRow.tsx
@@ -18,7 +18,7 @@ const VirtualizedRow: FC<VirtualizedRowProps> = ({
       {isVisible ? (
         children
       ) : (
-        <div style={{ width: '100%', height: itemHeight }} />
+        <td style={{ width: '100%', height: itemHeight }} />
       )}
     </tr>
   );


### PR DESCRIPTION
## Description

> [!NOTE]
>
> **💡 What this PR aims to do**
> Prevent an app crash when uploading a CSV file with at least 200 rows
>
> **🚫 What this PR doesn't attempt to fix:**
> This PR is not aiming to address the issue with the Completed Action component's payments incorrect order

Currently, there is a palpable performance hit whenever we're calculating the sums for each token present on the Advanced Payment form. This is because we're performing this calculation for each and every single payment row present. This means that when you upload a CSV file with like 200 rows, you are pretty much performing the calculation 200 times which is causing the huge lag and could oftentimes cause our app to crash.

This PR aims to semi-resolve this lag issue by building a map of token sums outside of the validation functions. So whenever the Payment Builder form needs needs to know the token sum for a payment row's token, it just needs to perform an object search, using the token as the key i.e. `tokenSums[tokenAddress]`. At this point, `tokenSums` is something that has already been built before the validation check, which means that the validator doesn't need to calculate the token sum again.

This solution is not perfect because you can still see the table lagging when you're scrolling it up and down. But I guess this is a small win since it prevents the app from crashing/being non-responsive 😅 

![advanced payment](https://github.com/user-attachments/assets/d6b4fd70-1514-4000-8a0d-15492d8c8f52)

## Testing

1. Bring up the Advanced Payments form
2. Upload this [CSV file](https://drive.google.com/file/d/1iMFNpRtMwyc3teh2mVPeBlRPEyZBRwFQ/view?usp=sharing), it should be 400 rows
3. Verify that the app does not crash

Resolves #3673 