### PR TITLE
Fix: Username field should show correct count

### DIFF
--- a/src/components/frame/v5/pages/UserProfilePage/partials/UserAccountForm/hooks.tsx
+++ b/src/components/frame/v5/pages/UserProfilePage/partials/UserAccountForm/hooks.tsx
@@ -128,7 +128,8 @@ export const useUserProfilePageForm = () => {
           descriptionClassName,
           inputProps: {
             maxCharNumber: MAX_DISPLAYNAME_CHARS,
-            shouldNumberOfCharsBeVisible: true,
+            shouldNumberOfCharsBeVisible: canChangeUsername,
+            defaultValue: user?.profile?.displayName || '',
             name: 'displayName',
             isDisabled: !canChangeUsername,
             register,


### PR DESCRIPTION
## Description

This PR fixes an issue on the username field on the profile page which would always show `0/30`. I made a decision to hide the counter all together when the field is disabled as this seems more logical to me - I can easily add this back in if preferred.

## Testing

Step 1 - Navigate to [http://localhost:9091/account/profile](http://localhost:9091/account/profile) and ensure the max character limit does not display.

<img width="1277" alt="Screenshot 2024-11-18 at 15 56 04" src="https://github.com/user-attachments/assets/efa49061-bc48-4b80-a543-64da60c35e66">

Step 2 - Open `src/components/frame/v5/pages/UserProfilePage/partials/UserAccountForm/hooks.tsx` and change line 131 to `shouldNumberOfCharsBeVisible: true,` and line 134 to `isDisabled: false,`. Confirm the character count is visible and updates correctly.

<img width="1278" alt="Screenshot 2024-11-18 at 15 57 09" src="https://github.com/user-attachments/assets/dee6ada9-a80d-42fd-8b3a-1ae1258bedb4">

## Diffs

**Changes** 🏗

* Added default value prop to display name field
* Made `shouldNumberOfCharsBeVisible` dependant on whether field is disabled or not

Resolves #3472
