### PR TITLE
fix: auto focus after open search input

### DIFF
--- a/src/components/v5/shared/SearchSelect/SearchSelect.tsx
+++ b/src/components/v5/shared/SearchSelect/SearchSelect.tsx
@@ -112,7 +112,11 @@ const SearchSelect = React.forwardRef<HTMLDivElement, SearchSelectProps>(
               onChange={onChange}
               state={state}
               message={message}
+              shouldFocus
               value={searchValue}
+              className={clsx({
+                'focus:shadow-transparent': !searchValue.length,
+              })}
               placeholder={
                 placeholder ??
                 formatText({

--- a/src/components/v5/shared/SearchSelect/partials/SearchInput/SearchInput.tsx
+++ b/src/components/v5/shared/SearchSelect/partials/SearchInput/SearchInput.tsx
@@ -1,5 +1,6 @@
 import { MagnifyingGlass, X } from '@phosphor-icons/react';
-import React, { type FC, useLayoutEffect, useRef } from 'react';
+import clsx from 'clsx';
+import React, { type FC, useRef, useEffect } from 'react';
 
 import { formatText } from '~utils/intl.ts';
 import InputBase from '~v5/common/Fields/InputBase/index.ts';
@@ -13,11 +14,12 @@ const SearchInput: FC<SearchInputProps> = ({
   value,
   placeholder = formatText({ id: 'placeholder.search' }),
   shouldFocus = false,
+  className,
   ...props
 }) => {
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (searchInputRef.current && shouldFocus) {
       searchInputRef?.current?.focus();
     }
@@ -30,7 +32,7 @@ const SearchInput: FC<SearchInputProps> = ({
         onChange={(e) => {
           onChange?.(e.target.value);
         }}
-        className="peer w-full rounded-lg px-8.5 text-3"
+        className={clsx('peer w-full rounded-lg px-8.5 text-3', className)}
         placeholder={placeholder}
         value={value}
         ref={searchInputRef}


### PR DESCRIPTION
## Description

Add auto onfocus on input after click `Select member`.

## Testing

- create new Advanced payment
- click `Select member`

## Diffs

**New stuff** ✨

add auto focus for input

https://github.com/user-attachments/assets/08e6a1e7-520c-4af0-ab5b-9491cf7493cf

Resolves https://github.com/JoinColony/colonyCDapp/issues/3455
