### PR TITLE
feat: add meatball menu and duplicate and delete functionality

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/AddTransactionModal/AddTransactionModal.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/AddTransactionModal/AddTransactionModal.tsx
@@ -19,6 +19,7 @@ import useCloseModalClick from './useCloseModalClick.ts';
 const AddTransactionModal: FC<AddTransactionFormModalProps> = ({
   onSubmit,
   onClose,
+  defaultValues,
   ...rest
 }) => {
   const {
@@ -39,6 +40,7 @@ const AddTransactionModal: FC<AddTransactionFormModalProps> = ({
     >
       <Form<AddTransactionTableModel>
         onSubmit={onSubmit}
+        defaultValues={defaultValues}
         className="flex h-full w-full flex-grow flex-col"
         innerRef={formRef}
       >

--- a/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/ArbitraryTransactionsTable/ArbitraryTransactionsTable.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/ArbitraryTransactionsTable/ArbitraryTransactionsTable.tsx
@@ -14,9 +14,7 @@ import Button from '~v5/shared/Button/Button.tsx';
 import AddTransactionModal from '../AddTransactionModal/AddTransactionModal.tsx';
 
 import { useArbitraryTxsTableColumns } from './hooks.tsx';
-
-const displayName =
-  'v5.common.ActionsContent.partials.ArbitraryTransactionsTable';
+import { MSG, displayName } from './translation.ts';
 
 interface ArbitraryTransactionsTableProps {
   name: string;
@@ -57,7 +55,7 @@ const ArbitraryTransactionsTable: FC<ArbitraryTransactionsTableProps> = ({
   );
 
   const getMenuProps = ({ index, original: rowValues }) =>
-    !readonly
+    !readonly && data.length > 0
       ? {
           cardClassName: 'min-w-[9.625rem] whitespace-nowrap',
           items: [

--- a/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/ArbitraryTransactionsTable/ArbitraryTransactionsTable.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/ArbitraryTransactionsTable/ArbitraryTransactionsTable.tsx
@@ -1,4 +1,4 @@
-import { Plus } from '@phosphor-icons/react';
+import { CopySimple, Plus, Trash } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { type FC, useState } from 'react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
@@ -50,6 +50,30 @@ const ArbitraryTransactionsTable: FC<ArbitraryTransactionsTableProps> = ({
     }),
   );
 
+  const getMenuProps = ({ index }) =>
+    !readonly
+      ? {
+          cardClassName: 'min-w-[9.625rem] whitespace-nowrap',
+          items: [
+            {
+              key: 'duplicate',
+              onClick: () =>
+                fieldArrayMethods.insert(index + 1, {
+                  ...value[index],
+                }),
+              label: formatText({ id: 'table.row.duplicate' }),
+              icon: CopySimple,
+            },
+            {
+              key: 'remove',
+              onClick: () => fieldArrayMethods.remove(index),
+              label: formatText({ id: 'table.row.remove' }),
+              icon: Trash,
+            },
+          ],
+        }
+      : undefined;
+
   return (
     <div className="pt-4">
       <h5 className="mb-4 text-2">
@@ -64,6 +88,7 @@ const ArbitraryTransactionsTable: FC<ArbitraryTransactionsTableProps> = ({
         })}
         getRowId={({ key }) => key}
         columns={columns}
+        getMenuProps={getMenuProps}
         data={data.length === 0 ? [{} as AddTransactionTableModel] : data}
         verticalLayout={isMobile}
       />

--- a/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/ArbitraryTransactionsTable/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/ArbitraryTransactionsTable/hooks.tsx
@@ -114,7 +114,7 @@ export const useArbitraryTxsTableColumns = ({
         size: isMobile ? 100 : 67,
       }),
     ],
-    [columnHelper, isMobile, openTransactionModal],
+    [columnHelper, isMobile, openTransactionModal, isError],
   );
 
   return columns;

--- a/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/ArbitraryTransactionsTable/translation.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/ArbitraryTransactionsTable/translation.ts
@@ -1,0 +1,11 @@
+import { defineMessages } from 'react-intl';
+
+export const displayName =
+  'v5.common.ActionsContent.partials.ArbitraryTransactionsTable';
+
+export const MSG = defineMessages({
+  contractTableEditRow: {
+    id: `${displayName}.contractTableEditRow`,
+    defaultMessage: 'Edit details',
+  },
+});

--- a/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/types.ts
@@ -2,6 +2,7 @@ import { type ModalProps } from '~v5/shared/Modal/types.ts';
 
 export interface AddTransactionFormModalProps extends ModalProps {
   onSubmit: (link: AddTransactionTableModel) => void;
+  defaultValues: AddTransactionTableModel;
 }
 
 export interface AddTransactionTableModel {


### PR DESCRIPTION
## Description
Implement meatball menu with "edit", "duplicate row" and "delete functionality"

- [x] "Edit details" should open a modal and fill form with the data
- [x] "Duplicate row" should create row duplication
- [x] "Delete row" should remove row from the table

![image](https://github.com/user-attachments/assets/ff9d5fdb-e200-4b21-ae1e-728f58172074)

Figma: https://www.figma.com/design/5V8pr7iMwXsT9L3VAZsmUt/Actions-%26-Motions?node-id=24968-204505&node-type=frame&t=JJb12klGvkI2mJ8F-0

> [!TIP]
> I recommend reviewing [this PR](https://github.com/JoinColony/colonyCDapp/pull/3694) beforehand to better understand the context of Arbitrary transactions. 🙌

## Testing

> [!NOTE]  
>  Add ARBISCAN_API=https://api.arbiscan.io/api to .env.secrets. For ARBISCAN_API_KEY, contact me or create a personal key [here](https://arbiscan.io/myapikey).


Step 1. Open "Arbitrary transaction" Motion (Open any motion and then select "Arbitrary transaction" from dropdown) 
Step 2. Add a New Transaction. Create a transaction with the following values:
| Field | Value |
| ----- | ----- |
| Contract address: | `0x90A6146E3C8bfde9779069608F0d94B89C7aAf65` |
| Method: | **setResolver** |
| _resolver (address): | `0xb77D57F4959eAfA0339424b83FcFaf9c15407461` |

Step 3. Create a Transaction with Updated ABI: After entering the contract address, scroll to the bottom and update the latest object input type to bool.

<img width="470" alt="image" src="https://github.com/user-attachments/assets/2fa9fe97-c87f-41f5-baba-4c3f5fe308d4">
 
| Field | Value |
| ----- | ----- |
| Contract address: | `0x90A6146E3C8bfde9779069608F0d94B89C7aAf65` |
| Method: | **setResolver** |
| _resolver (bool): | `1` |

Step 4. Duplicate the Second Row: Ensure the row is duplicated successfully.
<img width="691" alt="image" src="https://github.com/user-attachments/assets/c8c66926-df26-4876-8c67-b21dc64e2e71">

<img width="681" alt="image" src="https://github.com/user-attachments/assets/72e50ac1-7de2-491e-9346-2e48a871ca6b">

Step 5. Edit the Second Row: Update the row with the following values:
| Field | Value |
| ----- | ----- |
| Method: | **setOwner** |
| owner_ (address): | `0xb77D57F4959eAfA0339424b83FcFaf9c15407461` |

Step 6. Verify the Second Row Update: Ensure only the second row was updated.
<img width="674" alt="image" src="https://github.com/user-attachments/assets/05aac657-5f00-4a1e-8182-f2ae037221b6">

Step 7. Delete the Second Row: Ensure the first and third rows still have the correct data.
<img width="699" alt="image" src="https://github.com/user-attachments/assets/9e2a5e05-2596-48b1-9049-56c7ea28589c">

**Feel free to perform additional tests not covered here to ensure this functionality works as expected.**

Contributes to #3732
