### PR TITLE
fix: add info about opposed agreement

### DIFF
--- a/src/i18n/en-motion-states.ts
+++ b/src/i18n/en-motion-states.ts
@@ -6,7 +6,7 @@ const motionStatesMessageDescriptors = {
       ${MotionState.Staking} {Staking}
       ${MotionState.Voting} {Voting}
       ${MotionState.Reveal} {Reveal}
-      ${MotionState.Opposed} {Objected}
+      ${MotionState.Opposed} {Opposed}
       ${MotionState.Motion} {Motion}
       ${MotionState.Failed} {Failed}
       ${MotionState.Finalizable} {Finalizable}

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -55,6 +55,12 @@ export const getMotionState = (
       return MotionState.Uninstalled;
     }
     case NetworkMotionState.Staking: {
+      if (
+        BigNumber.from(nayStakes).gte(requiredStake) &&
+        BigNumber.from(yayStakes).isZero()
+      ) {
+        return MotionState.Opposed;
+      }
       return BigNumber.from(yayStakes).gte(requiredStake) &&
         BigNumber.from(nayStakes).isZero()
         ? MotionState.Supported


### PR DESCRIPTION
## Description

Display badge with opposed greeement

## Testing

- create agreement
- fully oppose the agreement
- display item in `Recent activity`

## Diffs

**Changes** 🏗

![Screenshot 2024-11-20 at 15 54 38](https://github.com/user-attachments/assets/326924f3-1673-4ca7-91c7-e2132de327ee)

Resolves https://github.com/JoinColony/colonyCDapp/issues/3463