### PR TITLE
Fix: Staged payments form should be disabled when extension is not enabled

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
@@ -121,8 +121,8 @@ const UserSelect: FC<UserSelectProps> = ({
                 />
                 <p
                   className={clsx('ml-2 truncate text-md font-medium', {
-                    'text-warning-400': !selectedUser?.isVerified,
-                    'text-gray-900': selectedUser?.isVerified,
+                    'text-warning-400': !selectedUser?.isVerified && !disabled,
+                    'text-gray-900': selectedUser?.isVerified && !disabled,
                   })}
                 >
                   {formatText(userName || '')}

--- a/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/StagedPaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/StagedPaymentForm.tsx
@@ -12,6 +12,7 @@ import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/
 import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/CreatedIn.tsx';
 import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx';
 import Description from '~v5/common/ActionSidebar/partials/Description/Description.tsx';
+import { useIsFieldDisabled } from '~v5/common/ActionSidebar/partials/hooks.ts';
 import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/TeamsSelect.tsx';
 import UserSelect from '~v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx';
 import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
@@ -26,6 +27,8 @@ const StagedPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
   const hasNoDecisionMethods = useHasNoDecisionMethods();
 
   const { renderStakedExpenditureModal } = useStagePayment(getFormOptions);
+
+  const isFieldDisabled = useIsFieldDisabled();
 
   const decisionMethodFilterFn = createUnsupportedDecisionMethodFilter([
     DecisionMethod.MultiSig,
@@ -45,9 +48,12 @@ const StagedPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
           },
         }}
         title={formatText({ id: 'actionSidebar.fundFrom' })}
-        isDisabled={hasNoDecisionMethods}
+        isDisabled={hasNoDecisionMethods || isFieldDisabled}
       >
-        <TeamsSelect name={FROM_FIELD_NAME} disabled={hasNoDecisionMethods} />
+        <TeamsSelect
+          name={FROM_FIELD_NAME}
+          disabled={hasNoDecisionMethods || isFieldDisabled}
+        />
       </ActionFormRow>
       <ActionFormRow
         icon={UserFocus}
@@ -60,12 +66,19 @@ const StagedPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
           },
         }}
         title={formatText({ id: 'actionSidebar.recipient' })}
+        isDisabled={hasNoDecisionMethods || isFieldDisabled}
       >
-        <UserSelect name={RECIPIENT_FIELD_NAME} />
+        <UserSelect
+          name={RECIPIENT_FIELD_NAME}
+          disabled={hasNoDecisionMethods || isFieldDisabled}
+        />
       </ActionFormRow>
-      <DecisionMethodField filterOptionsFn={decisionMethodFilterFn} />
-      <CreatedIn />
-      <Description />
+      <DecisionMethodField
+        filterOptionsFn={decisionMethodFilterFn}
+        disabled={isFieldDisabled}
+      />
+      <CreatedIn disabled={isFieldDisabled} />
+      <Description disabled={isFieldDisabled} />
       <StagedPaymentRecipientsField name="stages" />
       {renderStakedExpenditureModal()}
     </>

--- a/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/hooks.ts
@@ -164,8 +164,11 @@ export const useStagePayment = (
   const validationSchema = useValidationSchema();
   const { setExpectedExpenditureType } = usePaymentBuilderContext();
 
-  const { renderStakedExpenditureModal, showStakedExpenditureModal } =
-    useShowCreateStakedExpenditureModal(Action.StagedPayment);
+  const {
+    renderStakedExpenditureModal,
+    showStakedExpenditureModal,
+    shouldShowStakedExpenditureModal,
+  } = useShowCreateStakedExpenditureModal(Action.StagedPayment);
 
   useActionFormBaseHook({
     validationSchema,
@@ -194,7 +197,7 @@ export const useStagePayment = (
       return getStagedPaymentPayload(colony, payload, networkInverseFee);
     }),
     primaryButton: {
-      type: 'button',
+      type: shouldShowStakedExpenditureModal ? 'button' : 'submit',
       onClick: showStakedExpenditureModal,
     },
   });

--- a/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/partials/StagedPaymentRecipientsField/StagedPaymentRecipientField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/partials/StagedPaymentRecipientsField/StagedPaymentRecipientField.tsx
@@ -8,6 +8,7 @@ import { useMobile, useTablet } from '~hooks';
 import { formatText } from '~utils/intl.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import { useBuildTokenSumsMap } from '~v5/common/ActionSidebar/partials/forms/shared/hooks/useBuildTokenSumsMap.ts';
+import { useIsFieldDisabled } from '~v5/common/ActionSidebar/partials/hooks.ts';
 import Table from '~v5/common/Table/Table.tsx';
 import Button from '~v5/shared/Button/Button.tsx';
 
@@ -21,6 +22,7 @@ import {
 const StagedPaymentRecipientsField: FC<StagedPaymentRecipientsFieldProps> = ({
   name,
 }) => {
+  const isFieldDisabled = useIsFieldDisabled();
   const hasNoDecisionMethods = useHasNoDecisionMethods();
   const {
     colony: { nativeToken },
@@ -71,7 +73,7 @@ const StagedPaymentRecipientsField: FC<StagedPaymentRecipientsFieldProps> = ({
       <h5 className="mb-3 mt-6 text-2">
         {formatText({ id: 'actionSidebar.stages' })}
       </h5>
-      {!!data.length && !hasNoDecisionMethods && (
+      {!!data.length && !hasNoDecisionMethods && !isFieldDisabled && (
         <Table<StagedPaymentRecipientsTableModel>
           tableClassName={clsx(
             '[&_tfoot>tr>td]:border-gray-200 [&_tfoot>tr>td]:py-2 md:[&_tfoot>tr>td]:border-t',
@@ -111,7 +113,9 @@ const StagedPaymentRecipientsField: FC<StagedPaymentRecipientsFieldProps> = ({
               tokenAddress: nativeToken?.tokenAddress || '',
             });
           }}
-          disabled={hasNoDecisionMethods || data.length === 400}
+          disabled={
+            hasNoDecisionMethods || data.length === 400 || isFieldDisabled
+          }
         >
           {formatText({ id: 'button.addMilestone' })}
         </Button>

--- a/src/components/v5/common/ActionSidebar/partials/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/hooks.ts
@@ -74,19 +74,40 @@ export const useSubmitButtonDisabled = () => {
 };
 
 export const useIsFieldDisabled = () => {
-  const { extensionData, loading } = useExtensionData(
-    Extension.VotingReputation,
-  );
+  const {
+    extensionData: votingReputationExtensionData,
+    loading: votingReputationLoading,
+  } = useExtensionData(Extension.VotingReputation);
+
+  const {
+    extensionData: stagedExpenditureExtensionData,
+    loading: stagedExpenditureLoading,
+  } = useExtensionData(Extension.StagedExpenditure);
+
   const selectedAction = useActiveActionType();
-  const isExtensionEnabled =
-    extensionData &&
-    isInstalledExtensionData(extensionData) &&
-    extensionData.isEnabled;
+
+  const isVotingReputationExtensionEnabled =
+    votingReputationExtensionData &&
+    isInstalledExtensionData(votingReputationExtensionData) &&
+    votingReputationExtensionData.isEnabled;
 
   if (
     selectedAction === Action.CreateDecision &&
-    !isExtensionEnabled &&
-    !loading
+    !isVotingReputationExtensionEnabled &&
+    !votingReputationLoading
+  ) {
+    return true;
+  }
+
+  const isStagedExpenditureExtensionEnabled =
+    stagedExpenditureExtensionData &&
+    isInstalledExtensionData(stagedExpenditureExtensionData) &&
+    stagedExpenditureExtensionData.isEnabled;
+
+  if (
+    selectedAction === Action.StagedPayment &&
+    !isStagedExpenditureExtensionEnabled &&
+    !stagedExpenditureLoading
   ) {
     return true;
   }

--- a/src/components/v5/shared/ActionTypeNotification/ActionTypeNotification.tsx
+++ b/src/components/v5/shared/ActionTypeNotification/ActionTypeNotification.tsx
@@ -28,10 +28,15 @@ const MSG = defineMessages({
     defaultMessage:
       'This will disable the Colony and prevent any further activity until resolved.',
   },
-  createDecisionError: {
-    id: `${displayName}.createDecisionError`,
+  votingReputationExtensionNotEnabledError: {
+    id: `${displayName}.votingReputationExtensionNotEnabledError`,
     defaultMessage:
       'Agreements requires the Reputation weighted extension to be enabled.',
+  },
+  stagedExpenditureExtensionNotEnabledError: {
+    id: `${displayName}.stagedExpenditureExtensionNotEnabledError`,
+    defaultMessage:
+      'Staged payments requires the Staged payments extension to be enabled.',
   },
   learnMore: {
     id: `${displayName}.learnMore`,
@@ -70,7 +75,11 @@ export const ActionTypeNotification: FC<ActionTypeNotificationProps> = ({
         return formatText(MSG.enterRecoveryModeError);
       case Action.CreateDecision:
         return isFieldDisabled
-          ? formatText(MSG.createDecisionError)
+          ? formatText(MSG.votingReputationExtensionNotEnabledError)
+          : undefined;
+      case Action.StagedPayment:
+        return isFieldDisabled
+          ? formatText(MSG.stagedExpenditureExtensionNotEnabledError)
           : undefined;
       default:
         return undefined;


### PR DESCRIPTION
## Description

This PR disables the staged payments form and shows an error when the staged payments extension is not installed.

## Testing

* Step 1 - Install the staged payment extension
* Step 2 - Create a staged payment action
* Step 3 - Deprecate the staged payment extension
* Step 4 - Open the previous stage payment action and select "Redo" from the meatball menu
* Step 5 - Check the form shows an error and that the fields are disabled

<img width="707" alt="Screenshot 2024-11-20 at 16 00 42" src="https://github.com/user-attachments/assets/5ab3bc73-ad2e-469b-ac7b-08dc19631b15">


## Diffs

**Changes** 🏗

* Error now shows on Staged Payments form if extension is not enabled
* Staged Payment form inputs are disabled if extension is not enabled
* `useIsFieldDisabled` now returns true if Staged Payments extension is not enabled

Resolves #3420
