### PR TITLE
Fix: Finalize agreement issues

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
@@ -70,9 +70,10 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
   const isMotionAgreement =
     actionData.type === ColonyActionType.CreateDecisionMotion;
   const isMotionClaimable =
-    (isMotionFinalized || isMotionFailedNotFinalizable || isMotionAgreement) &&
-    !isMotionFailed &&
-    !isMotionFailedNotFinalizable;
+    ((isMotionFinalized || isMotionFailedNotFinalizable) &&
+      !isMotionFailed &&
+      !isMotionFailedNotFinalizable) ||
+    (isMotionAgreement && !isClaimed);
 
   const handleSuccess = () => {
     startPollingAction(getSafePollingInterval());
@@ -114,6 +115,18 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
    */
   const wrongMotionState = !motionState || motionState === MotionState.Invalid;
 
+  const statusId = (() => {
+    if (isMotionAgreement) {
+      return isClaimed
+        ? 'motion.finalizeStep.finalizeAgreement'
+        : 'motion.finalizeStep.claimable.finalizeAgreement';
+    }
+
+    return isMotionFailedNotFinalizable
+      ? 'motion.finalizeStep.failed.statusText'
+      : 'motion.finalizeStep.statusText';
+  })();
+
   return (
     <MenuWithStatusText
       statusText={
@@ -123,11 +136,7 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
           iconAlignment="top"
           iconSize={16}
         >
-          {formatText({
-            id: isMotionFailedNotFinalizable
-              ? 'motion.finalizeStep.failed.statusText'
-              : 'motion.finalizeStep.statusText',
-          })}
+          {formatText({ id: statusId })}
         </StatusText>
       }
       content={

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/hooks.tsx
@@ -220,7 +220,14 @@ export const useClaimConfig = (
   );
 
   const getDescriptionItems = (): DescriptionListItem[] => {
-    if (!isMotionFailedNotFinalizable && !isMotionFinalized) {
+    const isMotionAgreement =
+      actionData.type === ColonyActionType.CreateDecisionMotion;
+
+    if (
+      !isMotionFailedNotFinalizable &&
+      !isMotionFinalized &&
+      !isMotionAgreement
+    ) {
       return [];
     }
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1459,6 +1459,8 @@
     "motion.staking.accordion.title.hide": "Hide staking information",
     "motion.finalize.label": "Finalize",
     "motion.finalizeStep.statusText": "Finalize to execute the agreed transactions and return stakes.",
+    "motion.finalizeStep.finalizeAgreement": "Agreement process is complete and stakes have been returned.",
+    "motion.finalizeStep.claimable.finalizeAgreement": "Agreement process is complete, finalize to return stakes.",
     "motion.finalizeStep.claimable.statusText": "Action has passed and has been executed.",
     "motion.finalizeStep.title": "Your overview",
     "motion.finalizeStep.failedNotAchieving.statusText": "Action failed due to not achieving required stake.",


### PR DESCRIPTION
## Description

This PR resolves a couple of issues when finalizing agreements with the "Return stakes" button not showing, and the stake details not showing.

## Testing

* Step 1 - Install the voting reputation extension
* Step 2 - Create an agreement using the "Create agreement" button in the menu
* Step 3 - Fully stake both support and oppose.
* Step 4 - Vote to oppose the agreement.
* Step 5 - Reveal your vote.
* Step 6 - Check the "Return stakes"  button appears, the stake information is shown, and the correct message is shown.

<img width="1064" alt="Screenshot 2024-11-22 at 13 44 51" src="https://github.com/user-attachments/assets/ab1afdce-04cf-4a6c-95b6-58373dec6e64">

* Step 7 - Click the "Return stakes" button. Check the button disappears, the message updates and the claimed pill appears.

<img width="1062" alt="Screenshot 2024-11-22 at 13 44 58" src="https://github.com/user-attachments/assets/7170c630-a47b-44d9-b4b3-2e1a674940b6">

* Step 8 - Repeat the process, this time voting to support the agreement.

<img width="1055" alt="Screenshot 2024-11-22 at 13 45 50" src="https://github.com/user-attachments/assets/3df28e6a-abea-4143-8f57-23e8696049b6">

<img width="1057" alt="Screenshot 2024-11-22 at 13 45 57" src="https://github.com/user-attachments/assets/486300ca-ed88-499c-88bd-037db2655a30">

Further testing: Check the other motions are unaffected and advanced payment motions are unaffected.

## Diffs

**Changes** 🏗

* `isMotionClaimable` variable now handles `isMotionAgreement` correctly
* `StatusText` component now handles agreements correctly
* `getDescriptionItems` now correctly returns items for agreements

Resolves #3330
Resolves #3323
