### PR TITLE
Fix Reputation Cache Update Lambda

### DIFF
--- a/amplify/backend/function/fetchColonyBalances/src/package-lock.json
+++ b/amplify/backend/function/fetchColonyBalances/src/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@colony/colony-js": "^7.2.0",
+        "@colony/colony-js": "^8.0.0-next.0",
         "@colony/events": "3.0.0",
         "cross-fetch": "^4.0.0",
         "ethers": "^5.7.2"
@@ -19,13 +19,45 @@
       }
     },
     "node_modules/@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
+      "license": "GPL-3.0-only",
       "dependencies": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/core": {
+      "version": "3.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+      "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+      "license": "GPL-3.0-only",
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/events": {
+      "version": "4.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+      "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "@colony/core": "^3.0.0-next.0",
+        "fetch-retry": "^5.0.4",
+        "typia": "^3.8.3"
       },
       "engines": {
         "node": "^16 || ^18 || ^20",
@@ -67,9 +99,10 @@
       }
     },
     "node_modules/@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
+      "license": "GPL-3.0-only",
       "engines": {
         "node": "^16 || ^18 || ^20",
         "pnpm": "^8"
@@ -1629,13 +1662,31 @@
   },
   "dependencies": {
     "@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
       "requires": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "dependencies": {
+        "@colony/core": {
+          "version": "3.0.0-next.0",
+          "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+          "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+          "requires": {}
+        },
+        "@colony/events": {
+          "version": "4.0.0-next.0",
+          "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+          "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+          "requires": {
+            "@colony/core": "^3.0.0-next.0",
+            "fetch-retry": "^5.0.4",
+            "typia": "^3.8.3"
+          }
+        }
       }
     },
     "@colony/core": {
@@ -1655,9 +1706,9 @@
       }
     },
     "@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
       "requires": {}
     },
     "@ethersproject/abi": {

--- a/amplify/backend/function/fetchColonyBalances/src/package.json
+++ b/amplify/backend/function/fetchColonyBalances/src/package.json
@@ -8,7 +8,7 @@
     "@types/aws-lambda": "^8.10.92"
   },
   "dependencies": {
-    "@colony/colony-js": "^7.2.0",
+    "@colony/colony-js": "^8.0.0-next.0",
     "@colony/events": "3.0.0",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.7.2"

--- a/amplify/backend/function/fetchDomainBalance/src/package-lock.json
+++ b/amplify/backend/function/fetchDomainBalance/src/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@colony/colony-js": "^7.2.0",
+        "@colony/colony-js": "^8.0.0-next.0",
         "@colony/events": "3.0.0",
         "cross-fetch": "^4.0.0",
         "date-fns": "^3.6.0",
@@ -20,13 +20,45 @@
       }
     },
     "node_modules/@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
+      "license": "GPL-3.0-only",
       "dependencies": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/core": {
+      "version": "3.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+      "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+      "license": "GPL-3.0-only",
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/events": {
+      "version": "4.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+      "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "@colony/core": "^3.0.0-next.0",
+        "fetch-retry": "^5.0.4",
+        "typia": "^3.8.3"
       },
       "engines": {
         "node": "^16 || ^18 || ^20",
@@ -66,9 +98,10 @@
       }
     },
     "node_modules/@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
+      "license": "GPL-3.0-only",
       "engines": {
         "node": "^16 || ^18 || ^20",
         "pnpm": "^8"

--- a/amplify/backend/function/fetchDomainBalance/src/package.json
+++ b/amplify/backend/function/fetchDomainBalance/src/package.json
@@ -11,7 +11,7 @@
     "date-fns": "^3.6.0",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.1.3",
-    "@colony/colony-js": "^7.2.0",
+    "@colony/colony-js": "^8.0.0-next.0",
     "@colony/events": "3.0.0"
   }
 }

--- a/amplify/backend/function/fetchMotionState/src/package-lock.json
+++ b/amplify/backend/function/fetchMotionState/src/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@colony/colony-js": "^7.2.0",
+        "@colony/colony-js": "^8.0.0-next.0",
         "@colony/events": "3.0.0",
         "cross-fetch": "^4.0.0",
         "ethers": "^5.1.3"
@@ -19,13 +19,45 @@
       }
     },
     "node_modules/@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
+      "license": "GPL-3.0-only",
       "dependencies": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/core": {
+      "version": "3.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+      "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+      "license": "GPL-3.0-only",
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/events": {
+      "version": "4.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+      "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "@colony/core": "^3.0.0-next.0",
+        "fetch-retry": "^5.0.4",
+        "typia": "^3.8.3"
       },
       "engines": {
         "node": "^16 || ^18 || ^20",
@@ -67,9 +99,10 @@
       }
     },
     "node_modules/@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
+      "license": "GPL-3.0-only",
       "engines": {
         "node": "^16 || ^18 || ^20",
         "pnpm": "^8"
@@ -1620,13 +1653,31 @@
   },
   "dependencies": {
     "@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
       "requires": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "dependencies": {
+        "@colony/core": {
+          "version": "3.0.0-next.0",
+          "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+          "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+          "requires": {}
+        },
+        "@colony/events": {
+          "version": "4.0.0-next.0",
+          "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+          "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+          "requires": {
+            "@colony/core": "^3.0.0-next.0",
+            "fetch-retry": "^5.0.4",
+            "typia": "^3.8.3"
+          }
+        }
       }
     },
     "@colony/core": {
@@ -1646,9 +1697,9 @@
       }
     },
     "@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
       "requires": {}
     },
     "@ethersproject/abi": {

--- a/amplify/backend/function/fetchMotionState/src/package.json
+++ b/amplify/backend/function/fetchMotionState/src/package.json
@@ -8,7 +8,7 @@
     "@types/aws-lambda": "^8.10.92"
   },
   "dependencies": {
-    "@colony/colony-js": "^7.2.0",
+    "@colony/colony-js": "^8.0.0-next.0",
     "@colony/events": "3.0.0",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.1.3"

--- a/amplify/backend/function/fetchMotionTimeoutPeriods/src/package-lock.json
+++ b/amplify/backend/function/fetchMotionTimeoutPeriods/src/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@colony/colony-js": "^7.2.0",
+        "@colony/colony-js": "^8.0.0-next.0",
         "@colony/events": "3.0.0",
         "cross-fetch": "^4.0.0",
         "ethers": "^5.7.2"
@@ -19,13 +19,45 @@
       }
     },
     "node_modules/@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
+      "license": "GPL-3.0-only",
       "dependencies": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/core": {
+      "version": "3.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+      "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+      "license": "GPL-3.0-only",
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/events": {
+      "version": "4.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+      "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "@colony/core": "^3.0.0-next.0",
+        "fetch-retry": "^5.0.4",
+        "typia": "^3.8.3"
       },
       "engines": {
         "node": "^16 || ^18 || ^20",
@@ -67,9 +99,10 @@
       }
     },
     "node_modules/@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
+      "license": "GPL-3.0-only",
       "engines": {
         "node": "^16 || ^18 || ^20",
         "pnpm": "^8"
@@ -1629,13 +1662,31 @@
   },
   "dependencies": {
     "@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
       "requires": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "dependencies": {
+        "@colony/core": {
+          "version": "3.0.0-next.0",
+          "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+          "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+          "requires": {}
+        },
+        "@colony/events": {
+          "version": "4.0.0-next.0",
+          "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+          "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+          "requires": {
+            "@colony/core": "^3.0.0-next.0",
+            "fetch-retry": "^5.0.4",
+            "typia": "^3.8.3"
+          }
+        }
       }
     },
     "@colony/core": {
@@ -1655,9 +1706,9 @@
       }
     },
     "@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
       "requires": {}
     },
     "@ethersproject/abi": {

--- a/amplify/backend/function/fetchMotionTimeoutPeriods/src/package.json
+++ b/amplify/backend/function/fetchMotionTimeoutPeriods/src/package.json
@@ -8,7 +8,7 @@
     "@types/aws-lambda": "^8.10.92"
   },
   "dependencies": {
-    "@colony/colony-js": "^7.2.0",
+    "@colony/colony-js": "^8.0.0-next.0",
     "@colony/events": "3.0.0",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.7.2"

--- a/amplify/backend/function/fetchVoterRewards/src/package-lock.json
+++ b/amplify/backend/function/fetchVoterRewards/src/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@colony/colony-js": "^7.2.0",
+        "@colony/colony-js": "^8.0.0-next.0",
         "@colony/events": "3.0.0",
         "cross-fetch": "^4.0.0",
         "ethers": "^5.1.3"
@@ -19,13 +19,45 @@
       }
     },
     "node_modules/@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
+      "license": "GPL-3.0-only",
       "dependencies": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/core": {
+      "version": "3.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+      "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+      "license": "GPL-3.0-only",
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/events": {
+      "version": "4.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+      "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "@colony/core": "^3.0.0-next.0",
+        "fetch-retry": "^5.0.4",
+        "typia": "^3.8.3"
       },
       "engines": {
         "node": "^16 || ^18 || ^20",
@@ -67,9 +99,10 @@
       }
     },
     "node_modules/@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
+      "license": "GPL-3.0-only",
       "engines": {
         "node": "^16 || ^18 || ^20",
         "pnpm": "^8"
@@ -1629,13 +1662,31 @@
   },
   "dependencies": {
     "@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
       "requires": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "dependencies": {
+        "@colony/core": {
+          "version": "3.0.0-next.0",
+          "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+          "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+          "requires": {}
+        },
+        "@colony/events": {
+          "version": "4.0.0-next.0",
+          "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+          "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+          "requires": {
+            "@colony/core": "^3.0.0-next.0",
+            "fetch-retry": "^5.0.4",
+            "typia": "^3.8.3"
+          }
+        }
       }
     },
     "@colony/core": {
@@ -1655,9 +1706,9 @@
       }
     },
     "@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
       "requires": {}
     },
     "@ethersproject/abi": {

--- a/amplify/backend/function/fetchVoterRewards/src/package.json
+++ b/amplify/backend/function/fetchVoterRewards/src/package.json
@@ -8,7 +8,7 @@
     "@types/aws-lambda": "^8.10.92"
   },
   "dependencies": {
-    "@colony/colony-js": "^7.2.0",
+    "@colony/colony-js": "^8.0.0-next.0",
     "@colony/events": "3.0.0",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.1.3"

--- a/amplify/backend/function/getUserReputation/src/package-lock.json
+++ b/amplify/backend/function/getUserReputation/src/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@colony/colony-js": "^7.2.0",
+        "@colony/colony-js": "^8.0.0-next.0",
         "@colony/events": "3.0.0",
         "cross-fetch": "^4.0.0",
         "ethers": "^5.7.2"
@@ -19,13 +19,45 @@
       }
     },
     "node_modules/@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
+      "license": "GPL-3.0-only",
       "dependencies": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/core": {
+      "version": "3.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+      "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+      "license": "GPL-3.0-only",
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/events": {
+      "version": "4.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+      "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "@colony/core": "^3.0.0-next.0",
+        "fetch-retry": "^5.0.4",
+        "typia": "^3.8.3"
       },
       "engines": {
         "node": "^16 || ^18 || ^20",
@@ -67,9 +99,10 @@
       }
     },
     "node_modules/@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
+      "license": "GPL-3.0-only",
       "engines": {
         "node": "^16 || ^18 || ^20",
         "pnpm": "^8"
@@ -1629,13 +1662,31 @@
   },
   "dependencies": {
     "@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
       "requires": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "dependencies": {
+        "@colony/core": {
+          "version": "3.0.0-next.0",
+          "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+          "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+          "requires": {}
+        },
+        "@colony/events": {
+          "version": "4.0.0-next.0",
+          "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+          "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+          "requires": {
+            "@colony/core": "^3.0.0-next.0",
+            "fetch-retry": "^5.0.4",
+            "typia": "^3.8.3"
+          }
+        }
       }
     },
     "@colony/core": {
@@ -1655,9 +1706,9 @@
       }
     },
     "@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
       "requires": {}
     },
     "@ethersproject/abi": {

--- a/amplify/backend/function/getUserReputation/src/package.json
+++ b/amplify/backend/function/getUserReputation/src/package.json
@@ -8,7 +8,7 @@
     "@types/aws-lambda": "^8.10.92"
   },
   "dependencies": {
-    "@colony/colony-js": "^7.2.0",
+    "@colony/colony-js": "^8.0.0-next.0",
     "@colony/events": "3.0.0",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.7.2"

--- a/amplify/backend/function/getUserTokenBalance/src/package-lock.json
+++ b/amplify/backend/function/getUserTokenBalance/src/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@colony/colony-js": "^7.2.0",
+        "@colony/colony-js": "^8.0.0-next.0",
         "@colony/events": "3.0.0",
         "cross-fetch": "^4.0.0",
         "ethers": "^5.7.2"
@@ -19,13 +19,45 @@
       }
     },
     "node_modules/@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
+      "license": "GPL-3.0-only",
       "dependencies": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/core": {
+      "version": "3.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+      "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+      "license": "GPL-3.0-only",
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/events": {
+      "version": "4.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+      "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "@colony/core": "^3.0.0-next.0",
+        "fetch-retry": "^5.0.4",
+        "typia": "^3.8.3"
       },
       "engines": {
         "node": "^16 || ^18 || ^20",
@@ -67,9 +99,10 @@
       }
     },
     "node_modules/@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
+      "license": "GPL-3.0-only",
       "engines": {
         "node": "^16 || ^18 || ^20",
         "pnpm": "^8"
@@ -1629,13 +1662,31 @@
   },
   "dependencies": {
     "@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
       "requires": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "dependencies": {
+        "@colony/core": {
+          "version": "3.0.0-next.0",
+          "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+          "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+          "requires": {}
+        },
+        "@colony/events": {
+          "version": "4.0.0-next.0",
+          "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+          "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+          "requires": {
+            "@colony/core": "^3.0.0-next.0",
+            "fetch-retry": "^5.0.4",
+            "typia": "^3.8.3"
+          }
+        }
       }
     },
     "@colony/core": {
@@ -1655,9 +1706,9 @@
       }
     },
     "@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
       "requires": {}
     },
     "@ethersproject/abi": {

--- a/amplify/backend/function/getUserTokenBalance/src/package.json
+++ b/amplify/backend/function/getUserTokenBalance/src/package.json
@@ -8,7 +8,7 @@
     "@types/aws-lambda": "^8.10.92"
   },
   "dependencies": {
-    "@colony/colony-js": "^7.2.0",
+    "@colony/colony-js": "^8.0.0-next.0",
     "@colony/events": "3.0.0",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.7.2"

--- a/amplify/backend/function/qaSSMtest/src/package-lock.json
+++ b/amplify/backend/function/qaSSMtest/src/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@colony/colony-js": "^7.2.0",
+        "@colony/colony-js": "^8.0.0-next.0",
         "@colony/events": "3.0.0",
         "cross-fetch": "^4.0.0",
         "ethers": "^5.7.2"
@@ -19,13 +19,45 @@
       }
     },
     "node_modules/@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
+      "license": "GPL-3.0-only",
       "dependencies": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/core": {
+      "version": "3.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+      "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+      "license": "GPL-3.0-only",
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/events": {
+      "version": "4.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+      "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "@colony/core": "^3.0.0-next.0",
+        "fetch-retry": "^5.0.4",
+        "typia": "^3.8.3"
       },
       "engines": {
         "node": "^16 || ^18 || ^20",
@@ -67,9 +99,10 @@
       }
     },
     "node_modules/@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
+      "license": "GPL-3.0-only",
       "engines": {
         "node": "^16 || ^18 || ^20",
         "pnpm": "^8"
@@ -1629,13 +1662,31 @@
   },
   "dependencies": {
     "@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
       "requires": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "dependencies": {
+        "@colony/core": {
+          "version": "3.0.0-next.0",
+          "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+          "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+          "requires": {}
+        },
+        "@colony/events": {
+          "version": "4.0.0-next.0",
+          "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+          "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+          "requires": {
+            "@colony/core": "^3.0.0-next.0",
+            "fetch-retry": "^5.0.4",
+            "typia": "^3.8.3"
+          }
+        }
       }
     },
     "@colony/core": {
@@ -1655,9 +1706,9 @@
       }
     },
     "@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
       "requires": {}
     },
     "@ethersproject/abi": {

--- a/amplify/backend/function/qaSSMtest/src/package.json
+++ b/amplify/backend/function/qaSSMtest/src/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "license": "Apache-2.0",
   "dependencies": {
-    "@colony/colony-js": "^7.2.0",
+    "@colony/colony-js": "^8.0.0-next.0",
     "@colony/events": "3.0.0",
     "cross-fetch": "^4.0.0",
     "ethers": "^5.7.2"

--- a/amplify/backend/function/updateContributorsWithReputation/src/graphql.js
+++ b/amplify/backend/function/updateContributorsWithReputation/src/graphql.js
@@ -51,6 +51,8 @@ module.exports = {
         domains {
           items {
             nativeId
+            nativeSkillId
+            isRoot
           }
         }
         lastUpdatedContributorsWithReputation

--- a/amplify/backend/function/updateContributorsWithReputation/src/index.js
+++ b/amplify/backend/function/updateContributorsWithReputation/src/index.js
@@ -28,6 +28,7 @@ const {
   updateReputationInDomain,
   getDomainDatabaseId,
   calculatePercentageReputation,
+  loggingFnFactory,
 } = require('./utils');
 
 Logger.setLogLevel(Logger.levels.ERROR);
@@ -39,6 +40,7 @@ let networkAddress;
 let reputationOracleEndpoint =
   'http://reputation-monitor:3001/reputation/local';
 let network = Network.Custom;
+let log = loggingFnFactory();
 
 const setEnvVariables = async () => {
   const ENV = process.env.ENV;
@@ -60,6 +62,7 @@ const setEnvVariables = async () => {
       'reputationEndpoint',
       'chainNetwork',
     ]);
+    log = loggingFnFactory(ENV);
   } else {
     const {
       etherRouterAddress,
@@ -85,7 +88,7 @@ exports.handler = async (event) => {
       return true;
     }
 
-    console.log(`Colony ${colonyAddress} reputation update started`);
+    log(`Colony ${colonyAddress} reputation update started`);
 
     const provider = new providers.StaticJsonRpcProvider(rpcURL);
 
@@ -123,7 +126,7 @@ exports.handler = async (event) => {
       return true;
     }
 
-    console.log({ totalRepInColony: totalRepInColony?.toString() });
+    log({ totalRepInColony: totalRepInColony?.toString() });
 
     // query database rep metadata
     const { data: response } =
@@ -140,14 +143,13 @@ exports.handler = async (event) => {
     const lastReputationMiningCycleCompletion =
       response?.getReputationMiningCycleMetadata?.lastCompletedAt;
 
-    console.log({
+    log({
       lastUpdatedCache,
       lastReputationMiningCycleCompletion,
       willUpdateCache: !(
         new Date(lastReputationMiningCycleCompletion).valueOf() <
         new Date(lastUpdatedCache).valueOf()
       ),
-      // willUpdateCache: 'forced true',
     });
 
     // TODO use latest hash to decide if to update reputation
@@ -198,7 +200,7 @@ exports.handler = async (event) => {
 
         const totalAddresses = sortedAddresses.length;
 
-        console.log({
+        log({
           nativeId,
           nativeSkillId,
           totalRepInDomain: totalRepInDomain?.toString(),
@@ -320,7 +322,7 @@ exports.handler = async (event) => {
 
     for (const { status, reason } of promiseResults) {
       if (status === 'rejected') {
-        console.log(
+        log(
           `ERROR: Some reputation entries could not be processed -- ${reason}`,
         );
         allFulfilled = false;

--- a/amplify/backend/function/updateContributorsWithReputation/src/index.js
+++ b/amplify/backend/function/updateContributorsWithReputation/src/index.js
@@ -5,7 +5,6 @@ const {
   constants: { AddressZero },
   utils: { Logger, getAddress },
 } = require('ethers');
-const Decimal = require('decimal.js');
 
 const {
   getContributorReputation,
@@ -208,7 +207,6 @@ exports.handler = async (event) => {
         const promiseStatuses = await Promise.allSettled(
           sortedAddresses.map(async ({ address, reputationBN }, idx) => {
             const contributorAddress = getAddress(address);
-            const contributorRepDecimal = new Decimal(reputationBN.toString());
 
             const colonyReputationPercentage = calculatePercentageReputation(
               reputationBN,

--- a/amplify/backend/function/updateContributorsWithReputation/src/index.js
+++ b/amplify/backend/function/updateContributorsWithReputation/src/index.js
@@ -17,6 +17,7 @@ const {
 
 const {
   graphqlRequest,
+  repMinerRequest,
   getContributorType,
   sortAddressesDescendingByReputation,
   createContributorReputationInDb,

--- a/amplify/backend/function/updateContributorsWithReputation/src/index.js
+++ b/amplify/backend/function/updateContributorsWithReputation/src/index.js
@@ -152,13 +152,12 @@ exports.handler = async (event) => {
       ),
     });
 
-    // TODO use latest hash to decide if to update reputation
     // We only need to update the cache if the reputation mining cycle has completed since the last time we updated the cache
     if (
       new Date(lastReputationMiningCycleCompletion).valueOf() <
       new Date(lastUpdatedCache).valueOf()
     ) {
-      return true;
+      // return true;
     }
 
     const promiseResults = await Promise.allSettled(

--- a/amplify/backend/function/updateContributorsWithReputation/src/package-lock.json
+++ b/amplify/backend/function/updateContributorsWithReputation/src/package-lock.json
@@ -10,9 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@colony/colony-js": "^7.2.0",
-        "@colony/events": "3.0.0",
         "cross-fetch": "^4.0.0",
-        "decimal.js": "^10.2.1",
         "ethers": "^5.7.2"
       },
       "devDependencies": {
@@ -943,10 +941,6 @@
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
-    },
-    "node_modules/decimal.js": {
-      "version": "10.2.1",
-      "license": "MIT"
     },
     "node_modules/defaults": {
       "version": "1.0.4",
@@ -2075,9 +2069,6 @@
       "requires": {
         "node-fetch": "^2.6.12"
       }
-    },
-    "decimal.js": {
-      "version": "10.2.1"
     },
     "defaults": {
       "version": "1.0.4",

--- a/amplify/backend/function/updateContributorsWithReputation/src/package-lock.json
+++ b/amplify/backend/function/updateContributorsWithReputation/src/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@colony/colony-js": "^7.2.0",
+        "@colony/colony-js": "^8.0.0-next.0",
         "cross-fetch": "^4.0.0",
         "decimal.js": "^10.2.1",
         "ethers": "^5.7.2"
@@ -19,13 +19,14 @@
       }
     },
     "node_modules/@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
+      "license": "GPL-3.0-only",
       "dependencies": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
       },
       "engines": {
         "node": "^16 || ^18 || ^20",
@@ -36,9 +37,9 @@
       }
     },
     "node_modules/@colony/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@colony/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-TQzdFh+ayJdEh2lR04LyvyPEt1wEo0h/dukUTVY6lY9N8zpUvHZL4JCpyy//fUV1rlly+wQvxoRjcXzHYTguaw==",
+      "version": "3.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+      "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
       "license": "GPL-3.0-only",
       "engines": {
         "node": "^16 || ^18 || ^20",
@@ -49,12 +50,12 @@
       }
     },
     "node_modules/@colony/events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-eFM51N75ZXHJ/E5HqAGZa/5btlEhD7Vw5bbkF91fHfF1tsb+TYrb1vVvCKmx2XihzuMRKm1v0iS7VPjFwoTADg==",
+      "version": "4.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+      "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@colony/core": "^2.3.0",
+        "@colony/core": "^3.0.0-next.0",
         "fetch-retry": "^5.0.4",
         "typia": "^3.8.3"
       },
@@ -67,9 +68,10 @@
       }
     },
     "node_modules/@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
+      "license": "GPL-3.0-only",
       "engines": {
         "node": "^16 || ^18 || ^20",
         "pnpm": "^8"
@@ -732,6 +734,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -746,6 +749,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -754,6 +758,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -767,7 +772,8 @@
     "node_modules/array-timsort": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
-      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ=="
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -786,7 +792,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/bech32": {
       "version": "1.1.4",
@@ -796,6 +803,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -828,6 +836,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -837,6 +846,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -851,12 +861,14 @@
     "node_modules/chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "license": "MIT",
       "dependencies": {
         "restore-cursor": "^3.1.0"
       },
@@ -868,6 +880,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -879,6 +892,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "license": "ISC",
       "engines": {
         "node": ">= 10"
       }
@@ -887,6 +901,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -895,6 +910,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -905,20 +921,23 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
       "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/comment-json": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.3.tgz",
-      "integrity": "sha512-SsxdiOf064DWoZLH799Ata6u7iV658A11PlWtZATDlXPpKGJnbJZ5Z24ybixAi+LUUqJ/GKowAejtC5GFUG7Tw==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.5.tgz",
+      "integrity": "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==",
+      "license": "MIT",
       "dependencies": {
         "array-timsort": "^1.0.3",
         "core-util-is": "^1.0.3",
@@ -933,7 +952,8 @@
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
     },
     "node_modules/cross-fetch": {
       "version": "4.0.0",
@@ -953,6 +973,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "license": "MIT",
       "dependencies": {
         "clone": "^1.0.2"
       },
@@ -964,6 +985,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
       "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -988,12 +1010,14 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -1002,6 +1026,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -1060,6 +1085,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "license": "MIT",
       "dependencies": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
@@ -1072,12 +1098,14 @@
     "node_modules/fetch-retry": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.6.tgz",
-      "integrity": "sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ=="
+      "integrity": "sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ==",
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -1092,6 +1120,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1100,6 +1129,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
       "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1125,6 +1155,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -1149,7 +1180,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -1159,6 +1191,7 @@
       "version": "8.2.6",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
       "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+      "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
@@ -1184,6 +1217,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1192,6 +1226,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1200,6 +1235,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -1214,12 +1250,14 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -1235,6 +1273,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1250,7 +1289,8 @@
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "license": "ISC"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -1275,6 +1315,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -1289,6 +1330,7 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
       "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "license": "MIT",
       "dependencies": {
         "bl": "^4.1.0",
         "chalk": "^4.1.0",
@@ -1311,6 +1353,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1319,6 +1362,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
       "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
+      "license": "MIT",
       "dependencies": {
         "drange": "^1.0.2",
         "ret": "^0.2.0"
@@ -1331,6 +1375,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -1344,6 +1389,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
@@ -1352,6 +1398,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -1364,6 +1411,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
       "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -1372,6 +1420,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -1380,6 +1429,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -1401,12 +1451,14 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scrypt-js": {
       "version": "3.0.1",
@@ -1415,12 +1467,14 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -1429,6 +1483,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -1442,6 +1497,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -1453,6 +1509,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -1463,12 +1520,14 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "license": "MIT",
       "dependencies": {
         "os-tmpdir": "~1.0.2"
       },
@@ -1482,14 +1541,16 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -1498,9 +1559,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "license": "Apache-2.0",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -1514,6 +1576,7 @@
       "version": "3.8.9",
       "resolved": "https://registry.npmjs.org/typia/-/typia-3.8.9.tgz",
       "integrity": "sha512-yvQ67nhtzme+rnEUZfSOIgxBOHYrrQ3WBU1J4SrAhI3ntBhSelYwGiJkeaCvqchzK6O1RoIs3kCBS4XHIlp2NA==",
+      "license": "MIT",
       "dependencies": {
         "commander": "^10.0.0",
         "comment-json": "^4.2.3",
@@ -1530,12 +1593,14 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
       }
@@ -1558,6 +1623,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -1589,35 +1655,35 @@
   },
   "dependencies": {
     "@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
       "requires": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
       }
     },
     "@colony/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@colony/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-TQzdFh+ayJdEh2lR04LyvyPEt1wEo0h/dukUTVY6lY9N8zpUvHZL4JCpyy//fUV1rlly+wQvxoRjcXzHYTguaw==",
+      "version": "3.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+      "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
       "requires": {}
     },
     "@colony/events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-eFM51N75ZXHJ/E5HqAGZa/5btlEhD7Vw5bbkF91fHfF1tsb+TYrb1vVvCKmx2XihzuMRKm1v0iS7VPjFwoTADg==",
+      "version": "4.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+      "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
       "requires": {
-        "@colony/core": "^2.3.0",
+        "@colony/core": "^3.0.0-next.0",
         "fetch-retry": "^5.0.4",
         "typia": "^3.8.3"
       }
     },
     "@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
       "requires": {}
     },
     "@ethersproject/abi": {
@@ -2053,9 +2119,9 @@
       "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
     },
     "comment-json": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.3.tgz",
-      "integrity": "sha512-SsxdiOf064DWoZLH799Ata6u7iV658A11PlWtZATDlXPpKGJnbJZ5Z24ybixAi+LUUqJ/GKowAejtC5GFUG7Tw==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.5.tgz",
+      "integrity": "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==",
       "requires": {
         "array-timsort": "^1.0.3",
         "core-util-is": "^1.0.3",
@@ -2455,9 +2521,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "type-fest": {
       "version": "0.21.3",
@@ -2465,9 +2531,9 @@
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
     },
     "typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "peer": true
     },
     "typia": {

--- a/amplify/backend/function/updateContributorsWithReputation/src/package-lock.json
+++ b/amplify/backend/function/updateContributorsWithReputation/src/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@colony/colony-js": "^7.2.0",
         "cross-fetch": "^4.0.0",
+        "decimal.js": "^10.2.1",
         "ethers": "^5.7.2"
       },
       "devDependencies": {
@@ -941,6 +942,12 @@
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+      "license": "MIT"
     },
     "node_modules/defaults": {
       "version": "1.0.4",
@@ -2069,6 +2076,11 @@
       "requires": {
         "node-fetch": "^2.6.12"
       }
+    },
+    "decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "defaults": {
       "version": "1.0.4",

--- a/amplify/backend/function/updateContributorsWithReputation/src/package-lock.json
+++ b/amplify/backend/function/updateContributorsWithReputation/src/package-lock.json
@@ -9,75 +9,12 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@colony/colony-js": "^8.0.0-next.0",
         "cross-fetch": "^4.0.0",
         "decimal.js": "^10.2.1",
         "ethers": "^5.7.2"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.92"
-      }
-    },
-    "node_modules/@colony/colony-js": {
-      "version": "8.0.0-next.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
-      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
-      "license": "GPL-3.0-only",
-      "dependencies": {
-        "@colony/core": "^3.0.0-next.0",
-        "@colony/events": "^4.0.0-next.0",
-        "@colony/tokens": "^1.0.0-next.0"
-      },
-      "engines": {
-        "node": "^16 || ^18 || ^20",
-        "pnpm": "^8"
-      },
-      "peerDependencies": {
-        "ethers": "^5.1.3"
-      }
-    },
-    "node_modules/@colony/core": {
-      "version": "3.0.0-next.0",
-      "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
-      "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
-      "license": "GPL-3.0-only",
-      "engines": {
-        "node": "^16 || ^18 || ^20",
-        "pnpm": "^8"
-      },
-      "peerDependencies": {
-        "ethers": "^5.1.3"
-      }
-    },
-    "node_modules/@colony/events": {
-      "version": "4.0.0-next.0",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
-      "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
-      "license": "GPL-3.0-only",
-      "dependencies": {
-        "@colony/core": "^3.0.0-next.0",
-        "fetch-retry": "^5.0.4",
-        "typia": "^3.8.3"
-      },
-      "engines": {
-        "node": "^16 || ^18 || ^20",
-        "pnpm": "^8"
-      },
-      "peerDependencies": {
-        "ethers": "^5.1.3"
-      }
-    },
-    "node_modules/@colony/tokens": {
-      "version": "1.0.0-next.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
-      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
-      "license": "GPL-3.0-only",
-      "engines": {
-        "node": "^16 || ^18 || ^20",
-        "pnpm": "^8"
-      },
-      "peerDependencies": {
-        "ethers": "^5.1.3"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -730,85 +667,9 @@
       "version": "3.0.0",
       "license": "MIT"
     },
-    "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/array-timsort": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
-      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
-      "license": "MIT"
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/bech32": {
       "version": "1.1.4",
       "license": "MIT"
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
@@ -816,143 +677,6 @@
     },
     "node_modules/brorand": {
       "version": "1.1.0",
-      "license": "MIT"
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "license": "MIT"
-    },
-    "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-width": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/comment-json": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.5.tgz",
-      "integrity": "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==",
-      "license": "MIT",
-      "dependencies": {
-        "array-timsort": "^1.0.3",
-        "core-util-is": "^1.0.3",
-        "esprima": "^4.0.1",
-        "has-own-prop": "^2.0.0",
-        "repeat-string": "^1.6.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cross-fetch": {
@@ -968,27 +692,6 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "license": "MIT"
-    },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/drange": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
-      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -1006,34 +709,6 @@
     "node_modules/elliptic/node_modules/bn.js": {
       "version": "4.12.0",
       "license": "MIT"
-    },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/ethers": {
       "version": "5.7.2",
@@ -1081,59 +756,6 @@
         "@ethersproject/wordlists": "5.7.0"
       }
     },
-    "node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/fetch-retry": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.6.tgz",
-      "integrity": "sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ==",
-      "license": "MIT"
-    },
-    "node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/has-own-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
-      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/hash.js": {
       "version": "1.1.7",
       "license": "MIT",
@@ -1151,132 +773,13 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
     },
-    "node_modules/inquirer": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
-      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.1",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.21",
-        "mute-stream": "0.0.8",
-        "ora": "^5.4.1",
-        "run-async": "^2.4.0",
-        "rxjs": "^7.5.5",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6",
-        "wrap-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-interactive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "license": "MIT"
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
-    },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
@@ -1285,12 +788,6 @@
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "license": "MIT"
-    },
-    "node_modules/mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "license": "ISC"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -1311,299 +808,14 @@
         }
       }
     },
-    "node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.1.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.5.0",
-        "is-interactive": "^1.0.0",
-        "is-unicode-supported": "^0.1.0",
-        "log-symbols": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/randexp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
-      "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
-      "license": "MIT",
-      "dependencies": {
-        "drange": "^1.0.2",
-        "ret": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ret": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
-      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
-    },
     "node_modules/scrypt-js": {
       "version": "3.0.1",
       "license": "MIT"
-    },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "license": "MIT"
-    },
-    "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
-    "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/typia": {
-      "version": "3.8.9",
-      "resolved": "https://registry.npmjs.org/typia/-/typia-3.8.9.tgz",
-      "integrity": "sha512-yvQ67nhtzme+rnEUZfSOIgxBOHYrrQ3WBU1J4SrAhI3ntBhSelYwGiJkeaCvqchzK6O1RoIs3kCBS4XHIlp2NA==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^10.0.0",
-        "comment-json": "^4.2.3",
-        "inquirer": "^8.2.5",
-        "randexp": "^0.5.3"
-      },
-      "bin": {
-        "typia": "lib/executable/typia.js"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.5.2"
-      }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
-    },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -1617,20 +829,6 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ws": {
@@ -1654,38 +852,6 @@
     }
   },
   "dependencies": {
-    "@colony/colony-js": {
-      "version": "8.0.0-next.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
-      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
-      "requires": {
-        "@colony/core": "^3.0.0-next.0",
-        "@colony/events": "^4.0.0-next.0",
-        "@colony/tokens": "^1.0.0-next.0"
-      }
-    },
-    "@colony/core": {
-      "version": "3.0.0-next.0",
-      "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
-      "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
-      "requires": {}
-    },
-    "@colony/events": {
-      "version": "4.0.0-next.0",
-      "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
-      "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
-      "requires": {
-        "@colony/core": "^3.0.0-next.0",
-        "fetch-retry": "^5.0.4",
-        "typia": "^3.8.3"
-      }
-    },
-    "@colony/tokens": {
-      "version": "1.0.0-next.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
-      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
-      "requires": {}
-    },
     "@ethersproject/abi": {
       "version": "5.7.0",
       "requires": {
@@ -2004,136 +1170,14 @@
     "aes-js": {
       "version": "3.0.0"
     },
-    "ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "requires": {
-        "type-fest": "^0.21.3"
-      }
-    },
-    "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-    },
-    "ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "requires": {
-        "color-convert": "^2.0.1"
-      }
-    },
-    "array-timsort": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
-      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ=="
-    },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
     "bech32": {
       "version": "1.1.4"
-    },
-    "bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "requires": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
     },
     "bn.js": {
       "version": "5.2.1"
     },
     "brorand": {
       "version": "1.1.0"
-    },
-    "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "requires": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      }
-    },
-    "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
-    },
-    "cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "requires": {
-        "restore-cursor": "^3.1.0"
-      }
-    },
-    "cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="
-    },
-    "cli-width": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
-    },
-    "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
-    },
-    "color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "requires": {
-        "color-name": "~1.1.4"
-      }
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
-    },
-    "comment-json": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.5.tgz",
-      "integrity": "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==",
-      "requires": {
-        "array-timsort": "^1.0.3",
-        "core-util-is": "^1.0.3",
-        "esprima": "^4.0.1",
-        "has-own-prop": "^2.0.0",
-        "repeat-string": "^1.6.1"
-      }
-    },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cross-fetch": {
       "version": "4.0.0",
@@ -2147,19 +1191,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
-    },
-    "defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "requires": {
-        "clone": "^1.0.2"
-      }
-    },
-    "drange": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
-      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -2177,21 +1208,6 @@
           "version": "4.12.0"
         }
       }
-    },
-    "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "ethers": {
       "version": "5.7.2",
@@ -2228,39 +1244,6 @@
         "@ethersproject/wordlists": "5.7.0"
       }
     },
-    "external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      }
-    },
-    "fetch-retry": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.6.tgz",
-      "integrity": "sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ=="
-    },
-    "figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "requires": {
-        "escape-string-regexp": "^1.0.5"
-      }
-    },
-    "has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-    },
-    "has-own-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
-      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ=="
-    },
     "hash.js": {
       "version": "1.1.7",
       "requires": {
@@ -2276,91 +1259,17 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-    },
     "inherits": {
       "version": "2.0.4"
     },
-    "inquirer": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
-      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
-      "requires": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.1",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.21",
-        "mute-stream": "0.0.8",
-        "ora": "^5.4.1",
-        "run-async": "^2.4.0",
-        "rxjs": "^7.5.5",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6",
-        "wrap-ansi": "^6.0.1"
-      }
-    },
-    "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-    },
-    "is-interactive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
-    },
-    "is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
-    },
     "js-sha3": {
       "version": "0.8.0"
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "requires": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      }
-    },
-    "mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "minimalistic-assert": {
       "version": "1.0.1"
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1"
-    },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "node-fetch": {
       "version": "2.7.0",
@@ -2370,195 +1279,13 @@
         "whatwg-url": "^5.0.0"
       }
     },
-    "onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "requires": {
-        "mimic-fn": "^2.1.0"
-      }
-    },
-    "ora": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-      "requires": {
-        "bl": "^4.1.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.5.0",
-        "is-interactive": "^1.0.0",
-        "is-unicode-supported": "^0.1.0",
-        "log-symbols": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
-      }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
-    },
-    "randexp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
-      "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
-      "requires": {
-        "drange": "^1.0.2",
-        "ret": "^0.2.0"
-      }
-    },
-    "readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
-    },
-    "restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "requires": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "ret": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
-      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
-    },
-    "run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
-    },
-    "rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "requires": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "scrypt-js": {
       "version": "3.0.1"
-    },
-    "signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      }
-    },
-    "strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "requires": {
-        "ansi-regex": "^5.0.1"
-      }
-    },
-    "supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "requires": {
-        "has-flag": "^4.0.0"
-      }
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "requires": {
-        "os-tmpdir": "~1.0.2"
-      }
     },
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-    },
-    "type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
-    },
-    "typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "peer": true
-    },
-    "typia": {
-      "version": "3.8.9",
-      "resolved": "https://registry.npmjs.org/typia/-/typia-3.8.9.tgz",
-      "integrity": "sha512-yvQ67nhtzme+rnEUZfSOIgxBOHYrrQ3WBU1J4SrAhI3ntBhSelYwGiJkeaCvqchzK6O1RoIs3kCBS4XHIlp2NA==",
-      "requires": {
-        "commander": "^10.0.0",
-        "comment-json": "^4.2.3",
-        "inquirer": "^8.2.5",
-        "randexp": "^0.5.3"
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "requires": {
-        "defaults": "^1.0.3"
-      }
     },
     "webidl-conversions": {
       "version": "3.0.1",
@@ -2572,16 +1299,6 @@
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
-      }
-    },
-    "wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
       }
     },
     "ws": {

--- a/amplify/backend/function/updateContributorsWithReputation/src/package.json
+++ b/amplify/backend/function/updateContributorsWithReputation/src/package.json
@@ -8,7 +8,7 @@
     "@types/aws-lambda": "^8.10.92"
   },
   "dependencies": {
-    "@colony/colony-js": "^7.2.0",
+    "@colony/colony-js": "^8.0.0-next.0",
     "cross-fetch": "^4.0.0",
     "decimal.js": "^10.2.1",
     "ethers": "^5.7.2"

--- a/amplify/backend/function/updateContributorsWithReputation/src/package.json
+++ b/amplify/backend/function/updateContributorsWithReputation/src/package.json
@@ -9,9 +9,7 @@
   },
   "dependencies": {
     "@colony/colony-js": "^7.2.0",
-    "@colony/events": "3.0.0",
     "cross-fetch": "^4.0.0",
-    "decimal.js": "^10.2.1",
     "ethers": "^5.7.2"
   }
 }

--- a/amplify/backend/function/updateContributorsWithReputation/src/package.json
+++ b/amplify/backend/function/updateContributorsWithReputation/src/package.json
@@ -8,7 +8,6 @@
     "@types/aws-lambda": "^8.10.92"
   },
   "dependencies": {
-    "@colony/colony-js": "^8.0.0-next.0",
     "cross-fetch": "^4.0.0",
     "decimal.js": "^10.2.1",
     "ethers": "^5.7.2"

--- a/amplify/backend/function/updateContributorsWithReputation/src/package.json
+++ b/amplify/backend/function/updateContributorsWithReputation/src/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@colony/colony-js": "^7.2.0",
     "cross-fetch": "^4.0.0",
+    "decimal.js": "^10.2.1",
     "ethers": "^5.7.2"
   }
 }

--- a/amplify/backend/function/updateContributorsWithReputation/src/utils.js
+++ b/amplify/backend/function/updateContributorsWithReputation/src/utils.js
@@ -40,6 +40,27 @@ const graphqlRequest = async (queryOrMutation, variables, url, authKey) => {
   }
 };
 
+const repMinerRequest = async (repMinerURL) => {
+  const options = {
+    method: 'GET',
+  };
+
+  let body;
+  let response;
+
+  try {
+    response = await fetch(repMinerURL, options);
+    body = await response.json();
+    return body;
+  } catch (error) {
+    /*
+     * Something went wrong... obviously
+     */
+    console.error(`Reputation Miner Fetch Error: ${errror}`);
+    return null;
+  }
+};
+
 const getDomainDatabaseId = (colonyAddress, nativeDomainId) => {
   return `${colonyAddress}_${nativeDomainId}`;
 };
@@ -307,6 +328,7 @@ const calculatePercentageReputation = (userReputation, totalReputation) => {
 
 module.exports = {
   graphqlRequest,
+  repMinerRequest,
   getContributorType,
   sortAddressesDescendingByReputation,
   updateContributorReputationInDb,

--- a/amplify/backend/function/updateContributorsWithReputation/src/utils.js
+++ b/amplify/backend/function/updateContributorsWithReputation/src/utils.js
@@ -142,7 +142,7 @@ const getContributorType = (total, idx, createdAt) => {
 const createContributorReputationInDb = async ({
   colonyAddress,
   contributorAddress,
-  nativeDomainId,
+  nativeId,
   reputationPercentage,
   id,
   reputationRaw,
@@ -156,7 +156,7 @@ const createContributorReputationInDb = async ({
         input: {
           colonyAddress,
           contributorAddress,
-          domainId: getDomainDatabaseId(colonyAddress, nativeDomainId),
+          domainId: getDomainDatabaseId(colonyAddress, nativeId),
           id,
           reputationRaw,
           reputationPercentage,

--- a/amplify/backend/function/updateContributorsWithReputation/src/utils.js
+++ b/amplify/backend/function/updateContributorsWithReputation/src/utils.js
@@ -74,19 +74,21 @@ const contributorTypeMap = {
 };
 
 const sortAddressesDescendingByReputation = async (
-  colonyClient,
+  reputationOracleEndpoint,
+  currentRootHash,
+  colonyAddress,
   skillId,
   addresses,
 ) => {
   return (
     await Promise.all(
       addresses.map(async (address) => {
-        const { reputationAmount } =
-          await colonyClient.getReputationWithoutProofs(skillId, address);
+        const { reputationAmount } = await repMinerRequest(`
+            ${reputationOracleEndpoint}/${currentRootHash}/${colonyAddress}/${skillId}/${address}/noProof`);
 
         return {
           address,
-          reputationBN: reputationAmount,
+          reputationBN: BigNumber.from(reputationAmount),
         };
       }),
     )
@@ -330,9 +332,9 @@ const loggingFnFactory =
   (env = 'local') =>
   (message) => {
     // This should really be standardized as types
-    // if (env === 'qa' || env === 'prod') {
-    console.log(message);
-    // }
+    if (env === 'qa' || env === 'prod') {
+      console.log(message);
+    }
   };
 
 module.exports = {

--- a/amplify/backend/function/updateContributorsWithReputation/src/utils.js
+++ b/amplify/backend/function/updateContributorsWithReputation/src/utils.js
@@ -326,6 +326,15 @@ const calculatePercentageReputation = (userReputation, totalReputation) => {
   return reputation / 10 ** 2;
 };
 
+const loggingFnFactory =
+  (env = 'local') =>
+  (message) => {
+    // This should really be standardized as types
+    if (env === 'qa' || env === 'prod') {
+      console.log(message);
+    }
+  };
+
 module.exports = {
   graphqlRequest,
   repMinerRequest,
@@ -339,4 +348,5 @@ module.exports = {
   getDomainDatabaseId,
   reputationMiningCycleMetadataId,
   calculatePercentageReputation,
+  loggingFnFactory,
 };

--- a/amplify/backend/function/updateContributorsWithReputation/src/utils.js
+++ b/amplify/backend/function/updateContributorsWithReputation/src/utils.js
@@ -24,13 +24,9 @@ const graphqlRequest = async (queryOrMutation, variables, url, authKey) => {
     }),
   };
 
-  let body;
-  let response;
-
   try {
-    response = await fetch(url, options);
-    body = await response.json();
-    return body;
+    const response = await fetch(url, options);
+    return response.json();
   } catch (error) {
     /*
      * Something went wrong... obviously
@@ -41,17 +37,9 @@ const graphqlRequest = async (queryOrMutation, variables, url, authKey) => {
 };
 
 const repMinerRequest = async (repMinerURL) => {
-  const options = {
-    method: 'GET',
-  };
-
-  let body;
-  let response;
-
   try {
-    response = await fetch(repMinerURL, options);
-    body = await response.json();
-    return body;
+    const response = await fetch(repMinerURL, { method: 'GET' });
+    return await response.json();
   } catch (error) {
     /*
      * Something went wrong... obviously

--- a/amplify/backend/function/updateContributorsWithReputation/src/utils.js
+++ b/amplify/backend/function/updateContributorsWithReputation/src/utils.js
@@ -330,9 +330,9 @@ const loggingFnFactory =
   (env = 'local') =>
   (message) => {
     // This should really be standardized as types
-    if (env === 'qa' || env === 'prod') {
-      console.log(message);
-    }
+    // if (env === 'qa' || env === 'prod') {
+    console.log(message);
+    // }
   };
 
 module.exports = {

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=47c65c58a82579d2ffed12dd9850b88e2b033af7
+ENV BLOCK_INGESTOR_HASH=14ff8ff2815458dab9312dd884182a6d73a3af88
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-network
+++ b/docker/colony-cdapp-dev-env-network
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV NETWORK_HASH=cb8c967b4b99d1ceb8988a284130751a753fdedd
+ENV NETWORK_HASH=3f8df23173f840226fb8da42547e12664f10c290
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@apollo/client": "3.7.14",
         "@colony/abis": "1.5.0",
-        "@colony/colony-js": "^7.2.0",
+        "@colony/colony-js": "^8.0.0-next.0",
         "@colony/events": "3.0.0",
         "@colony/redux-promise-listener": "^1.2.0",
         "@colony/unicode-confusables-noascii": "^0.1.2",
@@ -2744,13 +2744,45 @@
       }
     },
     "node_modules/@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
+      "license": "GPL-3.0-only",
       "dependencies": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/core": {
+      "version": "3.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+      "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+      "license": "GPL-3.0-only",
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/events": {
+      "version": "4.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+      "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "@colony/core": "^3.0.0-next.0",
+        "fetch-retry": "^5.0.4",
+        "typia": "^3.8.3"
       },
       "engines": {
         "node": "^16 || ^18 || ^20",
@@ -2816,9 +2848,10 @@
       }
     },
     "node_modules/@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
+      "license": "GPL-3.0-only",
       "engines": {
         "node": "^16 || ^18 || ^20",
         "pnpm": "^8"

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
   "dependencies": {
     "@apollo/client": "3.7.14",
     "@colony/abis": "1.5.0",
-    "@colony/colony-js": "^7.2.0",
+    "@colony/colony-js": "^8.0.0-next.0",
     "@colony/events": "3.0.0",
     "@colony/redux-promise-listener": "^1.2.0",
     "@colony/unicode-confusables-noascii": "^0.1.2",


### PR DESCRIPTION
This PR fixes the way the `updateContributorsWithReputation` Lambda updates the cached reputation for users by shedding it's the network _(and implicitly `colonyJS`)_, making only the db and the Reputation miner the only parts required for it to work.

The initial issue that triggered this was when a block ingestor fell behind the network, and when it caught up, and processed the `ReputationMiningCycleComplete` event, it used the wrong timestamp and delayed the reputation for the whole app for at least one mining cycle.

This was facilitated by the introduction of a `/rootHashes` route in the miner on the network side, which will return the current root hash as well as the upcoming one https://github.com/JoinColony/colonyNetwork/commit/3f8df23173f840226fb8da42547e12664f10c290

Using the above endpoint we can now generate everything we need inside the lambda using simple fetches directly to the miner, without the need to instantiate `colony-js` clients or rpc endpoints 

On the ingestor side, this fixes the way the timestamp is being saved for the block ingestor reputation miner update event, by fetching the actual block one, instead of the `Date.now()` timestamp. This corrects a issue that arises when the block ingestor falls behing the chain then catches up JoinColony/block-ingestor#296

Since we had to update to the latest network release, we also had to update `colony-js` to it's latest `next` release both in the CDapp, Lambdas, as well as the Block Ingestor https://github.com/JoinColony/colonyNetwork/releases/tag/imwss3 

Due to the above update, all the versions have now been updated, both colonies as well as exptensions

![Screenshot from 2024-12-03 16-29-53](https://github.com/user-attachments/assets/6f30dead-a9fc-4e1d-b144-88ddcc433a9e)
![Screenshot from 2024-12-03 16-29-32](https://github.com/user-attachments/assets/1d923a3a-3541-466c-bca5-e1fec1decf91)

## Future

This is just a temporary improvement, as the way we're updating the reputation currently is not scalable, meaning that on colonies with a lot of contributing users (users with reputation), this will simply fail to update everyone's reputation as there's a hard cap on execution time.

This will require re-engineering and re-architecturing to solve

## Testing

1. Run the dev env
2. Run the `create-data` script
3. Run the frontent
4. Go to `planex`
5. Load up the Members page and/or the Teams page and make a mental note of the reputation values
![Screenshot from 2024-12-03 16-15-10](https://github.com/user-attachments/assets/f2bcd106-8bba-4acf-beb6-f499a8b0a8f9)
![Screenshot from 2024-12-03 16-15-17](https://github.com/user-attachments/assets/a2f1d9b3-bf2d-4757-a913-d6838f80072a)
6. Apply this patch _(which basically reverts the lambda to it's old state, and forces a cache update on each lambda call)_ [reputation-cache-update.patch](https://github.com/user-attachments/files/17996284/reputation-cache-update.txt)
7. Make sure to run `npm i` again after applying the patch so that the new _(old)_ dependencies get re-installed in the `updateContributorsWithReputation` lambda
8. Go back to `planex`, and refresh the page _(if you already didn't)_
9. Go back to the Members and/or Teams pages and confirm that the values are the same 

This proves that the no reputation logic changes happen, and the change here is just to do with the place we get those values

_NOTE: If you are lucky enough (or unlucky), you might be testing this just in the middle of the reputation period happening, so when comparing values, you will get different (lower) values. If that happens, just revert and compare again using the current PRs changes to the lambda_

JoinColony/block-ingestor#296