### PR TITLE
Fix: Activity table fixes and table refactoring

### DIFF
--- a/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
@@ -54,6 +54,7 @@ export const useActionsTableProps = (
     loadingMotionStates,
     refetchMotionStates,
     showUserAvatar,
+    isRecentActivityVariant,
   });
   const {
     actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],

--- a/src/components/common/ColonyActionsTable/hooks/useColonyActionsTableColumns.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useColonyActionsTableColumns.tsx
@@ -27,6 +27,7 @@ const useColonyActionsTableColumns = ({
   loadingMotionStates,
   refetchMotionStates,
   showUserAvatar = true,
+  isRecentActivityVariant = false,
 }) => {
   const isMobile = useMobile();
 
@@ -122,6 +123,9 @@ const useColonyActionsTableColumns = ({
           );
         },
         colSpan: (isExpanded) => (isExpanded ? 0 : undefined),
+        cellContentWrapperClassName: isRecentActivityVariant
+          ? 'flex items-end'
+          : '',
       }),
       helper.display({
         id: 'expander',
@@ -145,6 +149,7 @@ const useColonyActionsTableColumns = ({
     ];
   }, [
     isMobile,
+    isRecentActivityVariant,
     loading,
     loadingMotionStates,
     refetchMotionStates,

--- a/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/TokenTable/TokenTable.tsx
@@ -139,7 +139,7 @@ const TokenTable: FC<TokenTableProps> = ({ token }) => {
           getSortedRowModel={getSortedRowModel()}
           getPaginationRowModel={getPaginationRowModel()}
           columns={columns}
-          className="-mx-[1.125rem] !w-[calc(100%+2.25rem)] px-[1.125rem] [&_td]:px-[1.125rem] [&_td]:py-4 [&_th]:!rounded-none [&_th]:border-y"
+          className="-mx-[1.125rem] !w-[calc(100%+2.25rem)] border-none px-[1.125rem] [&_td]:px-[1.125rem] [&_td]:py-4 [&_th]:!rounded-none [&_th]:border-y"
           tableClassName="rounded-none border-none"
           initialState={{
             sorting: [

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransfersTable.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransfersTable.tsx
@@ -75,7 +75,7 @@ const FiatTransfersTable = () => {
         renderSubComponent={({ row }) => (
           <FiatTransferDescription actionRow={row} loading={loading} />
         )}
-        className="pb-8 pt-1.5 [&_td:nth-child(1)>div]:font-medium [&_td:nth-child(1)>div]:text-gray-900 [&_td:nth-child(2)>div]:text-gray-600 [&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none"
+        className="pb-5 [&_td:nth-child(1)>div]:font-medium [&_td:nth-child(1)>div]:text-gray-900 [&_td:nth-child(2)>div]:text-gray-600 [&_tr.expanded-below:not(last-child)_td>*:not(.expandable)]:!pb-2 [&_tr.expanded-below_td]:border-none"
         emptyContent={
           !sortedData.length &&
           !loading && (

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/partials/PermissionsTable/PermissionsTable.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/partials/PermissionsTable/PermissionsTable.tsx
@@ -58,20 +58,22 @@ const PermissionsTable: FC<PermissionsTableProps> = ({
     <div className={className}>
       {formRole === UserRole.Custom ? (
         <Table<CustomPermissionTableModel>
-          className="sm:[&_td:nth-child(2)>div]:px-0 sm:[&_td>div]:min-h-[2.875rem] sm:[&_td>div]:py-2 sm:[&_th:nth-child(2)]:px-0"
+          className={clsx(
+            'sm:[&_td:nth-child(2)>div]:px-0 sm:[&_td>div]:min-h-[2.875rem] sm:[&_td>div]:py-2 sm:[&_th:nth-child(2)]:px-0',
+            {
+              '!border-negative-300': !!formState.errors.permissions,
+            },
+          )}
           data={ALLOWED_CUSTOM_PERMISSION_TABLE_CONTENT}
           columns={customPermissionsTableColumns}
           verticalLayout={isMobile}
           withBorder={false}
-          tableClassName={clsx({
-            '!border-negative-300': !!formState.errors.permissions,
-          })}
           tableBodyRowKeyProp="type"
         />
       ) : (
         <Table<PermissionsTableModel>
           {...permissionsTableProps}
-          tableClassName={clsx({
+          className={clsx({
             '!border-negative-300': !!formState.errors.role,
           })}
         />

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/PaymentBuilderRecipientsField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/PaymentBuilderRecipientsField.tsx
@@ -155,7 +155,7 @@ const PaymentBuilderRecipientsField: FC<PaymentBuilderRecipientsFieldProps> = ({
               '[&_tfoot>tr>td:empty]:hidden [&_th]:w-[6.25rem]': isTablet,
               '[&_table]:table-auto lg:[&_table]:table-fixed [&_tbody_td]:h-[3.375rem] [&_td:first-child]:pl-4 [&_td]:pr-4 [&_tfoot_td:first-child]:pl-4 [&_tfoot_td:not(:first-child)]:pl-0 [&_th:first-child]:pl-4 [&_th:not(:first-child)]:pl-0 [&_th]:pr-4':
                 !isTablet,
-              '[&_table]:!border-negative-400 md:[&_tfoot_td]:!border-negative-400 md:[&_th]:border-negative-400':
+              '!border-negative-400 md:[&_tfoot_td]:!border-negative-400 md:[&_th]:border-negative-400':
                 !!fieldState.error,
             },
           )}

--- a/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/partials/StagedPaymentRecipientsField/StagedPaymentRecipientField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/partials/StagedPaymentRecipientsField/StagedPaymentRecipientField.tsx
@@ -75,14 +75,16 @@ const StagedPaymentRecipientsField: FC<StagedPaymentRecipientsFieldProps> = ({
       </h5>
       {!!data.length && !hasNoDecisionMethods && !isFieldDisabled && (
         <Table<StagedPaymentRecipientsTableModel>
+          className={clsx({
+            '!border-negative-400 md:[&_tfoot>tr>td]:!border-negative-400 md:[&_tfoot_td]:!border-negative-400 md:[&_th]:border-negative-400':
+              !!fieldState.error,
+          })}
           tableClassName={clsx(
             '[&_tfoot>tr>td]:border-gray-200 [&_tfoot>tr>td]:py-2 md:[&_tfoot>tr>td]:border-t',
             {
               '[&_tfoot>tr>td:empty]:hidden [&_th]:w-[6.25rem]': isTablet,
               '[&_table]:table-auto lg:[&_table]:table-fixed [&_td:first-child]:pl-4 [&_td]:pr-5 [&_tfoot_td:first-child]:pl-4 [&_tfoot_td:not(:first-child)]:pl-0 [&_th:first-child]:pl-4 [&_th:not(:first-child)]:pl-0 [&_th]:pr-5':
                 !isTablet,
-              '!border-negative-400 md:[&_tfoot>tr>td]:!border-negative-400 md:[&_tfoot_td]:!border-negative-400 md:[&_th]:border-negative-400':
-                !!fieldState.error,
             },
           )}
           verticalLayout={isTablet}

--- a/src/components/v5/common/Table/Table.tsx
+++ b/src/components/v5/common/Table/Table.tsx
@@ -1,6 +1,4 @@
-import { ArrowDown } from '@phosphor-icons/react';
 import {
-  flexRender,
   useReactTable,
   getCoreRowModel as libGetCoreRowModel,
   createColumnHelper,
@@ -11,11 +9,10 @@ import React, { useEffect, useMemo } from 'react';
 
 import { useMobile } from '~hooks';
 import { formatText } from '~utils/intl.ts';
-import MeatBallMenu from '~v5/shared/MeatBallMenu/index.ts';
 
+import { TableFooter } from './partials/TableFooter.tsx';
+import { TableLayout } from './partials/TableLayout/TableLayout.tsx';
 import TablePagination from './partials/TablePagination/index.ts';
-import { TableRowDivider } from './partials/TableRowDivider.tsx';
-import { TableRow } from './partials/VirtualizedRow/VirtualizedRow.tsx';
 import { type TableProps } from './types.ts';
 import { getDefaultRenderCellWrapper, makeMenuColumn } from './utils.tsx';
 
@@ -95,11 +92,6 @@ const Table = <T,>({
   const { rows } = table.getRowModel();
   const headerGroups = table.getHeaderGroups();
   const footerGroups = table.getFooterGroups();
-  const hasFooter = footerGroups.map((footerGroup) =>
-    footerGroup.headers
-      .map((column) => column.column.columnDef)
-      .some((columnDef) => columnDef.footer),
-  )[0];
   const goToNextPage = nextPage || table.nextPage;
   const goToPreviousPage = previousPage || table.previousPage;
   const canGoToNextPage =
@@ -110,8 +102,9 @@ const Table = <T,>({
       : canPreviousPage;
   const pageCount = table.getPageCount();
   const hasPagination = pageCount > 1 || canGoToNextPage || canGoToPreviousPage;
+  const showPagination =
+    alwaysShowPagination || (hasPagination && showPageNumber);
   const totalColumnsCount = table.getVisibleFlatColumns().length;
-  const shouldShowEmptyContent = emptyContent && data.length === 0;
   const hasExpandableRows = !!renderSubComponent;
 
   useEffect(() => {
@@ -125,372 +118,52 @@ const Table = <T,>({
   }, [isMobile, hasExpandableRows, rows]);
 
   return (
-    <div className={className}>
+    <div
+      className={clsx(className, {
+        'border-separate border-spacing-0 rounded-lg border border-gray-200':
+          showTableBorder,
+      })}
+    >
       <table
-        className={clsx(
-          'w-full table-fixed',
-          {
-            'border-separate border-spacing-0 rounded-lg border border-gray-200':
-              showTableBorder,
-          },
-          tableClassName,
-        )}
+        className={clsx('w-full table-fixed', tableClassName)}
         cellPadding="0"
         cellSpacing="0"
       >
-        {verticalLayout ? (
-          rows.map((row) => {
-            const cells = row.getVisibleCells();
-
-            return (
-              <tbody
-                key={row.id}
-                className={clsx(
-                  getRowClassName(row),
-                  '[&:not(:last-child)>tr:last-child>td]:border-b [&:not(:last-child)>tr:last-child>th]:border-b [&_tr:first-child_td]:pt-2 [&_tr:first-child_th]:h-[2.875rem] [&_tr:first-child_th]:pt-2 [&_tr:last-child_td]:pb-2 [&_tr:last-child_th]:h-[2.875rem] [&_tr:last-child_th]:pb-2',
-                )}
-              >
-                {headerGroups.map((headerGroup) =>
-                  headerGroup.headers.map((header, index) => {
-                    const rowWithMeatBallMenu = index === 0 && !!getMenuProps;
-                    const meatBallMenuProps = getMenuProps?.(row);
-                    const colSpan =
-                      meatBallMenuProps && rowWithMeatBallMenu ? undefined : 2;
-
-                    return (
-                      <TableRow
-                        key={row.id + headerGroup.id + header.id}
-                        itemHeight={virtualizedProps?.virtualizedRowHeight || 0}
-                        isEnabled={!!virtualizedProps}
-                        className={clsx({
-                          '[&:not(:last-child)>td]:border-b [&:not(:last-child)>td]:border-gray-100':
-                            withBorder,
-                        })}
-                      >
-                        <th
-                          className={`
-                            h-[2.625rem]
-                            border-r
-                            border-r-gray-200
-                            bg-gray-50
-                            px-4
-                            py-1
-                            text-left
-                            text-sm
-                            font-normal
-                            first:rounded-tl-lg
-                            last:rounded-tr-lg
-                          `}
-                          style={{
-                            width:
-                              header.column.columnDef.staticSize ||
-                              (header.getSize() !== 150
-                                ? `${header.column.getSize()}${sizeUnit}`
-                                : undefined),
-                          }}
-                        >
-                          {header.isPlaceholder
-                            ? null
-                            : flexRender(
-                                header.column.columnDef.header,
-                                header.getContext(),
-                              )}
-                        </th>
-                        <td
-                          className={clsx(
-                            'h-full text-left text-sm font-normal',
-                            {
-                              'py-1 pl-4': !colSpan,
-                              'px-4 py-1': colSpan,
-                            },
-                          )}
-                          colSpan={colSpan}
-                        >
-                          {flexRender(
-                            header.column.columnDef.cell,
-                            cells[index].getContext(),
-                          )}
-                        </td>
-                        {rowWithMeatBallMenu && meatBallMenuProps && (
-                          <td
-                            className="px-4"
-                            style={
-                              meatBallMenuSize || meatBallMenuStaticSize
-                                ? {
-                                    width: `${
-                                      meatBallMenuSize || meatBallMenuStaticSize
-                                    }${sizeUnit}`,
-                                  }
-                                : undefined
-                            }
-                          >
-                            <MeatBallMenu
-                              {...meatBallMenuProps}
-                              buttonClassName="ml-auto"
-                              contentWrapperClassName={clsx(
-                                meatBallMenuProps?.contentWrapperClassName,
-                                '!left-6 right-6 !z-[65] sm:!left-auto',
-                              )}
-                            />
-                          </td>
-                        )}
-                      </TableRow>
-                    );
-                  }),
-                )}
-              </tbody>
-            );
-          })
-        ) : (
-          <>
-            {showTableHead && (
-              <thead>
-                {headerGroups.map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => (
-                      <th
-                        key={header.id}
-                        className={clsx(
-                          header.column.columnDef.headCellClassName,
-                          'group border-b border-b-gray-200 bg-gray-50 px-[1.125rem] py-2.5 text-left text-sm font-normal text-gray-600 first:rounded-tl-lg last:rounded-tr-lg empty:p-0',
-                          {
-                            'cursor-pointer':
-                              header.column.getCanSort() &&
-                              !shouldShowEmptyContent,
-                          },
-                        )}
-                        onClick={
-                          shouldShowEmptyContent
-                            ? undefined
-                            : header.column.getToggleSortingHandler()
-                        }
-                        style={{
-                          width:
-                            header.column.columnDef.staticSize ||
-                            (header.getSize() !== 150
-                              ? `${header.column.getSize()}${sizeUnit}`
-                              : undefined),
-                        }}
-                      >
-                        {header.isPlaceholder
-                          ? null
-                          : flexRender(
-                              header.column.columnDef.header,
-                              header.getContext(),
-                            )}
-                        {header.column.getCanSort() ? (
-                          <ArrowDown
-                            size={12}
-                            className={clsx(
-                              'mb-0.5 ml-1 inline-block align-middle transition-[transform,opacity]',
-                              {
-                                'rotate-180':
-                                  header.column.getIsSorted() === 'asc' &&
-                                  !shouldShowEmptyContent,
-                                'rotate-0':
-                                  header.column.getIsSorted() === 'desc' &&
-                                  !shouldShowEmptyContent,
-                                'opacity-0 group-hover:opacity-100':
-                                  header.column.getIsSorted() === false ||
-                                  shouldShowEmptyContent,
-                              },
-                            )}
-                          />
-                        ) : null}
-                      </th>
-                    ))}
-                  </tr>
-                ))}
-              </thead>
-            )}
-            <tbody className="w-full">
-              {shouldShowEmptyContent ? (
-                <tr className="[&:not(:last-child)>td]:border-b [&:not(:last-child)>td]:border-gray-100">
-                  <td colSpan={totalColumnsCount} className="h-full">
-                    <div className="flex flex-col items-start justify-center px-[1.1rem] py-4 text-md text-gray-500">
-                      {emptyContent}
-                    </div>
-                  </td>
-                </tr>
-              ) : (
-                rows.map((row) => {
-                  const showExpandableContent =
-                    row.getIsExpanded() && renderSubComponent;
-
-                  const rowKey = tableBodyRowKeyProp
-                    ? data[row.index]?.[tableBodyRowKeyProp]
-                    : null;
-
-                  const key =
-                    typeof rowKey === 'string' || typeof rowKey === 'number'
-                      ? rowKey
-                      : row.id;
-
-                  return (
-                    <React.Fragment key={key}>
-                      <TableRow
-                        itemHeight={virtualizedProps?.virtualizedRowHeight || 0}
-                        isEnabled={!!virtualizedProps}
-                        className={clsx(getRowClassName(row), {
-                          'translate-z-0 relative [&>tr:first-child>td]:pr-9 [&>tr:last-child>td]:p-0 [&>tr:last-child>th]:p-0':
-                            getMenuProps,
-                          '[&:not(:last-child)>td]:border-b [&:not(:last-child)>td]:border-gray-100':
-                            (!showExpandableContent &&
-                              row.getCanExpand() &&
-                              !withNarrowBorder) ||
-                            withBorder,
-                          'expanded-below': showExpandableContent,
-                        })}
-                      >
-                        {row.getVisibleCells().map((cell, index) => {
-                          const renderCellWrapperCommonArgs = [
-                            clsx(
-                              'flex h-full flex-col items-start justify-center p-4 text-md',
-                              {
-                                'text-gray-500': !isDisabled,
-                                'text-gray-300': isDisabled,
-                              },
-                              cell.column.columnDef.cellContentWrapperClassName,
-                            ),
-                            flexRender(
-                              cell.column.columnDef.cell,
-                              cell.getContext(),
-                            ),
-                          ] as const;
-
-                          const colSpan =
-                            typeof cell.column.columnDef.colSpan === 'number'
-                              ? cell.column.columnDef.colSpan
-                              : cell.column.columnDef.colSpan?.(
-                                  row.getIsExpanded(),
-                                );
-
-                          const hideCell = colSpan === 0;
-
-                          return (
-                            <td
-                              key={cell?.id}
-                              className={clsx('h-full', {
-                                hidden: hideCell,
-                              })}
-                              colSpan={colSpan}
-                              style={
-                                // If !showTableHead then apply the column sizing from the first headerGroup
-                                !showTableHead
-                                  ? {
-                                      width:
-                                        headerGroups[0].headers[index].column
-                                          .columnDef.staticSize ||
-                                        (headerGroups[0].headers[
-                                          index
-                                        ].getSize() !== 150
-                                          ? `${headerGroups[0].headers[index].column.getSize()}${sizeUnit}`
-                                          : undefined),
-                                    }
-                                  : undefined
-                              }
-                            >
-                              {renderCellWrapper(
-                                ...renderCellWrapperCommonArgs,
-                                {
-                                  cell,
-                                  row,
-                                  renderDefault: () =>
-                                    getDefaultRenderCellWrapper<T>()(
-                                      ...renderCellWrapperCommonArgs,
-                                      { cell, row, renderDefault: () => null },
-                                    ),
-                                },
-                              )}
-                            </td>
-                          );
-                        })}
-                      </TableRow>
-                      {showExpandableContent && (
-                        <tr
-                          className={clsx({
-                            '[&:not(:last-child)>td]:border-b [&:not(:last-child)>td]:border-gray-100':
-                              !withNarrowBorder,
-                          })}
-                        >
-                          <td colSpan={row.getVisibleCells().length}>
-                            {renderSubComponent({ row })}
-                          </td>
-                        </tr>
-                      )}
-                      {
-                        /** Unfortunately Safari is not yet that friendly to allow the usage of absolutely positioned (pseudo)-element inside tables
-                         * So, for the moment, this is our best shot for showing borders with paddings from the tr margins
-                         */
-                        withNarrowBorder && <TableRowDivider />
-                      }
-                    </React.Fragment>
-                  );
-                })
-              )}
-            </tbody>
-          </>
-        )}
-        {hasFooter && (
-          <tfoot>
-            {footerGroups.map((footerGroup) => (
-              <tr key={footerGroup.id}>
-                {footerGroup.headers.map((column, index) => {
-                  const isLastColumn = index === footerGroup.headers.length - 1;
-
-                  return (
-                    <td
-                      colSpan={isLastColumn ? footerColSpan : 1}
-                      key={column.id}
-                      className={clsx(
-                        'h-full px-[1.1rem] text-md text-gray-500',
-                        {
-                          'border-t border-gray-200': !verticalLayout,
-                        },
-                      )}
-                    >
-                      {flexRender(
-                        column.column.columnDef.footer,
-                        column.getContext(),
-                      )}
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
-          </tfoot>
-        )}
+        <TableLayout
+          verticalLayout={verticalLayout}
+          rows={rows}
+          headerGroups={headerGroups}
+          getRowClassName={getRowClassName}
+          getMenuProps={getMenuProps}
+          renderSubComponent={renderSubComponent}
+          showTableHead={showTableHead}
+          emptyContent={emptyContent}
+          totalColumnsCount={totalColumnsCount}
+          withBorder={withBorder}
+          withNarrowBorder={withNarrowBorder}
+          virtualizedProps={virtualizedProps}
+          sizeUnit={sizeUnit}
+          meatBallMenuSize={meatBallMenuSize}
+          meatBallMenuStaticSize={meatBallMenuStaticSize}
+          renderCellWrapper={renderCellWrapper}
+          data={data}
+          isDisabled={isDisabled}
+          tableBodyRowKeyProp={tableBodyRowKeyProp}
+        />
+        <TableFooter
+          colSpan={footerColSpan}
+          verticalLayout={verticalLayout}
+          groups={footerGroups}
+        />
       </table>
-      {(hasPagination || alwaysShowPagination) &&
-        showPageNumber &&
-        (canGoToPreviousPage || canGoToNextPage) && (
-          <TablePagination
-            onNextClick={goToNextPage}
-            onPrevClick={goToPreviousPage}
-            canGoToNextPage={canGoToNextPage}
-            canGoToPreviousPage={canGoToPreviousPage}
-            pageNumberLabel={formatText(
-              {
-                id: showTotalPagesNumber
-                  ? 'table.pageNumberWithTotal'
-                  : 'table.pageNumber',
-              },
-              {
-                actualPage: table.getState().pagination.pageIndex + 1,
-                pageNumber: pageCount === 0 ? 1 : pageCount,
-              },
-            )}
-            disabled={paginationDisabled}
-          >
-            {additionalPaginationButtonsContent}
-          </TablePagination>
-        )}
-      {alwaysShowPagination && !hasPagination && (
+      {showPagination && (
         <TablePagination
-          onNextClick={() => {}}
-          onPrevClick={() => {}}
-          canGoToNextPage
-          canGoToPreviousPage={false}
+          onNextClick={hasPagination ? goToNextPage : () => {}}
+          onPrevClick={hasPagination ? goToPreviousPage : () => {}}
+          canGoToNextPage={
+            hasPagination ? canGoToNextPage : alwaysShowPagination
+          }
+          canGoToPreviousPage={hasPagination ? canGoToPreviousPage : false}
           pageNumberLabel={formatText(
             {
               id: showTotalPagesNumber
@@ -498,11 +171,13 @@ const Table = <T,>({
                 : 'table.pageNumber',
             },
             {
-              actualPage: 1,
-              pageNumber: 1,
+              actualPage: hasPagination
+                ? table.getState().pagination.pageIndex + 1
+                : 1,
+              pageNumber: hasPagination ? pageCount : 1,
             },
           )}
-          disabled
+          disabled={!hasPagination || paginationDisabled}
         >
           {additionalPaginationButtonsContent}
         </TablePagination>

--- a/src/components/v5/common/Table/partials/TableFooter.tsx
+++ b/src/components/v5/common/Table/partials/TableFooter.tsx
@@ -1,0 +1,52 @@
+import { flexRender, type HeaderGroup } from '@tanstack/react-table';
+import clsx from 'clsx';
+import React from 'react';
+
+interface TableFooterProps<T> {
+  colSpan?: number;
+  verticalLayout?: boolean;
+  groups: HeaderGroup<T>[];
+}
+
+export const TableFooter = <T,>({
+  colSpan,
+  verticalLayout,
+  groups,
+}: TableFooterProps<T>) => {
+  const hasFooter = groups.map((footerGroup) =>
+    footerGroup.headers
+      .map((column) => column.column.columnDef)
+      .some((columnDef) => columnDef.footer),
+  )[0];
+
+  if (!hasFooter) {
+    return null;
+  }
+
+  return (
+    <tfoot>
+      {groups.map((footerGroup) => (
+        <tr key={footerGroup.id}>
+          {footerGroup.headers.map((column, index) => {
+            const isLastColumn = index === footerGroup.headers.length - 1;
+
+            return (
+              <td
+                colSpan={isLastColumn ? colSpan : 1}
+                key={column.id}
+                className={clsx('h-full px-[1.1rem] text-md text-gray-500', {
+                  'border-t border-gray-200': !verticalLayout,
+                })}
+              >
+                {flexRender(
+                  column.column.columnDef.footer,
+                  column.getContext(),
+                )}
+              </td>
+            );
+          })}
+        </tr>
+      ))}
+    </tfoot>
+  );
+};

--- a/src/components/v5/common/Table/partials/TableLayout/HorizontalLayout.tsx
+++ b/src/components/v5/common/Table/partials/TableLayout/HorizontalLayout.tsx
@@ -1,0 +1,126 @@
+import clsx from 'clsx';
+import React from 'react';
+
+import { TableRowDivider } from '../TableRowDivider.tsx';
+import { TableRow } from '../VirtualizedRow/VirtualizedRow.tsx';
+
+import { HorizontalTableCell } from './HorizontalTableCell.tsx';
+import { HorizontalTableHeader } from './HorizontalTableHeader.tsx';
+import { type HorizontalLayoutProps } from './types.ts';
+
+export const HorizontalLayout = <T,>({
+  rows,
+  headerGroups,
+  showTableHead,
+  emptyContent,
+  totalColumnsCount,
+  getRowClassName,
+  withBorder,
+  sizeUnit,
+  virtualizedProps,
+  renderSubComponent,
+  getMenuProps,
+  tableBodyRowKeyProp,
+  withNarrowBorder,
+  renderCellWrapper,
+  isDisabled,
+  data,
+}: HorizontalLayoutProps<T>) => {
+  const shouldShowEmptyContent = !!emptyContent && data.length === 0;
+
+  const getTableCellStyle = (index: number) =>
+    !showTableHead
+      ? {
+          width:
+            headerGroups[0].headers[index].column.columnDef.staticSize ||
+            (headerGroups[0].headers[index].getSize() !== 150
+              ? `${headerGroups[0].headers[index].column.getSize()}${sizeUnit}`
+              : undefined),
+        }
+      : undefined;
+
+  return (
+    <>
+      {showTableHead && (
+        <HorizontalTableHeader
+          groups={headerGroups}
+          disabled={shouldShowEmptyContent}
+          sizeUnit={sizeUnit}
+        />
+      )}
+      <tbody className="w-full">
+        {shouldShowEmptyContent ? (
+          <tr className="[&:not(:last-child)>td]:border-b [&:not(:last-child)>td]:border-gray-100">
+            <td colSpan={totalColumnsCount} className="h-full">
+              <div className="flex flex-col items-start justify-center px-[1.1rem] py-4 text-md text-gray-500">
+                {emptyContent}
+              </div>
+            </td>
+          </tr>
+        ) : (
+          rows.map((row) => {
+            const showExpandableContent =
+              row.getIsExpanded() && renderSubComponent;
+
+            const rowKey = tableBodyRowKeyProp
+              ? data[row.index]?.[tableBodyRowKeyProp]
+              : null;
+
+            const key =
+              typeof rowKey === 'string' || typeof rowKey === 'number'
+                ? rowKey
+                : row.id;
+
+            return (
+              <React.Fragment key={key}>
+                <TableRow
+                  itemHeight={virtualizedProps?.virtualizedRowHeight || 0}
+                  isEnabled={!!virtualizedProps}
+                  className={clsx(getRowClassName(row), {
+                    'translate-z-0 relative [&>tr:first-child>td]:pr-9 [&>tr:last-child>td]:p-0 [&>tr:last-child>th]:p-0':
+                      getMenuProps,
+                    '[&:not(:last-child)>td]:border-b [&:not(:last-child)>td]:border-gray-100':
+                      (!showExpandableContent &&
+                        row.getCanExpand() &&
+                        !withNarrowBorder) ||
+                      withBorder,
+                    'expanded-below': showExpandableContent,
+                  })}
+                >
+                  {row.getVisibleCells().map((cell, index) => (
+                    <HorizontalTableCell
+                      key={`${key}-${cell?.id || index}`}
+                      style={getTableCellStyle(index)}
+                      row={row}
+                      cell={cell}
+                      renderCellWrapper={renderCellWrapper}
+                      isDisabled={isDisabled}
+                    />
+                  ))}
+                </TableRow>
+                {showExpandableContent && (
+                  <tr
+                    className={clsx({
+                      '[&:not(:last-child)>td]:border-b [&:not(:last-child)>td]:border-gray-100':
+                        !withNarrowBorder,
+                    })}
+                  >
+                    <td colSpan={row.getVisibleCells().length}>
+                      {renderSubComponent({ row })}
+                    </td>
+                  </tr>
+                )}
+                {
+                  /** Unfortunately Safari is not yet that friendly to allow the usage of absolutely positioned (pseudo)-element inside tables
+                   * So, for the moment, this is our best shot for showing borders with paddings from the tr margins
+                   */
+                  withNarrowBorder && <TableRowDivider />
+                }
+              </React.Fragment>
+            );
+          })
+        )}
+      </tbody>
+    </>
+  );
+};

--- a/src/components/v5/common/Table/partials/TableLayout/HorizontalTableCell.tsx
+++ b/src/components/v5/common/Table/partials/TableLayout/HorizontalTableCell.tsx
@@ -1,0 +1,63 @@
+import { flexRender, type Row, type Cell } from '@tanstack/react-table';
+import clsx from 'clsx';
+import React, { type CSSProperties } from 'react';
+
+import { getDefaultRenderCellWrapper } from '~v5/common/Table/utils.tsx';
+
+import { type HorizontalLayoutProps } from './types.ts';
+
+type HorizontalTableCellProps<T> = {
+  isDisabled?: boolean;
+  style?: CSSProperties;
+  row: Row<T>;
+  cell: Cell<T, unknown>;
+} & Pick<HorizontalLayoutProps<T>, 'renderCellWrapper'>;
+
+export const HorizontalTableCell = <T,>({
+  isDisabled,
+  style,
+  row,
+  cell,
+  renderCellWrapper,
+}: HorizontalTableCellProps<T>) => {
+  const renderCellWrapperCommonArgs = [
+    clsx(
+      'flex h-full flex-col items-start justify-center p-4 text-md',
+      {
+        'text-gray-500': !isDisabled,
+        'text-gray-300': isDisabled,
+      },
+      cell.column.columnDef.cellContentWrapperClassName,
+    ),
+    flexRender(cell.column.columnDef.cell, cell.getContext()),
+  ] as const;
+
+  const colSpan =
+    typeof cell.column.columnDef.colSpan === 'number'
+      ? cell.column.columnDef.colSpan
+      : cell.column.columnDef.colSpan?.(row.getIsExpanded());
+
+  const hideCell = colSpan === 0;
+
+  return (
+    <td
+      key={cell?.id}
+      className={clsx('h-full', {
+        hidden: hideCell,
+      })}
+      colSpan={colSpan}
+      style={style}
+    >
+      {renderCellWrapper(...renderCellWrapperCommonArgs, {
+        cell,
+        row,
+        renderDefault: () =>
+          getDefaultRenderCellWrapper<T>()(...renderCellWrapperCommonArgs, {
+            cell,
+            row,
+            renderDefault: () => null,
+          }),
+      })}
+    </td>
+  );
+};

--- a/src/components/v5/common/Table/partials/TableLayout/HorizontalTableHeader.tsx
+++ b/src/components/v5/common/Table/partials/TableLayout/HorizontalTableHeader.tsx
@@ -1,0 +1,74 @@
+import { ArrowDown } from '@phosphor-icons/react';
+import { flexRender, type HeaderGroup } from '@tanstack/react-table';
+import clsx from 'clsx';
+import React from 'react';
+
+import { type HorizontalLayoutProps } from './types.ts';
+
+type HorizontalTableHeaderProps<T> = Pick<
+  HorizontalLayoutProps<T>,
+  'sizeUnit'
+> & {
+  groups: HeaderGroup<T>[];
+  disabled?: boolean;
+};
+
+export const HorizontalTableHeader = <T,>({
+  groups,
+  disabled,
+  sizeUnit,
+}: HorizontalTableHeaderProps<T>) => {
+  return (
+    <thead>
+      {groups.map((group) => (
+        <tr key={group.id}>
+          {group.headers.map((header) => (
+            <th
+              key={header.id}
+              className={clsx(
+                header.column.columnDef.headCellClassName,
+                'group border-b border-b-gray-200 bg-gray-50 px-[1.125rem] py-2.5 text-left text-sm font-normal text-gray-600 first:rounded-tl-lg last:rounded-tr-lg empty:p-0',
+                {
+                  'cursor-pointer': header.column.getCanSort() && !disabled,
+                },
+              )}
+              onClick={
+                disabled ? undefined : header.column.getToggleSortingHandler()
+              }
+              style={{
+                width:
+                  header.column.columnDef.staticSize ||
+                  (header.getSize() !== 150
+                    ? `${header.column.getSize()}${sizeUnit}`
+                    : undefined),
+              }}
+            >
+              {header.isPlaceholder
+                ? null
+                : flexRender(
+                    header.column.columnDef.header,
+                    header.getContext(),
+                  )}
+              {header.column.getCanSort() ? (
+                <ArrowDown
+                  size={12}
+                  className={clsx(
+                    'mb-0.5 ml-1 inline-block align-middle transition-[transform,opacity]',
+                    {
+                      'rotate-180':
+                        header.column.getIsSorted() === 'asc' && !disabled,
+                      'rotate-0':
+                        header.column.getIsSorted() === 'desc' && !disabled,
+                      'opacity-0 group-hover:opacity-100':
+                        header.column.getIsSorted() === false || disabled,
+                    },
+                  )}
+                />
+              ) : null}
+            </th>
+          ))}
+        </tr>
+      ))}
+    </thead>
+  );
+};

--- a/src/components/v5/common/Table/partials/TableLayout/TableLayout.tsx
+++ b/src/components/v5/common/Table/partials/TableLayout/TableLayout.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { HorizontalLayout } from './HorizontalLayout.tsx';
+import {
+  type HorizontalLayoutProps,
+  type TableLayoutProps,
+  type VerticalLayoutProps,
+} from './types.ts';
+import { VerticalLayout } from './VerticalLayout.tsx';
+
+export const TableLayout = <T,>({
+  verticalLayout,
+  ...props
+}: TableLayoutProps<T>) => {
+  return verticalLayout ? (
+    <VerticalLayout {...(props as VerticalLayoutProps<T>)} />
+  ) : (
+    <HorizontalLayout {...(props as HorizontalLayoutProps<T>)} />
+  );
+};

--- a/src/components/v5/common/Table/partials/TableLayout/VerticalLayout.tsx
+++ b/src/components/v5/common/Table/partials/TableLayout/VerticalLayout.tsx
@@ -1,0 +1,121 @@
+import { flexRender } from '@tanstack/react-table';
+import clsx from 'clsx';
+import React from 'react';
+
+import MeatBallMenu from '~v5/shared/MeatBallMenu/MeatBallMenu.tsx';
+
+import { TableRow } from '../VirtualizedRow/VirtualizedRow.tsx';
+
+import { type VerticalLayoutProps } from './types.ts';
+
+export const VerticalLayout = <T,>({
+  rows,
+  headerGroups,
+  getRowClassName,
+  getMenuProps,
+  virtualizedProps,
+  sizeUnit,
+  meatBallMenuSize,
+  meatBallMenuStaticSize,
+  withBorder,
+}: VerticalLayoutProps<T>) => {
+  return (
+    <>
+      {rows.map((row) => {
+        const cells = row.getVisibleCells();
+
+        return (
+          <tbody
+            key={row.id}
+            className={clsx(
+              getRowClassName(row),
+              '[&:not(:last-child)>tr:last-child>td]:border-b [&:not(:last-child)>tr:last-child>th]:border-b [&_tr:first-child_td]:pt-2 [&_tr:first-child_th]:h-[2.875rem] [&_tr:first-child_th]:pt-2 [&_tr:last-child_td]:pb-2 [&_tr:last-child_th]:h-[2.875rem] [&_tr:last-child_th]:pb-2',
+            )}
+          >
+            {headerGroups.map((headerGroup) =>
+              headerGroup.headers.map((header, index) => {
+                const rowWithMeatBallMenu = index === 0 && !!getMenuProps;
+                const meatBallMenuProps = getMenuProps?.(row);
+                const hasMeatballMenu =
+                  !!meatBallMenuProps && rowWithMeatBallMenu;
+                const width = meatBallMenuSize || meatBallMenuStaticSize;
+                const colSpan = hasMeatballMenu ? undefined : 2;
+
+                return (
+                  <TableRow
+                    key={row.id + headerGroup.id + header.id}
+                    itemHeight={virtualizedProps?.virtualizedRowHeight || 0}
+                    isEnabled={!!virtualizedProps}
+                    className={clsx({
+                      '[&:not(:last-child)>td]:border-b [&:not(:last-child)>td]:border-gray-100':
+                        withBorder,
+                    })}
+                  >
+                    <th
+                      className={`
+                        h-[2.625rem]
+                        border-r
+                        border-r-gray-200
+                        bg-gray-50
+                        px-4
+                        py-1
+                        text-left
+                        text-sm
+                        font-normal
+                        first:rounded-tl-lg
+                        last:rounded-tr-lg
+                      `}
+                      style={{
+                        width:
+                          header.column.columnDef.staticSize ||
+                          (header.getSize() !== 150
+                            ? `${header.column.getSize()}${sizeUnit}`
+                            : undefined),
+                      }}
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                    </th>
+                    <td
+                      className={clsx('h-full text-left text-sm font-normal', {
+                        'py-1 pl-4': !colSpan,
+                        'px-4 py-1': colSpan,
+                      })}
+                      colSpan={colSpan}
+                    >
+                      {flexRender(
+                        header.column.columnDef.cell,
+                        cells[index].getContext(),
+                      )}
+                    </td>
+                    {hasMeatballMenu && (
+                      <td
+                        className="px-4"
+                        style={{
+                          ...(width && { width: `${width}${sizeUnit}` }),
+                        }}
+                      >
+                        <MeatBallMenu
+                          {...meatBallMenuProps}
+                          buttonClassName="ml-auto"
+                          contentWrapperClassName={clsx(
+                            meatBallMenuProps?.contentWrapperClassName,
+                            '!left-6 right-6 !z-[65] sm:!left-auto',
+                          )}
+                        />
+                      </td>
+                    )}
+                  </TableRow>
+                );
+              }),
+            )}
+          </tbody>
+        );
+      })}
+    </>
+  );
+};

--- a/src/components/v5/common/Table/partials/TableLayout/types.ts
+++ b/src/components/v5/common/Table/partials/TableLayout/types.ts
@@ -1,0 +1,39 @@
+import { type HeaderGroup, type Row } from '@tanstack/react-table';
+import { type PropsWithChildren } from 'react';
+
+import { type TableProps } from '~v5/common/Table/types.ts';
+
+export type BaseTableLayoutProps<T> = Pick<
+  TableProps<T>,
+  | 'verticalLayout'
+  | 'getMenuProps'
+  | 'virtualizedProps'
+  | 'sizeUnit'
+  | 'withBorder'
+> &
+  Required<Pick<TableProps<T>, 'getRowClassName'>> & {
+    rows: Row<T>[];
+    headerGroups: HeaderGroup<T>[];
+  } & PropsWithChildren;
+
+export type HorizontalLayoutProps<T> = BaseTableLayoutProps<T> &
+  Pick<
+    TableProps<T>,
+    | 'showTableHead'
+    | 'emptyContent'
+    | 'renderSubComponent'
+    | 'tableBodyRowKeyProp'
+    | 'withNarrowBorder'
+    | 'isDisabled'
+    | 'data'
+  > &
+  Required<Pick<TableProps<T>, 'renderCellWrapper'>> & {
+    totalColumnsCount: number;
+  };
+
+export type VerticalLayoutProps<T> = BaseTableLayoutProps<T> &
+  Pick<TableProps<T>, 'meatBallMenuSize' | 'meatBallMenuStaticSize'>;
+
+export type TableLayoutProps<T> =
+  | HorizontalLayoutProps<T>
+  | VerticalLayoutProps<T>;

--- a/src/components/v5/frame/ColonyHome/ColonyHome.tsx
+++ b/src/components/v5/frame/ColonyHome/ColonyHome.tsx
@@ -29,7 +29,7 @@ const ColonyHome = () => {
   const { defaultValues } = useGetActionData(selectedAction || undefined);
 
   return (
-    <div className="flex flex-col gap-6 sm:min-h-full md:gap-4.5">
+    <div className="flex flex-grow flex-col gap-6 sm:min-h-full md:gap-4.5">
       <div className="flex flex-col gap-8 sm:gap-6">
         <DashboardHeader />
         <TeamFilter />

--- a/src/components/v5/frame/PageLayout/PageLayout.tsx
+++ b/src/components/v5/frame/PageLayout/PageLayout.tsx
@@ -74,9 +74,12 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
               )}
             >
               <div
-                className={clsx('mx-auto max-w-[79.875rem] pb-4 pt-6 md:pt-0', {
-                  '!pt-0': enableMobileAndDesktopLayoutBreakpoints,
-                })}
+                className={clsx(
+                  'mx-auto flex min-h-full max-w-[79.875rem] flex-grow flex-col pb-4 pt-6 md:pt-0',
+                  {
+                    '!pt-0': enableMobileAndDesktopLayoutBreakpoints,
+                  },
+                )}
               >
                 {(pageTitle || isTablet) && (
                   <section


### PR DESCRIPTION
## Description

This PR aims to refactor (a tiny bit) the `Table` component and addresses the following issues

- [X] The pagination should be displayed inside the table container and not outside for all tables
[Figma link](https://www.figma.com/design/l1dOM5qiQYwF0ElvKDqqjg/Design-System---Colony-v3?node-id=1776-8565&t=JazItdUIdCedG0rv-4)
- [X] When there are not enough items for there to be more than 1 page, the recent activity table should go as tall as it can until it either fills the bottom of the dashboard area, or reaches the max height it would be with 7 items.
- [X] For activity tables, the content - namely the `metadata` and `status pill` - is moving upon expanding a row

**Tabs closed (note the position of the pill, title and metadata):**
<img width="391" alt="image" src="https://github.com/user-attachments/assets/3ec1aa80-57d8-440d-ba20-474b6dd36721">
**With one tab open (again, note the position of the pill, title and metadata):**
<img width="404" alt="image" src="https://github.com/user-attachments/assets/b63d0d98-762f-4910-a5d8-8cfc07c1bcf3">

- [X] For the recent activity table, the status pills should have only `16px` between the expandable icon
<img width="466" alt="image" src="https://github.com/user-attachments/assets/27243d17-006a-4a4f-97af-f20cce378b7b">

## Testing

TODO: Please test the above mentioned issues have been resolved, as well as the `Table` component refactoring didn't introduce bugs. 

* Step 1. Visit http://localhost:9091/planex
* Step 2. Set your viewport to mobile
* Step 3. Try expanding an existing action

https://github.com/user-attachments/assets/f4844621-3029-4b7c-8c87-a36e37623b37


* Step 4. Ensure the description and status pills of the other actions doesn't change their position
* Step 5. Check the spacing between the status pill and expandable icon is `16px`
 
![Screenshot 2024-11-22 at 16 03 44](https://github.com/user-attachments/assets/9bbf2df6-358a-4888-8a11-d8172bc043af)

* Step 6. Now go to http://localhost:9091/planex/activity
* Step 7. Check the table pagination is displayed inside the table
![Screenshot 2024-11-22 at 16 05 45](https://github.com/user-attachments/assets/d326c65c-f7e2-4916-beeb-f1becce2f5e3)

* Step 8. Run `node scripts/create-colony-url.js` and complete creating a colony
* Step 9. Create a `Mint tokens` action
![Screenshot 2024-11-22 at 16 07 19](https://github.com/user-attachments/assets/aab992ad-a240-45ce-8f78-4d3ea0d8ee18)

* Step 10. Go to the newly created colony `Dashboard` page
* Step 11. Check the height of the `Recent activity` table - it should occupy the whole available page height
![Screenshot 2024-11-22 at 16 09 01](https://github.com/user-attachments/assets/7fbd9fe1-9d65-4e3b-b86f-3159b4f52d17)

### Further testing
Please check the tables from 
http://localhost:9091/planex/balances
http://localhost:9091/planex/incoming
http://localhost:9091/account/crypto-to-fiat

Also please try creating an `Advanced payment` or `Manage tokens` action and check the tables there for both `mobile` and `desktop`

Any further testing ideas are highly welcomed 🙌  and thanks a lot for reaching this far in the testing 🥇 

## Diffs

**Changes** 🏗

* The `Table` component has been split up into more manageable partial components 

Resolves #2695 
Resolves #3550 
Resolves #3668 
