### PR TITLE
Fix: Remove unnecessary subtraction for timeOffset

### DIFF
--- a/amplify/backend/function/fetchDomainBalance/src/utils.js
+++ b/amplify/backend/function/fetchDomainBalance/src/utils.js
@@ -69,7 +69,7 @@ const subtractYearsFor = (numberOfYears, timeframePeriodEndDate) => {
   const now = timeframePeriodEndDate
     ? new Date(timeframePeriodEndDate)
     : new Date();
-  const timeOffset = numberOfYears > 0 ? numberOfYears - 1 : 0;
+  const timeOffset = numberOfYears > 0 ? numberOfYears : 0;
   return startOfDay(new Date(startOfYear(new Date(subYears(now, timeOffset)))));
 };
 
@@ -77,7 +77,7 @@ const subtractMonthsFor = (numberOfMonths, timeframePeriodEndDate) => {
   const now = timeframePeriodEndDate
     ? new Date(timeframePeriodEndDate)
     : new Date();
-  const timeOffset = numberOfMonths > 0 ? numberOfMonths - 1 : 0;
+  const timeOffset = numberOfMonths > 0 ? numberOfMonths : 0;
   return startOfDay(
     new Date(startOfMonth(new Date(subMonths(now, timeOffset)))),
   );
@@ -87,7 +87,7 @@ const subtractWeeksFor = (numberOfWeeks, timeframePeriodEndDate) => {
   const now = timeframePeriodEndDate
     ? new Date(timeframePeriodEndDate)
     : new Date();
-  const timeOffset = numberOfWeeks > 0 ? numberOfWeeks - 1 : 0;
+  const timeOffset = numberOfWeeks > 0 ? numberOfWeeks : 0;
   return startOfDay(new Date(startOfWeek(new Date(subWeeks(now, timeOffset)))));
 };
 
@@ -95,7 +95,7 @@ const subtractDaysFor = (numberOfDays, timeframePeriodEndDate) => {
   const now = timeframePeriodEndDate
     ? new Date(timeframePeriodEndDate)
     : new Date();
-  const timeOffset = numberOfDays > 0 ? numberOfDays - 1 : 0;
+  const timeOffset = numberOfDays > 0 ? numberOfDays : 0;
   return startOfDay(new Date(subDays(now, timeOffset)));
 };
 


### PR DESCRIPTION
Fix: Remove unnecessary subtraction for timeOffset

## Description

- There was an issue introduced by [this commit](https://github.com/JoinColony/colonyCDapp/commit/f6ca7655143dacc7976dbd82223b8e80f957e41b) causing the domain balance to no longer include the last timeframe key - actually it duplicated the first key in the `periodBalance`.
- With this PR, all requested timeframe entries are properly retrieved
![Screenshot 2024-11-25 at 07 56 10](https://github.com/user-attachments/assets/338b70e4-917c-4c5c-a74c-0448bb58b189)


## Testing

TODO: Please check the `getDomainBalance` query retrieves all entries as requested. 

* Step 1. Let's start easy with testing the fix, so please visit http://localhost:9091/planex
* Step 2. Check the `Total in and out` card's chart includes latest `4 months` - not only the latest `3 months` as in `master`
![Screenshot 2024-11-25 at 07 56 10](https://github.com/user-attachments/assets/338b70e4-917c-4c5c-a74c-0448bb58b189)
* Step 3. Now let us run some queries, so go to http://localhost:20002/
* Step 4. Run the following query
```
query MyQuery {
  getDomainBalance(
    input: {
      colonyAddress: "<COLONY_ADDRESS_HERE>", 
      timeframePeriod: 10, 
      timeframeType: DAILY
    }
  ) {
    timeframe {
      key
    }
  }
}
```
* Step 5. Change the `timeframePeriod` and `timeframeType` and make sure it includes all needed entries
> [!IMPORTANT]
> Keep in mind that using `TOTAL` as a value for `timeframeType` will return an empty array for the `timeframe`

> [!NOTE]
> P.S. you can also make use of the `timeframePeriodEndDate` field - in the format of `YYYY-MM-DDThh:mm:ss.sssZ` - to set the last date from which the timeframe keys should be included

As always, please don't let these testing steps hinder your ✨ creativity ✨ 

Resolves #3762
