### PR TITLE
Fix: Prevent TX button from being stuck in a pending state

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransaction.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransaction.tsx
@@ -15,6 +15,7 @@ import {
   getGroupValues,
   getActiveTransactionIdx,
   getGroupId,
+  getHasZeroAddressTransaction,
 } from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { arrayToObject } from '~utils/arrays/index.ts';
@@ -55,6 +56,8 @@ const GroupedTransaction: FC<GroupedTransactionProps> = ({
   const groupId = getGroupId(transactionGroup);
   const status = getGroupStatus(transactionGroup);
   const values = getGroupValues<TransactionType>(transactionGroup);
+  const hasZeroAddressTransaction =
+    getHasZeroAddressTransaction(transactionGroup);
 
   const groupMsgId = `transaction.group`;
 
@@ -95,7 +98,8 @@ const GroupedTransaction: FC<GroupedTransactionProps> = ({
     !GROUP_KEYS_WHICH_CANNOT_LINK.includes(
       values.group.key as TRANSACTION_METHODS,
     ) &&
-    status === TransactionStatus.Succeeded;
+    status === TransactionStatus.Succeeded &&
+    !hasZeroAddressTransaction;
 
   const createdAt =
     transactionGroup?.[0].createdAt &&
@@ -127,7 +131,7 @@ const GroupedTransaction: FC<GroupedTransactionProps> = ({
               onClick={handleNavigateToAction}
               disabled={!canLinkToAction || hideSummary}
               className={clsx(
-                'flex w-full flex-col items-start gap-1  sm:px-6',
+                'flex w-full flex-col items-start gap-1 sm:px-6',
                 {
                   'cursor-default': !canLinkToAction,
                 },

--- a/src/state/transactionState.ts
+++ b/src/state/transactionState.ts
@@ -115,17 +115,14 @@ export const getGroupStatus = (txGroup: TransactionType[]) => {
   if (txGroup.some((tx) => tx.status === TransactionStatus.Failed)) {
     return TransactionStatus.Failed;
   }
-  if (
-    txGroup.every(
-      (tx) =>
-        tx.status === TransactionStatus.Succeeded &&
-        tx.hash !== DEFAULT_TX_HASH,
-    )
-  ) {
+  if (txGroup.every((tx) => tx.status === TransactionStatus.Succeeded)) {
     return TransactionStatus.Succeeded;
   }
   return TransactionStatus.Pending;
 };
+
+export const getHasZeroAddressTransaction = (txGroup: TransactionType[]) =>
+  txGroup.some((tx) => tx.hash === DEFAULT_TX_HASH);
 
 // Get the index of the first transaction in a group that is ready to sign
 export const getActiveTransactionIdx = (txGroup: TransactionType[]) => {


### PR DESCRIPTION
## Description

I found that some grouped transactions do legitimately have transactions with a zero address hash so I removed the part inside `getGroupStatus` where it determines if a transaction group is considered to have succeeded if there are no transactions with an address zero hash.

![perpetual-pending-fix](https://github.com/user-attachments/assets/8ea9faef-a5dd-4ac6-8f23-c0fb022fa3d4)

## Testing

> [!NOTE]
> If you do end up seeing the TX Button in a "stuck" pending state, verify if it is indeed pending by checking the same transaction inside the User Hub. If the transaction is marked as Pending inside the User Hub then, it really is in a "Pending" state. Maybe it's an environment issue or something 🤔 

1. Connect Leela's wallet
2. Install the Reputation extension
3. Uninstall it
4. Repeat steps 1-2 a couple of times and verify that the TX Button is not stuck in a Pending state
5. Install the Multi-Sig extension
6. Give Amy and Leela permissions to take actions via Multi-Sig
7. Create an advanced payment
8. Fund it via Multi-Sig
9. Remove your default Yay vote
10. Reject the Multi-Sig motion
11. Repeat steps 8-10
12. Verify that the TX Button is not stuck in a perpetual loading state

Resolves #3760 