### PR TITLE
feat: add search pill to filters

### DIFF
--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/ActionsTableFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/ActionsTableFilters.tsx
@@ -63,7 +63,7 @@ const ActionsTableFilters: FC = () => {
   return (
     <>
       {isMobile ? (
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col items-start gap-2">
           <div className="flex items-center gap-2">
             <FilterButton
               isOpen={isOpened}

--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/ActionsTableFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/ActionsTableFilters.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlass } from '@phosphor-icons/react';
+import { MagnifyingGlass, X } from '@phosphor-icons/react';
 import React, { useState, type FC } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
 
@@ -22,14 +22,15 @@ const ActionsTableFilters: FC = () => {
   const [isOpened, setOpened] = useState(false);
   const [isSearchOpened, setIsSearchOpened] = useState(false);
   const isMobile = useMobile();
-  const { getTooltipProps, setTooltipRef, setTriggerRef, visible } =
-    usePopperTooltip({
-      delayShow: 200,
-      delayHide: 200,
-      placement: 'bottom-start',
-      trigger: 'click',
-      interactive: true,
-    });
+  const { getTooltipProps, setTooltipRef, setTriggerRef } = usePopperTooltip({
+    delayShow: 200,
+    delayHide: 200,
+    placement: 'bottom-start',
+    trigger: 'click',
+    interactive: true,
+    visible: isSearchOpened,
+    onVisibleChange: setIsSearchOpened,
+  });
 
   const filtersContent = (
     <div>
@@ -59,6 +60,19 @@ const ActionsTableFilters: FC = () => {
     />
   );
 
+  const searchPill = (
+    <div className="flex items-center justify-end rounded-lg bg-blue-100 px-3 py-2 text-sm text-blue-400">
+      <p className="max-w-[12.5rem] truncate sm:max-w-full">{searchFilter}</p>
+      <button
+        type="button"
+        onClick={() => setSearchFilter('')}
+        className="ml-2 flex-shrink-0"
+      >
+        <X size={12} className="text-inherit" />
+      </button>
+    </div>
+  );
+
   return (
     <>
       {isMobile ? (
@@ -78,6 +92,7 @@ const ActionsTableFilters: FC = () => {
           >
             <MagnifyingGlass size={14} />
           </Button>
+          {!!searchFilter && searchPill}
           <Modal
             isFullOnMobile={false}
             onClose={() => setOpened(false)}
@@ -102,13 +117,15 @@ const ActionsTableFilters: FC = () => {
         <>
           <div className="flex flex-row items-start justify-end gap-2">
             <ActiveFiltersList />
+            {!!searchFilter && searchPill}
             <FilterButton
-              isOpen={visible}
+              isOpen={isSearchOpened}
               setTriggerRef={setTriggerRef}
+              onClick={() => setIsSearchOpened((prev) => !prev)}
               customLabel={formatText({ id: 'allFilters' })}
             />
           </div>
-          {visible && (
+          {isSearchOpened && (
             <PopoverBase
               setTooltipRef={setTooltipRef}
               tooltipProps={getTooltipProps}

--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/ActionsTableFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/ActionsTableFilters.tsx
@@ -63,47 +63,51 @@ const ActionsTableFilters: FC = () => {
   return (
     <>
       {isMobile ? (
-        <div className="flex items-center gap-2">
-          <FilterButton
-            isOpen={isOpened}
-            onClick={() => setOpened(!isOpened)}
-            numberSelectedFilters={selectedFiltersCount}
-            customLabel={formatText({ id: 'allFilters' })}
-          />
-          <Button
-            mode="tertiary"
-            className="flex sm:hidden"
-            size="small"
-            aria-label={formatText({ id: 'ariaLabel.openSearchModal' })}
-            onClick={openSearch}
-          >
-            <MagnifyingGlass size={14} />
-          </Button>
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <FilterButton
+              isOpen={isOpened}
+              onClick={() => setOpened(!isOpened)}
+              numberSelectedFilters={selectedFiltersCount}
+              customLabel={formatText({ id: 'allFilters' })}
+            />
+            <Button
+              mode="tertiary"
+              className="flex sm:hidden"
+              size="small"
+              aria-label={formatText({ id: 'ariaLabel.openSearchModal' })}
+              onClick={openSearch}
+            >
+              <MagnifyingGlass size={14} />
+            </Button>
+            <Modal
+              isFullOnMobile={false}
+              onClose={() => setOpened(false)}
+              isOpen={isOpened}
+              withPaddingBottom
+            >
+              {filtersContent}
+            </Modal>
+            <Modal
+              isFullOnMobile={false}
+              onClose={closeSearch}
+              isOpen={isSearchOpened}
+              withPaddingBottom
+            >
+              <p className="mb-4 uppercase text-gray-400 text-4">
+                {formatText({
+                  id: 'activityFeedTable.filters.searchModalTitle',
+                })}
+              </p>
+              <div className="sm:mb-6 sm:px-3.5">{searchInput}</div>
+            </Modal>
+          </div>
           {!!searchFilter && (
             <SearchPill
               value={searchFilter}
               onClick={() => setSearchFilter('')}
             />
           )}
-          <Modal
-            isFullOnMobile={false}
-            onClose={() => setOpened(false)}
-            isOpen={isOpened}
-            withPaddingBottom
-          >
-            {filtersContent}
-          </Modal>
-          <Modal
-            isFullOnMobile={false}
-            onClose={closeSearch}
-            isOpen={isSearchOpened}
-            withPaddingBottom
-          >
-            <p className="mb-4 uppercase text-gray-400 text-4">
-              {formatText({ id: 'activityFeedTable.filters.searchModalTitle' })}
-            </p>
-            <div className="sm:mb-6 sm:px-3.5">{searchInput}</div>
-          </Modal>
         </div>
       ) : (
         <>

--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/ActionsTableFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/ActionsTableFilters.tsx
@@ -1,11 +1,12 @@
-import { MagnifyingGlass, X } from '@phosphor-icons/react';
+import { MagnifyingGlass } from '@phosphor-icons/react';
 import React, { useState, type FC } from 'react';
-import { usePopperTooltip } from 'react-popper-tooltip';
 
 import { useFiltersContext } from '~common/ColonyActionsTable/FiltersContext/FiltersContext.ts';
 import { useMobile } from '~hooks/index.ts';
 import { formatText } from '~utils/intl.ts';
+import { useSearchFilter } from '~v5/common/Filter/hooks.ts';
 import SearchInput from '~v5/common/Filter/partials/SearchInput/index.ts';
+import SearchPill from '~v5/common/Pills/SearchPill/SearchPill.tsx';
 import Button from '~v5/shared/Button/Button.tsx';
 import FilterButton from '~v5/shared/Filter/FilterButton.tsx';
 import Modal from '~v5/shared/Modal/index.ts';
@@ -20,17 +21,16 @@ const ActionsTableFilters: FC = () => {
     useFiltersContext();
 
   const [isOpened, setOpened] = useState(false);
-  const [isSearchOpened, setIsSearchOpened] = useState(false);
   const isMobile = useMobile();
-  const { getTooltipProps, setTooltipRef, setTriggerRef } = usePopperTooltip({
-    delayShow: 200,
-    delayHide: 200,
-    placement: 'bottom-start',
-    trigger: 'click',
-    interactive: true,
-    visible: isSearchOpened,
-    onVisibleChange: setIsSearchOpened,
-  });
+  const {
+    isSearchOpened,
+    openSearch,
+    closeSearch,
+    toggleSearch,
+    getTooltipProps,
+    setTooltipRef,
+    setTriggerRef,
+  } = useSearchFilter();
 
   const filtersContent = (
     <div>
@@ -51,26 +51,13 @@ const ActionsTableFilters: FC = () => {
 
   const searchInput = (
     <SearchInput
-      onSearchButtonClick={() => setIsSearchOpened(false)}
+      onSearchButtonClick={closeSearch}
       searchValue={searchFilter}
       setSearchValue={setSearchFilter}
       searchInputPlaceholder={formatText({
         id: 'activityFeedTable.filters.searchPlaceholder',
       })}
     />
-  );
-
-  const searchPill = (
-    <div className="flex items-center justify-end rounded-lg bg-blue-100 px-3 py-2 text-sm text-blue-400">
-      <p className="max-w-[12.5rem] truncate sm:max-w-full">{searchFilter}</p>
-      <button
-        type="button"
-        onClick={() => setSearchFilter('')}
-        className="ml-2 flex-shrink-0"
-      >
-        <X size={12} className="text-inherit" />
-      </button>
-    </div>
   );
 
   return (
@@ -88,11 +75,16 @@ const ActionsTableFilters: FC = () => {
             className="flex sm:hidden"
             size="small"
             aria-label={formatText({ id: 'ariaLabel.openSearchModal' })}
-            onClick={() => setIsSearchOpened(true)}
+            onClick={openSearch}
           >
             <MagnifyingGlass size={14} />
           </Button>
-          {!!searchFilter && searchPill}
+          {!!searchFilter && (
+            <SearchPill
+              value={searchFilter}
+              onClick={() => setSearchFilter('')}
+            />
+          )}
           <Modal
             isFullOnMobile={false}
             onClose={() => setOpened(false)}
@@ -103,7 +95,7 @@ const ActionsTableFilters: FC = () => {
           </Modal>
           <Modal
             isFullOnMobile={false}
-            onClose={() => setIsSearchOpened(false)}
+            onClose={closeSearch}
             isOpen={isSearchOpened}
             withPaddingBottom
           >
@@ -117,11 +109,16 @@ const ActionsTableFilters: FC = () => {
         <>
           <div className="flex flex-row items-start justify-end gap-2">
             <ActiveFiltersList />
-            {!!searchFilter && searchPill}
+            {!!searchFilter && (
+              <SearchPill
+                value={searchFilter}
+                onClick={() => setSearchFilter('')}
+              />
+            )}
             <FilterButton
               isOpen={isSearchOpened}
               setTriggerRef={setTriggerRef}
-              onClick={() => setIsSearchOpened((prev) => !prev)}
+              onClick={toggleSearch}
               customLabel={formatText({ id: 'allFilters' })}
             />
           </div>

--- a/src/components/frame/Extensions/pages/PermissionsPage/partials/PermissionsPageContent.tsx
+++ b/src/components/frame/Extensions/pages/PermissionsPage/partials/PermissionsPageContent.tsx
@@ -8,7 +8,6 @@ import useToggle from '~hooks/useToggle/index.ts';
 import { formatText } from '~utils/intl.ts';
 import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import PermissionsModal from '~v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/partials/PermissionsModal/PermissionsModal.tsx';
-import Button from '~v5/shared/Button/Button.tsx';
 import MeatBallMenu from '~v5/shared/MeatBallMenu/MeatBallMenu.tsx';
 
 import { defaultPermissionsPageFilterValue } from '../hooks.tsx';
@@ -172,18 +171,6 @@ const PermissionsPageContent: FC<
             items={items}
             {...filters}
           />
-          <Button
-            mode="primarySolid"
-            size="small"
-            isFullSize={false}
-            onClick={() => {
-              toggleActionSidebarOn({
-                [ACTION_TYPE_FIELD_NAME]: Action.ManagePermissions,
-              });
-            }}
-          >
-            {formatText({ id: 'permissionsPage.managePermissions' })}
-          </Button>
         </div>
       </div>
       {children}

--- a/src/components/frame/Extensions/pages/PermissionsPage/partials/PermissionsPageFilter.tsx
+++ b/src/components/frame/Extensions/pages/PermissionsPage/partials/PermissionsPageFilter.tsx
@@ -1,9 +1,13 @@
 import { MagnifyingGlass } from '@phosphor-icons/react';
+import clsx from 'clsx';
 import React, { type FC, useCallback } from 'react';
 
+import { Action } from '~constants/actions.ts';
+import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { useMobile } from '~hooks';
 import useToggle from '~hooks/useToggle/index.ts';
 import { formatText } from '~utils/intl.ts';
+import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import { useSearchFilter } from '~v5/common/Filter/hooks.ts';
 import SearchInputMobile from '~v5/common/Filter/partials/SearchInput/SearchInput.tsx';
 import SearchPill from '~v5/common/Pills/SearchPill/SearchPill.tsx';
@@ -33,6 +37,9 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
     setTooltipRef,
     setTriggerRef,
   } = useSearchFilter();
+  const {
+    actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
+  } = useActionSidebarContext();
   const isMobile = useMobile();
   const [isModalOpen, { toggleOff: toggleModalOff, toggleOn: toggleModalOn }] =
     useToggle();
@@ -60,28 +67,46 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
 
   return (
     <>
-      <div className="flex flex-row gap-2">
-        {!!searchValue && !isMobile && (
-          <SearchPill value={searchValue} onClick={() => onSearch('')} />
-        )}
-        <FilterButton
-          isOpen={isSearchOpened}
-          onClick={toggleModalOn}
-          setTriggerRef={setTriggerRef}
-          customLabel={formatText({ id: 'allFilters' })}
-          numberSelectedFilters={activeFiltersNumber}
-        />
-        {isMobile && (
+      <div
+        className={clsx('flex flex-col', {
+          'items-start gap-2': isMobile && searchValue,
+        })}
+      >
+        <div className="flex flex-row gap-2">
+          {!!searchValue && !isMobile && (
+            <SearchPill value={searchValue} onClick={() => onSearch('')} />
+          )}
+          <FilterButton
+            isOpen={isSearchOpened}
+            onClick={toggleModalOn}
+            setTriggerRef={setTriggerRef}
+            customLabel={formatText({ id: 'allFilters' })}
+            numberSelectedFilters={activeFiltersNumber}
+          />
+          {isMobile && (
+            <Button
+              mode="tertiary"
+              className="flex sm:hidden"
+              size="small"
+              aria-label={formatText({ id: 'ariaLabel.openSearchModal' })}
+              onClick={openSearch}
+            >
+              <MagnifyingGlass size={14} />
+            </Button>
+          )}
           <Button
-            mode="tertiary"
-            className="flex sm:hidden"
+            mode="primarySolid"
             size="small"
-            aria-label={formatText({ id: 'ariaLabel.openSearchModal' })}
-            onClick={openSearch}
+            isFullSize={false}
+            onClick={() => {
+              toggleActionSidebarOn({
+                [ACTION_TYPE_FIELD_NAME]: Action.ManagePermissions,
+              });
+            }}
           >
-            <MagnifyingGlass size={14} />
+            {formatText({ id: 'permissionsPage.managePermissions' })}
           </Button>
-        )}
+        </div>
         {!!searchValue && isMobile && (
           <SearchPill value={searchValue} onClick={() => onSearch('')} />
         )}

--- a/src/components/frame/Extensions/pages/PermissionsPage/partials/PermissionsPageFilter.tsx
+++ b/src/components/frame/Extensions/pages/PermissionsPage/partials/PermissionsPageFilter.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlass } from '@phosphor-icons/react';
+import { MagnifyingGlass, X } from '@phosphor-icons/react';
 import React, { type FC, useCallback, useState } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
 
@@ -24,17 +24,15 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
   filterValue,
   activeFiltersNumber,
 }) => {
-  const {
-    getTooltipProps,
-    setTooltipRef,
-    setTriggerRef,
-    visible: isFiltersOpen,
-  } = usePopperTooltip({
+  const [isSearchOpened, setIsSearchOpened] = useState(false);
+  const { getTooltipProps, setTooltipRef, setTriggerRef } = usePopperTooltip({
     delayShow: 200,
     delayHide: 200,
     placement: 'bottom-end',
     trigger: 'click',
     interactive: true,
+    visible: isSearchOpened,
+    onVisibleChange: setIsSearchOpened,
   });
   const isMobile = useMobile();
   const [isModalOpen, { toggleOff: toggleModalOff, toggleOn: toggleModalOn }] =
@@ -45,7 +43,6 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
     },
     [onSearch],
   );
-  const [isSearchOpened, setIsSearchOpened] = useState(false);
 
   const RootItems = items.map(
     ({ icon, items: nestedItems, label, name, title }) => (
@@ -62,11 +59,25 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
     ),
   );
 
+  const searchPill = (
+    <div className="flex items-center justify-end rounded-lg bg-blue-100 px-3 py-2 text-sm text-blue-400">
+      <p className="max-w-[12.5rem] truncate sm:max-w-full">{searchValue}</p>
+      <button
+        type="button"
+        onClick={() => onSearch('')}
+        className="ml-2 flex-shrink-0"
+      >
+        <X size={12} className="text-inherit" />
+      </button>
+    </div>
+  );
+
   return (
     <>
       <div className="flex flex-row gap-2">
+        {!!searchValue && !isMobile && searchPill}
         <FilterButton
-          isOpen={isFiltersOpen}
+          isOpen={isSearchOpened}
           onClick={toggleModalOn}
           setTriggerRef={setTriggerRef}
           customLabel={formatText({ id: 'allFilters' })}
@@ -83,6 +94,7 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
             <MagnifyingGlass size={14} />
           </Button>
         )}
+        {!!searchValue && isMobile && searchPill}
       </div>
       {isMobile && (
         <>
@@ -119,7 +131,7 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
           </Modal>
         </>
       )}
-      {isFiltersOpen && !isMobile && (
+      {isSearchOpened && !isMobile && (
         <PopoverBase
           setTooltipRef={setTooltipRef}
           tooltipProps={getTooltipProps}
@@ -134,6 +146,7 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
           <div className="mb-6 px-3.5">
             <SearchInputDesktop
               onChange={onInputChange}
+              onClose={() => setIsSearchOpened(false)}
               placeholder={formatText({ id: 'permissionsPage.filter.search' })}
               value={searchValue}
             />

--- a/src/components/frame/Extensions/pages/PermissionsPage/partials/PermissionsPageFilter.tsx
+++ b/src/components/frame/Extensions/pages/PermissionsPage/partials/PermissionsPageFilter.tsx
@@ -1,11 +1,12 @@
-import { MagnifyingGlass, X } from '@phosphor-icons/react';
-import React, { type FC, useCallback, useState } from 'react';
-import { usePopperTooltip } from 'react-popper-tooltip';
+import { MagnifyingGlass } from '@phosphor-icons/react';
+import React, { type FC, useCallback } from 'react';
 
 import { useMobile } from '~hooks';
 import useToggle from '~hooks/useToggle/index.ts';
 import { formatText } from '~utils/intl.ts';
+import { useSearchFilter } from '~v5/common/Filter/hooks.ts';
 import SearchInputMobile from '~v5/common/Filter/partials/SearchInput/SearchInput.tsx';
+import SearchPill from '~v5/common/Pills/SearchPill/SearchPill.tsx';
 import Button from '~v5/shared/Button/index.ts';
 import FilterButton from '~v5/shared/Filter/FilterButton.tsx';
 import Modal from '~v5/shared/Modal/index.ts';
@@ -24,16 +25,14 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
   filterValue,
   activeFiltersNumber,
 }) => {
-  const [isSearchOpened, setIsSearchOpened] = useState(false);
-  const { getTooltipProps, setTooltipRef, setTriggerRef } = usePopperTooltip({
-    delayShow: 200,
-    delayHide: 200,
-    placement: 'bottom-end',
-    trigger: 'click',
-    interactive: true,
-    visible: isSearchOpened,
-    onVisibleChange: setIsSearchOpened,
-  });
+  const {
+    isSearchOpened,
+    openSearch,
+    closeSearch,
+    getTooltipProps,
+    setTooltipRef,
+    setTriggerRef,
+  } = useSearchFilter();
   const isMobile = useMobile();
   const [isModalOpen, { toggleOff: toggleModalOff, toggleOn: toggleModalOn }] =
     useToggle();
@@ -59,23 +58,12 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
     ),
   );
 
-  const searchPill = (
-    <div className="flex items-center justify-end rounded-lg bg-blue-100 px-3 py-2 text-sm text-blue-400">
-      <p className="max-w-[12.5rem] truncate sm:max-w-full">{searchValue}</p>
-      <button
-        type="button"
-        onClick={() => onSearch('')}
-        className="ml-2 flex-shrink-0"
-      >
-        <X size={12} className="text-inherit" />
-      </button>
-    </div>
-  );
-
   return (
     <>
       <div className="flex flex-row gap-2">
-        {!!searchValue && !isMobile && searchPill}
+        {!!searchValue && !isMobile && (
+          <SearchPill value={searchValue} onClick={() => onSearch('')} />
+        )}
         <FilterButton
           isOpen={isSearchOpened}
           onClick={toggleModalOn}
@@ -89,12 +77,14 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
             className="flex sm:hidden"
             size="small"
             aria-label={formatText({ id: 'ariaLabel.openSearchModal' })}
-            onClick={() => setIsSearchOpened(true)}
+            onClick={openSearch}
           >
             <MagnifyingGlass size={14} />
           </Button>
         )}
-        {!!searchValue && isMobile && searchPill}
+        {!!searchValue && isMobile && (
+          <SearchPill value={searchValue} onClick={() => onSearch('')} />
+        )}
       </div>
       {isMobile && (
         <>
@@ -111,7 +101,7 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
           </Modal>
           <Modal
             isFullOnMobile={false}
-            onClose={() => setIsSearchOpened(false)}
+            onClose={closeSearch}
             isOpen={isSearchOpened}
             withPaddingBottom
           >
@@ -120,7 +110,7 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
             </p>
             <div className="sm:mb-6 sm:px-3.5">
               <SearchInputMobile
-                onSearchButtonClick={() => setIsSearchOpened(false)}
+                onSearchButtonClick={closeSearch}
                 setSearchValue={onInputChange}
                 searchValue={searchValue}
                 searchInputPlaceholder={formatText({
@@ -146,7 +136,7 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
           <div className="mb-6 px-3.5">
             <SearchInputDesktop
               onChange={onInputChange}
-              onClose={() => setIsSearchOpened(false)}
+              onClose={closeSearch}
               placeholder={formatText({ id: 'permissionsPage.filter.search' })}
               value={searchValue}
             />

--- a/src/components/frame/v5/pages/AgreementsPage/AgreementsPage.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/AgreementsPage.tsx
@@ -12,7 +12,6 @@ import { formatText } from '~utils/intl.ts';
 import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import EmptyContent from '~v5/common/EmptyContent/EmptyContent.tsx';
 import ContentWithTeamFilter from '~v5/frame/ContentWithTeamFilter/ContentWithTeamFilter.tsx';
-import Button from '~v5/shared/Button/Button.tsx';
 
 import { useFiltersContext } from './FiltersContext/FiltersContext.ts';
 import { useGetAgreements } from './hooks.ts';
@@ -77,21 +76,7 @@ const AgreementsPage: FC = () => {
             {formatText({ id: 'agreementsPage.subtitle' })}
           </h4>
         </div>
-        <div className="flex items-center gap-2">
-          <AgreementsPageFilters />
-          <Button
-            mode="primarySolid"
-            size="small"
-            isFullSize={false}
-            onClick={() => {
-              toggleActionSidebarOn({
-                [ACTION_TYPE_FIELD_NAME]: Action.CreateDecision,
-              });
-            }}
-          >
-            {formatText({ id: 'agreementsPage.createAgreement' })}
-          </Button>
-        </div>
+        <AgreementsPageFilters />
       </div>
       {loading || loadingMotionStateFilter ? (
         <ul className="grid gap-6 sm:grid-cols-2">

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/AgreementsPageFilters.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/AgreementsPageFilters.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlass } from '@phosphor-icons/react';
+import { MagnifyingGlass, X } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { useState, type FC } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
@@ -23,14 +23,15 @@ const AgreementsPageFilters: FC = () => {
   const [isOpened, setOpened] = useState(false);
   const [isSearchOpened, setIsSearchOpened] = useState(false);
   const isMobile = useMobile();
-  const { getTooltipProps, setTooltipRef, setTriggerRef, visible } =
-    usePopperTooltip({
-      delayShow: 200,
-      delayHide: 200,
-      placement: 'bottom-start',
-      trigger: 'click',
-      interactive: true,
-    });
+  const { getTooltipProps, setTooltipRef, setTriggerRef } = usePopperTooltip({
+    delayShow: 200,
+    delayHide: 200,
+    placement: 'bottom-start',
+    trigger: 'click',
+    interactive: true,
+    visible: isSearchOpened,
+    onVisibleChange: setIsSearchOpened,
+  });
 
   const SearchInputComponent = (
     <SearchInput
@@ -41,6 +42,18 @@ const AgreementsPageFilters: FC = () => {
         id: 'agreementsPage.filter.searchPlaceholder',
       })}
     />
+  );
+  const searchPill = (
+    <div className="flex items-center justify-end rounded-lg bg-blue-100 px-3 py-2 text-sm text-blue-400">
+      <p className="max-w-[12.5rem] truncate sm:max-w-full">{searchFilter}</p>
+      <button
+        type="button"
+        onClick={() => setSearchFilter('')}
+        className="ml-2 flex-shrink-0"
+      >
+        <X size={12} className="text-inherit" />
+      </button>
+    </div>
   );
   const FiltersContent = (
     <div>
@@ -83,6 +96,7 @@ const AgreementsPageFilters: FC = () => {
           >
             <MagnifyingGlass size={14} />
           </Button>
+          {!!searchFilter && searchPill}
           <Modal
             isFullOnMobile={false}
             onClose={() => setOpened(false)}
@@ -106,14 +120,15 @@ const AgreementsPageFilters: FC = () => {
       ) : (
         <>
           <div className="flex flex-row items-start justify-end gap-2">
+            {!!searchFilter && searchPill}
             <ActiveFiltersList />
             <FilterButton
-              isOpen={visible}
+              isOpen={isSearchOpened}
               setTriggerRef={setTriggerRef}
               customLabel={formatText({ id: 'allFilters' })}
             />
           </div>
-          {visible && (
+          {isSearchOpened && (
             <PopoverBase
               setTooltipRef={setTooltipRef}
               tooltipProps={getTooltipProps}

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/AgreementsPageFilters.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/AgreementsPageFilters.tsx
@@ -1,12 +1,13 @@
-import { MagnifyingGlass, X } from '@phosphor-icons/react';
+import { MagnifyingGlass } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { useState, type FC } from 'react';
-import { usePopperTooltip } from 'react-popper-tooltip';
 
 import { useFiltersContext } from '~frame/v5/pages/AgreementsPage/FiltersContext/FiltersContext.ts';
 import { useMobile } from '~hooks/index.ts';
 import { formatText } from '~utils/intl.ts';
+import { useSearchFilter } from '~v5/common/Filter/hooks.ts';
 import SearchInput from '~v5/common/Filter/partials/SearchInput/index.ts';
+import SearchPill from '~v5/common/Pills/SearchPill/SearchPill.tsx';
 import Button from '~v5/shared/Button/Button.tsx';
 import FilterButton from '~v5/shared/Filter/FilterButton.tsx';
 import Modal from '~v5/shared/Modal/index.ts';
@@ -21,39 +22,25 @@ const AgreementsPageFilters: FC = () => {
   const { searchFilter, setSearchFilter, selectedFiltersCount } =
     useFiltersContext();
   const [isOpened, setOpened] = useState(false);
-  const [isSearchOpened, setIsSearchOpened] = useState(false);
   const isMobile = useMobile();
-  const { getTooltipProps, setTooltipRef, setTriggerRef } = usePopperTooltip({
-    delayShow: 200,
-    delayHide: 200,
-    placement: 'bottom-start',
-    trigger: 'click',
-    interactive: true,
-    visible: isSearchOpened,
-    onVisibleChange: setIsSearchOpened,
-  });
+  const {
+    isSearchOpened,
+    openSearch,
+    closeSearch,
+    getTooltipProps,
+    setTooltipRef,
+    setTriggerRef,
+  } = useSearchFilter();
 
   const SearchInputComponent = (
     <SearchInput
-      onSearchButtonClick={() => setIsSearchOpened(false)}
+      onSearchButtonClick={closeSearch}
       searchValue={searchFilter}
       setSearchValue={setSearchFilter}
       searchInputPlaceholder={formatText({
         id: 'agreementsPage.filter.searchPlaceholder',
       })}
     />
-  );
-  const searchPill = (
-    <div className="flex items-center justify-end rounded-lg bg-blue-100 px-3 py-2 text-sm text-blue-400">
-      <p className="max-w-[12.5rem] truncate sm:max-w-full">{searchFilter}</p>
-      <button
-        type="button"
-        onClick={() => setSearchFilter('')}
-        className="ml-2 flex-shrink-0"
-      >
-        <X size={12} className="text-inherit" />
-      </button>
-    </div>
   );
   const FiltersContent = (
     <div>
@@ -92,11 +79,16 @@ const AgreementsPageFilters: FC = () => {
             className="flex h-9 sm:hidden"
             size="small"
             aria-label={formatText({ id: 'ariaLabel.openSearchModal' })}
-            onClick={() => setIsSearchOpened(true)}
+            onClick={openSearch}
           >
             <MagnifyingGlass size={14} />
           </Button>
-          {!!searchFilter && searchPill}
+          {!!searchFilter && (
+            <SearchPill
+              value={searchFilter}
+              onClick={() => setSearchFilter('')}
+            />
+          )}
           <Modal
             isFullOnMobile={false}
             onClose={() => setOpened(false)}
@@ -107,7 +99,7 @@ const AgreementsPageFilters: FC = () => {
           </Modal>
           <Modal
             isFullOnMobile={false}
-            onClose={() => setIsSearchOpened(false)}
+            onClose={closeSearch}
             isOpen={isSearchOpened}
             withPaddingBottom
           >
@@ -120,7 +112,12 @@ const AgreementsPageFilters: FC = () => {
       ) : (
         <>
           <div className="flex flex-row items-start justify-end gap-2">
-            {!!searchFilter && searchPill}
+            {!!searchFilter && (
+              <SearchPill
+                value={searchFilter}
+                onClick={() => setSearchFilter('')}
+              />
+            )}
             <ActiveFiltersList />
             <FilterButton
               isOpen={isSearchOpened}

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/AgreementsPageFilters.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/AgreementsPageFilters.tsx
@@ -2,9 +2,12 @@ import { MagnifyingGlass } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { useState, type FC } from 'react';
 
+import { Action } from '~constants/actions.ts';
+import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { useFiltersContext } from '~frame/v5/pages/AgreementsPage/FiltersContext/FiltersContext.ts';
 import { useMobile } from '~hooks/index.ts';
 import { formatText } from '~utils/intl.ts';
+import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import { useSearchFilter } from '~v5/common/Filter/hooks.ts';
 import SearchInput from '~v5/common/Filter/partials/SearchInput/index.ts';
 import SearchPill from '~v5/common/Pills/SearchPill/SearchPill.tsx';
@@ -22,6 +25,9 @@ const AgreementsPageFilters: FC = () => {
   const { searchFilter, setSearchFilter, selectedFiltersCount } =
     useFiltersContext();
   const [isOpened, setOpened] = useState(false);
+  const {
+    actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
+  } = useActionSidebarContext();
   const isMobile = useMobile();
   const {
     isSearchOpened,
@@ -65,49 +71,63 @@ const AgreementsPageFilters: FC = () => {
   );
 
   return (
-    <>
+    <div className="flex flex-row items-center gap-2">
       {isMobile ? (
-        <div className="flex items-center gap-2">
-          <FilterButton
-            isOpen={isOpened}
-            onClick={() => setOpened(!isOpened)}
-            numberSelectedFilters={selectedFiltersCount}
-            customLabel={formatText({ id: 'allFilters' })}
-          />
-          <Button
-            mode="tertiary"
-            className="flex h-9 sm:hidden"
-            size="small"
-            aria-label={formatText({ id: 'ariaLabel.openSearchModal' })}
-            onClick={openSearch}
-          >
-            <MagnifyingGlass size={14} />
-          </Button>
+        <div className="flex flex-col items-start gap-2">
+          <div className="flex items-center gap-2">
+            <FilterButton
+              isOpen={isOpened}
+              onClick={() => setOpened(!isOpened)}
+              numberSelectedFilters={selectedFiltersCount}
+              customLabel={formatText({ id: 'allFilters' })}
+            />
+            <Button
+              mode="tertiary"
+              className="flex h-9 sm:hidden"
+              size="small"
+              aria-label={formatText({ id: 'ariaLabel.openSearchModal' })}
+              onClick={openSearch}
+            >
+              <MagnifyingGlass size={14} />
+            </Button>
+            <Button
+              mode="primarySolid"
+              size="small"
+              isFullSize={false}
+              onClick={() => {
+                toggleActionSidebarOn({
+                  [ACTION_TYPE_FIELD_NAME]: Action.CreateDecision,
+                });
+              }}
+            >
+              {formatText({ id: 'agreementsPage.createAgreement' })}
+            </Button>
+            <Modal
+              isFullOnMobile={false}
+              onClose={() => setOpened(false)}
+              isOpen={isOpened}
+              withPaddingBottom
+            >
+              {FiltersContent}
+            </Modal>
+            <Modal
+              isFullOnMobile={false}
+              onClose={closeSearch}
+              isOpen={isSearchOpened}
+              withPaddingBottom
+            >
+              <p className="mb-4 uppercase text-gray-400 text-4">
+                {formatText({ id: 'agreementsPage.filter.searchPlaceholder' })}
+              </p>
+              <div className="sm:mb-6 sm:px-3.5">{SearchInputComponent}</div>
+            </Modal>
+          </div>
           {!!searchFilter && (
             <SearchPill
               value={searchFilter}
               onClick={() => setSearchFilter('')}
             />
           )}
-          <Modal
-            isFullOnMobile={false}
-            onClose={() => setOpened(false)}
-            isOpen={isOpened}
-            withPaddingBottom
-          >
-            {FiltersContent}
-          </Modal>
-          <Modal
-            isFullOnMobile={false}
-            onClose={closeSearch}
-            isOpen={isSearchOpened}
-            withPaddingBottom
-          >
-            <p className="mb-4 uppercase text-gray-400 text-4">
-              {formatText({ id: 'agreementsPage.filter.searchPlaceholder' })}
-            </p>
-            <div className="sm:mb-6 sm:px-3.5">{SearchInputComponent}</div>
-          </Modal>
         </div>
       ) : (
         <>
@@ -124,6 +144,18 @@ const AgreementsPageFilters: FC = () => {
               setTriggerRef={setTriggerRef}
               customLabel={formatText({ id: 'allFilters' })}
             />
+            <Button
+              mode="primarySolid"
+              size="small"
+              isFullSize={false}
+              onClick={() => {
+                toggleActionSidebarOn({
+                  [ACTION_TYPE_FIELD_NAME]: Action.CreateDecision,
+                });
+              }}
+            >
+              {formatText({ id: 'agreementsPage.createAgreement' })}
+            </Button>
           </div>
           {isSearchOpened && (
             <PopoverBase
@@ -143,7 +175,7 @@ const AgreementsPageFilters: FC = () => {
           )}
         </>
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/BalanceTable.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/BalanceTable.tsx
@@ -33,7 +33,6 @@ import { MEATBALL_MENU_COLUMN_ID } from '~v5/common/Table/consts.ts';
 import Table from '~v5/common/Table/index.ts';
 import { type TableProps } from '~v5/common/Table/types.ts';
 import TableHeader from '~v5/common/TableHeader/TableHeader.tsx';
-import Button from '~v5/shared/Button/index.ts';
 import Link from '~v5/shared/Link/index.ts';
 
 import BalanceFilters from './Filters/BalanceFilters/BalanceFilters.tsx';
@@ -175,14 +174,7 @@ const BalanceTable: FC = () => {
   return (
     <>
       <TableHeader title={formatText({ id: 'balancePage.table.title' })}>
-        <BalanceFilters />
-        <Button
-          mode="primarySolid"
-          onClick={toggleAddFundsModalOn}
-          size="small"
-        >
-          {formatText({ id: 'balancePage.table.addFunds' })}
-        </Button>
+        <BalanceFilters toggleAddFundsModalOn={toggleAddFundsModalOn} />
       </TableHeader>
       <Table<BalanceTableFieldModel>
         getRowId={({ token }) => (token ? token.tokenAddress : uniqueId())}

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/BalanceFilters/BalanceFilters.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/BalanceFilters/BalanceFilters.tsx
@@ -1,10 +1,11 @@
-import { MagnifyingGlass, X } from '@phosphor-icons/react';
+import { MagnifyingGlass } from '@phosphor-icons/react';
 import React, { useState, type FC } from 'react';
-import { usePopperTooltip } from 'react-popper-tooltip';
 
 import { useMobile } from '~hooks/index.ts';
 import { formatText } from '~utils/intl.ts';
+import { useSearchFilter } from '~v5/common/Filter/hooks.ts';
 import SearchInput from '~v5/common/Filter/partials/SearchInput/index.ts';
+import SearchPill from '~v5/common/Pills/SearchPill/SearchPill.tsx';
 import Button from '~v5/shared/Button/Button.tsx';
 import FilterButton from '~v5/shared/Filter/FilterButton.tsx';
 import Modal from '~v5/shared/Modal/index.ts';
@@ -21,17 +22,15 @@ const BalanceFilters: FC = () => {
     useFiltersContext();
 
   const [isOpened, setOpened] = useState(false);
-  const [isSearchOpened, setIsSearchOpened] = useState(false);
   const isMobile = useMobile();
-  const { getTooltipProps, setTooltipRef, setTriggerRef } = usePopperTooltip({
-    delayShow: 200,
-    delayHide: 200,
-    placement: 'bottom-end',
-    trigger: 'click',
-    interactive: true,
-    visible: isSearchOpened,
-    onVisibleChange: setIsSearchOpened,
-  });
+  const {
+    isSearchOpened,
+    openSearch,
+    closeSearch,
+    getTooltipProps,
+    setTooltipRef,
+    setTriggerRef,
+  } = useSearchFilter();
 
   const filtersContent = (
     <div>
@@ -52,26 +51,13 @@ const BalanceFilters: FC = () => {
 
   const searchInput = (
     <SearchInput
-      onSearchButtonClick={() => setIsSearchOpened(false)}
+      onSearchButtonClick={closeSearch}
       searchValue={searchFilter}
       setSearchValue={setSearchFilter}
       searchInputPlaceholder={formatText({
         id: 'balancePage.filter.search',
       })}
     />
-  );
-
-  const searchPill = (
-    <div className="flex items-center justify-end rounded-lg bg-blue-100 px-3 py-2 text-sm text-blue-400">
-      <p className="max-w-[12.5rem] truncate sm:max-w-full">{searchFilter}</p>
-      <button
-        type="button"
-        onClick={() => setSearchFilter('')}
-        className="ml-2 flex-shrink-0"
-      >
-        <X size={12} className="text-inherit" />
-      </button>
-    </div>
   );
 
   return (
@@ -89,11 +75,16 @@ const BalanceFilters: FC = () => {
             className="flex sm:hidden"
             size="small"
             aria-label={formatText({ id: 'ariaLabel.openSearchModal' })}
-            onClick={() => setIsSearchOpened(true)}
+            onClick={openSearch}
           >
             <MagnifyingGlass size={14} />
           </Button>
-          {!!searchFilter && searchPill}
+          {!!searchFilter && (
+            <SearchPill
+              value={searchFilter}
+              onClick={() => setSearchFilter('')}
+            />
+          )}
           <Modal
             isFullOnMobile={false}
             onClose={() => setOpened(false)}
@@ -104,7 +95,7 @@ const BalanceFilters: FC = () => {
           </Modal>
           <Modal
             isFullOnMobile={false}
-            onClose={() => setIsSearchOpened(false)}
+            onClose={closeSearch}
             isOpen={isSearchOpened}
             withPaddingBottom
           >
@@ -118,7 +109,12 @@ const BalanceFilters: FC = () => {
         <>
           <div className="flex flex-row items-start justify-end gap-2">
             <ActiveFiltersList />
-            {!!searchFilter && searchPill}
+            {!!searchFilter && (
+              <SearchPill
+                value={searchFilter}
+                onClick={() => setSearchFilter('')}
+              />
+            )}
             <FilterButton
               isOpen={isSearchOpened}
               setTriggerRef={setTriggerRef}

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/BalanceFilters/BalanceFilters.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/BalanceFilters/BalanceFilters.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlass } from '@phosphor-icons/react';
+import { MagnifyingGlass, X } from '@phosphor-icons/react';
 import React, { useState, type FC } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
 
@@ -23,14 +23,15 @@ const BalanceFilters: FC = () => {
   const [isOpened, setOpened] = useState(false);
   const [isSearchOpened, setIsSearchOpened] = useState(false);
   const isMobile = useMobile();
-  const { getTooltipProps, setTooltipRef, setTriggerRef, visible } =
-    usePopperTooltip({
-      delayShow: 200,
-      delayHide: 200,
-      placement: 'bottom-end',
-      trigger: 'click',
-      interactive: true,
-    });
+  const { getTooltipProps, setTooltipRef, setTriggerRef } = usePopperTooltip({
+    delayShow: 200,
+    delayHide: 200,
+    placement: 'bottom-end',
+    trigger: 'click',
+    interactive: true,
+    visible: isSearchOpened,
+    onVisibleChange: setIsSearchOpened,
+  });
 
   const filtersContent = (
     <div>
@@ -60,6 +61,19 @@ const BalanceFilters: FC = () => {
     />
   );
 
+  const searchPill = (
+    <div className="flex items-center justify-end rounded-lg bg-blue-100 px-3 py-2 text-sm text-blue-400">
+      <p className="max-w-[12.5rem] truncate sm:max-w-full">{searchFilter}</p>
+      <button
+        type="button"
+        onClick={() => setSearchFilter('')}
+        className="ml-2 flex-shrink-0"
+      >
+        <X size={12} className="text-inherit" />
+      </button>
+    </div>
+  );
+
   return (
     <div className="mr-2">
       {isMobile ? (
@@ -79,6 +93,7 @@ const BalanceFilters: FC = () => {
           >
             <MagnifyingGlass size={14} />
           </Button>
+          {!!searchFilter && searchPill}
           <Modal
             isFullOnMobile={false}
             onClose={() => setOpened(false)}
@@ -103,13 +118,14 @@ const BalanceFilters: FC = () => {
         <>
           <div className="flex flex-row items-start justify-end gap-2">
             <ActiveFiltersList />
+            {!!searchFilter && searchPill}
             <FilterButton
-              isOpen={visible}
+              isOpen={isSearchOpened}
               setTriggerRef={setTriggerRef}
               customLabel={formatText({ id: 'allFilters' })}
             />
           </div>
-          {visible && (
+          {isSearchOpened && (
             <PopoverBase
               setTooltipRef={setTooltipRef}
               tooltipProps={getTooltipProps}

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/BalanceFilters/BalanceFilters.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/BalanceFilters/BalanceFilters.tsx
@@ -17,7 +17,11 @@ import BalanceTableFiltersItem from '../partials/BalanceTableFiltersItem/Balance
 
 import { filterItems } from './consts.tsx';
 
-const BalanceFilters: FC = () => {
+interface BalanceFiltersProps {
+  toggleAddFundsModalOn: () => void;
+}
+
+const BalanceFilters: FC<BalanceFiltersProps> = ({ toggleAddFundsModalOn }) => {
   const { searchFilter, setSearchFilter, selectedFiltersCount } =
     useFiltersContext();
 
@@ -63,47 +67,56 @@ const BalanceFilters: FC = () => {
   return (
     <div className="mr-2">
       {isMobile ? (
-        <div className="flex items-center gap-2">
-          <FilterButton
-            isOpen={isOpened}
-            onClick={() => setOpened(!isOpened)}
-            numberSelectedFilters={selectedFiltersCount}
-            customLabel={formatText({ id: 'allFilters' })}
-          />
-          <Button
-            mode="tertiary"
-            className="flex sm:hidden"
-            size="small"
-            aria-label={formatText({ id: 'ariaLabel.openSearchModal' })}
-            onClick={openSearch}
-          >
-            <MagnifyingGlass size={14} />
-          </Button>
+        <div className="flex flex-col items-start gap-2">
+          <div className="flex items-center gap-2">
+            <FilterButton
+              isOpen={isOpened}
+              onClick={() => setOpened(!isOpened)}
+              numberSelectedFilters={selectedFiltersCount}
+              customLabel={formatText({ id: 'allFilters' })}
+            />
+            <Button
+              mode="tertiary"
+              className="flex sm:hidden"
+              size="small"
+              aria-label={formatText({ id: 'ariaLabel.openSearchModal' })}
+              onClick={openSearch}
+            >
+              <MagnifyingGlass size={14} />
+            </Button>
+            <Button
+              mode="primarySolid"
+              onClick={toggleAddFundsModalOn}
+              size="small"
+            >
+              {formatText({ id: 'balancePage.table.addFunds' })}
+            </Button>
+            <Modal
+              isFullOnMobile={false}
+              onClose={() => setOpened(false)}
+              isOpen={isOpened}
+              withPaddingBottom
+            >
+              {filtersContent}
+            </Modal>
+            <Modal
+              isFullOnMobile={false}
+              onClose={closeSearch}
+              isOpen={isSearchOpened}
+              withPaddingBottom
+            >
+              <p className="mb-4 uppercase text-gray-400 text-4">
+                {formatText({ id: 'balancePage.filter.searchModalTitle' })}
+              </p>
+              <div className="sm:mb-6 sm:px-3.5">{searchInput}</div>
+            </Modal>
+          </div>
           {!!searchFilter && (
             <SearchPill
               value={searchFilter}
               onClick={() => setSearchFilter('')}
             />
           )}
-          <Modal
-            isFullOnMobile={false}
-            onClose={() => setOpened(false)}
-            isOpen={isOpened}
-            withPaddingBottom
-          >
-            {filtersContent}
-          </Modal>
-          <Modal
-            isFullOnMobile={false}
-            onClose={closeSearch}
-            isOpen={isSearchOpened}
-            withPaddingBottom
-          >
-            <p className="mb-4 uppercase text-gray-400 text-4">
-              {formatText({ id: 'balancePage.filter.searchModalTitle' })}
-            </p>
-            <div className="sm:mb-6 sm:px-3.5">{searchInput}</div>
-          </Modal>
         </div>
       ) : (
         <>
@@ -120,6 +133,13 @@ const BalanceFilters: FC = () => {
               setTriggerRef={setTriggerRef}
               customLabel={formatText({ id: 'allFilters' })}
             />
+            <Button
+              mode="primarySolid"
+              onClick={toggleAddFundsModalOn}
+              size="small"
+            >
+              {formatText({ id: 'balancePage.table.addFunds' })}
+            </Button>
           </div>
           {isSearchOpened && (
             <PopoverBase

--- a/src/components/frame/v5/pages/FundsPage/partials/Filter/Filter.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/Filter/Filter.tsx
@@ -3,6 +3,7 @@ import React, { useCallback } from 'react';
 
 import { useMobile } from '~hooks/index.ts';
 import useToggle from '~hooks/useToggle/index.ts';
+import { formatText } from '~utils/intl.ts';
 import { formatMessage } from '~utils/yup/tests/helpers.ts';
 import { useSearchFilter } from '~v5/common/Filter/hooks.ts';
 import SearchInputMobile from '~v5/common/Filter/partials/SearchInput/SearchInput.tsx';
@@ -13,6 +14,8 @@ import Modal from '~v5/shared/Modal/index.ts';
 import PopoverBase from '~v5/shared/PopoverBase/index.ts';
 import SearchInputDesktop from '~v5/shared/SearchSelect/partials/SearchInput/index.ts';
 import Header from '~v5/shared/SubNavigationItem/partials/Header.tsx';
+
+import AcceptButton from '../AcceptButton/AcceptButton.tsx';
 
 import FilterItem from './FilterItem.tsx';
 import { type FilterProps, type FilterValue } from './types.ts';
@@ -29,6 +32,9 @@ function Filter<TValue extends FilterValue>({
   searchInputPlaceholder,
   filtersHeader = 'filters',
   buttonText,
+  unclaimedClaims,
+  isButtonDisabled,
+  shouldShowButton,
 }: FilterProps<TValue>) {
   const {
     isSearchOpened,
@@ -69,28 +75,38 @@ function Filter<TValue extends FilterValue>({
 
   return (
     <>
-      <div className="flex flex-row gap-2">
-        {!!searchValue && !isMobile && (
-          <SearchPill value={searchValue} onClick={() => onSearch('')} />
-        )}
-        <FilterButton
-          isOpen={isSearchOpened}
-          onClick={toggleModalOn}
-          setTriggerRef={setTriggerRef}
-          customLabel={buttonText}
-          numberSelectedFilters={isMobile ? filterCount : undefined}
-        />
-        {isMobile && (
-          <Button
-            mode="tertiary"
-            className="flex sm:hidden"
-            size="small"
-            aria-label={formatMessage({ id: 'ariaLabel.openSearchModal' })}
-            onClick={openSearch}
-          >
-            <MagnifyingGlass size={14} />
-          </Button>
-        )}
+      <div className="flex flex-col items-start gap-2">
+        <div className="flex flex-row gap-2">
+          {!!searchValue && !isMobile && (
+            <SearchPill value={searchValue} onClick={() => onSearch('')} />
+          )}
+          <FilterButton
+            isOpen={isSearchOpened}
+            onClick={toggleModalOn}
+            setTriggerRef={setTriggerRef}
+            customLabel={buttonText}
+            numberSelectedFilters={isMobile ? filterCount : undefined}
+          />
+          {isMobile && (
+            <Button
+              mode="tertiary"
+              className="flex sm:hidden"
+              size="small"
+              aria-label={formatMessage({ id: 'ariaLabel.openSearchModal' })}
+              onClick={openSearch}
+            >
+              <MagnifyingGlass size={14} />
+            </Button>
+          )}
+          {shouldShowButton && (
+            <AcceptButton
+              tokenAddresses={unclaimedClaims}
+              disabled={isButtonDisabled}
+            >
+              {formatText({ id: 'incomingFundsPage.table.claimAllFunds' })}
+            </AcceptButton>
+          )}
+        </div>
         {!!searchValue && isMobile && (
           <SearchPill value={searchValue} onClick={() => onSearch('')} />
         )}

--- a/src/components/frame/v5/pages/FundsPage/partials/Filter/Filter.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/Filter/Filter.tsx
@@ -18,7 +18,7 @@ import Header from '~v5/shared/SubNavigationItem/partials/Header.tsx';
 import AcceptButton from '../AcceptButton/AcceptButton.tsx';
 
 import FilterItem from './FilterItem.tsx';
-import { type FilterProps, type FilterValue } from './types.ts';
+import { type ExtendedFilterProps, type FilterValue } from './types.ts';
 
 const displayName = 'v5.pages.FundsPage.partials.Filter';
 
@@ -35,7 +35,7 @@ function Filter<TValue extends FilterValue>({
   unclaimedClaims,
   isButtonDisabled,
   shouldShowButton,
-}: FilterProps<TValue>) {
+}: ExtendedFilterProps<TValue>) {
   const {
     isSearchOpened,
     openSearch,

--- a/src/components/frame/v5/pages/FundsPage/partials/Filter/Filter.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/Filter/Filter.tsx
@@ -1,11 +1,12 @@
-import { MagnifyingGlass, X } from '@phosphor-icons/react';
-import React, { useCallback, useState } from 'react';
-import { usePopperTooltip } from 'react-popper-tooltip';
+import { MagnifyingGlass } from '@phosphor-icons/react';
+import React, { useCallback } from 'react';
 
 import { useMobile } from '~hooks/index.ts';
 import useToggle from '~hooks/useToggle/index.ts';
 import { formatMessage } from '~utils/yup/tests/helpers.ts';
+import { useSearchFilter } from '~v5/common/Filter/hooks.ts';
 import SearchInputMobile from '~v5/common/Filter/partials/SearchInput/SearchInput.tsx';
+import SearchPill from '~v5/common/Pills/SearchPill/SearchPill.tsx';
 import Button from '~v5/shared/Button/Button.tsx';
 import FilterButton from '~v5/shared/Filter/FilterButton.tsx';
 import Modal from '~v5/shared/Modal/index.ts';
@@ -29,16 +30,14 @@ function Filter<TValue extends FilterValue>({
   filtersHeader = 'filters',
   buttonText,
 }: FilterProps<TValue>) {
-  const [isSearchOpened, setIsSearchOpened] = useState(false);
-  const { getTooltipProps, setTooltipRef, setTriggerRef } = usePopperTooltip({
-    delayShow: 200,
-    delayHide: 200,
-    placement: 'bottom-end',
-    trigger: 'click',
-    interactive: true,
-    visible: isSearchOpened,
-    onVisibleChange: setIsSearchOpened,
-  });
+  const {
+    isSearchOpened,
+    openSearch,
+    closeSearch,
+    getTooltipProps,
+    setTooltipRef,
+    setTriggerRef,
+  } = useSearchFilter();
   const isMobile = useMobile();
   const [isModalOpen, { toggleOff: toggleModalOff, toggleOn: toggleModalOn }] =
     useToggle();
@@ -68,23 +67,12 @@ function Filter<TValue extends FilterValue>({
     return acc + Object.values(obj).filter((item) => item === true).length;
   }, 0);
 
-  const searchPill = (
-    <div className="flex items-center justify-end rounded-lg bg-blue-100 px-3 py-2 text-sm text-blue-400">
-      <p className="max-w-[12.5rem] truncate sm:max-w-full">{searchValue}</p>
-      <button
-        type="button"
-        onClick={() => onSearch('')}
-        className="ml-2 flex-shrink-0"
-      >
-        <X size={12} className="text-inherit" />
-      </button>
-    </div>
-  );
-
   return (
     <>
       <div className="flex flex-row gap-2">
-        {!!searchValue && !isMobile && searchPill}
+        {!!searchValue && !isMobile && (
+          <SearchPill value={searchValue} onClick={() => onSearch('')} />
+        )}
         <FilterButton
           isOpen={isSearchOpened}
           onClick={toggleModalOn}
@@ -98,12 +86,14 @@ function Filter<TValue extends FilterValue>({
             className="flex sm:hidden"
             size="small"
             aria-label={formatMessage({ id: 'ariaLabel.openSearchModal' })}
-            onClick={() => setIsSearchOpened(true)}
+            onClick={openSearch}
           >
             <MagnifyingGlass size={14} />
           </Button>
         )}
-        {!!searchValue && isMobile && searchPill}
+        {!!searchValue && isMobile && (
+          <SearchPill value={searchValue} onClick={() => onSearch('')} />
+        )}
       </div>
       {isMobile && (
         <>
@@ -120,7 +110,7 @@ function Filter<TValue extends FilterValue>({
           </Modal>
           <Modal
             isFullOnMobile={false}
-            onClose={() => setIsSearchOpened(false)}
+            onClose={closeSearch}
             isOpen={isSearchOpened}
             withPaddingBottom
           >
@@ -129,7 +119,7 @@ function Filter<TValue extends FilterValue>({
             </p>
             <div className="sm:mb-6 sm:px-3.5">
               <SearchInputMobile
-                onSearchButtonClick={() => setIsSearchOpened(false)}
+                onSearchButtonClick={closeSearch}
                 setSearchValue={onInputChange}
                 searchValue={searchValue}
                 searchInputPlaceholder={searchInputPlaceholder}
@@ -153,7 +143,7 @@ function Filter<TValue extends FilterValue>({
           <div className="mb-6 px-3.5">
             <SearchInputDesktop
               onChange={onInputChange}
-              onClose={() => setIsSearchOpened(false)}
+              onClose={closeSearch}
               placeholder={searchInputPlaceholder}
               value={searchValue}
             />

--- a/src/components/frame/v5/pages/FundsPage/partials/Filter/Filter.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/Filter/Filter.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlass } from '@phosphor-icons/react';
+import { MagnifyingGlass, X } from '@phosphor-icons/react';
 import React, { useCallback, useState } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
 
@@ -29,17 +29,15 @@ function Filter<TValue extends FilterValue>({
   filtersHeader = 'filters',
   buttonText,
 }: FilterProps<TValue>) {
-  const {
-    getTooltipProps,
-    setTooltipRef,
-    setTriggerRef,
-    visible: isFiltersOpen,
-  } = usePopperTooltip({
+  const [isSearchOpened, setIsSearchOpened] = useState(false);
+  const { getTooltipProps, setTooltipRef, setTriggerRef } = usePopperTooltip({
     delayShow: 200,
     delayHide: 200,
     placement: 'bottom-end',
     trigger: 'click',
     interactive: true,
+    visible: isSearchOpened,
+    onVisibleChange: setIsSearchOpened,
   });
   const isMobile = useMobile();
   const [isModalOpen, { toggleOff: toggleModalOff, toggleOn: toggleModalOn }] =
@@ -70,13 +68,25 @@ function Filter<TValue extends FilterValue>({
     return acc + Object.values(obj).filter((item) => item === true).length;
   }, 0);
 
-  const [isSearchOpened, setIsSearchOpened] = useState(false);
+  const searchPill = (
+    <div className="flex items-center justify-end rounded-lg bg-blue-100 px-3 py-2 text-sm text-blue-400">
+      <p className="max-w-[12.5rem] truncate sm:max-w-full">{searchValue}</p>
+      <button
+        type="button"
+        onClick={() => onSearch('')}
+        className="ml-2 flex-shrink-0"
+      >
+        <X size={12} className="text-inherit" />
+      </button>
+    </div>
+  );
 
   return (
     <>
       <div className="flex flex-row gap-2">
+        {!!searchValue && !isMobile && searchPill}
         <FilterButton
-          isOpen={isFiltersOpen}
+          isOpen={isSearchOpened}
           onClick={toggleModalOn}
           setTriggerRef={setTriggerRef}
           customLabel={buttonText}
@@ -93,6 +103,7 @@ function Filter<TValue extends FilterValue>({
             <MagnifyingGlass size={14} />
           </Button>
         )}
+        {!!searchValue && isMobile && searchPill}
       </div>
       {isMobile && (
         <>
@@ -127,7 +138,7 @@ function Filter<TValue extends FilterValue>({
           </Modal>
         </>
       )}
-      {isFiltersOpen && !isMobile && (
+      {isSearchOpened && !isMobile && (
         <PopoverBase
           setTooltipRef={setTooltipRef}
           tooltipProps={getTooltipProps}
@@ -142,6 +153,7 @@ function Filter<TValue extends FilterValue>({
           <div className="mb-6 px-3.5">
             <SearchInputDesktop
               onChange={onInputChange}
+              onClose={() => setIsSearchOpened(false)}
               placeholder={searchInputPlaceholder}
               value={searchValue}
             />

--- a/src/components/frame/v5/pages/FundsPage/partials/Filter/types.ts
+++ b/src/components/frame/v5/pages/FundsPage/partials/Filter/types.ts
@@ -34,6 +34,9 @@ export interface FilterProps<TValue extends FilterValue> {
   searchInputPlaceholder: string;
   filtersHeader?: string;
   buttonText?: string;
+  unclaimedClaims: string[];
+  isButtonDisabled?: boolean;
+  shouldShowButton?: boolean;
 }
 
 export interface NestedFilterProps<

--- a/src/components/frame/v5/pages/FundsPage/partials/Filter/types.ts
+++ b/src/components/frame/v5/pages/FundsPage/partials/Filter/types.ts
@@ -34,6 +34,10 @@ export interface FilterProps<TValue extends FilterValue> {
   searchInputPlaceholder: string;
   filtersHeader?: string;
   buttonText?: string;
+}
+
+export interface ExtendedFilterProps<TValue extends FilterValue>
+  extends FilterProps<TValue> {
   unclaimedClaims: string[];
   isButtonDisabled?: boolean;
   shouldShowButton?: boolean;

--- a/src/components/frame/v5/pages/FundsPage/partials/FundsTable/FundsTable.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/FundsTable/FundsTable.tsx
@@ -14,7 +14,6 @@ import Table from '~v5/common/Table/index.ts';
 import TableHeader from '~v5/common/TableHeader/TableHeader.tsx';
 import CloseButton from '~v5/shared/Button/CloseButton.tsx';
 
-import AcceptButton from '../AcceptButton/index.ts';
 import Filter from '../Filter/index.ts';
 
 import { useFundsTable, useFundsTableColumns } from './hooks.tsx';
@@ -73,15 +72,12 @@ const FundsTable: FC = () => {
                 </div>
               ) : null,
             )}
-          <Filter {...filters} />
-          {unclaimedClaims.length > 0 && (
-            <AcceptButton
-              tokenAddresses={allUnclaimedClaims}
-              disabled={!searchedTokens.length}
-            >
-              {formatText({ id: 'incomingFundsPage.table.claimAllFunds' })}
-            </AcceptButton>
-          )}
+          <Filter
+            {...filters}
+            unclaimedClaims={allUnclaimedClaims}
+            isButtonDisabled={!searchedTokens.length}
+            shouldShowButton={unclaimedClaims.length > 0}
+          />
         </div>
       </TableHeader>
       <Table<FundsTableModel>

--- a/src/components/frame/v5/pages/TeamsPage/TeamsPage.tsx
+++ b/src/components/frame/v5/pages/TeamsPage/TeamsPage.tsx
@@ -2,26 +2,20 @@ import { Binoculars } from '@phosphor-icons/react';
 import { isEqual } from 'lodash';
 import React, { type FC } from 'react';
 
-import { Action } from '~constants/actions.ts';
-import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { useSetPageHeadingTitle } from '~context/PageHeadingContext/PageHeadingContext.ts';
 import { ModelSortDirection } from '~gql';
 import { useMobile } from '~hooks';
 import { formatText } from '~utils/intl.ts';
-import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import EmptyContent from '~v5/common/EmptyContent/EmptyContent.tsx';
 import TeamCardList from '~v5/common/TeamCardList/index.ts';
 import ContentWithTeamFilter from '~v5/frame/ContentWithTeamFilter/ContentWithTeamFilter.tsx';
-import Button, { CloseButton } from '~v5/shared/Button/index.ts';
+import { CloseButton } from '~v5/shared/Button/index.ts';
 
 import { useTeams } from './hooks.tsx';
 import TeamsPageFilter from './partials/TeamsPageFilter/TeamsPageFilter.tsx';
 
 const TeamsPage: FC = () => {
   useSetPageHeadingTitle(formatText({ id: 'teamsPage.title' }));
-  const {
-    actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
-  } = useActionSidebarContext();
   const { filters, searchedTeams, defaultFilterValue, hasFilterChanged } =
     useTeams();
   const isMobile = useMobile();
@@ -63,16 +57,6 @@ const TeamsPage: FC = () => {
                 </div>
               )}
             <TeamsPageFilter {...filters} />
-            <Button
-              onClick={() =>
-                toggleActionSidebarOn({
-                  [ACTION_TYPE_FIELD_NAME]: Action.CreateNewTeam,
-                })
-              }
-              text={formatText({ id: 'teamsPage.createNewTeam' })}
-              mode="primarySolid"
-              size="small"
-            />
           </div>
         </div>
         {searchedTeams.length > 0 ? (

--- a/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/TeamsPageFilter.tsx
+++ b/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/TeamsPageFilter.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlass, X } from '@phosphor-icons/react';
+import { MagnifyingGlass } from '@phosphor-icons/react';
 import React, { type FC, useCallback, useState } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
 
@@ -6,6 +6,7 @@ import { useMobile } from '~hooks';
 import useToggle from '~hooks/useToggle/index.ts';
 import { formatText } from '~utils/intl.ts';
 import SearchInputMobile from '~v5/common/Filter/partials/SearchInput/SearchInput.tsx';
+import SearchPill from '~v5/common/Pills/SearchPill/SearchPill.tsx';
 import Button from '~v5/shared/Button/index.ts';
 import FilterButton from '~v5/shared/Filter/FilterButton.tsx';
 import Modal from '~v5/shared/Modal/index.ts';
@@ -44,19 +45,6 @@ const TeamsPageFilter: FC<TeamsPageFilterProps> = ({
     [onSearch],
   );
 
-  const searchPill = (
-    <div className="flex items-center justify-end rounded-lg bg-blue-100 px-3 py-2 text-sm text-blue-400">
-      <p className="max-w-[12.5rem] truncate sm:max-w-full">{searchValue}</p>
-      <button
-        type="button"
-        onClick={() => onSearch('')}
-        className="ml-2 flex-shrink-0"
-      >
-        <X size={12} className="text-inherit" />
-      </button>
-    </div>
-  );
-
   const RootItems = items.map(
     ({ icon, items: nestedItems, label, name, title, filterName }) => (
       <FilterItem
@@ -76,7 +64,9 @@ const TeamsPageFilter: FC<TeamsPageFilterProps> = ({
   return (
     <>
       <div className="flex flex-row gap-2">
-        {!!searchValue && !isMobile && searchPill}
+        {!!searchValue && !isMobile && (
+          <SearchPill value={searchValue} onClick={() => onSearch('')} />
+        )}
         <FilterButton
           isOpen={isSearchOpened}
           onClick={toggleModalOn}
@@ -95,7 +85,9 @@ const TeamsPageFilter: FC<TeamsPageFilterProps> = ({
             >
               <MagnifyingGlass size={14} />
             </Button>
-            {!!searchValue && searchPill}
+            {!!searchValue && (
+              <SearchPill value={searchValue} onClick={() => onSearch('')} />
+            )}
           </>
         )}
       </div>

--- a/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/TeamsPageFilter.tsx
+++ b/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/TeamsPageFilter.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlass } from '@phosphor-icons/react';
+import { MagnifyingGlass, X } from '@phosphor-icons/react';
 import React, { type FC, useCallback, useState } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
 
@@ -24,17 +24,15 @@ const TeamsPageFilter: FC<TeamsPageFilterProps> = ({
   filterValue,
   hasFilterChanged,
 }) => {
-  const {
-    getTooltipProps,
-    setTooltipRef,
-    setTriggerRef,
-    visible: isFiltersOpen,
-  } = usePopperTooltip({
+  const [isSearchOpened, setIsSearchOpened] = useState(false);
+  const { getTooltipProps, setTooltipRef, setTriggerRef } = usePopperTooltip({
     delayShow: 200,
     delayHide: 200,
     placement: 'bottom-end',
     trigger: 'click',
     interactive: true,
+    visible: isSearchOpened,
+    onVisibleChange: setIsSearchOpened,
   });
   const isMobile = useMobile();
   const [isModalOpen, { toggleOff: toggleModalOff, toggleOn: toggleModalOn }] =
@@ -45,7 +43,19 @@ const TeamsPageFilter: FC<TeamsPageFilterProps> = ({
     },
     [onSearch],
   );
-  const [isSearchOpened, setIsSearchOpened] = useState(false);
+
+  const searchPill = (
+    <div className="flex items-center justify-end rounded-lg bg-blue-100 px-3 py-2 text-sm text-blue-400">
+      <p className="max-w-[12.5rem] truncate sm:max-w-full">{searchValue}</p>
+      <button
+        type="button"
+        onClick={() => onSearch('')}
+        className="ml-2 flex-shrink-0"
+      >
+        <X size={12} className="text-inherit" />
+      </button>
+    </div>
+  );
 
   const RootItems = items.map(
     ({ icon, items: nestedItems, label, name, title, filterName }) => (
@@ -66,23 +76,27 @@ const TeamsPageFilter: FC<TeamsPageFilterProps> = ({
   return (
     <>
       <div className="flex flex-row gap-2">
+        {!!searchValue && !isMobile && searchPill}
         <FilterButton
-          isOpen={isFiltersOpen}
+          isOpen={isSearchOpened}
           onClick={toggleModalOn}
           setTriggerRef={setTriggerRef}
           customLabel={formatText({ id: 'teamsPage.filter.filterButton' })}
           numberSelectedFilters={hasFilterChanged && isMobile ? 1 : 0}
         />
         {isMobile && (
-          <Button
-            mode="tertiary"
-            className="flex sm:hidden"
-            size="small"
-            aria-label={formatText({ id: 'ariaLabel.openSearchModal' })}
-            onClick={() => setIsSearchOpened(true)}
-          >
-            <MagnifyingGlass size={14} />
-          </Button>
+          <>
+            <Button
+              mode="tertiary"
+              className="flex sm:hidden"
+              size="small"
+              aria-label={formatText({ id: 'ariaLabel.openSearchModal' })}
+              onClick={() => setIsSearchOpened(true)}
+            >
+              <MagnifyingGlass size={14} />
+            </Button>
+            {!!searchValue && searchPill}
+          </>
         )}
       </div>
       {isMobile && (
@@ -120,7 +134,7 @@ const TeamsPageFilter: FC<TeamsPageFilterProps> = ({
           </Modal>
         </>
       )}
-      {isFiltersOpen && !isMobile && (
+      {isSearchOpened && !isMobile && (
         <PopoverBase
           setTooltipRef={setTooltipRef}
           tooltipProps={getTooltipProps}
@@ -135,6 +149,7 @@ const TeamsPageFilter: FC<TeamsPageFilterProps> = ({
           <div className="mb-6 px-3.5">
             <SearchInputDesktop
               onChange={onInputChange}
+              onClose={() => setIsSearchOpened(false)}
               placeholder={formatText({ id: 'teamsPage.filter.search' })}
               value={searchValue}
             />

--- a/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/TeamsPageFilter.tsx
+++ b/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/TeamsPageFilter.tsx
@@ -2,9 +2,12 @@ import { MagnifyingGlass } from '@phosphor-icons/react';
 import React, { type FC, useCallback, useState } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
 
+import { Action } from '~constants/actions.ts';
+import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { useMobile } from '~hooks';
 import useToggle from '~hooks/useToggle/index.ts';
 import { formatText } from '~utils/intl.ts';
+import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import SearchInputMobile from '~v5/common/Filter/partials/SearchInput/SearchInput.tsx';
 import SearchPill from '~v5/common/Pills/SearchPill/SearchPill.tsx';
 import Button from '~v5/shared/Button/index.ts';
@@ -35,6 +38,9 @@ const TeamsPageFilter: FC<TeamsPageFilterProps> = ({
     visible: isSearchOpened,
     onVisibleChange: setIsSearchOpened,
   });
+  const {
+    actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],
+  } = useActionSidebarContext();
   const isMobile = useMobile();
   const [isModalOpen, { toggleOff: toggleModalOff, toggleOn: toggleModalOn }] =
     useToggle();
@@ -63,19 +69,19 @@ const TeamsPageFilter: FC<TeamsPageFilterProps> = ({
 
   return (
     <>
-      <div className="flex flex-row gap-2">
-        {!!searchValue && !isMobile && (
-          <SearchPill value={searchValue} onClick={() => onSearch('')} />
-        )}
-        <FilterButton
-          isOpen={isSearchOpened}
-          onClick={toggleModalOn}
-          setTriggerRef={setTriggerRef}
-          customLabel={formatText({ id: 'teamsPage.filter.filterButton' })}
-          numberSelectedFilters={hasFilterChanged && isMobile ? 1 : 0}
-        />
-        {isMobile && (
-          <>
+      <div className="flex flex-col items-start gap-2">
+        <div className="flex flex-row gap-2">
+          {!!searchValue && !isMobile && (
+            <SearchPill value={searchValue} onClick={() => onSearch('')} />
+          )}
+          <FilterButton
+            isOpen={isSearchOpened}
+            onClick={toggleModalOn}
+            setTriggerRef={setTriggerRef}
+            customLabel={formatText({ id: 'teamsPage.filter.filterButton' })}
+            numberSelectedFilters={hasFilterChanged && isMobile ? 1 : 0}
+          />
+          {isMobile && (
             <Button
               mode="tertiary"
               className="flex sm:hidden"
@@ -85,10 +91,20 @@ const TeamsPageFilter: FC<TeamsPageFilterProps> = ({
             >
               <MagnifyingGlass size={14} />
             </Button>
-            {!!searchValue && (
-              <SearchPill value={searchValue} onClick={() => onSearch('')} />
-            )}
-          </>
+          )}
+          <Button
+            onClick={() =>
+              toggleActionSidebarOn({
+                [ACTION_TYPE_FIELD_NAME]: Action.CreateNewTeam,
+              })
+            }
+            text={formatText({ id: 'teamsPage.createNewTeam' })}
+            mode="primarySolid"
+            size="small"
+          />
+        </div>
+        {!!searchValue && isMobile && (
+          <SearchPill value={searchValue} onClick={() => onSearch('')} />
         )}
       </div>
       {isMobile && (

--- a/src/components/v5/common/Filter/Filter.tsx
+++ b/src/components/v5/common/Filter/Filter.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlass } from '@phosphor-icons/react';
+import { MagnifyingGlass, X } from '@phosphor-icons/react';
 import React, { type FC, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { usePopperTooltip } from 'react-popper-tooltip';
@@ -29,21 +29,31 @@ const Filter: FC<FilterProps> = ({
   const [isOpened, setOpened] = useState(false);
   const [isSearchOpened, setIsSearchOpened] = useState(false);
   const isMobile = useMobile();
-  const {
-    getTooltipProps,
-    setTooltipRef,
-    setTriggerRef,
-    visible: isFiltersOpen,
-  } = usePopperTooltip({
+  const { getTooltipProps, setTooltipRef, setTriggerRef } = usePopperTooltip({
     delayShow: 200,
     delayHide: 200,
     placement: 'bottom-end',
     trigger: 'click',
     interactive: true,
+    visible: isSearchOpened,
+    onVisibleChange: setIsSearchOpened,
   });
 
   const { selectedFilterCount } = useFilterContext();
   const { searchValue, setSearchValue } = useSearchContext();
+
+  const searchPill = (
+    <div className="flex items-center justify-end rounded-lg bg-blue-100 px-3 py-2 text-sm text-blue-400">
+      <p className="max-w-[12.5rem] truncate sm:max-w-full">{searchValue}</p>
+      <button
+        type="button"
+        onClick={() => setSearchValue('')}
+        className="ml-2 flex-shrink-0"
+      >
+        <X size={12} className="text-inherit" />
+      </button>
+    </div>
+  );
 
   return (
     <>
@@ -64,6 +74,7 @@ const Filter: FC<FilterProps> = ({
           >
             <MagnifyingGlass size={14} />
           </Button>
+          {!!searchValue && searchPill}
           <Modal
             isFullOnMobile={false}
             onClose={() => setOpened(false)}
@@ -93,13 +104,14 @@ const Filter: FC<FilterProps> = ({
         <>
           <div className="flex flex-row gap-2">
             <TableFiltering />
+            {!!searchValue && searchPill}
             <FilterButton
-              isOpen={isFiltersOpen}
+              isOpen={isSearchOpened}
               setTriggerRef={setTriggerRef}
               customLabel={customLabel}
             />
           </div>
-          {isFiltersOpen && (
+          {isSearchOpened && (
             <PopoverBase
               setTooltipRef={setTooltipRef}
               tooltipProps={getTooltipProps}

--- a/src/components/v5/common/Filter/Filter.tsx
+++ b/src/components/v5/common/Filter/Filter.tsx
@@ -1,7 +1,6 @@
-import { MagnifyingGlass, X } from '@phosphor-icons/react';
+import { MagnifyingGlass } from '@phosphor-icons/react';
 import React, { type FC, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { usePopperTooltip } from 'react-popper-tooltip';
 
 import { useFilterContext } from '~context/FilterContext/FilterContext.ts';
 import { useSearchContext } from '~context/SearchContext/SearchContext.ts';
@@ -11,8 +10,10 @@ import FilterButton from '~v5/shared/Filter/FilterButton.tsx';
 import Modal from '~v5/shared/Modal/index.ts';
 import PopoverBase from '~v5/shared/PopoverBase/index.ts';
 
+import SearchPill from '../Pills/SearchPill/SearchPill.tsx';
 import TableFiltering from '../TableFiltering/index.ts';
 
+import { useSearchFilter } from './hooks.ts';
 import FilterOptions from './partials/FilterOptions.tsx';
 import SearchInput from './partials/SearchInput/index.ts';
 import { type FilterProps } from './types.ts';
@@ -27,33 +28,18 @@ const Filter: FC<FilterProps> = ({
 }) => {
   const { formatMessage } = useIntl();
   const [isOpened, setOpened] = useState(false);
-  const [isSearchOpened, setIsSearchOpened] = useState(false);
+  const {
+    isSearchOpened,
+    openSearch,
+    closeSearch,
+    getTooltipProps,
+    setTooltipRef,
+    setTriggerRef,
+  } = useSearchFilter();
   const isMobile = useMobile();
-  const { getTooltipProps, setTooltipRef, setTriggerRef } = usePopperTooltip({
-    delayShow: 200,
-    delayHide: 200,
-    placement: 'bottom-end',
-    trigger: 'click',
-    interactive: true,
-    visible: isSearchOpened,
-    onVisibleChange: setIsSearchOpened,
-  });
 
   const { selectedFilterCount } = useFilterContext();
   const { searchValue, setSearchValue } = useSearchContext();
-
-  const searchPill = (
-    <div className="flex items-center justify-end rounded-lg bg-blue-100 px-3 py-2 text-sm text-blue-400">
-      <p className="max-w-[12.5rem] truncate sm:max-w-full">{searchValue}</p>
-      <button
-        type="button"
-        onClick={() => setSearchValue('')}
-        className="ml-2 flex-shrink-0"
-      >
-        <X size={12} className="text-inherit" />
-      </button>
-    </div>
-  );
 
   return (
     <>
@@ -70,11 +56,16 @@ const Filter: FC<FilterProps> = ({
             className="flex sm:hidden"
             size="small"
             aria-label={formatMessage({ id: 'ariaLabel.openSearchModal' })}
-            onClick={() => setIsSearchOpened(true)}
+            onClick={openSearch}
           >
             <MagnifyingGlass size={14} />
           </Button>
-          {!!searchValue && searchPill}
+          {!!searchValue && (
+            <SearchPill
+              value={searchValue}
+              onClick={() => setSearchValue('')}
+            />
+          )}
           <Modal
             isFullOnMobile={false}
             onClose={() => setOpened(false)}
@@ -85,14 +76,14 @@ const Filter: FC<FilterProps> = ({
           </Modal>
           <Modal
             isFullOnMobile={false}
-            onClose={() => setIsSearchOpened(false)}
+            onClose={closeSearch}
             isOpen={isSearchOpened}
             withPaddingBottom
           >
             <p className="mb-4 text-gray-400 text-4">{searchInputLabel}</p>
             <div className="sm:mb-6 sm:px-3.5">
               <SearchInput
-                onSearchButtonClick={() => setIsSearchOpened(false)}
+                onSearchButtonClick={closeSearch}
                 searchValue={searchValue}
                 setSearchValue={setSearchValue}
                 searchInputPlaceholder={searchInputPlaceholder}
@@ -104,7 +95,12 @@ const Filter: FC<FilterProps> = ({
         <>
           <div className="flex flex-row gap-2">
             <TableFiltering />
-            {!!searchValue && searchPill}
+            {!!searchValue && (
+              <SearchPill
+                value={searchValue}
+                onClick={() => setSearchValue('')}
+              />
+            )}
             <FilterButton
               isOpen={isSearchOpened}
               setTriggerRef={setTriggerRef}
@@ -125,7 +121,7 @@ const Filter: FC<FilterProps> = ({
             >
               <div className="sm:mb-6 sm:px-3.5">
                 <SearchInput
-                  onSearchButtonClick={() => setIsSearchOpened(false)}
+                  onSearchButtonClick={closeSearch}
                   searchValue={searchValue}
                   setSearchValue={setSearchValue}
                   searchInputPlaceholder={searchInputPlaceholder}

--- a/src/components/v5/common/Filter/Filter.tsx
+++ b/src/components/v5/common/Filter/Filter.tsx
@@ -44,52 +44,54 @@ const Filter: FC<FilterProps> = ({
   return (
     <>
       {isMobile ? (
-        <div className="flex items-center gap-2">
-          <FilterButton
-            isOpen={isOpened}
-            onClick={() => setOpened(!isOpened)}
-            numberSelectedFilters={selectedFilterCount}
-            customLabel={customLabel}
-          />
-          <Button
-            mode="tertiary"
-            className="flex sm:hidden"
-            size="small"
-            aria-label={formatMessage({ id: 'ariaLabel.openSearchModal' })}
-            onClick={openSearch}
-          >
-            <MagnifyingGlass size={14} />
-          </Button>
+        <div className="flex flex-col items-start gap-2">
+          <div className="flex items-center gap-2">
+            <FilterButton
+              isOpen={isOpened}
+              onClick={() => setOpened(!isOpened)}
+              numberSelectedFilters={selectedFilterCount}
+              customLabel={customLabel}
+            />
+            <Button
+              mode="tertiary"
+              className="flex sm:hidden"
+              size="small"
+              aria-label={formatMessage({ id: 'ariaLabel.openSearchModal' })}
+              onClick={openSearch}
+            >
+              <MagnifyingGlass size={14} />
+            </Button>
+            <Modal
+              isFullOnMobile={false}
+              onClose={() => setOpened(false)}
+              isOpen={isOpened}
+              withPaddingBottom
+            >
+              <FilterOptions excludeFilterType={excludeFilterType} />
+            </Modal>
+            <Modal
+              isFullOnMobile={false}
+              onClose={closeSearch}
+              isOpen={isSearchOpened}
+              withPaddingBottom
+            >
+              <p className="mb-4 text-gray-400 text-4">{searchInputLabel}</p>
+              <div className="sm:mb-6 sm:px-3.5">
+                <SearchInput
+                  onSearchButtonClick={closeSearch}
+                  searchValue={searchValue}
+                  setSearchValue={setSearchValue}
+                  searchInputPlaceholder={searchInputPlaceholder}
+                />
+              </div>
+            </Modal>
+          </div>
           {!!searchValue && (
             <SearchPill
               value={searchValue}
               onClick={() => setSearchValue('')}
             />
           )}
-          <Modal
-            isFullOnMobile={false}
-            onClose={() => setOpened(false)}
-            isOpen={isOpened}
-            withPaddingBottom
-          >
-            <FilterOptions excludeFilterType={excludeFilterType} />
-          </Modal>
-          <Modal
-            isFullOnMobile={false}
-            onClose={closeSearch}
-            isOpen={isSearchOpened}
-            withPaddingBottom
-          >
-            <p className="mb-4 text-gray-400 text-4">{searchInputLabel}</p>
-            <div className="sm:mb-6 sm:px-3.5">
-              <SearchInput
-                onSearchButtonClick={closeSearch}
-                searchValue={searchValue}
-                setSearchValue={setSearchValue}
-                searchInputPlaceholder={searchInputPlaceholder}
-              />
-            </div>
-          </Modal>
         </div>
       ) : (
         <>

--- a/src/components/v5/common/Filter/hooks.ts
+++ b/src/components/v5/common/Filter/hooks.ts
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { usePopperTooltip } from 'react-popper-tooltip';
+
+export const useSearchFilter = () => {
+  const [isSearchOpened, setIsSearchOpened] = useState(false);
+  const { getTooltipProps, setTooltipRef, setTriggerRef } = usePopperTooltip({
+    delayShow: 200,
+    delayHide: 200,
+    placement: 'bottom-start',
+    trigger: 'click',
+    interactive: true,
+    visible: isSearchOpened,
+    onVisibleChange: setIsSearchOpened,
+  });
+
+  const closeSearch = () => {
+    setIsSearchOpened(false);
+  };
+
+  const openSearch = () => {
+    setIsSearchOpened(true);
+  };
+
+  const toggleSearch = () => {
+    setIsSearchOpened((prev) => !prev);
+  };
+
+  return {
+    getTooltipProps,
+    setTooltipRef,
+    setTriggerRef,
+    isSearchOpened,
+    closeSearch,
+    openSearch,
+    toggleSearch,
+  };
+};

--- a/src/components/v5/common/Filter/partials/SearchInput/SearchInput.tsx
+++ b/src/components/v5/common/Filter/partials/SearchInput/SearchInput.tsx
@@ -79,6 +79,11 @@ const SearchInput: FC<SearchInputProps> = ({
         )}
         type="text"
         onInput={onInput}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            onSearchButtonClick();
+          }
+        }}
         placeholder={searchInputPlaceholder}
         defaultValue={searchValue}
       />

--- a/src/components/v5/common/Filter/partials/SearchInput/SearchInput.tsx
+++ b/src/components/v5/common/Filter/partials/SearchInput/SearchInput.tsx
@@ -82,6 +82,10 @@ const SearchInput: FC<SearchInputProps> = ({
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
             onSearchButtonClick();
+
+            if (isMobile) {
+              setSearchValue(value);
+            }
           }
         }}
         placeholder={searchInputPlaceholder}

--- a/src/components/v5/common/Pills/SearchPill/SearchPill.tsx
+++ b/src/components/v5/common/Pills/SearchPill/SearchPill.tsx
@@ -1,0 +1,24 @@
+import { X } from '@phosphor-icons/react';
+import React, { type FC } from 'react';
+
+interface SearchPillProps {
+  value?: string;
+  onClick: () => void;
+}
+
+const SearchPill: FC<SearchPillProps> = ({ value, onClick }) => {
+  if (!value) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center justify-end rounded-lg bg-blue-100 px-3 py-2 text-sm text-blue-400">
+      <p className="max-w-[12.5rem] truncate sm:max-w-full">{value}</p>
+      <button type="button" onClick={onClick} className="ml-2 flex-shrink-0">
+        <X size={12} className="text-inherit" />
+      </button>
+    </div>
+  );
+};
+
+export default SearchPill;

--- a/src/components/v5/shared/SearchSelect/partials/SearchInput/SearchInput.tsx
+++ b/src/components/v5/shared/SearchSelect/partials/SearchInput/SearchInput.tsx
@@ -11,6 +11,7 @@ const displayName = 'v5.SearchSelect.partials.SearchInput';
 
 const SearchInput: FC<SearchInputProps> = ({
   onChange,
+  onClose,
   value,
   placeholder = formatText({ id: 'placeholder.search' }),
   shouldFocus = false,
@@ -41,6 +42,11 @@ const SearchInput: FC<SearchInputProps> = ({
             <MagnifyingGlass size={14} />
           </span>
         }
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            onClose?.();
+          }
+        }}
         prefix={
           value ? (
             <button

--- a/src/components/v5/shared/SearchSelect/partials/SearchInput/types.ts
+++ b/src/components/v5/shared/SearchSelect/partials/SearchInput/types.ts
@@ -2,5 +2,6 @@ import { type InputBaseProps } from '~v5/common/Fields/InputBase/types.ts';
 
 export interface SearchInputProps extends Omit<InputBaseProps, 'onChange'> {
   onChange?: (value: string) => void;
+  onClose?: () => void;
   shouldFocus?: boolean;
 }


### PR DESCRIPTION
## Description

- Added search pill next to filters
- When clicking 'enter' key while typing in search input - filter menu closes
<img width="1235" alt="image" src="https://github.com/user-attachments/assets/749e6654-d857-4956-9b6b-b107293f6607">

## Testing

* Go to any page with filters i.e. activity feed, balances
* Open filters menu and use search
* Click 'enter' key and check if menu closes

Resolves https://github.com/JoinColony/colonyCDapp/issues/3666
