### PR TITLE
Fix: Split payment action form has pre-selected team filled

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/PaymentsSection.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/PaymentsSection.tsx
@@ -5,12 +5,8 @@ import { Action } from '~constants/actions.ts';
 import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { usePageLayoutContext } from '~context/PageLayoutContext/PageLayoutContext.ts';
 import { useTotalInOutBalanceContext } from '~context/TotalInOutBalanceContext/TotalInOutBalanceContext.ts';
-import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
 import { formatText } from '~utils/intl.ts';
-import {
-  ACTION_TYPE_FIELD_NAME,
-  FROM_FIELD_NAME,
-} from '~v5/common/ActionSidebar/consts.ts';
+import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import Button from '~v5/shared/Button/Button.tsx';
 
 import { MSG } from '../consts.ts';
@@ -23,7 +19,6 @@ export const PaymentsSection = () => {
     totalOut,
     previousTotalOut,
   } = useTotalInOutBalanceContext();
-  const selectedDomain = useGetSelectedDomainFilter();
   const { setShowTabletSidebar } = usePageLayoutContext();
 
   const {
@@ -35,7 +30,6 @@ export const PaymentsSection = () => {
 
     toggleActionSidebarOn({
       [ACTION_TYPE_FIELD_NAME]: Action.PaymentGroup,
-      [FROM_FIELD_NAME]: selectedDomain?.nativeId ?? '',
     });
   };
 

--- a/src/context/ActionSidebarContext/ActionSidebarContextProvider.tsx
+++ b/src/context/ActionSidebarContext/ActionSidebarContextProvider.tsx
@@ -9,11 +9,16 @@ import { type FieldValues } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
 import { useTablet } from '~hooks';
+import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
 import useToggle from '~hooks/useToggle/index.ts';
 import { TX_SEARCH_PARAM } from '~routes/routeConstants.ts';
 import { isChildOf } from '~utils/checks/isChildOf.ts';
 import { getElementWithSelector } from '~utils/elements.ts';
 import { removeQueryParamFromUrl } from '~utils/urls.ts';
+import {
+  FROM_FIELD_NAME,
+  TEAM_FIELD_NAME,
+} from '~v5/common/ActionSidebar/consts.ts';
 
 import {
   useAnalyticsContext,
@@ -54,6 +59,8 @@ const ActionSidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
     },
   ] = useToggle();
   const { trackEvent } = useAnalyticsContext();
+  const selectedDomain = useGetSelectedDomainFilter();
+  const selectedDomainNativeId = selectedDomain?.nativeId ?? '';
   const navigate = useNavigate();
 
   const removeTxParamOnClose = useCallback(() => {
@@ -77,14 +84,23 @@ const ActionSidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
     return undefined;
   });
 
+  const getSidebarInitialValues = useCallback(
+    (initialValues = {}) => ({
+      [FROM_FIELD_NAME]: selectedDomainNativeId,
+      [TEAM_FIELD_NAME]: selectedDomainNativeId,
+      ...initialValues,
+    }),
+    [selectedDomainNativeId],
+  );
+
   const toggleOn = useCallback(
     (initialValues) => {
-      setActionSidebarInitialValues(initialValues);
+      setActionSidebarInitialValues(getSidebarInitialValues(initialValues));
       // Track the event when the action panel is opened
       trackEvent(OPEN_ACTION_PANEL_EVENT);
       return toggleActionSidebarOn();
     },
-    [toggleActionSidebarOn, trackEvent],
+    [getSidebarInitialValues, toggleActionSidebarOn, trackEvent],
   );
 
   const toggleOff = useCallback(() => {
@@ -95,11 +111,11 @@ const ActionSidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const toggle = useCallback(
     (initialValues) => {
       if (!isActionSidebarOpen) {
-        setActionSidebarInitialValues(initialValues);
+        setActionSidebarInitialValues(getSidebarInitialValues(initialValues));
       }
       return toggleActionSidebar();
     },
-    [isActionSidebarOpen, toggleActionSidebar],
+    [isActionSidebarOpen, getSidebarInitialValues, toggleActionSidebar],
   );
 
   const value = useMemo<ActionSidebarContextValue>(


### PR DESCRIPTION
## Description

- The issue was caused by the fact the other two payment action forms (`Simple Payment` and `Advanced Payment`) were relying on the team field to be called `from`, while `Split payment` was using `team` as the field id.

## Testing

TODO: Please check opening the action sidebar by clicking `Pay` and having a team filter in place will populate the `Simple payment`/`Advanced payment`/`Split payment` with the active team filter. 

* Step 1. Go to http://localhost:9091/planex
* Step 2. Select `Andromeda` from the team filters
![Screenshot 2024-11-25 at 15 11 11](https://github.com/user-attachments/assets/f387bfba-d9bc-4f62-aed3-9f2b34094ef7)

* Step 3. Click `Pay` from the `Total in and out` card
![Screenshot 2024-11-25 at 15 11 25](https://github.com/user-attachments/assets/bf24c71d-643c-4f08-9bbc-df821f553c62)

* Step 4. The `Payments` actions sidebar should open
![Screenshot 2024-11-25 at 15 12 39](https://github.com/user-attachments/assets/379c7f73-ac38-4ed7-af86-ce24bc1e5f1e)

* Step 5. Check for each individual action - `Simple`, `Advanced` and `Split` - that `Andromeda` is pre-filled
* Step 6. Now let's move to checking the actions sidebar triggered from the **navigation sidebar**
* Step 7. Click on `Make payment` and check for each individual action - `Simple`, `Advanced` and `Split` - that `Andromeda` is prefilled
![Screenshot 2024-11-26 at 15 08 39](https://github.com/user-attachments/assets/2e06fbd5-7a83-4f51-9c5f-9b9de68de184)

* Step 8. Click on `Manage colony` and check for the following actions that `Andromeda` is pre-filled: `Transfer funds`, `Edit a team`, `Manage reputation` and `Manage permissions`
![Screenshot 2024-11-26 at 15 06 12](https://github.com/user-attachments/assets/542e4dc2-46c3-4cfd-bf83-c4993402fdf1)
![Screenshot 2024-11-26 at 15 12 03](https://github.com/user-attachments/assets/41aec632-0d29-41bc-b397-8433bfa995d3)
![Screenshot 2024-11-26 at 15 12 11](https://github.com/user-attachments/assets/ec85fc45-2d8f-4473-a5d2-b26900c340f0)
![Screenshot 2024-11-26 at 15 12 19](https://github.com/user-attachments/assets/11ab15d4-81b3-4e3a-ab9e-d41dd8a08efb)
![Screenshot 2024-11-26 at 15 12 26](https://github.com/user-attachments/assets/d112cafc-774d-4991-99b4-9b72c7124f9b)


https://github.com/user-attachments/assets/69447a9b-b1aa-4b1d-9426-dc17a439fa1c

Resolves #3674 
