### PR TITLE
fix: long activity title overflow issue

### DIFF
--- a/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
@@ -94,11 +94,11 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
           )}
         </>
       )}
-      <div className="flex flex-grow flex-col-reverse gap-0.5 md:flex-row md:items-center md:justify-between md:gap-4">
-        <div>
+      <div className="flex min-w-0 flex-grow flex-col-reverse gap-0.5 md:flex-row md:items-center md:justify-between md:gap-4">
+        <div className="flex w-full min-w-0 flex-col">
           <p
             className={clsx(
-              'line-clamp-2 text-md font-medium text-gray-900 md:line-clamp-1',
+              'min-w-0 truncate text-md font-medium text-gray-900',
               {
                 'overflow-hidden rounded skeleton sm:w-64': isLoading,
               },

--- a/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
@@ -98,7 +98,7 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
         <div className="flex w-full min-w-0 flex-col">
           <p
             className={clsx(
-              'min-w-0 truncate text-md font-medium text-gray-900',
+              'line-clamp-2 min-w-0 break-words text-md font-medium text-gray-900 md:line-clamp-1',
               {
                 'overflow-hidden rounded skeleton sm:w-64': isLoading,
               },

--- a/src/components/v5/common/CompletedAction/partials/Blocks/Blocks.tsx
+++ b/src/components/v5/common/CompletedAction/partials/Blocks/Blocks.tsx
@@ -3,7 +3,11 @@ import React, { type PropsWithChildren } from 'react';
 export const ActionTitle = ({
   children,
 }: PropsWithChildren<Record<never, any>>) => {
-  return <h3 className="mb-2 text-2xl font-bold text-gray-900">{children}</h3>;
+  return (
+    <h3 className="mb-2 line-clamp-4 break-words text-2xl font-bold text-gray-900">
+      {children}
+    </h3>
+  );
 };
 
 export const ActionSubtitle = ({


### PR DESCRIPTION
## Description
<img width="400" alt="image" src="https://github.com/user-attachments/assets/4b018249-5448-4777-8ce7-a5920303a0c5">

## Testing
Step 1. Create any motion with the title: `12312321312312312312312312312313123123123123412341234124312`
Step 2. Create second motion with the title: `long long long name long long long name long long long name`
Step 3. Open Activity page
Step 4. Change the screen size to Mobile and check that the title is truncated in 2 lines 🎉 
<img width="418" alt="image" src="https://github.com/user-attachments/assets/1ca42b1f-fec2-4bd4-949c-c70e029fb84f">
<img width="419" alt="image" src="https://github.com/user-attachments/assets/2c6129e7-8a1d-4e2c-b190-f0d4e45349d7">
Step 5. Open each motion from the activity feed (you probably need to open the wider screen to open motion from the list) and verify that the title for Completed Action still looks good:
<img width="283" alt="image" src="https://github.com/user-attachments/assets/893ecebc-4c61-4552-b3ff-c9ea3b1ec340">
<img width="362" alt="image" src="https://github.com/user-attachments/assets/2274a230-a290-494c-b203-a30eeecc99b6">


Resolves #3433
