### PR TITLE
fix: team filter should order by reputation then alphabetically

### DIFF
--- a/src/components/frame/v5/pages/TeamsPage/hooks.tsx
+++ b/src/components/frame/v5/pages/TeamsPage/hooks.tsx
@@ -257,7 +257,7 @@ export const useTeams = () => {
   const [searchValue, setSearchValue] = useState('');
 
   const defaultFilterValue: TeamsPageFilters = {
-    field: TeamsPageFiltersField.FUNDS,
+    field: TeamsPageFiltersField.REPUTATION,
     direction: ModelSortDirection.Desc,
   };
   const [hasFilterChanged, setHasFilterChanged] = useState(false);

--- a/src/components/v5/shared/TeamFilter/TeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/TeamFilter.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useColonyFiltersContext } from '~context/GlobalFiltersContext/ColonyFiltersContext.ts';
 import { useMobile } from '~hooks';
 import { TEAM_SEARCH_PARAM } from '~routes';
+import { notMaybe } from '~utils/arrays/index.ts';
 
 import DesktopTeamFilter from './partials/DesktopTeamFilter/DesktopTeamFilter.tsx';
 import MobileTeamFilter from './partials/MobileTeamFilter.tsx';
@@ -16,6 +18,10 @@ const TeamFilter = () => {
 
   const { filteredTeam, updateTeamFilter } = useColonyFiltersContext();
 
+  const {
+    colony: { domains },
+  } = useColonyContext();
+
   // We need to set the query param based on the already stored filteredTeam
   // but only on the pages where we actually use this component
   useEffect(() => {
@@ -25,11 +31,31 @@ const TeamFilter = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // this is in memo due to being a dependency for the other memos inside the components
+  const allDomains = useMemo(() => {
+    const filteredDomains = domains?.items.filter(notMaybe) || [];
+
+    return filteredDomains.sort((a, b) => {
+      const reputationA = parseFloat(a.reputationPercentage || '0');
+      const reputationB = parseFloat(b.reputationPercentage || '0');
+
+      // Sort by reputation percentage in descending order
+      if (reputationA !== reputationB) {
+        return reputationB - reputationA;
+      }
+
+      // If reputation percentages are equal or missing, sort alphabetically by name
+      const nameA = a.metadata?.name || '';
+      const nameB = b.metadata?.name || '';
+      return nameA.localeCompare(nameB);
+    });
+  }, [domains?.items]);
+
   if (isMobile) {
-    return <MobileTeamFilter />;
+    return <MobileTeamFilter allDomains={allDomains} />;
   }
 
-  return <DesktopTeamFilter />;
+  return <DesktopTeamFilter allDomains={allDomains} />;
 };
 
 TeamFilter.displayName = displayName;

--- a/src/components/v5/shared/TeamFilter/partials/DesktopTeamFilter/DesktopTeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/DesktopTeamFilter/DesktopTeamFilter.tsx
@@ -2,9 +2,8 @@ import clsx from 'clsx';
 import { throttle } from 'lodash';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
-import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
-import { notMaybe } from '~utils/arrays/index.ts';
+import { type Domain } from '~types/graphql.ts';
 
 import AllTeamsItem from '../AllTeamsItem.tsx';
 import CreateNewTeamItem from '../CreateNewTeamItem.tsx';
@@ -15,24 +14,15 @@ import { getOrderedDomains } from './helpers.ts';
 
 const displayName = 'v5.shared.TeamFilter.DesktopTeamFilter';
 
-const DesktopTeamFilter = () => {
+const DesktopTeamFilter = ({ allDomains }: { allDomains: Domain[] }) => {
   const [teamsWidth, setTeamsWidth] = useState(0);
   const [overflowingItemIndex, setOverFlowingItemIndex] = useState(-1);
 
   const teamItemsRef = useRef<HTMLDivElement[]>([]);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const {
-    colony: { domains },
-  } = useColonyContext();
-
   const selectedDomain = useGetSelectedDomainFilter();
   const isAllTeamsFilterActive = selectedDomain === undefined;
-
-  // this is in memo due to being a dependency for the other memo
-  const allDomains = useMemo(() => {
-    return domains?.items.filter(notMaybe) || [];
-  }, [domains?.items]);
 
   useEffect(() => {
     const { current: teamsElement } = containerRef;

--- a/src/components/v5/shared/TeamFilter/partials/MobileTeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/MobileTeamFilter.tsx
@@ -1,8 +1,7 @@
 import React, { useMemo } from 'react';
 
-import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
-import { notMaybe } from '~utils/arrays/index.ts';
+import { type Domain } from '~types/graphql.ts';
 import ArrowScroller from '~v5/common/ArrowScroller/ArrowScroller.tsx';
 
 import AllTeamsItem from './AllTeamsItem.tsx';
@@ -13,16 +12,8 @@ import TeamItem from './TeamItem.tsx';
 
 const displayName = 'v5.shared.TeamFilter.MobileTeamFilter';
 
-const MobileTeamFilter = () => {
-  const {
-    colony: { domains },
-  } = useColonyContext();
+const MobileTeamFilter = ({ allDomains }: { allDomains: Domain[] }) => {
   const selectedDomain = useGetSelectedDomainFilter();
-
-  const allDomains = useMemo(
-    () => domains?.items.filter(notMaybe) || [],
-    [domains?.items],
-  );
 
   const selectedDomainIndex = useMemo(
     () =>


### PR DESCRIPTION
## Description

This PR sorts the order of the teams in the team switcher so that the teams with the highest reputation will show first, then sorting by alphabetical order.

## Testing

* Step 1 - Check the team switcher on the dashboard. It should already be in the correct order, although this will be hard to tell apart from it being different than the usual order, so lets manipulate some reputation values for the sake of testing.

<img width="985" alt="Screenshot 2024-11-25 at 22 22 29" src="https://github.com/user-attachments/assets/b28697b8-978a-4b36-a19b-ce11a7f19dd0">

* Step 2 - Copy your colony address, and run this mutation.

```
mutation MyMutation {
  updateDomain(input: {id: "{COLONY_ADDRESS}_3", reputationPercentage: "50"}) {
    id
  }
}
```

* Step 3 - Refresh the dashboard, Serenity will now have a reputation percentage of 50 and appear at the front of the list.

<img width="968" alt="Screenshot 2024-11-25 at 22 23 16" src="https://github.com/user-attachments/assets/19140407-5a0c-4a7f-bc1c-319341867aad">

* Step 4 - Run another mutation to set Ascendant to also have a reputation percentage of 50.

```
mutation MyMutation {
  updateDomain(input: {id: "{COLONY_ADDRESS}_5", reputationPercentage: "50"}) {
    id
  }
}
```

* Step 5 - Refresh the dashboard, Serenity and Ascendant will now have the same percentage and be ordered alphabetically so Ascendant should appear at the front of the list.

<img width="956" alt="Screenshot 2024-11-25 at 22 23 49" src="https://github.com/user-attachments/assets/d47bfae3-48ef-4cde-8ca8-a1071d05af76">

Feel free to mess with other domain reputation percentage values for further testing.

## Diffs

**Changes** 🏗

* Domains in the team switcher are sorted by reputation percentage then alphabetically
* Moved `allDomains` up into TeamFilter component

Resolves #3655 
