### PR TITLE
Fix: Multi-sig extension settings issues

### DIFF
--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/MultiSigSettings/MultiSigSettings.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/MultiSigSettings/MultiSigSettings.tsx
@@ -1,11 +1,12 @@
 import { CaretDown } from '@phosphor-icons/react';
-import React, { type FC } from 'react';
+import React, { useEffect, type FC } from 'react';
 import { defineMessages } from 'react-intl';
 
 import { InputGroup } from '~common/Extensions/Fields/InputGroup/InputGroup.tsx';
 import RadioBase from '~common/Extensions/Fields/RadioList/RadioBase.tsx';
 import { useExtensionDetailsPageContext } from '~frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContext.ts';
 import useToggle from '~hooks/useToggle/index.ts';
+import { isInstalledExtensionData } from '~utils/extensions.ts';
 import { formatText } from '~utils/intl.ts';
 import Select from '~v5/common/Fields/Select/Select.tsx';
 import AccordionItem from '~v5/shared/Accordion/partials/AccordionItem/index.ts';
@@ -105,8 +106,31 @@ const MultiSigSettings: FC = () => {
     handleGlobalThresholdTypeChange,
   } = useThresholdData(extensionData);
 
-  const [isCustomSettingsVisible, { toggle: toggleCustomSettings }] =
+  const [isCustomSettingsVisible, { toggle: toggleCustomSettings, toggleOn }] =
     useToggle();
+
+  useEffect(() => {
+    const multiSigConfig = isInstalledExtensionData(extensionData)
+      ? extensionData.params?.multiSig || null
+      : null;
+
+    const { colonyThreshold, domainThresholds } = multiSigConfig || {};
+
+    if (!domainThresholds) {
+      return;
+    }
+
+    // If any custom settings have been adjusted, show the custom thresholds accordion on load
+    const shouldShowCustomSettings = domainThresholds.some((domain) => {
+      const { domainThreshold } = domain || {};
+
+      return domainThreshold !== colonyThreshold;
+    });
+
+    if (shouldShowCustomSettings) {
+      toggleOn();
+    }
+  }, [extensionData, toggleOn]);
 
   const handleOnKeyDown = (e) => {
     if (['.', ','].includes(e.key)) {

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/utils.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/utils.tsx
@@ -4,7 +4,10 @@ import { type UseFormReset, type FieldValues } from 'react-hook-form';
 import { toast } from 'react-toastify';
 
 import { ExtensionDetailsPageTabId } from '~frame/Extensions/pages/ExtensionDetailsPage/types.ts';
-import { waitForDbAfterExtensionAction } from '~frame/Extensions/pages/ExtensionDetailsPage/utils.tsx';
+import {
+  waitForDbAfterExtensionAction,
+  waitForDbAfterExtensionSettingsChange,
+} from '~frame/Extensions/pages/ExtensionDetailsPage/utils.tsx';
 import {
   ExtensionMethods,
   type RefetchExtensionDataFn,
@@ -204,6 +207,13 @@ export const handleWaitingForDbAfterFormCompletion = async ({
         reset();
         setActiveTab(ExtensionDetailsPageTabId.Overview);
       }
+    }
+
+    if (isSaveChanges && extensionData.configurable) {
+      await waitForDbAfterExtensionSettingsChange({
+        extensionData,
+        refetchExtensionData,
+      });
     }
 
     if (method === ExtensionMethods.ENABLE) {

--- a/src/utils/waitForCondition.ts
+++ b/src/utils/waitForCondition.ts
@@ -1,0 +1,37 @@
+type CheckConditionFunction = () => Promise<boolean>;
+
+export function waitForCondition(
+  checkCondition: CheckConditionFunction,
+  options: {
+    interval?: number;
+    timeout?: number;
+    customError?: string;
+  },
+): Promise<void> {
+  const {
+    interval = 1000,
+    timeout = 30000,
+    customError = `After ${timeout / 1000} seconds, failed to meet condition`,
+  } = options;
+
+  return new Promise<void>((resolve, reject) => {
+    const initTime = new Date().valueOf();
+    const intervalId = setInterval(async () => {
+      // Check if the timeout has been reached
+      if (new Date().valueOf() - initTime > timeout) {
+        // After timeout, assume something went wrong
+        clearInterval(intervalId);
+        reject(new Error(customError));
+        return;
+      }
+
+      // Check the condition
+      const conditionMet = await checkCondition();
+
+      if (conditionMet) {
+        clearInterval(intervalId);
+        resolve();
+      }
+    }, interval);
+  });
+}


### PR DESCRIPTION
## Description

This PR adds an improvement and fixes an issue with the extensions settings tabs.

The extension data is now refetched when saving changes to an extension and properly waits for these updates to be reflected in the database.

The multi-sig custom settings accordion is now open by default if any threshold is different than the colony threshold.

## Testing

* Step 1 - Install the Multi-Sig extension
* Step 2 - Change the threshold setting to "Fixed threshold" with a value of `2`.

<img width="1728" alt="Screenshot 2024-11-27 at 10 06 02" src="https://github.com/user-attachments/assets/03307a78-be52-4ae3-82dd-ed02207a60c0">

* Step 3 - Without refreshing, navigate to the dashboard, then back to the multi-sig extension page. Check the threshold is still set to 2. (If you really want to be sure the threshold has updated correctly, then go through the extra steps of assigning multi-sig permissions and checking the threshold is as expected)

<img width="1728" alt="Screenshot 2024-11-27 at 10 06 25" src="https://github.com/user-attachments/assets/60370506-6033-4910-a13f-d787eb39ceaa">

* Step 4 - Open the "Customize thresholds per team" accordion and set one of the domains to "Majority approval", then click "Save changes"

<img width="1728" alt="Screenshot 2024-11-27 at 10 09 29" src="https://github.com/user-attachments/assets/c725ecb2-9a2c-4882-8a94-3d928aab36c0">

* Step 5 - Without refreshing, navigate to the dashboard, then back to the multi-sig extension page. Check the "Customize thresholds per team" accordion is already open.

## Diffs

**New stuff** ✨

* Added new `waitForCondition` utility function
* Added new `waitForDbAfterExtensionSettingsChange` function which is called on save changes with configurable extensions to ensure extension data is refetched after the change in settings is applied

**Changes** 🏗

* Added new useEffect to MultiSigSettings component to compare domain thresholds against the global threshold and toggle the accordion open if any domain thresholds do not match

Resolves #3598
Resolves #3034
