### PR TITLE
Fix: Handle decision method validation properly for Split and Staged payments

### DIFF
--- a/src/components/v5/common/ActionSidebar/hooks/permissions/helpers.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/helpers.ts
@@ -124,6 +124,7 @@ export const getPermissionsDomainIdForAction = (
   switch (actionType) {
     case Action.SimplePayment:
     case Action.PaymentBuilder:
+    case Action.StagedPayment:
       if (!isMotion) {
         return from;
       }
@@ -133,6 +134,7 @@ export const getPermissionsDomainIdForAction = (
       return undefined;
     case Action.ManageReputation:
     case Action.EditExistingTeam:
+    case Action.SplitPayment:
       if (!isMotion) {
         return team;
       }


### PR DESCRIPTION
## Description

We have a hook called `getPermissionsDomainIdForAction` which checks if there is an available decision method for a user on any given form. It has a section where it checks if the user has permissions to do the current action based on the currently selected team on the form itself.

The problem was that, we weren't handling the Staged and Split payment types. As a result, the form's "team" value is being incorrectly set to the root domain ID even before the user gets the chance to select the team on the form. So what ends up happening is that the hook incorrectly asserts that the user doesn't have permissions to do the current action type since the user doesn't have any permissions on the root domain. This is wrong because the user hasn't even selected the team at this point.

This PR adds cases for the Split & Staged payment types so that the `getPermissionsDomainIdForAction` hook correctly waits and correctly processes the selected team before it does its magic.

![split-staged-fixes](https://github.com/user-attachments/assets/50708953-f9ec-45f5-be78-3c8910f05f64)

## Testing

1. Disable the Reputation and Staking extensions
2. Enable the Staged payments extension
3. Assign Payer permissions for Fry in team Andromeda
4. Connect Fry's wallet and bring up the Split Payments form
5. Verify that the form is editable
6. Select team General
7. Fill in all other required fields
8. Verify that you can see this error banner:

<img width="696" alt="image" src="https://github.com/user-attachments/assets/7154213c-1d87-4742-a3cd-525a45b7ffa5">

9. Verify that the form's submit button is disabled
10. Set the team field to Andromeda
11. Verify that the banner goes away
12. Verify that the form's submit button is enabled
13. Set the action type to Split Payments
14. Repeat steps 5 - 12

Resolves #3774