### PR TITLE
Fix: Minor UI fixes for notifications tab

### DIFF
--- a/src/components/common/Extensions/UserHub/UserHub.tsx
+++ b/src/components/common/Extensions/UserHub/UserHub.tsx
@@ -100,7 +100,7 @@ const UserHub: FC<Props> = ({
           <>
             <div>
               <TitleLabel
-                className="pb-3"
+                className="pb-3.5"
                 text={formatText(MSG.titleColonyOverview)}
               />
               <ul className="-ml-4 flex w-[calc(100%+2rem)] flex-col">

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/NotificationsTab.tsx
@@ -70,7 +70,7 @@ const NotificationsTab = ({ closeUserHub }: { closeUserHub: () => void }) => {
         {hasUnreadNotifications && markAllAsRead && (
           <button
             onClick={() => markAllAsRead()}
-            className="text-xs font-medium text-blue-400"
+            className="text-xs font-medium text-blue-400 hover:text-gray-900"
             type="button"
           >
             {formatText(MSG.markAllAsRead)}

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/ActionNotification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/ActionNotification.tsx
@@ -85,7 +85,7 @@ const ActionNotification: FC<NotificationProps> = ({
       return null;
     }
 
-    return formatText({ id: 'action.title' }, titleValues);
+    return formatText({ id: 'action.title' }, titleValues, notification.id);
   }, [action, colony, titleValues]);
 
   const actionTitle =

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/ActionNotification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/ActionNotification.tsx
@@ -86,7 +86,7 @@ const ActionNotification: FC<NotificationProps> = ({
     }
 
     return formatText({ id: 'action.title' }, titleValues, notification.id);
-  }, [action, colony, titleValues]);
+  }, [action, colony, titleValues, notification.id]);
 
   const actionTitle =
     action?.metadata?.customTitle || action?.decisionData?.title || '';

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureNotification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureNotification.tsx
@@ -155,7 +155,11 @@ const ExpenditureNotification: FC<NotificationProps> = ({
       return null;
     }
 
-    return formatText({ id: 'action.title' }, actionTitleValues);
+    return formatText(
+      { id: 'action.title' },
+      actionTitleValues,
+      notification.id,
+    );
   }, [action, actionTitleValues, colony]);
 
   return (

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureNotification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureNotification.tsx
@@ -160,7 +160,7 @@ const ExpenditureNotification: FC<NotificationProps> = ({
       actionTitleValues,
       notification.id,
     );
-  }, [action, actionTitleValues, colony]);
+  }, [action, actionTitleValues, colony, notification.id]);
 
   return (
     <NotificationWrapper

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/NotificationWrapper.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/NotificationWrapper.tsx
@@ -47,9 +47,9 @@ const NotificationWrapper: FC<NotificationWrapperProps> = ({
   };
 
   return (
-    <li className="w-full ">
+    <li className="w-full border-b border-gray-100 last:border-none">
       <button
-        className="relative flex w-full gap-2 px-6 py-3.5 text-left sm:hover:bg-gray-50"
+        className="relative flex w-full gap-2 px-6 py-[0.875rem] text-left sm:hover:bg-gray-50"
         onClick={handleNotificationClicked}
         type="button"
       >

--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/TransactionsTab.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/TransactionsTab.tsx
@@ -24,7 +24,7 @@ const TransactionsTab: FC<TransactionsProps> = () => {
       <p className="px-6 pt-6 heading-5">
         {formatText({ id: 'transactions' })}
       </p>
-      <div className="h-full w-full px-6 sm:px-0">
+      <div className="h-full w-full px-6 pt-0.5 sm:px-0">
         {isEmpty ? (
           <EmptyContent
             title={{ id: 'empty.content.title.transactions' }}


### PR DESCRIPTION
## Description

- Fix some minor UI issues with the notifications tab
  - Add a border bottom to each notification (matching the transactions tab)
  - Add a hover state to the 'Mark all as read' button (gray-900)
  - Align the padding top and bottom of the notifications items with the design (14px or 0.875rem - also matching the transactions tab)

## Testing

* Make a couple of simple payments or mint tokens actions or something simple, so that you have a few notifications.

<img width="825" alt="Screenshot 2024-11-27 at 13 38 47" src="https://github.com/user-attachments/assets/0ea6fd82-66ef-4dd5-a07d-9f3c924354aa">

* Check that there is a border bottom on each item, which matches the border bottom of the transactions in the transactions tab.

* Check that when you hover over 'Mark all as read' it turns gray-900

<img width="293" alt="Screenshot 2024-11-27 at 13 40 05" src="https://github.com/user-attachments/assets/50e6d749-aa4c-491b-8f36-4272053c60b7">

* Check that the padding top and bottom of each item is correct

Figma:
<img width="605" alt="Screenshot 2024-11-27 at 13 42 35" src="https://github.com/user-attachments/assets/467d869a-f09f-4d37-a423-797baaf7b334">
<img width="609" alt="Screenshot 2024-11-27 at 13 42 43" src="https://github.com/user-attachments/assets/9b5e69d3-8c6e-4c15-bfd2-4afefc22081b">

Localhost:
<img width="1289" alt="Screenshot 2024-11-27 at 13 43 05" src="https://github.com/user-attachments/assets/4785cf71-f0e7-4224-a54e-aa5a242e37bf">



## Diffs

**Changes** 🏗

* Classname tweaks to userhub / notifications components

Resolves #3667
