### PR TITLE
Fix: Correctly keep track of form field value updates when redoing an action

### DIFF
--- a/src/components/shared/Fields/Form/Form.tsx
+++ b/src/components/shared/Fields/Form/Form.tsx
@@ -19,6 +19,7 @@ import { type Schema } from 'yup';
 
 import { type AdditionalFormOptionsContextValue } from '~context/AdditionalFormOptionsContext/AdditionalFormOptionsContext.ts';
 import AdditionalFormOptionsContextProvider from '~context/AdditionalFormOptionsContext/AdditionalFormOptionsContextProvider.tsx';
+import { useStableDepsEffect } from '~hooks/useStableDepsEffect.ts';
 
 const displayName = 'Form';
 
@@ -66,6 +67,7 @@ const Form = <FormData extends FieldValues>({
   id,
 }: FormProps<FormData>) => {
   const { readonly, ...formOptions } = options || {};
+
   // Resolver updated to have the access to all of the form values inside a field validator context
   const resolver = useMemo<Resolver<FormData> | undefined>(() => {
     if (!validationSchema) {
@@ -131,7 +133,7 @@ const Form = <FormData extends FieldValues>({
   );
 
   // Separate concern for handling defaultValues updates
-  useEffect(() => {
+  useStableDepsEffect(() => {
     const initializeForm = async () => {
       const resolvedDefaultValues =
         typeof defaultValues === 'function'
@@ -141,7 +143,7 @@ const Form = <FormData extends FieldValues>({
       const currentValues = getValues();
       const mergedValues = { ...currentValues, ...resolvedDefaultValues };
 
-      reset(mergedValues, { keepDirtyValues: true, keepValues: true });
+      reset(mergedValues, { keepDirtyValues: true });
     };
 
     initializeForm();

--- a/src/hooks/useStableDepsEffect.ts
+++ b/src/hooks/useStableDepsEffect.ts
@@ -1,0 +1,31 @@
+import isEqual from 'lodash/isEqual';
+import {
+  type DependencyList,
+  type EffectCallback,
+  useEffect,
+  useRef,
+} from 'react';
+
+/**
+ * A custom hook that uses lodash's isEqual function to perform a deep comparison check for dependencies
+ *
+ * This is useful for cases where object dependencies are recreated on every render but contain identical values
+ *
+ * Note: Be cautious when using this hook, as it does not provide unused dependency warnings like the standard `useEffect` hook
+ *
+ * @param effect - The effect callback to run.
+ * @param dependencies - An array of dependencies to deeply compare.
+ */
+export function useStableDepsEffect(
+  callback: EffectCallback,
+  dependencies: DependencyList,
+) {
+  const dependenciesRef = useRef<DependencyList | undefined>(undefined);
+
+  if (!isEqual(dependenciesRef.current, dependencies)) {
+    dependenciesRef.current = dependencies;
+  }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(callback, [dependenciesRef.current]);
+}


### PR DESCRIPTION
## Description

The issue was that, the `defaultValues` dependency was unstable. And so the hook in charge of initialising the form kept on resetting the form to use the default values. So even if Olga was setting the decision field to "Staking", under the hood, it kept on resetting back to "Decision". Fry doesn't have permissions in that scenario, hence the error banner.

This PR introduces a new hook called `useStableDepsEffect` which basically uses lodash's `isEqual` function to perform a comparison for the dependencies. So now, even if the `defaultValues` has a different reference on re-render, because its contents are identical each time, it won't cause the effect to run:

![redo-ap](https://github.com/user-attachments/assets/09a252cf-c0b8-4261-bc8d-147b0c10fc10)

## Testing

1. Connect Leela's wallet
2. Make sure that the Staking extension is enabled
3. Assign Payer permissions to Fry in team Andromeda
4. Create an Advanced Payment
5. Connect Fry's wallet
6. Go to the Dashboard
7. Find the Advanced Payment action that was just made it and redo it
8. Verify that you see this error banner:

<img width="696" alt="image" src="https://github.com/user-attachments/assets/ff71ec25-f4ab-4ace-a693-9ce0cae0740f">

9. Change the Decision method to "Staking"
10. Verify that the error goes away
11. Fill in all other fields
12. Verify that you are able to submit the form

Resolves #3777 #3703