### PR TITLE
Fix: Adjust the input allowed for the Claim Delay input field

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/ClaimDelayField/ClaimDelayField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/ClaimDelayField/ClaimDelayField.tsx
@@ -67,6 +67,7 @@ const ClaimDelayField: FC<ClaimDelayFieldProps> = ({
     >
       <input
         {...field}
+        value={field.value ?? ''}
         ref={inputRef}
         name={name}
         className={clsx(
@@ -85,6 +86,13 @@ const ClaimDelayField: FC<ClaimDelayFieldProps> = ({
             event.target.value,
             formattingOptions,
           );
+
+          if (
+            (!field.value && !formattedValue) ||
+            formattedValue === field.value
+          ) {
+            return;
+          }
 
           if (
             wrapperRef.current &&


### PR DESCRIPTION
## Description

I'm just simply doing a check to see if the most recent version of the input conforms with our cleave rule. If not, then don't allow the field value to be updated.

## Testing

1. Bring up the Advanced Payment form
2. Enter a space or a letter inside the Claim delay field
3. Verify that the field value doesn't get updated

Resolves #3479