### PR TITLE
Fix: Properly calculate the reputation percentage

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/hooks.ts
@@ -8,7 +8,10 @@ import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useUserReputation from '~hooks/useUserReputation.ts';
 import { getInputTextWidth } from '~utils/elements.ts';
 import { getSafeStringifiedNumber } from '~utils/numbers.ts';
-import { calculatePercentageReputation } from '~utils/reputation.ts';
+import {
+  calculatePercentageReputation,
+  getReputationDifference,
+} from '~utils/reputation.ts';
 import {
   getFormattedTokenValue,
   getTokenDecimalsWithFallback,
@@ -111,11 +114,10 @@ export const useReputationFields = () => {
     getTokenDecimalsWithFallback(nativeToken.decimals),
   );
 
-  const amountPercentageValue =
-    typeof newPercentageReputation === 'number' &&
-    typeof percentageReputation === 'number'
-      ? Math.abs(newPercentageReputation - percentageReputation)
-      : '~0';
+  const amountPercentageValue = getReputationDifference(
+    newPercentageReputation,
+    percentageReputation,
+  );
 
   const newValueIsGreaterThanZero = isSmite
     ? BigNumber.from(userReputation || '0').gte(amountValueCalculated)

--- a/src/components/v5/common/CompletedAction/partials/ManageReputation/ManageReputation.tsx
+++ b/src/components/v5/common/CompletedAction/partials/ManageReputation/ManageReputation.tsx
@@ -57,6 +57,7 @@ const ManageReputation: FC<ManageReputationProps> = ({ action }) => {
   const { colony } = useColonyContext();
   const { nativeToken } = colony;
   const {
+    isMultiSig,
     isMotion,
     transactionHash,
     metadata,
@@ -66,12 +67,16 @@ const ManageReputation: FC<ManageReputationProps> = ({ action }) => {
     amount,
     fromDomain,
     annotation,
+    multiSigData,
   } = action;
+
   const { networkMotionState } = useGetActionData(transactionHash);
   const motionFinished =
     networkMotionState === NetworkMotionState.Finalizable ||
     networkMotionState === NetworkMotionState.Finalized ||
     networkMotionState === NetworkMotionState.Failed;
+
+  const multiSigFinished = multiSigData?.isRejected || multiSigData?.isExecuted;
 
   const isSmite = [
     ColonyActionType.EmitDomainReputationPenalty,
@@ -190,7 +195,7 @@ const ManageReputation: FC<ManageReputationProps> = ({ action }) => {
       )}
       {positiveAmountValue && (
         <>
-          {isMotion && !motionFinished ? (
+          {(isMotion || isMultiSig) && !motionFinished && !multiSigFinished ? (
             <ManageReputationTableInMotion
               isSmite={isSmite}
               amount={positiveAmountValue}

--- a/src/components/v5/common/CompletedAction/partials/ManageReputation/partials/ManageReputationTableCompletedState/ManageReputationTableCompletedState.tsx
+++ b/src/components/v5/common/CompletedAction/partials/ManageReputation/partials/ManageReputationTableCompletedState/ManageReputationTableCompletedState.tsx
@@ -7,7 +7,10 @@ import { useMobile } from '~hooks/index.ts';
 import useUserReputation from '~hooks/useUserReputation.ts';
 import Numeral from '~shared/Numeral/index.ts';
 import { formatText } from '~utils/intl.ts';
-import { calculatePercentageReputation } from '~utils/reputation.ts';
+import {
+  calculatePercentageReputation,
+  getReputationDifference,
+} from '~utils/reputation.ts';
 import { getTokenDecimalsWithFallback } from '~utils/tokens.ts';
 import PillsBase from '~v5/common/Pills/index.ts';
 
@@ -41,11 +44,10 @@ const ManageReputationTableCompletedState: FC<
       updatedTotalReputation.toString(),
     ) || 0;
 
-  const UpdatedReputationPercentage =
-    typeof updatedPercentageReputation === 'number' &&
-    typeof oldPercentageReputation === 'number'
-      ? Math.abs(updatedPercentageReputation - oldPercentageReputation)
-      : '~0';
+  const UpdatedReputationPercentage = getReputationDifference(
+    updatedPercentageReputation,
+    oldPercentageReputation,
+  );
 
   const pill = (
     <PillsBase

--- a/src/components/v5/common/CompletedAction/partials/ManageReputation/partials/ManageReputationTableInMotion/hooks.ts
+++ b/src/components/v5/common/CompletedAction/partials/ManageReputation/partials/ManageReputationTableInMotion/hooks.ts
@@ -2,7 +2,10 @@ import { BigNumber } from 'ethers';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import useUserReputation from '~hooks/useUserReputation.ts';
-import { calculatePercentageReputation } from '~utils/reputation.ts';
+import {
+  calculatePercentageReputation,
+  getReputationDifference,
+} from '~utils/reputation.ts';
 import {
   getFormattedTokenValue,
   getTokenDecimalsWithFallback,
@@ -59,11 +62,11 @@ export const useManageReputationTableData = ({
     newReputation || 0,
     getTokenDecimalsWithFallback(nativeToken.decimals),
   );
-  const amountPercentageValue =
-    typeof newPercentageReputation === 'number' &&
-    typeof percentageReputation === 'number'
-      ? Math.abs(newPercentageReputation - percentageReputation)
-      : '~0';
+
+  const amountPercentageValue = getReputationDifference(
+    newPercentageReputation,
+    percentageReputation,
+  );
 
   return {
     amountPercentageValue,

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -99,3 +99,7 @@ export const getSafeStringifiedNumber = (
   // Default case if the type is unexpected
   return safeFallback;
 };
+
+export const isNumeric = (value: unknown) =>
+  (typeof value === 'string' || typeof value === 'number') &&
+  !Number.isNaN(Number(value));

--- a/src/utils/reputation.ts
+++ b/src/utils/reputation.ts
@@ -6,6 +6,8 @@ import {
   getFormattedNumeralValue,
 } from '~shared/Numeral/index.ts';
 
+import { isNumeric } from './numbers.ts';
+
 export enum ZeroValue {
   Zero = '0',
   NearZero = '~0',
@@ -50,3 +52,11 @@ export const formatReputationChange = (
   const value = adjustConvertedValue(absoluteChange, decimals);
   return getFormattedNumeralValue(value, absoluteChange);
 };
+
+export const getReputationDifference = (
+  percentageA: number | ZeroValue,
+  percentageB: number | ZeroValue,
+) =>
+  isNumeric(percentageA) && isNumeric(percentageB)
+    ? Math.abs(Number(percentageA) - Number(percentageB))
+    : ZeroValue.NearZero;


### PR DESCRIPTION
## Description

The calculation wasn't happening because this boolean check fails:

```js
typeof newPercentageReputation === 'number' && typeof percentageReputation === 'number'
```

It was failing because I guess that the real intention was to check if the values are numerically parsable. So I just tweaked it to set it free and reach its full potential 🪽

This is an issue on the Completed Action component as well so I fixed it there too.

BUT WAIT ✋🏻There's more!

I also updated the Completed Action form to handle the Manage Reputation Multi-Sig action. The Reputation motion's logic is that it shows the `<ManageReputationTableInMotion />` table when the motion hasn't finished yet. So I just did the equivalent of that for the Multi-Sig motion.

![rep-calc](https://github.com/user-attachments/assets/28278402-0ef6-4d4d-b551-60162ca8c573)

## Testing

1. Bring up the Manage Reputation form
2. Set it to Award reputation
3. Set the Member to ollie-orbit
4. Update the Change field
5. Verify that the percentage value shown for the Change field is (FINAL PERCENTAGE - ORIGINAL PERCENTAGE)
6. Keep track of the Change field percentage value
7. Fill in all other required fields
8. Submit the form
9. On the Completed Action component, verify that the percentage is correct based on the percentage value from the Change field

Resolves #3687