### PR TITLE
Fix: Conditionally show the Reputation Decision Method in the Funding Modal

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/hooks.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingModal/hooks.ts
@@ -1,6 +1,7 @@
 import { FUND_EXPENDITURE_REQUIRED_ROLE } from '~constants/permissions.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { useMemberContext } from '~context/MemberContext/MemberContext.ts';
 import useEnabledExtensions from '~hooks/useEnabledExtensions.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { addressHasRoles } from '~utils/checks/userHasRoles.ts';
@@ -15,6 +16,9 @@ export const useFundingDecisionMethods = (
   const { user } = useAppContext();
   const { isVotingReputationEnabled, isMultiSigEnabled } =
     useEnabledExtensions();
+  const { membersByAddress } = useMemberContext();
+
+  const { hasReputation } = membersByAddress[user?.walletAddress ?? ''] ?? {};
 
   const userHasFundingPermissions = user
     ? addressHasRoles({
@@ -35,6 +39,7 @@ export const useFundingDecisionMethods = (
       })
     : false;
   const shouldShowMultiSig = isMultiSigEnabled && userHasMultiSigPermissions;
+  const shouldShowReputation = isVotingReputationEnabled && hasReputation;
 
   return [
     {
@@ -42,7 +47,7 @@ export const useFundingDecisionMethods = (
       value: DecisionMethod.Permissions,
       isDisabled: !userHasFundingPermissions,
     },
-    ...(isVotingReputationEnabled
+    ...(shouldShowReputation
       ? [
           {
             label: formatText({


### PR DESCRIPTION
## Description

This PR conditionally shows the Reputation decision method in the Funding modal, depending on whether or not the user has some reputation.

![image](https://github.com/user-attachments/assets/81642450-f38f-4750-b82d-f3e30d6597b2)

## Testing

1. Connect Leela's wallet
2. Install the reputation extension
3. Connect Wallet 4
4. Set up your account
5. As Leela, make a Simple Payment and give Wallet 4 1000 CREDS
6. Visit the GraphQL playground: http://localhost:20002/
7. Run this query to get a beta invite code for the Planex colony:

```gql
query MyQuery {
  getColonyByName(name: "planex") {
    items {
      colonyMemberInviteCode
    }
  }
}
```

8. Copy the invite code value from the results:

```js
"colonyMemberInviteCode": "95b9c615-4df8-49d7-b084-b354d020b839"
```

9. As Wallet 4, visit http://localhost:9091/invite/planex/95b9c615-4df8-49d7-b084-b354d020b839
10. Bring up the Advanced Payments form
11. Set the decision method to Staking
12. Fill in all other required fields
13. Submit the form
14. On the Completed Action component, click Confirm details
15. Click Fund
16. On the Funding modal, expand the Decision method field
17. Verify that Reputation isn't in the list of decision methods

Resolves #3615 