### PR TITLE
Fix: Show user popover for user avatars in activity table

### DIFF
--- a/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
@@ -12,6 +12,7 @@ import { formatText } from '~utils/intl.ts';
 import { useGetExpenditureData } from '~v5/common/ActionSidebar/hooks/useGetExpenditureData.ts';
 import MotionCountDownTimer from '~v5/common/ActionSidebar/partials/Motions/partials/MotionCountDownTimer/index.ts';
 import { UserAvatar } from '~v5/shared/UserAvatar/UserAvatar.tsx';
+import UserInfoPopover from '~v5/shared/UserInfoPopover/UserInfoPopover.tsx';
 
 import { type ActionDescriptionProps } from './types.ts';
 
@@ -82,15 +83,24 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
           {loading ? (
             <div className="aspect-square h-[26px] w-auto rounded-full skeleton before:rounded-full" />
           ) : (
-            <UserAvatar
-              size={26}
-              userAddress={walletAddress}
-              userName={user?.profile?.displayName ?? undefined}
-              userAvatarSrc={
-                user?.profile?.thumbnail ?? user?.profile?.avatar ?? undefined
-              }
-              className="flex-shrink-0 flex-grow-0"
-            />
+            <UserInfoPopover
+              walletAddress={walletAddress}
+              user={user}
+              popperOptions={{
+                placement: 'bottom-start',
+              }}
+              withVerifiedBadge={false}
+            >
+              <UserAvatar
+                size={26}
+                userAddress={walletAddress}
+                userName={user?.profile?.displayName ?? undefined}
+                userAvatarSrc={
+                  user?.profile?.thumbnail ?? user?.profile?.avatar ?? undefined
+                }
+                className="flex-shrink-0 flex-grow-0"
+              />
+            </UserInfoPopover>
           )}
         </>
       )}

--- a/src/components/v5/shared/UserInfoPopover/partials/UserInfoPopoverTrigger.tsx
+++ b/src/components/v5/shared/UserInfoPopover/partials/UserInfoPopoverTrigger.tsx
@@ -29,10 +29,18 @@ const UserInfoPopoverTrigger = forwardRef<
     },
     ref,
   ) => {
+    const handleClick = (
+      event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    ) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onClick();
+    };
+
     return (
       <button
         ref={ref}
-        onClick={onClick}
+        onClick={handleClick}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         type="button"


### PR DESCRIPTION
## Description

![activity-popover](https://github.com/user-attachments/assets/199cca11-6b1b-41eb-a5ce-6484b249f931)

## Testing

1. Connect Leela's wallet
2. Make a Simple Payment
3. Visit the Activity page
4. Click on Leela's avatar
5. Verify that the user popover comes up

Resolves #3702