### PR TITLE
feat: add feature flag to arbitrary transactions

### DIFF
--- a/src/components/v5/common/ActionSidebar/hooks/useActionsList.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useActionsList.ts
@@ -2,12 +2,18 @@ import { useMemo } from 'react';
 
 import { Action } from '~constants/actions.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { useFeatureFlagsContext } from '~context/FeatureFlagsContext/FeatureFlagsContext.ts';
 import useEnabledExtensions from '~hooks/useEnabledExtensions.ts';
 import { type SearchSelectOptionProps } from '~v5/shared/SearchSelect/types.ts';
 
 const useActionsList = () => {
   const { colony } = useColonyContext();
   const { isStagedExpenditureEnabled } = useEnabledExtensions();
+
+  const featureFlags = useFeatureFlagsContext();
+  const isFeatureFlagArbitraryTxsEnabled =
+    featureFlags.ARBITRARY_TXS_ACTION?.isLoading ||
+    featureFlags.ARBITRARY_TXS_ACTION?.isEnabled;
 
   return useMemo((): SearchSelectOptionProps[] => {
     const actionsListOptions: SearchSelectOptionProps[] = [
@@ -133,7 +139,9 @@ const useActionsList = () => {
           // },
         ],
       },
-      {
+    ];
+    if (isFeatureFlagArbitraryTxsEnabled) {
+      actionsListOptions.push({
         key: '6',
         isAccordion: true,
         title: { id: 'actions.transactions' },
@@ -144,8 +152,8 @@ const useActionsList = () => {
             isNew: true,
           },
         ],
-      },
-    ];
+      });
+    }
     if (!isStagedExpenditureEnabled) {
       const stagedPaymentIndex = actionsListOptions[0].options.findIndex(
         ({ value }) => value === Action.StagedPayment,
@@ -160,7 +168,7 @@ const useActionsList = () => {
       actionsListOptions[2].options[2].isDisabled = true;
     }
     return actionsListOptions;
-  }, [colony, isStagedExpenditureEnabled]);
+  }, [colony, isStagedExpenditureEnabled, isFeatureFlagArbitraryTxsEnabled]);
 };
 
 export default useActionsList;

--- a/src/context/FeatureFlagsContext/FeatureFlagsContextProvider.tsx
+++ b/src/context/FeatureFlagsContext/FeatureFlagsContextProvider.tsx
@@ -34,6 +34,7 @@ const FeatureFlagsContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const cryptoToFiatWithdrawalsFeature = useFeatureFlag(
     FeatureFlag.CRYPTO_TO_FIAT_WITHDRAWALS,
   );
+  const arbitraryTxsAction = useFeatureFlag(FeatureFlag.ARBITRARY_TXS_ACTION);
 
   const featureFlags: Record<
     FeatureFlag,
@@ -42,8 +43,9 @@ const FeatureFlagsContextProvider: FC<PropsWithChildren> = ({ children }) => {
     () => ({
       [FeatureFlag.CRYPTO_TO_FIAT]: cryptoToFiatFeature,
       [FeatureFlag.CRYPTO_TO_FIAT_WITHDRAWALS]: cryptoToFiatWithdrawalsFeature,
+      [FeatureFlag.ARBITRARY_TXS_ACTION]: arbitraryTxsAction,
     }),
-    [cryptoToFiatFeature, cryptoToFiatWithdrawalsFeature],
+    [cryptoToFiatFeature, cryptoToFiatWithdrawalsFeature, arbitraryTxsAction],
   );
 
   return (

--- a/src/context/FeatureFlagsContext/types.ts
+++ b/src/context/FeatureFlagsContext/types.ts
@@ -1,6 +1,7 @@
 export enum FeatureFlag {
   CRYPTO_TO_FIAT = 'CRYPTO_TO_FIAT',
   CRYPTO_TO_FIAT_WITHDRAWALS = 'CRYPTO_TO_FIAT_WITHDRAWALS',
+  ARBITRARY_TXS_ACTION = 'ARBITRARY_TXS_ACTION',
 }
 
 export interface FeatureFlagValue {


### PR DESCRIPTION
## Description

Add `ARBITRARY_TXS_ACTION` feature flag to disable arbitrary transactions on prod 

## Testing
Step 1. Ensure that you have a QA or local API keys for POSTHOG
Step 2. Open any motion
Step 3. Verify that you can see Arbitrary transactions in Action Type list:
<img width="476" alt="image" src="https://github.com/user-attachments/assets/14e1276b-1cda-4a30-8ec7-b524410c8922">

Step 4. Navigate to `src/context/FeatureFlagsContext/FeatureFlagsContextProvider.tsx` and update like 46 with: 
```
{
        isEnabled: false,
        isLoading: false,
      }
```
<img width="561" alt="image" src="https://github.com/user-attachments/assets/30eef1da-124c-461d-80ac-1b2280612e46">

Step 5. Ensure that there is no "Arbitrary transactions" in Motion Action Type list:
<img width="494" alt="image" src="https://github.com/user-attachments/assets/f31b1ad2-3755-4e41-9428-e7662dc61a9f">


Resolves #3797
