### PR TITLE
fix: Update payment message descriptor case

### DIFF
--- a/src/components/common/ColonyActions/helpers/getActionTitleValues.ts
+++ b/src/components/common/ColonyActions/helpers/getActionTitleValues.ts
@@ -46,13 +46,6 @@ export enum ActionTitleMessageKeys {
 /* Maps actionTypes to message values as found in en-actions.ts */
 const getMessageDescriptorKeys = (actionType: AnyActionType) => {
   switch (true) {
-    case actionType === ColonyActionType.Payment:
-      return [
-        ActionTitleMessageKeys.Recipient,
-        ActionTitleMessageKeys.Amount,
-        ActionTitleMessageKeys.TokenSymbol,
-        ActionTitleMessageKeys.Initiator,
-      ];
     case actionType.includes(ColonyActionType.MoveFunds):
       return [
         ActionTitleMessageKeys.Amount,
@@ -159,6 +152,13 @@ const getMessageDescriptorKeys = (actionType: AnyActionType) => {
         ActionTitleMessageKeys.Initiator,
         ActionTitleMessageKeys.SplitAmount,
         ActionTitleMessageKeys.TokenSymbol,
+      ];
+    case actionType.includes(ColonyActionType.Payment):
+      return [
+        ActionTitleMessageKeys.Recipient,
+        ActionTitleMessageKeys.Amount,
+        ActionTitleMessageKeys.TokenSymbol,
+        ActionTitleMessageKeys.Initiator,
       ];
     default:
       return [];


### PR DESCRIPTION
## Description

Just a wee one-liner. It also fixes copies in the Activity Table for Simple Payment Reputation and Multi-Sig motions.

<img width="1258" alt="Screenshot 2024-11-28 at 14 23 34" src="https://github.com/user-attachments/assets/4134c42b-9eab-40f7-bdde-f66bd0cd0e15">

## Testing

1. Enable the Reputation and Multi-Sig extensions
2. Create a Simple Payment via Reputation motion
3. Stake it
4. Open the User Hub and open the Stakes tab
5. Verify that the correct copy is shown

<img width="688" alt="image" src="https://github.com/user-attachments/assets/4366e3e3-8d63-4840-8cef-b2fbf1b1d696">

6. Create a Simple Payment Multi-Sig motion
7. Go to the Dashboard
8. Verify that the correct copies are shown for the Simple Payment Reputation and Multi-Sig motions

Resolves #3755 