### PR TITLE
test: simple payment e2e tests

### DIFF
--- a/playwright/e2e/simple-payment.spec.ts
+++ b/playwright/e2e/simple-payment.spec.ts
@@ -67,12 +67,6 @@ test.describe('Simple payment', () => {
       await actionForm.getByPlaceholder('Enter amount').fill('1');
       await actionForm.getByRole('button', { name: 'Select method' }).click();
       await page.getByRole('button', { name: 'Permissions' }).click();
-      // await actionForm
-      //   .getByRole('button', { name: 'Enter a description' })
-      //   .click();
-      // await actionForm
-      //   .locator('[contenteditable="true"]')
-      //   .pressSequentially('**A simple payment**');
 
       await expect(
         actionForm.getByText(/^Pay \w+ 1 CREDS by \w+$/i),

--- a/playwright/e2e/simple-payment.spec.ts
+++ b/playwright/e2e/simple-payment.spec.ts
@@ -1,0 +1,253 @@
+import { expect, test } from '@playwright/test';
+
+import { selectWallet, setCookieConsent } from '../utils/common.ts';
+import {
+  openSimplePaymentDrawer,
+  tooltipMessages,
+  validationMessages,
+} from '../utils/simple-payment.ts';
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Simple payment', () => {
+  test.describe('User has required permissions', () => {
+    test.beforeEach(async ({ page, context, baseURL }) => {
+      await setCookieConsent(context, baseURL);
+
+      await page.goto('/planex');
+
+      await selectWallet(page, /dev wallet 1$/i);
+
+      await page.getByText('Loading Colony').waitFor({ state: 'hidden' });
+      await page
+        .getByTestId('loading-skeleton')
+        .last()
+        .waitFor({ state: 'hidden' });
+      await openSimplePaymentDrawer(page);
+    });
+
+    test('Should successfully create a simple payment', async ({ page }) => {
+      const actionDrawer = page.getByTestId('action-drawer');
+      const actionForm = page.getByTestId('action-form');
+
+      const menu = page.getByTestId('search-select-menu');
+      const memberAddress = '0x27fF0C145E191C22C75cD123C679C3e1F58a4469';
+
+      await actionForm.getByPlaceholder('Enter title').fill('Pay fry');
+
+      await expect(
+        actionForm.getByRole('button', { name: 'Simple payment' }),
+      ).toBeVisible();
+
+      await actionForm.getByRole('button', { name: 'Select team' }).click();
+      await menu.getByRole('button', { name: 'General' }).click();
+      await actionForm.getByLabel('Select user').click();
+      await page.getByPlaceholder('Search or add wallet address').click();
+      await page
+        .getByPlaceholder('Search or add wallet address')
+        .fill(memberAddress);
+      await page
+        .getByRole('button', {
+          name: memberAddress,
+        })
+        .click();
+
+      await actionForm.getByPlaceholder('Enter amount').fill('1');
+      await actionForm.getByRole('button', { name: 'Select method' }).click();
+      await page.getByRole('button', { name: 'Permissions' }).click();
+      // await actionForm
+      //   .getByRole('button', { name: 'Enter a description' })
+      //   .click();
+      // await actionForm
+      //   .locator('[contenteditable="true"]')
+      //   .pressSequentially('**A simple payment**');
+
+      await expect(
+        actionForm.getByText(/^Pay \w+ 1 CREDS by \w+$/i),
+      ).toBeVisible();
+      await actionForm.getByRole('button', { name: 'Create payment' }).click();
+
+      await actionForm
+        .getByRole('button', { name: 'Pending' })
+        .first()
+        .waitFor({ state: 'visible' });
+
+      await actionForm.waitFor({ state: 'hidden' });
+      await page.waitForURL(/planex\?tx=/);
+      await page
+        .getByTestId('loading-skeleton')
+        .last()
+        .waitFor({ state: 'hidden' });
+
+      await expect(
+        actionDrawer.getByText(
+          /Member used permissions to create this action/i,
+        ),
+      ).toBeVisible();
+    });
+
+    test('Should display validation errors for required fields and invalid inputs', async ({
+      page,
+    }) => {
+      const actionDrawer = page.getByTestId('action-drawer');
+      const actionForm = actionDrawer.getByTestId('action-form');
+      const titleField = actionForm.getByPlaceholder('Enter title');
+      const amountField = actionForm.getByPlaceholder('Enter amount');
+
+      const errorNotification = actionForm.getByTestId('action-sidebar-error');
+      const submitPaymentButton = actionForm.getByRole('button', {
+        name: 'Create payment',
+      });
+
+      // Verify the errors are shown when required fields are empty
+      await submitPaymentButton.click();
+
+      await errorNotification.waitFor({ state: 'visible' });
+      // Verify there is an error for each field
+      for (const message of validationMessages.allRequiredFields) {
+        await expect(actionForm.getByText(message)).toBeVisible();
+      }
+
+      // Enter more than 60 chars in the Title field
+      await titleField.fill(
+        'This is a test title that exceeds the maximum character limit of sixty.',
+      );
+
+      await expect(
+        actionDrawer.getByText(validationMessages.title.maxLengthExceeded),
+      ).toBeVisible();
+      // Enter amount more than the maximum available
+      await amountField.fill('100_000_000_000_000_000_000_000');
+
+      await submitPaymentButton.click();
+
+      await expect(
+        actionDrawer.getByText(validationMessages.amount.maxExceeded),
+      ).toBeVisible();
+
+      // Very small amount value should be accepted
+      await amountField.fill('0.0000000000000000000000001');
+
+      await expect(
+        actionDrawer.getByText(validationMessages.amount.mustBeGreaterThanZero),
+      ).toBeHidden();
+    });
+
+    test('Should display tooltips and user info on hover and click actions', async ({
+      page,
+    }) => {
+      const actionForm = page.getByTestId('action-form');
+      await actionForm.getByText('From', { exact: true }).hover();
+
+      await expect(page.getByText(tooltipMessages.from)).toBeVisible();
+
+      await actionForm.getByText('Recipient').nth(1).hover();
+
+      await expect(page.getByText(tooltipMessages.recipient)).toBeVisible();
+
+      await actionForm.getByText('Amount', { exact: true }).hover();
+
+      await expect(page.getByText(tooltipMessages.amount)).toBeVisible({
+        timeout: 10000,
+      });
+
+      await actionForm.getByText('Decision method').hover();
+
+      await expect(
+        page.getByText(tooltipMessages.decisionMethod),
+      ).toBeVisible();
+
+      // Verify the User info is shown when clicking on the username
+      await actionForm
+        .getByTestId('action-sidebar-description')
+        .getByRole('button')
+        .click();
+
+      await expect(page.getByTestId('user-info')).toBeVisible();
+
+      // Verify select token modal is shown when clicking on the token
+      await actionForm.getByRole('button', { name: 'Select token' }).click();
+
+      await expect(page.getByTestId('token-list')).toBeVisible();
+    });
+
+    test('Should display the confirmation modal when the user tries to close the form', async ({
+      page,
+    }) => {
+      const simplePaymentForm = page.getByTestId('action-form');
+      const dialog = page
+        .getByRole('dialog')
+        .filter({ hasText: 'Do you wish to cancel the action creation?' });
+      await simplePaymentForm.getByPlaceholder('Enter title').fill('Pay Fry');
+
+      await page.getByRole('button', { name: /close the modal/i }).click();
+
+      await dialog.waitFor({ state: 'visible' });
+
+      await expect(
+        dialog.getByRole('button', { name: 'Yes, cancel the action' }),
+      ).toBeVisible();
+
+      await expect(
+        dialog.getByRole('button', { name: 'No, go back to editing' }),
+      ).toBeVisible();
+
+      await dialog
+        .getByRole('button', { name: 'Yes, cancel the action' })
+        .click();
+
+      await dialog.waitFor({ state: 'hidden' });
+
+      await expect(simplePaymentForm).toBeVisible();
+    });
+  });
+
+  test.describe('User has no permissions', () => {
+    test.beforeEach(async ({ page, context, baseURL }) => {
+      await setCookieConsent(context, baseURL);
+
+      await page.goto('/planex');
+    });
+
+    test('Should not allow to create a simple payment with no permissions', async ({
+      page,
+    }) => {
+      // Log in with a wallet that has no permissions for simple payments
+      await selectWallet(page, /dev wallet 3$/i);
+      await page.getByText('Loading Colony').waitFor({ state: 'hidden' });
+      await page
+        .getByTestId('loading-skeleton')
+        .last()
+        .waitFor({ state: 'hidden' });
+
+      await openSimplePaymentDrawer(page);
+
+      const actionDrawer = page.getByTestId('action-drawer');
+      const actionForm = actionDrawer.getByTestId('action-form');
+
+      await expect(
+        actionForm.getByText(validationMessages.permissions),
+      ).toBeVisible();
+
+      await expect(
+        actionForm.getByRole('button', { name: 'Create payment' }),
+      ).toBeDisabled();
+
+      // User should still be able to change the action type
+      await actionForm.getByRole('button', { name: 'Simple payment' }).click();
+
+      await page
+        .getByTestId('search-select-menu')
+        .waitFor({ state: 'visible' });
+
+      await page
+        .getByTestId('search-select-menu')
+        .getByRole('button', { name: 'Advanced payment' })
+        .click();
+
+      await expect(
+        actionForm.getByRole('button', { name: 'Create payment' }),
+      ).toBeEnabled();
+    });
+  });
+});

--- a/playwright/utils/simple-payment.ts
+++ b/playwright/utils/simple-payment.ts
@@ -10,7 +10,7 @@ export const validationMessages = {
   },
   allRequiredFields: [
     'decisionMethod must be defined',
-    // TODO: Uncomment once issue #38102 is fixed
+    // TODO: Uncomment once issue #3802 is fixed
     // 'from is a required field',
     'recipient is a required field',
     'Amount must be greater than zero',

--- a/playwright/utils/simple-payment.ts
+++ b/playwright/utils/simple-payment.ts
@@ -1,0 +1,51 @@
+/* eslint-disable no-warning-comments */
+import { type Page } from '@playwright/test';
+
+export const validationMessages = {
+  title: {
+    maxLengthExceeded: 'Title must not exceed 60 characters',
+    isRequired: 'Title is required',
+  },
+  allRequiredFields: [
+    'decisionMethod must be defined',
+    // TODO: Uncomment once issue #38102 is fixed
+    // 'from is a required field',
+    'recipient is a required field',
+    'Amount must be greater than zero',
+    'Title is required',
+  ],
+  amount: {
+    isRequired: 'Amount is required',
+    mustBeGreaterThanZero: 'Amount must be greater than zero',
+    maxExceeded: 'Not enough funds to cover the payment and network fees',
+  },
+  permissions:
+    "You don't have the right permissions to create this action. Try another action type.",
+};
+
+export const tooltipMessages = {
+  from: /Team source of the funds/i,
+  recipient: /Member or address designated to receive the funds/i,
+  amount: /Quantity and type of funds of the payment/i,
+  decisionMethod: /Mechanism behind the decision-making process/i,
+};
+
+export const openSimplePaymentDrawer = async (page: Page) => {
+  const actionDrawer = page.getByTestId('action-drawer');
+
+  await page
+    .getByTestId('colony-page-sidebar')
+    .getByLabel('Start the payment group action')
+    .click();
+  await actionDrawer.waitFor({ state: 'visible' });
+  await actionDrawer
+    .getByRole('button', {
+      name: 'Simple payment Quick, one-click transfers',
+    })
+    .click();
+  await page.getByTestId('action-form').waitFor({ state: 'visible' });
+
+  await actionDrawer
+    .getByTestId('action-sidebar-description')
+    .waitFor({ state: 'visible' });
+};

--- a/playwright/utils/simple-payment.ts
+++ b/playwright/utils/simple-payment.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-warning-comments */
 import { type Page } from '@playwright/test';
 
+import { selectWallet } from './common.ts';
+
 export const validationMessages = {
   title: {
     maxLengthExceeded: 'Title must not exceed 60 characters',
@@ -48,4 +50,34 @@ export const openSimplePaymentDrawer = async (page: Page) => {
   await actionDrawer
     .getByTestId('action-sidebar-description')
     .waitFor({ state: 'visible' });
+};
+
+export const closeSimplePaymentDrawer = async (page: Page) => {
+  await page
+    .getByRole('button', { name: /close the modal/i })
+    // eslint-disable-next-line playwright/no-force-option
+    .click({ force: true });
+
+  const dialog = page
+    .getByRole('dialog')
+    .filter({ hasText: 'Do you wish to cancel the action creation?' });
+  if (await dialog.isVisible()) {
+    await dialog
+      .getByRole('button', { name: 'Yes, cancel the action' })
+      .click();
+  }
+};
+
+export const signInAndNavigateToColony = async (
+  page: Page,
+  { colonyUrl, wallet }: { colonyUrl: string; wallet: string | RegExp },
+) => {
+  await page.goto(colonyUrl);
+  await selectWallet(page, wallet);
+  // Wait for the Dashboard to load
+  await page.getByText('Loading Colony').waitFor({ state: 'hidden' });
+  await page
+    .getByTestId('loading-skeleton')
+    .last()
+    .waitFor({ state: 'hidden' });
 };

--- a/src/components/common/LoadingSkeleton/LoadingSkeleton.tsx
+++ b/src/components/common/LoadingSkeleton/LoadingSkeleton.tsx
@@ -11,7 +11,10 @@ const LoadingSkeleton: React.FC<LoadingSkeletonProps> = ({
   children,
 }) =>
   isLoading ? (
-    <span className={clsx('block overflow-hidden skeleton', className)} />
+    <span
+      className={clsx('block overflow-hidden skeleton', className)}
+      data-testid="loading-skeleton"
+    />
   ) : (
     <>{children}</>
   );

--- a/src/components/shared/Fields/Form/ActionForm.tsx
+++ b/src/components/shared/Fields/Form/ActionForm.tsx
@@ -61,6 +61,7 @@ export interface ActionFormProps<
     /** Function called when the form's primary button type is set to "button" */
     onClick?: MouseEventHandler<HTMLButtonElement>;
   };
+  testId?: string;
 }
 
 const ActionForm = <V extends Record<string, any>>({

--- a/src/components/shared/Fields/Form/Form.tsx
+++ b/src/components/shared/Fields/Form/Form.tsx
@@ -50,6 +50,7 @@ export interface FormProps<FormData extends FieldValues> {
   className?: string;
   innerRef?: Ref<UseFormReturn<FormData>>;
   id?: string;
+  testId?: string;
 }
 
 const Form = <FormData extends FieldValues>({
@@ -65,6 +66,7 @@ const Form = <FormData extends FieldValues>({
   className,
   innerRef,
   id,
+  testId,
 }: FormProps<FormData>) => {
   const { readonly, ...formOptions } = options || {};
 
@@ -153,7 +155,13 @@ const Form = <FormData extends FieldValues>({
     <AdditionalFormOptionsContextProvider value={{ readonly }}>
       <FormProvider {...formHelpers}>
         {/* noValidate attribute added to hide native browser validation */}
-        <form id={id} className={className} onSubmit={submitHandler} noValidate>
+        <form
+          id={id}
+          className={className}
+          onSubmit={submitHandler}
+          noValidate
+          data-testid={testId}
+        >
           {typeof children === 'function' ? children(formHelpers) : children}
         </form>
       </FormProvider>

--- a/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
@@ -222,6 +222,7 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
       exit="hidden"
       initial="hidden"
       animate="visible"
+      data-testid="action-drawer"
       className={clsx(
         className,
         `

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -200,7 +200,7 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
             <NotificationBanner
               icon={WarningCircle}
               status="error"
-              testId="action-sidebar-error"
+              testId="action-sidebar-custom-error"
             >
               {customError.message?.toString()}
             </NotificationBanner>

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -162,7 +162,10 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
           })}
         />
         {selectedAction && (
-          <div className="text-md text-gray-900">
+          <div
+            className="text-md text-gray-900"
+            data-testid="action-sidebar-description"
+          >
             <ActionSidebarDescription />
           </div>
         )}
@@ -194,7 +197,11 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
         )}
         {customError && (
           <div className="mt-7">
-            <NotificationBanner icon={WarningCircle} status="error">
+            <NotificationBanner
+              icon={WarningCircle}
+              status="error"
+              testId="action-sidebar-error"
+            >
               {customError.message?.toString()}
             </NotificationBanner>
           </div>
@@ -202,6 +209,7 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
         {flatFormErrors.length ? (
           <div className="mt-7">
             <NotificationBanner
+              testId="action-sidebar-error"
               status="error"
               icon={WarningCircle}
               description={
@@ -265,6 +273,7 @@ const ActionSidebarContent: FC<ActionSidebarContentProps> = ({
     <div
       className="flex w-full flex-grow overflow-hidden"
       data-tour={TourTargets.ActionsPanel}
+      data-testid="action-sidebar-content"
     >
       <div className="w-full flex-grow pb-6 pt-8">
         <ActionForm
@@ -310,6 +319,7 @@ const ActionSidebarContent: FC<ActionSidebarContentProps> = ({
 
             actionFormProps?.onSuccess?.();
           }}
+          testId="action-form"
         >
           <ActionSidebarFormContent
             getFormOptions={getFormOptions}

--- a/src/components/v5/common/ActionSidebar/partials/AmountField/partials/TokenList.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/partials/TokenList.tsx
@@ -22,7 +22,7 @@ export const TokenList: FC<TokenListProps> = ({
   onSelect,
 }) => {
   return (
-    <ul className="h-full overflow-y-auto">
+    <ul className="h-full overflow-y-auto" data-testid="token-list">
       {colonyTokens.map((colonyToken) => {
         const tokenBalance = getBalanceForTokenAndDomain(
           colonyBalances,
@@ -31,7 +31,11 @@ export const TokenList: FC<TokenListProps> = ({
         );
 
         return (
-          <li key={colonyToken.tokenAddress} className="mb-1 last:mb-0">
+          <li
+            key={colonyToken.tokenAddress}
+            className="mb-1 last:mb-0"
+            data-testid="token-list-item"
+          >
             <HoverWidthWrapper hoverClassName="font-medium block">
               <button
                 type="button"

--- a/src/components/v5/common/Fields/CardSelect/CardSelect.tsx
+++ b/src/components/v5/common/Fields/CardSelect/CardSelect.tsx
@@ -95,7 +95,7 @@ function CardSelect<TValue = string>({
     placeholder || formatText({ id: 'common.fields.cardSelect.placeholder' });
 
   return (
-    <div className="w-full sm:relative">
+    <div className="w-full sm:relative" data-testid="card-select">
       {readonly || disabled ? (
         <span
           className={clsx('text-md', {

--- a/src/components/v5/shared/MenuContainer/MenuContainer.tsx
+++ b/src/components/v5/shared/MenuContainer/MenuContainer.tsx
@@ -17,10 +17,12 @@ const MenuContainer = React.forwardRef<
       className,
       withPadding = true,
       checked = false,
+      testId,
     },
     ref,
   ) => (
     <div
+      data-testid={testId}
       className={clsx(
         className,
         'flex flex-col border bg-base-white',

--- a/src/components/v5/shared/MenuContainer/types.ts
+++ b/src/components/v5/shared/MenuContainer/types.ts
@@ -4,4 +4,5 @@ export interface MenuContainerProps {
   rounded?: 's' | 'm';
   withPadding?: boolean;
   checked?: boolean;
+  testId?: string;
 }

--- a/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/ColonyPageSidebar.tsx
+++ b/src/components/v5/shared/Navigation/Sidebar/sidebars/ColonyPageSidebar/ColonyPageSidebar.tsx
@@ -86,6 +86,7 @@ const ColonyPageSidebar = () => {
 
   return (
     <Sidebar
+      testId="colony-page-sidebar"
       className={colonyPageSidebarDesktopClass}
       showColonySwitcher={!isTablet}
       headerClassName="mb-[1.563rem]"

--- a/src/components/v5/shared/NotificationBanner/NotificationBanner.tsx
+++ b/src/components/v5/shared/NotificationBanner/NotificationBanner.tsx
@@ -15,9 +15,11 @@ const NotificationBanner: FC<NotificationBannerProps> = ({
   descriptionClassName,
   callToActionClassName,
   contentClassName,
+  testId,
 }) => {
   return (
     <div
+      data-testid={testId}
       className={clsx(
         'flex flex-row items-start gap-2 rounded-lg border px-[1.125rem] py-3 text-gray-900 @container/notificationBanner',
         {

--- a/src/components/v5/shared/NotificationBanner/types.ts
+++ b/src/components/v5/shared/NotificationBanner/types.ts
@@ -11,4 +11,5 @@ export type NotificationBannerProps = PropsWithChildren<{
   descriptionClassName?: string;
   callToActionClassName?: string;
   contentClassName?: string;
+  testId?: string;
 }>;

--- a/src/components/v5/shared/SearchSelect/SearchSelect.tsx
+++ b/src/components/v5/shared/SearchSelect/SearchSelect.tsx
@@ -222,6 +222,7 @@ const SearchSelect = React.forwardRef<HTMLDivElement, SearchSelectProps>(
     return (
       <Portal>
         <MenuContainer
+          testId="search-select-menu"
           className={clsx(
             className,
             'absolute z-dropdown max-h-[37.5rem] w-full max-w-[calc(100%-2.25rem)] bg-base-white px-2.5 py-6 sm:max-w-[20.375rem]',

--- a/src/components/v5/shared/UserInfoPopover/partials/UserInfo.tsx
+++ b/src/components/v5/shared/UserInfoPopover/partials/UserInfo.tsx
@@ -41,6 +41,7 @@ const UserInfo: FC<UserInfoProps> = ({
 
   return (
     <div
+      data-testid="user-info"
       className={clsx('flex flex-col', {
         'sm:min-w-[17rem]': !isTopContributorType,
         'sm:min-w-[20rem]': isTopContributorType,


### PR DESCRIPTION
## Description

 Added tests for Simple Payment action.
Test cases included in the PR:
- Should successfully create a simple payment
- Should display validation errors for required fields and invalid inputs
- Should display tooltips and user info on hover and click actions
- Should display the confirmation modal when the user tries to close the form
- Should not allow to create a simple payment with no permissions


## Testing

Step 1. Spin up the dev env and seed the test data 

`npm run dev`  followed by `node scripts/create-data.js`

Step 2. Remove your local playwright trace files

 `rm -rf playwright-report/` (from the root of the project )

Step 3. Build and start the frontend in preview mode

`npm run preview` 

Step 4. Run the tests in a separate terminal 

`npm run e2e simple-payment`

Step 5. The tests should pass ( if any failures - please send me .zip files from /playwright-report/data directory)



(Resolves | Contributes to) #31415
