### PR TITLE
Fix: Sort teams page alphabetically

### DIFF
--- a/src/components/frame/v5/pages/TeamsPage/hooks.tsx
+++ b/src/components/frame/v5/pages/TeamsPage/hooks.tsx
@@ -265,6 +265,14 @@ export const useTeams = () => {
     useState<TeamsPageFilters>(defaultFilterValue);
 
   const sortedTeams = [...teams].sort((a, b) => {
+    // If values match, sort alphabetically
+    if (a[filterValue.field] === b[filterValue.field]) {
+      const nameA = a.title || '';
+      const nameB = b.title || '';
+
+      return nameA.localeCompare(nameB);
+    }
+
     if (filterValue.direction === ModelSortDirection.Asc) {
       return a[filterValue.field] - b[filterValue.field];
     }

--- a/src/hooks/useTeamsOptions.ts
+++ b/src/hooks/useTeamsOptions.ts
@@ -1,14 +1,25 @@
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { type Domain } from '~types/graphql.ts';
 import { notNull } from '~utils/arrays/index.ts';
 import {
   type SearchSelectOption,
   type SearchSelectOptionProps,
 } from '~v5/shared/SearchSelect/types.ts';
 
-const sortByDomainId = (
-  { nativeId: firstDomainId },
-  { nativeId: secondDomainId },
-) => firstDomainId - secondDomainId;
+const sortByReputationAndName = (a: Domain, b: Domain) => {
+  const reputationA = parseFloat(a.reputationPercentage || '0');
+  const reputationB = parseFloat(b.reputationPercentage || '0');
+
+  // Sort by reputation percentage in descending order
+  if (reputationA !== reputationB) {
+    return reputationB - reputationA;
+  }
+
+  // If reputation percentages are equal or missing, sort alphabetically by name
+  const nameA = a.metadata?.name || '';
+  const nameB = b.metadata?.name || '';
+  return nameA.localeCompare(nameB);
+};
 
 const useTeamsOptions = (
   filterOptionsFn?: (option: SearchSelectOption) => boolean,
@@ -20,7 +31,7 @@ const useTeamsOptions = (
   const teams =
     domains?.items
       .filter(notNull)
-      .sort(sortByDomainId)
+      .sort(sortByReputationAndName)
       .map(({ metadata, nativeId, isRoot }) => {
         const { color, name: teamName } = metadata || {};
 


### PR DESCRIPTION
## Description

This PR adjusts the filter sorting on the teams page so that when the filter values are equal (i.e. if you have the reputation filter selected, and two teams have the same reputation) that they are then sorted alphabetically.

The same sort order has also been applied to the team select for all action forms.

## Testing

We are going to set 3 teams to have the same reputation. Copy your colony address from the dashboard and run these mutations.

```
mutation MyMutation {
  updateDomain(input: {id: "{COLONY_ADDRESS}_2", reputationPercentage: "20"}) {
    id
  }
}
```

```
mutation MyMutation {
  updateDomain(input: {id: "{COLONY_ADDRESS}_3", reputationPercentage: "20"}) {
    id
  }
}
```

```
mutation MyMutation {
  updateDomain(input: {id: "{COLONY_ADDRESS}_6", reputationPercentage: "20"}) {
    id
  }
}
```

Now Andromeda, Serenity and Daedalus will all have 20 reputation.

Navigate to the teams page [http://localhost:9091/planex/teams](http://localhost:9091/planex/teams) and check they appear in reputation order, and that those with matching reputation values are sorted alphabetically. Check also that it matches the order of the team switcher.

<img width="1728" alt="Screenshot 2024-11-29 at 12 15 45" src="https://github.com/user-attachments/assets/3edc7420-5879-47b1-ac2d-e58111a0f490">

This will also impact amount sorting, so if two teams have the same amounts they will appear alphabetically. Feel free to run some mutations to change the team amounts if you want to test this.

Create a simple payment action and check the teams appear in the same order in the team select field.

<img width="370" alt="Screenshot 2024-11-29 at 13 30 45" src="https://github.com/user-attachments/assets/c4bd0d78-e7e6-4433-ab21-e8fd58334568">


## Diffs

**Changes** 🏗

* Teams filter now sorts alphabetically for equal values
* Team select now sorts by reputation and name

Resolves #3803