### PR TITLE
Fix multisig widget loading state

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarLoadingSkeleton/ActionSidebarLoadingSkeleton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarLoadingSkeleton/ActionSidebarLoadingSkeleton.tsx
@@ -2,7 +2,8 @@ import clsx from 'clsx';
 import React from 'react';
 
 import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
-import MenuWithStatusText from '~v5/shared/MenuWithStatusText/MenuWithStatusText.tsx';
+
+import ActionSidebarWidgetLoadingSkeleton from '../ActionSidebarWidgetLoadingSkeleton/ActionSidebarWidgetLoadingSkeleton.tsx';
 
 const displayName = `v5.common.ActionSidebar.partials.ActionSidebarLoadingSkeleton`;
 
@@ -106,115 +107,7 @@ const ActionSidebarLoadingSkeleton = () => {
               sm:border-l-gray-200
             `}
       >
-        <div className="flex">
-          <div className="mr-[-.3450rem] mt-2">
-            {new Array(72).fill(0).map((_, index) => (
-              <LoadingSkeleton
-                // eslint-disable-next-line react/no-array-index-key
-                key={index}
-                isLoading
-                className="mb-[.0625rem] h-[.1875rem] w-[.0625rem] rounded"
-              />
-            ))}
-            <LoadingSkeleton
-              isLoading
-              className="mb-[.0625rem] h-[40px] w-[.0625rem] rounded"
-            />
-          </div>
-          <div>
-            <div className="mb-4 flex items-center gap-4">
-              <LoadingSkeleton
-                isLoading
-                className="h-[.625rem] w-[.625rem] rounded-3xl"
-              />
-              <LoadingSkeleton
-                isLoading
-                className="h-6 w-[3.75rem] rounded-3xl"
-              />
-            </div>
-            <div className="ml-6 w-[19.3125rem]">
-              <MenuWithStatusText
-                statusText={
-                  <div className="flex items-center gap-2">
-                    <LoadingSkeleton
-                      isLoading
-                      className=" h-[.875rem] w-[.875rem] rounded"
-                    />
-                    <LoadingSkeleton
-                      isLoading
-                      className=" h-[.6875rem] w-full rounded"
-                    />
-                  </div>
-                }
-                sections={[
-                  {
-                    key: '1',
-                    content: (
-                      <div className="flex gap-4">
-                        <div className="w-full">
-                          {new Array(4).fill(0).map((_, index) => (
-                            <div
-                              // eslint-disable-next-line react/no-array-index-key
-                              key={index}
-                              className="mt-2 items-center gap-2"
-                            >
-                              <LoadingSkeleton
-                                isLoading
-                                className={clsx('h-5 rounded', {
-                                  'w-[4rem]': index % 2 === 0,
-                                  'w-[2.9375rem]': index % 2 === 1,
-                                })}
-                              />
-                            </div>
-                          ))}
-                        </div>
-                        <div className="w-full">
-                          <LoadingSkeleton
-                            isLoading
-                            className="mt-2 h-5 w-0 rounded"
-                          />
-                          <div className="ml-[3.4375rem] flex w-full gap-2">
-                            <LoadingSkeleton
-                              isLoading
-                              className="mt-2 h-5 w-5 rounded-3xl"
-                            />
-                            <LoadingSkeleton
-                              isLoading
-                              className="mt-2 h-5 w-11 rounded"
-                            />
-                          </div>
-                          <LoadingSkeleton
-                            isLoading
-                            className="ml-[4.0625rem] mt-2 h-5 w-[4rem] rounded-3xl"
-                          />
-                          <LoadingSkeleton
-                            isLoading
-                            className="mt-2 h-5 w-full rounded"
-                          />
-                        </div>
-                      </div>
-                    ),
-                  },
-                ]}
-              />
-            </div>
-            {new Array(3).fill(0).map((_, index) => (
-              // eslint-disable-next-line react/no-array-index-key
-              <div key={index} className="mt-4 flex items-center gap-4">
-                <LoadingSkeleton
-                  isLoading
-                  className={clsx('h-[.625rem] w-[.625rem] rounded-3xl')}
-                />
-                <LoadingSkeleton
-                  isLoading
-                  className={clsx('h-6 w-[3.75rem] rounded-3xl', {
-                    'w-[4rem]': index === 1,
-                  })}
-                />
-              </div>
-            ))}
-          </div>
-        </div>
+        <ActionSidebarWidgetLoadingSkeleton />
       </div>
     </div>
   );

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarWidgetLoadingSkeleton/ActionSidebarWidgetLoadingSkeleton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarWidgetLoadingSkeleton/ActionSidebarWidgetLoadingSkeleton.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+const displayName = `v5.common.ActionSidebar.partials.ActionSidebarWidgetLoadingSkeleton`;
+
+const ActionSidebarWidgetLoadingSkeleton = () => {
+  return (
+    <div className="relative flex flex-col gap-4">
+      <div className="flex w-full items-center gap-4">
+        <div className="flex items-center justify-center">
+          <div className="h-[10px] w-[10px] rounded-full bg-gray-100" />
+        </div>
+        <div className="h-6 w-14 overflow-hidden rounded-full skeleton" />
+      </div>
+      <div className="ml-[1.625rem] overflow-hidden rounded-lg border border-gray-200">
+        <div className="flex w-full gap-2 border-b border-gray-200 bg-gray-50 p-[1.125rem] py-3">
+          <div className="h-4 w-4 overflow-hidden rounded-md skeleton" />
+          <div className="h-4 w-52 overflow-hidden rounded-md skeleton" />
+        </div>
+        <div>
+          <div className="flex flex-col gap-3 bg-base-white p-[1.125rem]">
+            <div className="h-5 w-16 overflow-hidden rounded-md skeleton" />
+            <div className="flex justify-between">
+              <div className="h-5 w-12 overflow-hidden rounded-md skeleton" />
+              <div className="flex gap-2">
+                <div className="h-5 w-5 overflow-hidden rounded-full skeleton" />
+                <div className="h-5 w-12 overflow-hidden rounded-md skeleton" />
+              </div>
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="h-5 w-16 overflow-hidden rounded-md skeleton" />
+              <div className="h-6 w-16 overflow-hidden rounded-full skeleton" />
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="h-5 w-12 overflow-hidden rounded-md skeleton" />
+              <div className="h-5 w-32 overflow-hidden rounded-md skeleton" />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="flex w-full items-center gap-4">
+        <div className="flex items-center justify-center">
+          <div className="h-[10px] w-[10px] rounded-full bg-gray-100" />
+        </div>
+        <div className="h-6 w-12 overflow-hidden rounded-full skeleton" />
+      </div>
+      <div className="flex w-full items-center gap-4">
+        <div className="flex items-center justify-center">
+          <div className="h-[10px] w-[10px] rounded-full bg-gray-100" />
+        </div>
+        <div className="h-6 w-16 overflow-hidden rounded-full skeleton" />
+      </div>
+      <div className="flex w-full items-center gap-4">
+        <div className="flex items-center justify-center">
+          <div className="h-[10px] w-[10px] rounded-full bg-gray-100" />
+        </div>
+        <div className="h-6 w-14 overflow-hidden rounded-full skeleton" />
+      </div>
+      <div className="absolute bottom-12 left-[4.5px] top-3 border-l-[1px] border-dashed border-l-gray-100" />
+      <div className="absolute bottom-3 left-[4.5px] top-72 border-l-[1px] border-solid border-l-gray-100" />
+    </div>
+  );
+};
+
+ActionSidebarWidgetLoadingSkeleton.displayName = displayName;
+
+export default ActionSidebarWidgetLoadingSkeleton;

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarWidgetLoadingSkeleton/ActionSidebarWidgetLoadingSkeleton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarWidgetLoadingSkeleton/ActionSidebarWidgetLoadingSkeleton.tsx
@@ -7,51 +7,51 @@ const ActionSidebarWidgetLoadingSkeleton = () => {
     <div className="relative flex flex-col gap-4">
       <div className="flex w-full items-center gap-4">
         <div className="flex items-center justify-center">
-          <div className="h-[10px] w-[10px] rounded-full bg-gray-100" />
+          <div className="h-2.5 w-2.5 rounded-full bg-gray-100" />
         </div>
         <div className="h-6 w-14 overflow-hidden rounded-full skeleton" />
       </div>
       <div className="ml-[1.625rem] overflow-hidden rounded-lg border border-gray-200">
-        <div className="flex w-full gap-2 border-b border-gray-200 bg-gray-50 p-[1.125rem] py-3">
-          <div className="h-4 w-4 overflow-hidden rounded-md skeleton" />
-          <div className="h-4 w-52 overflow-hidden rounded-md skeleton" />
+        <div className="flex w-full gap-2 border-b border-gray-200 bg-gray-50 p-4.5 py-3">
+          <div className="h-4 w-4 overflow-hidden rounded skeleton" />
+          <div className="h-4 w-52 overflow-hidden rounded skeleton" />
         </div>
         <div>
-          <div className="flex flex-col gap-3 bg-base-white p-[1.125rem]">
-            <div className="h-5 w-16 overflow-hidden rounded-md skeleton" />
+          <div className="flex flex-col gap-2 bg-base-white p-4.5">
+            <div className="h-5 w-16 overflow-hidden rounded skeleton" />
             <div className="flex justify-between">
-              <div className="h-5 w-12 overflow-hidden rounded-md skeleton" />
+              <div className="h-5 w-12 overflow-hidden rounded skeleton" />
               <div className="flex gap-2">
                 <div className="h-5 w-5 overflow-hidden rounded-full skeleton" />
-                <div className="h-5 w-12 overflow-hidden rounded-md skeleton" />
+                <div className="h-5 w-12 overflow-hidden rounded skeleton" />
               </div>
             </div>
             <div className="flex items-center justify-between">
-              <div className="h-5 w-16 overflow-hidden rounded-md skeleton" />
+              <div className="h-5 w-16 overflow-hidden rounded skeleton" />
               <div className="h-6 w-16 overflow-hidden rounded-full skeleton" />
             </div>
             <div className="flex items-center justify-between">
-              <div className="h-5 w-12 overflow-hidden rounded-md skeleton" />
-              <div className="h-5 w-32 overflow-hidden rounded-md skeleton" />
+              <div className="h-5 w-12 overflow-hidden rounded skeleton" />
+              <div className="h-5 w-32 overflow-hidden rounded skeleton" />
             </div>
           </div>
         </div>
       </div>
       <div className="flex w-full items-center gap-4">
         <div className="flex items-center justify-center">
-          <div className="h-[10px] w-[10px] rounded-full bg-gray-100" />
+          <div className="h-2.5 w-2.5 rounded-full bg-gray-100" />
         </div>
         <div className="h-6 w-12 overflow-hidden rounded-full skeleton" />
       </div>
       <div className="flex w-full items-center gap-4">
         <div className="flex items-center justify-center">
-          <div className="h-[10px] w-[10px] rounded-full bg-gray-100" />
+          <div className="h-2.5 w-2.5 rounded-full bg-gray-100" />
         </div>
         <div className="h-6 w-16 overflow-hidden rounded-full skeleton" />
       </div>
       <div className="flex w-full items-center gap-4">
         <div className="flex items-center justify-center">
-          <div className="h-[10px] w-[10px] rounded-full bg-gray-100" />
+          <div className="h-2.5 w-2.5 rounded-full bg-gray-100" />
         </div>
         <div className="h-6 w-14 overflow-hidden rounded-full skeleton" />
       </div>

--- a/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/MultiSigSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/MultiSigSidebar.tsx
@@ -3,11 +3,12 @@ import { type FC } from 'react';
 import React from 'react';
 
 import useExtensionData from '~hooks/useExtensionData.ts';
-import SpinnerLoader from '~shared/Preloaders/SpinnerLoader.tsx';
 import { isInstalledExtensionData } from '~utils/extensions.ts';
 import { isMultiSig } from '~utils/multiSig/index.ts';
 import useGetColonyAction from '~v5/common/ActionSidebar/hooks/useGetColonyAction.ts';
 import UninstalledMessage from '~v5/common/UninstalledMessage/index.ts';
+
+import ActionSidebarWidgetLoadingSkeleton from '../ActionSidebarWidgetLoadingSkeleton/ActionSidebarWidgetLoadingSkeleton.tsx';
 
 import MultiSigWidget from './partials/MultiSigWidget/MultiSigWidget.tsx';
 
@@ -23,13 +24,16 @@ const MultiSigSidebar: FC<MultiSigSidebarProps> = ({ transactionId }) => {
     Extension.MultisigPermissions,
   );
 
-  if (loadingAction || loadingExtension || !action) {
-    return <SpinnerLoader appearance={{ size: 'medium' }} />;
+  const isLoading = loadingAction || loadingExtension || !action;
+
+  if (action && !isMultiSig(action)) {
+    console.warn('Not a multisig action');
+
+    return null;
   }
 
-  if (!isMultiSig(action)) {
-    console.warn('Not a multisig action');
-    return null;
+  if (isLoading) {
+    return <ActionSidebarWidgetLoadingSkeleton />;
   }
 
   const isMultiSigExtensionInstalled =


### PR DESCRIPTION
## Description

- Fix the loading state of the multisig action sidebar widget to match the Figma designs. Previously it showed an awkward spinner in the top left of the sidebar, whereas it should really be matching the general loading state for this widget.

- As part of this work, I refactored that general action sidebar loading component a little and extracted the widget part into a more reusable component so it could also be used here.

Figma: https://www.figma.com/design/5V8pr7iMwXsT9L3VAZsmUt/Actions-%26-Motions?node-id=26993-210663&t=jBC7dx6GQVefvIes-4

## Testing

* Step 1. Install the multisig extension
* Step 2. Make any multisig action
* Step 3. Load that action so that it opens in the sidebar. As it loads, check the loading state. I used a screen recorder, and also changed line 35 of `src/components/v5/common/ActionSidebar/partials/MultiSigSidebar/MultiSigSidebar.tsx` to `if (true)` to force the loading state.


https://github.com/user-attachments/assets/cb0ceb73-4dcc-49ba-b212-581189845fc2

<img width="1069" alt="Screenshot 2024-11-29 at 17 43 44" src="https://github.com/user-attachments/assets/947d9b6b-8c1c-4cc2-bd0f-525e8a7a13c0">


## Diffs

**New stuff** ✨

* New component `ActionSidebarWidgetLoadingSkeleton`

**Changes** 🏗

* Refactored ActionSidebarLoadingSkeleton
* Changed the loading behaviour of the MultiSigSidebar

Resolves #3422
