### PR TITLE
Fix: Add team name fallbacks

### DIFF
--- a/src/components/frame/v5/pages/TeamsPage/hooks.tsx
+++ b/src/components/frame/v5/pages/TeamsPage/hooks.tsx
@@ -15,7 +15,7 @@ import { Action } from '~constants/actions.ts';
 import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useMemberContext } from '~context/MemberContext/MemberContext.ts';
-import { ModelSortDirection } from '~gql';
+import { DomainColor, ModelSortDirection } from '~gql';
 import { useMobile } from '~hooks';
 import { useActivityData } from '~hooks/useActivityData.ts';
 import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
@@ -83,15 +83,15 @@ export const useTeams = () => {
 
       const { metadata, id, nativeId, reputationPercentage } = item;
 
-      if (!metadata) {
-        return result;
-      }
-
       if (selectedDomain && selectedDomain.nativeId !== nativeId) {
         return result;
       }
 
-      const { color, description, name } = metadata;
+      const { color, description, name } = metadata || {
+        color: DomainColor.Root,
+        description: '',
+        name: `Team #${nativeId}`,
+      };
 
       const domainActionsCount = domainsActionCount?.find(
         ({ key }) => key === id,

--- a/src/components/frame/v5/pages/TeamsPage/hooks.tsx
+++ b/src/components/frame/v5/pages/TeamsPage/hooks.tsx
@@ -29,6 +29,7 @@ import {
 } from '~routes/index.ts';
 import Numeral from '~shared/Numeral/index.ts';
 import { convertToDecimal } from '~utils/convertToDecimal.ts';
+import { getDomainNameFallback } from '~utils/domains.ts';
 import { formatText } from '~utils/intl.ts';
 import { getBalanceForTokenAndDomain } from '~utils/tokens.ts';
 import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
@@ -90,7 +91,7 @@ export const useTeams = () => {
       const { color, description, name } = metadata || {
         color: DomainColor.Root,
         description: '',
-        name: `Team #${nativeId}`,
+        name: getDomainNameFallback({ nativeId }),
       };
 
       const domainActionsCount = domainsActionCount?.find(

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/FundsCards.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/FundsCards.tsx
@@ -8,6 +8,7 @@ import { useSubDomains } from '~hooks/useSubDomains.ts';
 import { notMaybe } from '~utils/arrays/index.ts';
 // import { formatText } from '~utils/intl.ts';
 // import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
+import { getDomainNameFallback } from '~utils/domains.ts';
 import WidgetCards from '~v5/common/WidgetCards/index.ts';
 
 // import { useIsAddNewTeamVisible } from './hooks.ts';
@@ -36,16 +37,17 @@ export const FundsCards = () => {
     <div className="flex flex-col gap-4 sm:flex-row sm:gap-2 md:pt-1">
       <WidgetCards.List className="w-full">
         <FundsCardsTotalItem />
-        {subTeams
-          ?.filter(notMaybe)
-          .map((item) => (
-            <FundsCardsItem
-              key={item?.id}
-              domainId={item?.id}
-              domainName={item?.metadata?.name}
-              nativeId={item.nativeId}
-            />
-          ))}
+        {subTeams?.filter(notMaybe).map((item) => (
+          <FundsCardsItem
+            key={item?.id}
+            domainId={item?.id}
+            domainName={getDomainNameFallback({
+              domainName: item?.metadata?.name,
+              nativeId: item.nativeId,
+            })}
+            nativeId={item.nativeId}
+          />
+        ))}
 
         {/* {isAddNewTeamVisible && (
           <WidgetCards.Item

--- a/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
@@ -47,7 +47,7 @@ const TeamItem: FC<TeamItemProps> = ({
     }
   };
 
-  const label = domain.metadata?.name ?? domain.id;
+  const label = domain.metadata?.name ?? `Team #${domain.nativeId}`;
 
   return (
     <button

--- a/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamItem.tsx
@@ -5,6 +5,7 @@ import { useColonyFiltersContext } from '~context/GlobalFiltersContext/ColonyFil
 import { useMobile } from '~hooks/index.ts';
 import { useScrollIntoView } from '~hooks/useScrollIntoView.ts';
 import { type Domain } from '~types/graphql.ts';
+import { getDomainNameFallback } from '~utils/domains.ts';
 import { getTeamColor } from '~utils/teams.ts';
 
 const displayName = 'v5.shared.TeamFilter.partials.TeamItem';
@@ -47,7 +48,10 @@ const TeamItem: FC<TeamItemProps> = ({
     }
   };
 
-  const label = domain.metadata?.name ?? `Team #${domain.nativeId}`;
+  const label = getDomainNameFallback({
+    domainName: domain.metadata?.name,
+    nativeId: domain.nativeId,
+  });
 
   return (
     <button

--- a/src/hooks/useTeamsOptions.ts
+++ b/src/hooks/useTeamsOptions.ts
@@ -1,5 +1,5 @@
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
-import { type Domain } from '~types/graphql.ts';
+import { type Domain, DomainColor } from '~types/graphql.ts';
 import { notNull } from '~utils/arrays/index.ts';
 import {
   type SearchSelectOption,
@@ -33,14 +33,14 @@ const useTeamsOptions = (
       .filter(notNull)
       .sort(sortByReputationAndName)
       .map(({ metadata, nativeId, isRoot }) => {
-        const { color, name: teamName } = metadata || {};
+        const { color: teamColor, name: teamName } = metadata || {};
 
         return {
-          label: teamName || '',
+          label: teamName || `Team #${nativeId}`,
           value: nativeId,
           isDisabled: false,
           isRoot,
-          color,
+          color: teamColor || DomainColor.Root,
         };
       }) || [];
 

--- a/src/hooks/useTeamsOptions.ts
+++ b/src/hooks/useTeamsOptions.ts
@@ -1,6 +1,7 @@
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { type Domain, DomainColor } from '~types/graphql.ts';
 import { notNull } from '~utils/arrays/index.ts';
+import { getDomainNameFallback } from '~utils/domains.ts';
 import {
   type SearchSelectOption,
   type SearchSelectOptionProps,
@@ -36,7 +37,10 @@ const useTeamsOptions = (
         const { color: teamColor, name: teamName } = metadata || {};
 
         return {
-          label: teamName || `Team #${nativeId}`,
+          label: getDomainNameFallback({
+            domainName: teamName,
+            nativeId,
+          }),
           value: nativeId,
           isDisabled: false,
           isRoot,

--- a/src/redux/sagas/actions/editDomain.ts
+++ b/src/redux/sagas/actions/editDomain.ts
@@ -13,6 +13,10 @@ import {
   UpdateDomainMetadataDocument,
   type UpdateDomainMetadataMutation,
   type UpdateDomainMetadataMutationVariables,
+  type CreateDomainMetadataMutation,
+  type CreateDomainMetadataMutationVariables,
+  CreateDomainMetadataDocument,
+  DomainColor,
 } from '~gql';
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
 import {
@@ -42,7 +46,7 @@ function* editDomainAction({
   payload: {
     colonyAddress,
     domainName,
-    domainColor,
+    domainColor = DomainColor.Root,
     domainPurpose,
     domain,
     annotationMessage,
@@ -165,6 +169,25 @@ function* editDomainAction({
                 newColor: domainColor,
                 newDescription: domainPurpose,
               }),
+            },
+          },
+          refetchQueries: [GetFullColonyByNameDocument],
+        }),
+      );
+    } else {
+      // Create new metadata if no metadata exists
+      yield mutateWithAuthRetry(() =>
+        apolloClient.mutate<
+          CreateDomainMetadataMutation,
+          CreateDomainMetadataMutationVariables
+        >({
+          mutation: CreateDomainMetadataDocument,
+          variables: {
+            input: {
+              id: getDomainDatabaseId(colonyAddress, domain.nativeId),
+              name: domainName || `Team #${domain.nativeId}`,
+              color: domainColor,
+              description: domainPurpose,
             },
           },
           refetchQueries: [GetFullColonyByNameDocument],

--- a/src/redux/sagas/actions/editDomain.ts
+++ b/src/redux/sagas/actions/editDomain.ts
@@ -25,6 +25,7 @@ import {
 } from '~state/transactionState.ts';
 import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { getDomainDatabaseId } from '~utils/databaseId.ts';
+import { getDomainNameFallback } from '~utils/domains.ts';
 
 import {
   createGroupTransaction,
@@ -185,7 +186,10 @@ function* editDomainAction({
           variables: {
             input: {
               id: getDomainDatabaseId(colonyAddress, domain.nativeId),
-              name: domainName || `Team #${domain.nativeId}`,
+              name: getDomainNameFallback({
+                domainName,
+                nativeId: domain.nativeId,
+              }),
               color: domainColor,
               description: domainPurpose,
             },

--- a/src/utils/domains.ts
+++ b/src/utils/domains.ts
@@ -30,3 +30,13 @@ export const extractColonyDomains = (
 ): Domain[] => {
   return colonyDomains?.items.filter(notMaybe) ?? [];
 };
+
+export const getDomainNameFallback = ({
+  domainName,
+  nativeId,
+}: {
+  domainName?: string;
+  nativeId: number;
+}) => {
+  return domainName || `Team #${nativeId}`;
+};


### PR DESCRIPTION
## Description

This PR adds fallbacks for when a team name is missing. This can occur when there is a database issue when creating a new team (although hopefully the likelihood of this occurring is less now that #3669 is merged).

It also makes a change to the "Edit domain" saga so that if a team is missing metadata that it will be properly created.

## Testing

* Step 1 - First we need to delete a domain metadata entry to simulate a failed metadata mutation when creating a team. Copy the colony address from the dashboard and run this mutation to remove the Andromeda metadata entry.

```
mutation MyMutation {
  deleteDomainMetadata(input: {id: "{COLONY_ADDRESS}_2"}) {
    id
  }
}
```

* Step 2 - Refresh and navigate to the teams page, check the fallback appears correctly in both the team switcher and the team cards. (Note the fallback format should be `Team #2`)

<img width="1320" alt="Screenshot 2024-12-02 at 11 40 36" src="https://github.com/user-attachments/assets/3cb9bfeb-aef5-4cd9-9d50-a2322df01d75">

* Step 3 - Check the team has a background colour when selected.
 
<img width="945" alt="Screenshot 2024-12-02 at 11 41 51" src="https://github.com/user-attachments/assets/25b3781b-2d06-43ab-a1b7-ef05a9c438be">

* Step 4 - Create an edit team action and check the team appears in the select menu.
 
<img width="682" alt="Screenshot 2024-12-02 at 11 40 59" src="https://github.com/user-attachments/assets/f4378d1b-2688-4ddb-9bbe-d861f2d1a262">

* Step 5 - Complete the rest of the form and submit (you might notice this unrelated issue whilst submitting: #3812)

<img width="670" alt="Screenshot 2024-12-02 at 11 41 37" src="https://github.com/user-attachments/assets/1a2b8ad2-b1fd-416b-af7c-e32147f6a096">

* Step 6 - Check the metadata has been properly created and the team name has been correctly updated.
 
<img width="997" alt="Screenshot 2024-12-02 at 11 42 16" src="https://github.com/user-attachments/assets/39e85d37-3b36-4bed-b06e-347c4d6eb60e">

* Step 7 - Edit the same team again to check that this time the metadata updates correctly and that the changelog is updated.

```
query MyQuery {
  getDomainMetadata(id: "{COLONY_ADDRESS}_2") {
    changelog {
      newColor
      newDescription
      newName
      oldColor
      oldDescription
      oldName
      transactionHash
    }
    id
    name
  }
}

```

<img width="506" alt="Screenshot 2024-12-02 at 12 01 51" src="https://github.com/user-attachments/assets/ee293396-e02a-4276-9dbb-2feb034586ce">

## Diffs

**Changes** 🏗

* Added missing team name, colour and description fallbacks to the team switcher, team select and team page
* Adjusted the "Edit domain" saga to create new domain metadata if none exists

Resolves #3811
