### PR TITLE
Fix: Allow Split Payments to be created via the Permission decision method

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/utils.ts
@@ -33,7 +33,7 @@ export const getSplitPaymentPayload = (
       ? undefined
       : findDomainByNativeId(createdIn, colony) || rootDomain;
 
-  if (!createdInDomain || !payments.length) {
+  if (!payments.length) {
     return null;
   }
 


### PR DESCRIPTION
## Description

We were setting the `createdInDomain` value to `undefined` for Split Payments created via the Permissions decision method. Then for some reason, we were subsequently returning a `null` payload to our `expenditureCreate` saga if `createdInDomain` was falsy.

So I just removed the falsy check for `createdInDomain` since we don't even use this value in our `createExpenditure` saga.   

![split-permissions](https://github.com/user-attachments/assets/cb51acaf-efe7-4dda-9620-aa9a987115ab)

## Testing

1. Bring up the Split Payment form
2. Set the decision method to Permissions
3. Fill in all other required fields
4. Submit the form
5. Verify that you are able to submit the form

Resolves #3814 