### PR TITLE
Fix: Add zero reputation teams to dashboard influence-by-team list

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/Chart.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/partials/Chart.tsx
@@ -22,14 +22,18 @@ interface ChartProps {
 export const Chart: FC<ChartProps> = ({ data, emptyChartItem, isLoading }) => {
   const { setActiveLegendItem } = useReputationChartContext();
 
+  const pieChartData = data.filter(
+    (dataItem) => dataItem.value && dataItem.value > 0,
+  );
+
   return (
     <>
       <div className="relative mb-3.5 mt-5 flex h-[136px] w-full flex-shrink-0 items-center justify-center">
         {isLoading ? <ChartLoadingLayer /> : null}
         <ResponsivePie
           {...pieChartConfig}
-          data={data.length ? data : [emptyChartItem]}
-          isInteractive={!!data.length}
+          data={pieChartData.length ? pieChartData : [emptyChartItem]}
+          isInteractive={!!pieChartData.length}
           onActiveIdChange={setActiveLegendItem}
           tooltip={ChartTooltip}
           layers={[ChartCustomArcsLayer]}
@@ -58,11 +62,6 @@ export const Chart: FC<ChartProps> = ({ data, emptyChartItem, isLoading }) => {
 
           {!!data.length &&
             data.map((chartItem) => {
-              // if there is no value, it's value doesn't display in the chart and therefore it shouldn't display in the legend
-              if (chartItem.value === undefined || chartItem.value <= 0) {
-                return null;
-              }
-
               return <LegendItem key={chartItem.id} chartItem={chartItem} />;
             })}
         </Legend>

--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/utils.ts
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/utils.ts
@@ -128,12 +128,12 @@ export const getContributorReputationChartData = (
       };
     });
 
-  const numberOfContributorsWithReputation = contributorsList.filter(
+  const contributorsWithReputation = contributorsList.filter(
     (contributor) => contributor.reputation && contributor.reputation > 0,
   );
 
-  if (numberOfContributorsWithReputation.length > WIDGET_TEAM_LIMIT) {
-    const reputationOtherContributors = numberOfContributorsWithReputation
+  if (contributorsWithReputation.length > WIDGET_TEAM_LIMIT) {
+    const reputationOtherContributors = contributorsWithReputation
       .slice(WIDGET_TEAM_LIMIT - 1)
       .reduce(
         (reputation, contributor) => reputation + (contributor.reputation || 0),

--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/utils.ts
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/utils.ts
@@ -79,11 +79,14 @@ export const getTeamReputationChartData = (
       };
     });
 
-  const reputationInOtherTeams = domainsWithoutRoot
-    .slice(WIDGET_TEAM_LIMIT)
-    .reduce((reputation, team) => reputation + Number(team.reputation || 0), 0);
-
   if (domainsWithoutRoot.length > WIDGET_TEAM_LIMIT) {
+    const reputationInOtherTeams = domainsWithoutRoot
+      .slice(WIDGET_TEAM_LIMIT - 1)
+      .reduce(
+        (reputation, team) => reputation + Number(team.reputation || 0),
+        0,
+      );
+
     topTeams[topTeams.length - 1] = {
       id: 'allOtherTeams',
       label: formatText(MSG.otherLabel),
@@ -125,14 +128,18 @@ export const getContributorReputationChartData = (
       };
     });
 
-  const reputationOtherContributors = contributorsList
-    .slice(WIDGET_TEAM_LIMIT)
-    .reduce(
-      (reputation, contributor) => reputation + (contributor.reputation || 0),
-      0,
-    );
+  const numberOfContributorsWithReputation = contributorsList.filter(
+    (contributor) => contributor.reputation && contributor.reputation > 0,
+  );
 
-  if (reputationOtherContributors > 0) {
+  if (numberOfContributorsWithReputation.length > WIDGET_TEAM_LIMIT) {
+    const reputationOtherContributors = numberOfContributorsWithReputation
+      .slice(WIDGET_TEAM_LIMIT - 1)
+      .reduce(
+        (reputation, contributor) => reputation + (contributor.reputation || 0),
+        0,
+      );
+
     topContributors[topContributors.length - 1] = {
       id: 'allOtherUsers',
       label: formatText(MSG.otherLabel),


### PR DESCRIPTION
## Description

- Any team which has zero reputation should be showing in the legend of the pie chart on the dashboard, but it should take up zero space in the actual pie chart.
- There should be a maximum of 5 teams shown in that legend. If there are more than 5 teams then it should show 4 teams and a 'All other' item which includes all of the others.

Full details and spec here: https://www.notion.so/colony/Dashboard-Colony-Home-322f296cb46240d3afddeddd7472ddd7?pvs=4#95f462343e974c048d88206eaaa860d8

## Testing

* Step 1. Go to Wayne Enterprises colony (it is easier to test with this colony since it starts with 4 subdomains by default). Check the Influence By Team chart on the dashboard (ensure you aren't filtering the app by a team). It should show 4 teams in both the pie chart and the legend below.
<img width="1316" alt="Screenshot 2024-12-02 at 17 13 41" src="https://github.com/user-attachments/assets/f0ab49bf-fbb9-464b-9a27-fa8443654dca">

* Step 2. Create a new team inside this colony. Check the chart again; this time there should still be 4 teams in the pie chart, but there should now be 5 teams underneath in the legend.
<img width="1322" alt="Screenshot 2024-12-02 at 17 14 31" src="https://github.com/user-attachments/assets/26f85e03-c6be-4056-9790-7aeaf3dcf00b">

* Step 3. Create another new team inside the colony. Again check the chart. There should still be 4 teams shown in the pie chart, and now there should be 4 teams in the legend underneath, followed by a 'All other' item.
<img width="1320" alt="Screenshot 2024-12-02 at 17 15 12" src="https://github.com/user-attachments/assets/fab966b8-13f4-47fb-bfe1-9859e534cc39">

## Diffs

**Changes** 🏗

* Changes to the dashboard charts

Resolves #3684 and 3686
