### PR TITLE
Fix: Show the correct motion passed or failed pill state

### DIFF
--- a/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
@@ -302,9 +302,13 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
                     withAdditionalStatuses
                   />
                 )}
-                {(!!isMotion || !!isMultiSig) && motionState && (
-                  <MotionOutcomeBadge motionState={motionState} />
-                )}
+                {(!!(
+                  isMotion && action?.motionData?.motionStateHistory.endedAt
+                ) ||
+                  !!isMultiSig) &&
+                  motionState && (
+                    <MotionOutcomeBadge motionState={motionState} />
+                  )}
               </div>
             )}
             {isMobile && getShareButton()}

--- a/src/components/v5/common/ActionSidebar/partials/Motions/Motions.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/Motions.tsx
@@ -60,14 +60,20 @@ const Motions: FC<MotionsProps> = ({ transactionId }) => {
 
   const [activeStepKey, setActiveStepKey] = useState<Steps>(networkMotionState);
 
+  const { hasPassed, endedAt } = motionStateHistory ?? {};
+
   const motionFinished =
     networkMotionState === NetworkMotionState.Finalizable ||
     networkMotionState === NetworkMotionState.Finalized ||
     networkMotionState === NetworkMotionState.Failed;
 
+  const motionOutcomeAvailable = motionFinished && endedAt;
+
   useEffect(() => {
     startPollingForAction();
+
     setActiveStepKey(networkMotionState);
+
     if (motionFinished) {
       setActiveStepKey(CustomStep.Finalize);
     }
@@ -88,8 +94,6 @@ const Motions: FC<MotionsProps> = ({ transactionId }) => {
   const isFullyStaked =
     objectingStakesPercentageValue === 100 &&
     supportingStakesPercentageValue === 100;
-
-  const hasVotedMotionPassed = motionStateHistory?.hasPassed;
 
   const motionStakedAndFinalizable =
     motionFinished &&
@@ -238,25 +242,24 @@ const Motions: FC<MotionsProps> = ({ transactionId }) => {
         key: CustomStep.VotedMotionOutcome,
         content: <OutcomeStep motionData={motionData} />,
         heading: {
-          icon: motionFinished
-            ? (hasVotedMotionPassed && ThumbsUp) || ThumbsDown
+          icon: motionOutcomeAvailable
+            ? (hasPassed && ThumbsUp) || ThumbsDown
             : undefined,
-          label: motionFinished
-            ? (hasVotedMotionPassed &&
-                formatText({ id: 'motion.support.wins.label' })) ||
+          label: motionOutcomeAvailable
+            ? (hasPassed && formatText({ id: 'motion.support.wins.label' })) ||
               formatText({ id: 'motion.oppose.wins.label' })
             : formatText({ id: 'motion.outcome.label' }) || '',
           className: clsx('z-base', {
             'border-purple-400 bg-base-white text-purple-400 md:enabled:hover:border-purple-400 md:enabled:hover:bg-purple-400 md:enabled:hover:text-base-white':
-              motionFinished && hasVotedMotionPassed,
+              motionOutcomeAvailable && hasPassed,
             'border-negative-400 bg-base-white text-negative-400 md:enabled:hover:border-negative-400 md:enabled:hover:bg-negative-400 md:enabled:hover:text-base-white':
-              motionFinished && !hasVotedMotionPassed,
+              motionOutcomeAvailable && !hasPassed,
           }),
           highlightedClassName: clsx({
             '!border-purple-400 !bg-purple-400 !text-base-white':
-              motionFinished && hasVotedMotionPassed,
+              motionOutcomeAvailable && hasPassed,
             '!border-negative-400 !bg-negative-400 !text-base-white':
-              motionFinished && !hasVotedMotionPassed,
+              motionOutcomeAvailable && !hasPassed,
           }),
           tooltipProps: {
             tooltipContent: getOutcomeStepTooltipText(
@@ -316,10 +319,10 @@ const Motions: FC<MotionsProps> = ({ transactionId }) => {
     motionStateHistory?.hasPassed,
     motionStateHistory?.hasFailed,
     motionStateHistory?.hasFailedNotFinalizable,
-    motionFinished,
-    hasVotedMotionPassed,
+    hasPassed,
     refetchAction,
     canInteract,
+    motionOutcomeAvailable,
   ]);
 
   if (


### PR DESCRIPTION
## Description

Had to add an extra boolean check to identify if a motion has indeed ended before we proceed to check if the motion has been supported or opposed.

![correct-motion-pill](https://github.com/user-attachments/assets/d7744878-8985-439c-b01b-9b76bdbe04e8)

## Testing

**Prerequisitse**

1. Install the Reputation extension
2. For the extension options, select `Custom (Advanced)`
3. Scroll the page down
4. Enter `0.01` for the following fields:
  - Staking Phase Duration
  - Voting Phase Duration
  - Reveal Phase Duration
5. Enable the extension

**Reveal flow** 

1. Create a Simple Payment via the Reputation decision method
2. Fully stake the Oppose option
3. Fully stake the Support option
4. Click Support and submit your vote
6. Reveal your vote
7. Verify that the motion pill for the vote is showing "👍🏻 Support wins"
8. Verify that the motion pill for the vote didn't initially show "👎🏻 Oppose wins"

**Non-reveal flow**

1. Create a Simple Payment via the Reputation decision method
2. Fully stake the Support option
3. Wait for the staking timer to naturally finish
4. Verify that the motion pill for the vote is showing "👍🏻 Supported"
6. Verify that the motion pill for the vote didn't initially show "👎🏻 Failed"

Resolves #3390 