### PR TITLE
Fix: Show correct role for the Manage Permissions form's completed action component

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/SetUserRoles/utils.ts
+++ b/src/components/v5/common/CompletedAction/partials/SetUserRoles/utils.ts
@@ -12,7 +12,7 @@ export const transformActionRolesToColonyRoles = (
 ): ColonyRole[] => {
   if (!roles) return [];
 
-  const roleKeys = Object.keys(roles);
+  const roleKeys = Object.keys(roles).filter((key) => roles[key]);
 
   const colonyRoles: ColonyRole[] = roleKeys
     .filter((key) => roles[key] !== null)


### PR DESCRIPTION
## Description

Just had to properly filter out the actual enabled roles for the user.

![fix-role-completed](https://github.com/user-attachments/assets/fd5fa0c2-2a46-4dc9-a6cf-1e38894ed5e2)

## Testing

1. Enable the Reputation extension
2. Bring up the Manage Permissions form
3. Set the Decision method to Reputation
4. Assign any role for chris-coder
5. Submit the form
6. Verify that the role is correct on the Completed Action form

Resolves #3822 