### PR TITLE
Fix: Close the saved draft agreement form without the cancel modal prompt

### DIFF
--- a/src/components/frame/v5/pages/AgreementsPage/partials/DraftCard/DraftCard.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/DraftCard/DraftCard.tsx
@@ -6,18 +6,18 @@ import {
 } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { useCallback, type FC } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { Action } from '~constants/actions.ts';
 import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useMobile } from '~hooks';
+import { useDraftAgreement } from '~hooks/useDraftAgreement.ts';
 import useToggle from '~hooks/useToggle/index.ts';
 import { removeDecisionAction } from '~redux/actionCreators/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
 import { MotionState } from '~utils/colonyMotions.ts';
-import { getDraftDecisionFromStore } from '~utils/decisions.ts';
 import { formatText } from '~utils/intl.ts';
 import {
   ACTION_TYPE_FIELD_NAME,
@@ -36,9 +36,8 @@ const DraftCard: FC = () => {
   const { user, userLoading: loading } = useAppContext();
   const isMobile = useMobile();
   const [isModalOpen, { toggleOff, toggleOn }] = useToggle();
-  const draftAgreement = useSelector(
-    getDraftDecisionFromStore(user?.walletAddress || '', colony.colonyAddress),
-  );
+
+  const { draftAgreement } = useDraftAgreement();
 
   const {
     actionSidebarToggle: [, { toggleOn: toggleActionSidebarOn }],

--- a/src/components/shared/Fields/Form/ActionForm.tsx
+++ b/src/components/shared/Fields/Form/ActionForm.tsx
@@ -62,6 +62,12 @@ export interface ActionFormProps<
     onClick?: MouseEventHandler<HTMLButtonElement>;
   };
   testId?: string;
+
+  /** On form close behaviour overrides */
+  onFormClose?: {
+    /** When satisfied, it causes the cancel modal to be shown */
+    shouldShowCancelModal?: boolean;
+  };
 }
 
 const ActionForm = <V extends Record<string, any>>({

--- a/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
@@ -21,6 +21,7 @@ import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSid
 import { useMobile } from '~hooks/index.ts';
 import useCopyToClipboard from '~hooks/useCopyToClipboard.ts';
 import useDisableBodyScroll from '~hooks/useDisableBodyScroll/index.ts';
+import { useDraftAgreement } from '~hooks/useDraftAgreement.ts';
 import useToggle from '~hooks/useToggle/index.ts';
 import { COLONY_ACTIVITY_ROUTE, TX_SEARCH_PARAM } from '~routes';
 import Tooltip from '~shared/Extensions/Tooltip/Tooltip.tsx';
@@ -101,6 +102,11 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
   }, [loadingAction, stopPollingForAction]);
 
   const { formRef, closeSidebarClick } = useCloseSidebarClick();
+
+  const { getIsDraftAgreement } = useDraftAgreement({
+    formContextOverride: formRef.current,
+  });
+
   const { isCopied, handleClipboardCopy } = useCopyToClipboard();
   const isMobile = useMobile();
 
@@ -263,7 +269,11 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
             <button
               type="button"
               className="flex items-center justify-center py-2.5 text-gray-400 transition sm:hover:text-blue-400"
-              onClick={closeSidebarClick}
+              onClick={() =>
+                closeSidebarClick({
+                  shouldShowCancelModal: !getIsDraftAgreement(),
+                })
+              }
               aria-label={formatText({ id: 'ariaLabel.closeModal' })}
             >
               <X size={18} />

--- a/src/components/v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useActionFormBaseHook.ts
@@ -15,6 +15,7 @@ const useActionFormBaseHook: UseActionFormBaseHook = ({
   getFormOptions,
   id,
   primaryButton,
+  onFormClose,
 }) => {
   const form = useFormContext();
 
@@ -33,6 +34,9 @@ const useActionFormBaseHook: UseActionFormBaseHook = ({
           type: primaryButton?.type,
           onClick: primaryButton?.onClick,
         },
+        onFormClose: {
+          shouldShowCancelModal: onFormClose?.shouldShowCancelModal,
+        },
       },
       form,
     );
@@ -44,6 +48,7 @@ const useActionFormBaseHook: UseActionFormBaseHook = ({
     id,
     primaryButton?.onClick,
     primaryButton?.type,
+    onFormClose?.shouldShowCancelModal,
   ]);
 
   useUnmountEffect(() => {

--- a/src/components/v5/common/ActionSidebar/hooks/useCloseSidebarClick.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useCloseSidebarClick.ts
@@ -2,27 +2,31 @@ import { useRef } from 'react';
 import { useFormContext, type UseFormReturn } from 'react-hook-form';
 
 import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
+import { type ActionFormProps } from '~shared/Fields/Form/ActionForm.tsx';
 
 const useCloseSidebarClick = () => {
   const formContext = useFormContext();
   const formRef = useRef<UseFormReturn<object>>(null);
+
   const {
     actionSidebarToggle: [, { toggleOff: toggleActionSidebarOff }],
     cancelModalToggle: [, { toggle: toggleCancelModal }],
   } = useActionSidebarContext();
 
-  return {
-    closeSidebarClick: () => {
-      const { dirtyFields } = (formContext || formRef.current)?.formState || {};
+  const closeSidebarClick = (args: ActionFormProps['onFormClose']) => {
+    const { dirtyFields } = (formContext || formRef.current)?.formState ?? {};
 
-      if (dirtyFields && Object.keys(dirtyFields).length > 0) {
-        toggleCancelModal();
-      } else {
-        toggleActionSidebarOff();
-      }
-    },
-    formRef,
+    const hasDirtyFields = dirtyFields && Object.keys(dirtyFields).length > 0;
+    const shouldShowCancelModal = args?.shouldShowCancelModal ?? true;
+
+    if (hasDirtyFields && shouldShowCancelModal) {
+      toggleCancelModal();
+    } else {
+      toggleActionSidebarOff();
+    }
   };
+
+  return { closeSidebarClick, formRef };
 };
 
 export default useCloseSidebarClick;

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/ActionSidebarContent.tsx
@@ -4,18 +4,16 @@ import clsx from 'clsx';
 import React, { useEffect, type FC, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { defineMessages } from 'react-intl';
-import { useSelector } from 'react-redux';
 
 import { TourTargets } from '~common/Tours/enums.ts';
 import { Action } from '~constants/actions.ts';
 import { useAdditionalFormOptionsContext } from '~context/AdditionalFormOptionsContext/AdditionalFormOptionsContext.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
-import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { GetTotalColonyActionsDocument, SearchActionsDocument } from '~gql';
+import { useDraftAgreement } from '~hooks/useDraftAgreement.ts';
 import useToggle from '~hooks/useToggle/index.ts';
 import { ActionForm } from '~shared/Fields/index.ts';
 import { DecisionMethod } from '~types/actions.ts';
-import { getDraftDecisionFromStore } from '~utils/decisions.ts';
 import { formatText } from '~utils/intl.ts';
 import { isQueryActive } from '~utils/isQueryActive.ts';
 import ActionTypeSelect from '~v5/common/ActionSidebar/ActionTypeSelect.tsx';
@@ -59,10 +57,9 @@ const MSG = defineMessages({
 
 const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
   getFormOptions,
-  actionFormProps: { primaryButton },
+  actionFormProps: { primaryButton, onFormClose },
   showApolloNetworkError,
 }) => {
-  const { colony } = useColonyContext();
   const { user } = useAppContext();
   const { formComponent: FormComponent, selectedAction } =
     useSidebarActionForm();
@@ -117,9 +114,7 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
     { toggleOn: showRemoveDraftModal, toggleOff: hideRemoveDraftModal },
   ] = useToggle();
 
-  const draftAgreement = useSelector(
-    getDraftDecisionFromStore(user?.walletAddress || '', colony.colonyAddress),
-  );
+  const { draftAgreement } = useDraftAgreement();
 
   useEffect(() => {
     if (
@@ -230,6 +225,7 @@ const ActionSidebarFormContent: FC<ActionSidebarFormContentProps> = ({
           <ActionButtons
             isActionDisabled={isSubmitDisabled}
             primaryButton={primaryButton}
+            onFormClose={onFormClose}
           />
         </div>
       )}

--- a/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/CreateDecisionForm/hooks.ts
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { useDraftAgreement } from '~hooks/useDraftAgreement.ts';
 import { createDecisionAction } from '~redux/actionCreators/index.ts';
 import { ActionTypes } from '~redux/index.ts';
 import { mapPayload, pipe } from '~utils/actions.ts';
@@ -24,13 +25,7 @@ export const useCreateDecision = (
   const walletAddress = user?.walletAddress || '';
   const dispatch = useDispatch();
 
-  // @TODO: checking if decision has draft status
-  // const draftDecision = useSelector(
-  //   getDraftDecisionFromStore(
-  //     user?.walletAddress || '',
-  //     colony?.colonyAddress ?? '',
-  //   ),
-  // );
+  const { getIsDraftAgreement } = useDraftAgreement();
 
   const handleSaveAgreementInLocalStorage = useCallback(
     (values: DecisionDraft) => {
@@ -80,5 +75,8 @@ export const useCreateDecision = (
       ),
       [],
     ),
+    onFormClose: {
+      shouldShowCancelModal: !getIsDraftAgreement(),
+    },
   });
 };

--- a/src/components/v5/common/ActionSidebar/types.ts
+++ b/src/components/v5/common/ActionSidebar/types.ts
@@ -4,16 +4,15 @@ import { type ActionFormProps } from '~shared/Fields/Form/ActionForm.tsx';
 import { type Address } from '~types';
 import { type ColonyAction } from '~types/graphql.ts';
 
-export interface ActionButtonsProps {
+export interface ActionButtonsProps
+  extends Pick<ActionFormOptions, 'primaryButton' | 'onFormClose'> {
   isActionDisabled?: boolean;
   onSubmitClick?: () => void;
-  primaryButton?: ActionFormProps['primaryButton'];
 }
 
 export interface ActionFormOptions
   extends Omit<ActionFormProps<any>, 'children' | 'onSuccess'> {
   onSuccess?: () => void;
-  primaryButton?: ActionFormProps['primaryButton'];
 }
 
 export interface ActionFormBaseProps {
@@ -37,6 +36,7 @@ export type UseActionFormBaseHook = (
     | 'onSuccess'
     | 'id'
     | 'primaryButton'
+    | 'onFormClose'
   >,
 ) => void;
 

--- a/src/hooks/useDraftAgreement.ts
+++ b/src/hooks/useDraftAgreement.ts
@@ -1,0 +1,48 @@
+import { useFormContext, type UseFormReturn } from 'react-hook-form';
+import { useSelector } from 'react-redux';
+
+import { Action } from '~constants/actions.ts';
+import { useAppContext } from '~context/AppContext/AppContext.ts';
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { getDraftDecisionFromStore } from '~utils/decisions.ts';
+import {
+  ACTION_TYPE_FIELD_NAME,
+  CREATED_IN_FIELD_NAME,
+  DESCRIPTION_FIELD_NAME,
+  TITLE_FIELD_NAME,
+} from '~v5/common/ActionSidebar/consts.ts';
+
+export const useDraftAgreement = ({
+  formContextOverride,
+}: {
+  formContextOverride?: UseFormReturn<object> | null;
+} = {}) => {
+  const formContext = useFormContext();
+  const { colony } = useColonyContext();
+  const { user } = useAppContext();
+
+  const draftAgreement = useSelector(
+    getDraftDecisionFromStore(user?.walletAddress || '', colony.colonyAddress),
+  );
+
+  const getIsDraftAgreement = () => {
+    const finalFormContext = formContextOverride ?? formContext;
+
+    if (!finalFormContext) {
+      return false;
+    }
+
+    const formValues = finalFormContext.getValues();
+
+    const selectedActionType = formValues[ACTION_TYPE_FIELD_NAME];
+
+    return (
+      selectedActionType === Action.CreateDecision &&
+      formValues[TITLE_FIELD_NAME] === draftAgreement?.title &&
+      formValues[DESCRIPTION_FIELD_NAME] === draftAgreement?.description &&
+      formValues[CREATED_IN_FIELD_NAME] === draftAgreement?.motionDomainId
+    );
+  };
+
+  return { getIsDraftAgreement, draftAgreement };
+};


### PR DESCRIPTION
## Description

Current behaviour is when you save a draft agreement and you click outside the form, then the form closes without prompting you. The problem is that when save a draft agreement and you click the close button of the form then it will still show you the "Do you wish to cancel the action creation" modal. So this PR just aligns the behaviour between clicking outside the form component and clicking the close form button.

![agreement-form](https://github.com/user-attachments/assets/b979b934-6f70-4b95-9b74-7664ecbb53c7)

## Testing

1. Install the Reputation extension
2. Set the viewport to mobile
3. Bring up the Create agreement form
4. Fill in all required fields
5. Click the close button

<img width="621" alt="Screenshot 2024-12-04 at 00 41 14" src="https://github.com/user-attachments/assets/e2feece9-a3e5-4f5d-9b8c-259cc96f210c">

6. Verify that the "Do you wish to cancel the action creation" modal is shown
7. Click the Save draft button
8. Click the close button
9. Verify that the form just closes without showing you the "Do you wish to cancel the action creation" modal

Resolves #2933 