### PR TITLE
Fix: gracefully handle coingecko url error

### DIFF
--- a/src/utils/currency/location.ts
+++ b/src/utils/currency/location.ts
@@ -3,7 +3,7 @@ import { SupportedCurrencies } from '~gql';
 
 import { locationApiConfig } from './config.ts';
 import { type IpLocationResponse, type IpifyResponse } from './types.ts';
-import { buildAPIEndpoint, fetchData } from './utils.ts';
+import { buildAPIEndpoint, fetchJsonData } from './utils.ts';
 
 const { ipGeolocatorEndpoint, ipLookupEndpoint } = locationApiConfig;
 
@@ -13,25 +13,19 @@ const { ipGeolocatorEndpoint, ipLookupEndpoint } = locationApiConfig;
  */
 const getUserIp = async () => {
   const url = buildAPIEndpoint(new URL(ipLookupEndpoint), { format: 'json' });
-  const ip = await fetchData<IpifyResponse>(
+  return fetchJsonData<IpifyResponse>(
     url,
-    (response) => {
-      return response.ip;
-    },
     'Unable to get user IP address.',
-  );
-
-  return ip;
+  ).then(({ ip }) => ip);
 };
 
 const getUserCountryCode = async (ip: string) => {
   const url = buildAPIEndpoint(new URL(ipGeolocatorEndpoint), { ip });
-  return fetchData<IpLocationResponse>(
+  return fetchJsonData<IpLocationResponse>(
     url,
-    // eslint-disable-next-line camelcase
-    ({ country_code2 }) => country_code2,
     'Failed to fetch user country code. ',
-  );
+    // eslint-disable-next-line camelcase
+  ).then(({ country_code2 }) => country_code2);
 };
 
 /**

--- a/src/utils/currency/tokenPriceByAddress.ts
+++ b/src/utils/currency/tokenPriceByAddress.ts
@@ -9,7 +9,7 @@ import {
   type TokenAddressPriceSuccessResponse,
   type TokenAddressPriceResponse,
 } from './types.ts';
-import { buildAPIEndpoint, fetchData, mapToAPIFormat } from './utils.ts';
+import { buildAPIEndpoint, fetchJsonData, mapToAPIFormat } from './utils.ts';
 
 // The functions defined in this file assume something about the shape of the api response.
 // If that changes, or if we change the api, these functions will need to be updated.
@@ -76,24 +76,21 @@ export const fetchTokenPriceByAddress = async ({
     conversionDenomination,
   );
 
-  const price = await fetchData<TokenAddressPriceResponse, number>(
+  return fetchJsonData<TokenAddressPriceResponse>(
     url,
-    (data) => {
-      if (isAddressPriceSuccessResponse(data)) {
-        return extractAddressPriceFromResponse(
-          data,
-          contractAddress,
-          conversionDenomination,
-        );
-      }
-
-      console.error(
-        `Unable to get price for ${contractAddress}. It probably doesn't have a listed exchange value.`,
-      );
-      return 0;
-    },
     `Api called failed at ${url}.`,
-  );
+  ).then((data) => {
+    if (isAddressPriceSuccessResponse(data)) {
+      return extractAddressPriceFromResponse(
+        data,
+        contractAddress,
+        conversionDenomination,
+      );
+    }
 
-  return price;
+    console.error(
+      `Unable to get price for ${contractAddress}. It probably doesn't have a listed exchange value.`,
+    );
+    return 0;
+  });
 };

--- a/src/utils/currency/utils.ts
+++ b/src/utils/currency/utils.ts
@@ -1,21 +1,18 @@
-export const fetchData = async <T, R = string>(
+export const fetchJsonData = async <T>(
   url: string,
-  cb: (data: T) => R,
   error = `Fetch to ${url} failed.`,
 ) => {
   try {
     const res = await fetch(url);
     if (res.ok) {
       const data: T = await res.json();
-      return cb(data);
+      return data;
     }
-
-    console.error(error, res.status, ': ', res.statusText);
+    console.error(res.status, ': ', res.statusText);
   } catch (e) {
-    console.error(error, e);
+    console.error(e);
   }
-
-  return null;
+  throw new Error(error);
 };
 
 export const convertTokenToCLNY = (


### PR DESCRIPTION
## Description

This PR handles the annoying Coingecko URL error.

![image](https://github.com/user-attachments/assets/fd5c6dbb-cbd4-4911-b27d-3d45221b4db3)

Additionally I changed the API of the `fetchData` function and renamed it to make a bit more sense (I was on the fence of removing it as it seemed kind of superfluous but I decided against it). That was done for the purpose of consistency and better error handling.

## Testing

* Step 1. Run the CDapp in dev mode
* Step 2. See that there are no error messages in the console

## Diffs

**Changes** 🏗

* Promisify `fetchData` into `fetchJsonData`
* Add check for dev environment before throwing token url errors
