### PR TITLE
Fix: Actions with metadata not completing correctly

### DIFF
--- a/src/redux/sagas/actions/createDomain.ts
+++ b/src/redux/sagas/actions/createDomain.ts
@@ -146,6 +146,16 @@ function* createDomainAction({
     const { domainId } = eventData?.DomainAdded || {};
     const nativeDomainId = toNumber(domainId);
 
+    yield createActionMetadataInDB(txHash, customActionTitle);
+
+    if (annotationMessage) {
+      yield uploadAnnotation({
+        txChannel: annotateCreateDomain,
+        message: annotationMessage,
+        txHash,
+      });
+    }
+
     /**
      * Save domain metadata in the database
      */
@@ -165,16 +175,6 @@ function* createDomainAction({
         },
       }),
     );
-
-    yield createActionMetadataInDB(txHash, customActionTitle);
-
-    if (annotationMessage) {
-      yield uploadAnnotation({
-        txChannel: annotateCreateDomain,
-        message: annotationMessage,
-        txHash,
-      });
-    }
 
     setTxHash?.(txHash);
 

--- a/src/redux/sagas/actions/editColony.ts
+++ b/src/redux/sagas/actions/editColony.ts
@@ -151,6 +151,16 @@ function* editColonyAction({
       },
     } = yield waitForTxResult(editColony.channel);
 
+    yield createActionMetadataInDB(txHash, customActionTitle);
+
+    if (annotationMessage) {
+      yield uploadAnnotation({
+        txChannel: annotateEditColony,
+        message: annotationMessage,
+        txHash,
+      });
+    }
+
     /**
      * Save the updated metadata in the database
      */
@@ -188,22 +198,12 @@ function* editColonyAction({
       );
     }
 
-    yield createActionMetadataInDB(txHash, customActionTitle);
-
-    if (annotationMessage) {
-      yield uploadAnnotation({
-        txChannel: annotateEditColony,
-        message: annotationMessage,
-        txHash,
-      });
-    }
+    setTxHash?.(txHash);
 
     yield put<AllActions>({
       type: ActionTypes.ACTION_EDIT_COLONY_SUCCESS,
       meta,
     });
-
-    setTxHash?.(txHash);
   } catch (error) {
     yield putError(ActionTypes.ACTION_EDIT_COLONY_ERROR, error, meta);
   } finally {

--- a/src/redux/sagas/actions/editDomain.ts
+++ b/src/redux/sagas/actions/editDomain.ts
@@ -142,6 +142,16 @@ function* editDomainAction({
       },
     } = yield waitForTxResult(editDomain.channel);
 
+    yield createActionMetadataInDB(txHash, customActionTitle);
+
+    if (annotationMessage) {
+      yield uploadAnnotation({
+        txChannel: annotateEditDomain,
+        message: annotationMessage,
+        txHash,
+      });
+    }
+
     /**
      * Save the updated metadata in the database
      */
@@ -170,16 +180,6 @@ function* editDomainAction({
           refetchQueries: [GetFullColonyByNameDocument],
         }),
       );
-    }
-
-    yield createActionMetadataInDB(txHash, customActionTitle);
-
-    if (annotationMessage) {
-      yield uploadAnnotation({
-        txChannel: annotateEditDomain,
-        message: annotationMessage,
-        txHash,
-      });
     }
 
     setTxHash?.(txHash);


### PR DESCRIPTION
## Description

This PR resolves an issue with the sagas involving metadata mutations, which was causing the onSuccess handler not to fire to evict the cache, and causing the `isSubmitting` form variable to return to false too soon.

## Testing

* Step 1 - Create an edit colony action
* Step 2 - Submit the form, check that the submit form stays pending until the form shows the completed action screen
* Step 3 - Without refreshing, check the new action appears in the recent activity table

https://github.com/user-attachments/assets/028d44a5-e9f3-4aef-9ce3-92677eab4988

Further testing: Check the same with create a new team and edit a team.

## Diffs

**Changes** 🏗

* Changed the mutation order in the sagas

Resolves #3693 
Resolves #3812