### PR TITLE
Fix: Simple payments when redoing an advanced payment

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/utils.ts
@@ -74,7 +74,7 @@ export const allTokensAmountValidation = ({
   const { from, _tokenSums } = formValues || {};
   const { tokenAddress: fieldTokenAddress } = parent || {};
 
-  if (!fieldTokenAddress) {
+  if (!fieldTokenAddress || !from || !_tokenSums) {
     return false;
   }
 

--- a/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/utils.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SimplePaymentForm/utils.tsx
@@ -56,7 +56,6 @@ export const getSimplePaymentPayload = (
     amount,
     tokenAddress,
     recipient,
-    payments,
     decisionMethod,
   } = values;
   const fromDomainId = Number(from);
@@ -74,16 +73,6 @@ export const getSimplePaymentPayload = (
         tokenAddress,
         networkInverseFee,
       }),
-      ...payments.map(
-        ({ recipient: paymentRecipientAddress, amount: paymentAmount }) =>
-          getPaymentPayload({
-            colony,
-            recipientAddress: paymentRecipientAddress,
-            amount: paymentAmount.toString(),
-            tokenAddress,
-            networkInverseFee,
-          }),
-      ),
     ],
     annotationMessage: annotationMessage
       ? sanitizeHTML(annotationMessage)


### PR DESCRIPTION
## Description

- Fix an issue with simple payments accidentally sending multiple payments inside on transaction. This occurs when you 'redo' an advanced payment, and then change the action type to be simple payment.

## Testing

* Create an advanced payment to Amy / whoever you like, just not Leela.
<img width="1054" alt="Screenshot 2024-12-05 at 17 36 21" src="https://github.com/user-attachments/assets/6720c190-cd16-4cca-a236-03f2bc3cea1d">

* Open the completed action modal and in the top right click on the hamburger menu to redo the action.
<img width="695" alt="Screenshot 2024-12-05 at 17 37 44" src="https://github.com/user-attachments/assets/43484454-fc3e-40b7-ac1a-ea50cc85e1d6">

* Change the action type to simple payment and set the recipient as Leela. Complete the action, and it should complete successfully and show a normal completed action screen.
<img width="1057" alt="Screenshot 2024-12-05 at 17 37 54" src="https://github.com/user-attachments/assets/de0d2df8-8ff8-48a9-8827-74d21058a129">


## Diffs

**Changes** 🏗

* Don't pass the payments (form value) array to the Simple Payment saga, since you should never be allowed to send more than one payment.

Resolves #3851