### PR TITLE
Fix: Clear expected expenditure type to prevent infinite loading

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/PaymentBuilder.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/PaymentBuilder.tsx
@@ -8,7 +8,6 @@ import { generatePath } from 'react-router-dom';
 import MeatballMenuCopyItem from '~common/ColonyActionsTable/partials/MeatballMenuCopyItem/MeatballMenuCopyItem.tsx';
 import { APP_URL } from '~constants';
 import { Action } from '~constants/actions.ts';
-import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { usePaymentBuilderContext } from '~context/PaymentBuilderContext/PaymentBuilderContext.ts';
@@ -90,25 +89,18 @@ const PaymentBuilder = ({ action }: PaymentBuilderProps) => {
     toggleOnCancelModal,
     toggleOffCancelModal,
   } = usePaymentBuilderContext();
-  const {
-    actionSidebarToggle: [isActionSidebarOpen],
-  } = useActionSidebarContext();
 
   useEffect(() => {
-    if (!isActionSidebarOpen) {
-      setExpectedExpenditureType(undefined);
-      return;
-    }
-
     if (expenditure?.type && expectedExpenditureType === undefined) {
       setExpectedExpenditureType(expenditure.type);
     }
-  }, [
-    expectedExpenditureType,
-    expenditure?.type,
-    setExpectedExpenditureType,
-    isActionSidebarOpen,
-  ]);
+  }, [expectedExpenditureType, expenditure?.type, setExpectedExpenditureType]);
+
+  useEffect(() => {
+    return () => {
+      setExpectedExpenditureType(undefined);
+    };
+  }, [setExpectedExpenditureType]);
 
   if (loadingExpenditure || expectedExpenditureType !== expenditure?.type) {
     return (


### PR DESCRIPTION
## Description

Thanks to an insightful investigation by @olgapod, the fix was straightforward and simply required clearing the expected expenditure type on `PaymentBuilder` unmount.

## Testing

- Install Staged Payment extension
- Create a staged payment
- Without refreshing the page, create an advanced payment
- Observe that advanced payment loads fine 

On master, it would keep loading forever due to a stale value of `expectedExpenditureType`.

Resolves #3862 
