### PR TITLE
Fix warnings to clean up 'Unchanged files with check annotations' section of PRs

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useMuteColonyItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useMuteColonyItem.tsx
@@ -79,6 +79,7 @@ const useMuteColonyItem = (): DropdownMenuItem => {
       },
     });
   }, [
+    MSG.toastNotificationsUnmuted,
     colonyAddress,
     mutedColonyAddresses,
     updateMutedColonies,
@@ -106,6 +107,7 @@ const useMuteColonyItem = (): DropdownMenuItem => {
       },
     });
   }, [
+    MSG.toastNotificationsMuted,
     colonyAddress,
     mutedColonyAddresses,
     updateMutedColonies,

--- a/src/context/MemberContext/MemberContextProvider.tsx
+++ b/src/context/MemberContext/MemberContextProvider.tsx
@@ -265,7 +265,6 @@ const MemberContextProvider: FC<PropsWithChildren> = ({ children }) => {
       membersByAddress,
       filteredMembers,
       verifiedMembers,
-      memberSearchData,
       allMembers,
       pagedMembers,
       moreMembers,
@@ -281,7 +280,6 @@ const MemberContextProvider: FC<PropsWithChildren> = ({ children }) => {
       followersCountLoading,
       contributorsCountLoading,
       totalFollowersCount,
-      totalContributorCount,
       hasActiveFilter,
     ],
   );

--- a/src/hooks/useOnElementScroll.tsx
+++ b/src/hooks/useOnElementScroll.tsx
@@ -53,5 +53,5 @@ export const useOnElementScroll = ({
     return () => {
       scrollElement?.removeEventListener('scroll', handleScroll);
     };
-  }, [callback, scrollableElementId, shouldExecute]);
+  }, [callback, scrollThrottle, scrollableElementId, shouldExecute]);
 };

--- a/src/hooks/useTokenLockStates.ts
+++ b/src/hooks/useTokenLockStates.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useGetColonyTokenLockedStateLazyQuery } from '~gql';
@@ -10,7 +10,7 @@ const useTokenLockStates = (): Record<string, boolean> => {
   const [getColonyTokenLockedState] = useGetColonyTokenLockedStateLazyQuery();
   const [tokenLockStatesMap, setTokenLockStatesMap] = useState({});
 
-  const fetchTokenStates = async () => {
+  const fetchTokenStates = useCallback(async () => {
     if (!tokens) {
       return;
     }
@@ -39,11 +39,11 @@ const useTokenLockStates = (): Record<string, boolean> => {
     });
 
     setTokenLockStatesMap(newTokenLockStatesMap);
-  };
+  }, [getColonyTokenLockedState, tokens]);
 
   useEffect(() => {
     fetchTokenStates();
-  }, []);
+  }, [fetchTokenStates]);
 
   return tokenLockStatesMap;
 };


### PR DESCRIPTION
## Description

- Fix a few warnings which we had in the app (to do with dependency arrays) which were showing up on every PR under the `Unchanged files with check annotations` section. Kinda ugly and distracting having these warnings on each PR...

Example:

<img width="1728" alt="Screenshot 2024-12-06 at 14 34 17" src="https://github.com/user-attachments/assets/3072ae2e-8b96-4da0-b8a0-26de1ecc5de1">


## Testing

Just some basic testing to make sure nothing broke might be a good idea. Also check this PR to see that there's no warnings in the files changed section under `Unchanged files with check annotations`.

* Check the mute colony button to ensure it still toggles on / off correctly
<img width="492" alt="Screenshot 2024-12-06 at 14 35 14" src="https://github.com/user-attachments/assets/b7cbc699-35af-41c1-a8fe-2bf9023717ac">

* Check that the members context still works by looking at the members page for example
<img width="1315" alt="Screenshot 2024-12-06 at 14 39 48" src="https://github.com/user-attachments/assets/f892a3bc-dade-4371-8f72-a8f63380aef9">

* Check that the useOnElementScroll hook still works by copying a colony address on the dashboard, and then scrolling the page. The green tooltip should disappear on scroll.
<img width="549" alt="Screenshot 2024-12-06 at 14 43 17" src="https://github.com/user-attachments/assets/367421f7-cea4-45e6-b970-aed80bd3c0b3">

* Check that the useTokenLockStates hook still works by attempting to make a simple payment using Gotham Guilder in Planet Express while Gotham Guilder is locked by Wayne Enterprises (this is the default state after running createData).
<img width="677" alt="Screenshot 2024-12-06 at 14 46 44" src="https://github.com/user-attachments/assets/f3359eef-828b-4182-b359-37dcc0a97add">


## Diffs

**Changes** 🏗

* Fixed some dependency array warnings

Contributes to: A better developer experience
