### PR TITLE
Fix: Equal split payment amount issue

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
@@ -79,7 +79,8 @@ const AmountField: FC<AmountFieldProps> = ({
   const handleFieldChange = (e: ChangeEvent<HTMLInputElement>) => {
     const formattedValue = formatNumeral(e.target.value, formattingOptions);
 
-    const unformattedValue = unformatNumeral(e.target.value);
+    // Strip 'M' from the input as the character 'M' is used as a placeholder in the unformatNumeral function and can result in weird values
+    const unformattedValue = unformatNumeral(e.target.value.replace('M', ''));
 
     if (
       wrapperRef.current &&
@@ -95,7 +96,7 @@ const AmountField: FC<AmountFieldProps> = ({
     onChange?.();
 
     field.onChange(unformattedValue.replace('-', ''));
-    setValue(formatNumeral(e.target.value, formattingOptions));
+    setValue(formattedValue);
   };
 
   const handleTokenSelect = (selectedTokenAddress: string) => {

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/ManageReputationTable.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/ManageReputationTable.tsx
@@ -44,7 +44,8 @@ const ManageReputationTable: FC = () => {
     useReputationAmountField(120);
 
   const handleFieldChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const unformattedValue = unformatNumeral(e.target.value);
+    // Strip 'M' from the input as the character 'M' is used as a placeholder in the unformatNumeral function and can result in weird values
+    const unformattedValue = unformatNumeral(e.target.value.replace('M', ''));
 
     field.onChange(unformattedValue);
     setValue(formatNumeral(e.target.value, formattingOptions));

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/hooks.tsx
@@ -230,7 +230,7 @@ export const useDistributionMethodUpdate = ({
                       getSelectedToken(colony, data[index].tokenAddress || '')
                         ?.decimals || DEFAULT_TOKEN_DECIMALS,
                     )
-                    .toString()
+                    .toFixed()
                 : undefined,
             });
           });

--- a/src/components/v5/common/CompletedAction/partials/SplitPayment/SplitPayment.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SplitPayment/SplitPayment.tsx
@@ -29,7 +29,6 @@ import { addressHasRoles } from '~utils/checks/userHasRoles.ts';
 import { findDomainByNativeId } from '~utils/domains.ts';
 import { formatText } from '~utils/intl.ts';
 import {
-  getNumeralTokenAmount,
   getSelectedToken,
   getTokenDecimalsWithFallback,
 } from '~utils/tokens.ts';
@@ -153,7 +152,10 @@ const SplitPayment = ({ action }: SplitPaymentProps) => {
     amount,
     -getTokenDecimalsWithFallback(splitToken?.decimals),
   );
-  const redoAmount = getNumeralTokenAmount(amount, splitToken?.decimals);
+  const redoAmount = moveDecimal(
+    amount,
+    -getTokenDecimalsWithFallback(splitToken?.decimals),
+  );
 
   const expenditureMeatballOptions: MeatBallMenuItem[] = [
     {


### PR DESCRIPTION
## Description

This PR fixes an issue where small amounts using the equal split type were defaulting to scientific notation which was breaking the amount fields in the table.

Whilst working on this I also found a weird edge case issue where entering `1M` (as in 1 million) would get adjusted by the cleave-zen `unformatNumeral` function to `1.` and if you added another `M` (`1.M`) the amount field would appear unchanged, but the action subtitle would show `1M00000000`.

## Testing

* Step 1 - Create a split payment action
* Step 2 - Select the "Equal" split type
* Step 3 - Enter the amount `0.00000001` - check that the app does not crash

<img width="683" alt="Screenshot 2024-12-06 at 16 31 29" src="https://github.com/user-attachments/assets/38d01e66-89d5-41f9-8e96-2c56a567bef7">

* Step 4 - Clear the amount field and enter `1M` check that the `M` is not entered and that the amount field just shows `1`, enter another `M` and check the amount field still just shows `1`.

<img width="674" alt="Screenshot 2024-12-06 at 16 31 39" src="https://github.com/user-attachments/assets/2ae936ef-3e26-4bca-855a-128fec420391">

Compared to master:

<img width="675" alt="Screenshot 2024-12-06 at 16 32 09" src="https://github.com/user-attachments/assets/cb713563-8ca0-4f78-a17b-86d89b5a67d5">


## Diffs

**Changes** 🏗

* unformatNumeral fix
* Equal amount now uses `toFixed`

Resolves #3751
