### PR TITLE
Fix: Tabs right arrow showing over loader

### DIFF
--- a/src/components/shared/Extensions/Tabs/Tabs.tsx
+++ b/src/components/shared/Extensions/Tabs/Tabs.tsx
@@ -29,7 +29,6 @@ const Tabs: FC<PropsWithChildren<TabsProps>> = ({
           upperContainerClassName,
         )}
         leftNavBtnClassName="absolute left-0 z-base"
-        rightNavBtnClassName="z-base"
         // @ts-ignore - react-tabs-scrollable has invalid type for this prop
         leftBtnIcon={<CaretLeft size={12} />}
         // @ts-ignore - react-tabs-scrollable has invalid type for this prop


### PR DESCRIPTION
## Description

This PR fixes an issue where the right arrow of the tabs component was showing on top of the loader.

## Testing

Navigate to http://localhost:9091/account/preferences Make sure you don't see the right arrow whilst the page is loading.

https://github.com/user-attachments/assets/4ca928fb-0824-434a-bcf8-3508fbe55425

## Diffs

**Changes** 🏗

* Removed unnecessary z-index

Resolves #3749
