### PR TITLE
fix: 'edit details' form to render a correct inputs and values

### DIFF
--- a/src/components/shared/Fields/Form/Form.tsx
+++ b/src/components/shared/Fields/Form/Form.tsx
@@ -143,7 +143,7 @@ const Form = <FormData extends FieldValues>({
       const currentValues = getValues();
       const mergedValues = { ...currentValues, ...resolvedDefaultValues };
 
-      reset(mergedValues, { keepDirtyValues: true });
+      reset(mergedValues, { keepDirtyValues: true, keepValues: true });
     };
 
     initializeForm();


### PR DESCRIPTION
## Description
After rebasing the master "Edit details," the form starts working incorrectly. Considering that this is dynamic fields for some reason "watch" was called during first load, so some values were deleted.
Thanks to @rumzledz for the fast one-line solution. 🙌  

## Testing
Step 1. Open "Arbitrary transaction"
Step 2. Add a random transaction (You can use this contract: `0xeeeafa86903cf2cb5c74a61d3e67844e226730c0`)
<img width="494" alt="image" src="https://github.com/user-attachments/assets/a5fb4cbd-c33d-4bca-949e-0f20e8428d3b">

Step 3. Submit form
Step 4. Select "Edit details" in the transaction table
<img width="683" alt="image" src="https://github.com/user-attachments/assets/3e8eb849-30d2-444e-9125-dcf82d87de68">

Step 5. Verify that form inputs and values are the same as it was submitted:
<img width="497" alt="image" src="https://github.com/user-attachments/assets/7e665b98-3a2a-4fde-8340-6f190c2794a3">


Resolves #3866 
