### PR TITLE
Guided tour feature flag and dark mode fixes

### DIFF
--- a/src/components/common/Extensions/UserNavigation/partials/UserMenu/UserMenu.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserMenu/UserMenu.tsx
@@ -8,11 +8,12 @@ import {
   Plugs,
 } from '@phosphor-icons/react';
 import clsx from 'clsx';
-import React, { type FC, useState } from 'react';
+import React, { type FC, useContext, useState } from 'react';
 
 import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useCurrencyContext } from '~context/CurrencyContext/CurrencyContext.ts';
+import { FeatureFlagsContext } from '~context/FeatureFlagsContext/FeatureFlagsContext.ts';
 import { useTablet } from '~hooks/index.ts';
 import ClnyTokenIcon from '~icons/ClnyTokenIcon.tsx';
 import { formatText } from '~utils/intl.ts';
@@ -61,6 +62,14 @@ const UserMenu: FC<UserMenuProps> = ({
   };
 
   const CurrencyIcon = currencyIcons[currency] || ClnyTokenIcon;
+
+  const featureFlags = useContext(FeatureFlagsContext);
+
+  const filteredUserMenuItems = userMenuItems.filter(({ featureFlag }) => {
+    if (!featureFlag) return true;
+    const flag = featureFlags[featureFlag];
+    return !flag?.isLoading && flag?.isEnabled;
+  });
 
   return (
     <PopoverBase
@@ -142,7 +151,7 @@ const UserMenu: FC<UserMenuProps> = ({
                 </p>
               </Link>
             </li>
-            {userMenuItems.map(({ id, icon: Icon, name: itemName }) => (
+            {filteredUserMenuItems.map(({ id, icon: Icon, name: itemName }) => (
               <li
                 key={id}
                 className="-ml-4 mb-2 w-[calc(100%+2rem)] rounded hover:bg-gray-50 sm:mb-0"

--- a/src/components/common/Extensions/UserNavigation/partials/UserMenu/consts.ts
+++ b/src/components/common/Extensions/UserNavigation/partials/UserMenu/consts.ts
@@ -6,6 +6,7 @@ import {
   MapTrifold,
 } from '@phosphor-icons/react';
 
+import { FeatureFlag } from '~context/FeatureFlagsContext/types.ts';
 import { ExtendedSupportedCurrencies, SupportedCurrencies } from '~gql';
 import ClnyTokenIcon from '~icons/ClnyTokenIcon.tsx';
 import EthereumIcon from '~icons/EthereumIcon.tsx';
@@ -39,11 +40,13 @@ export const userMenuItems: Array<{
   id: string;
   icon: Icon;
   name: UserMenuItemName;
+  featureFlag?: string;
 }> = [
   {
     id: '1',
     icon: MapTrifold,
     name: UserMenuItemName.GUIDED_TOURS,
+    featureFlag: FeatureFlag.GUIDED_TOURS,
   },
   {
     id: '2',

--- a/src/components/frame/Extensions/themes/utils.ts
+++ b/src/components/frame/Extensions/themes/utils.ts
@@ -81,6 +81,12 @@ export const applyTheme = (theme: string): void => {
 
   const root = document.documentElement;
 
+  if (theme === 'dark') {
+    root.classList.add('dark');
+  } else {
+    root.classList.remove('dark');
+  }
+
   Object.keys(themeObject).forEach((property) => {
     if (property === 'name') {
       return;

--- a/src/context/FeatureFlagsContext/FeatureFlagsContextProvider.tsx
+++ b/src/context/FeatureFlagsContext/FeatureFlagsContextProvider.tsx
@@ -34,6 +34,7 @@ const FeatureFlagsContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const cryptoToFiatWithdrawalsFeature = useFeatureFlag(
     FeatureFlag.CRYPTO_TO_FIAT_WITHDRAWALS,
   );
+  const guidedToursFeature = useFeatureFlag(FeatureFlag.GUIDED_TOURS);
 
   const featureFlags: Record<
     FeatureFlag,
@@ -42,8 +43,9 @@ const FeatureFlagsContextProvider: FC<PropsWithChildren> = ({ children }) => {
     () => ({
       [FeatureFlag.CRYPTO_TO_FIAT]: cryptoToFiatFeature,
       [FeatureFlag.CRYPTO_TO_FIAT_WITHDRAWALS]: cryptoToFiatWithdrawalsFeature,
+      [FeatureFlag.GUIDED_TOURS]: guidedToursFeature,
     }),
-    [cryptoToFiatFeature, cryptoToFiatWithdrawalsFeature],
+    [cryptoToFiatFeature, cryptoToFiatWithdrawalsFeature, guidedToursFeature],
   );
 
   return (

--- a/src/context/FeatureFlagsContext/types.ts
+++ b/src/context/FeatureFlagsContext/types.ts
@@ -1,6 +1,7 @@
 export enum FeatureFlag {
   CRYPTO_TO_FIAT = 'CRYPTO_TO_FIAT',
   CRYPTO_TO_FIAT_WITHDRAWALS = 'CRYPTO_TO_FIAT_WITHDRAWALS',
+  GUIDED_TOURS = 'GUIDED_TOURS',
 }
 
 export interface FeatureFlagValue {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -61,6 +61,20 @@ body.ReactModal__Body--open:not(.show-header-in-modal) .modal-blur-navigation {
   @apply blur-[0.125rem];
 }
 
+/* Styling for React Joyride */
+.__floater__body div:first-child {
+  border-color: var(--color-base-white);
+}
+
+.__floater__arrow svg polygon {
+  fill: var(--color-base-white);
+}
+
+.dark .__floater__arrow svg polygon {
+  fill: var(--color-base-white);
+}
+
+/* Styling for onboardJS */
 :root {
   --onboard-connect-sidebar-background: var(--color-gray-200);
   --onboard-main-scroll-container-background: var(--color-base-white);


### PR DESCRIPTION
## Description

This PR adds feature flags to the in app product tour, it currently only hides the menu item, which is the only way to trigger tours.

In the future the plan is to have some auto triggered tours, which will likely need a different solution when the time comes, unless anyone has some suggestion for moving the feature flag further up the chain now.

There is also a fix for the tooltip arrow in dark mode.

![image](https://github.com/user-attachments/assets/dd650e9e-6b82-4433-8f55-f0d9b0be35a3)


## Testing

### Tooltip arrow
1. Ensure you are in dark mode.
2. Start the "Using the app" guided tour.
3. Note the arrow on the tooltip.

### Feature flag
1. Enable or disable the feature flag within Posthog.
2. The "Guided tours" menu item should not be visible when the feature flag is disabled.

## Diffs

**New stuff** ✨

* Added "dark" class to `html` tag for CSS selector targeting.
* Added feature flag for guided tours.

