### PR TITLE
Fix: Preserve existing form value changes when the form re-renders

### DIFF
--- a/src/components/common/ColonyActionsTable/hooks/useBuildRedoEnabledActionsMap.ts
+++ b/src/components/common/ColonyActionsTable/hooks/useBuildRedoEnabledActionsMap.ts
@@ -110,6 +110,9 @@ export const useBuildRedoEnabledActionsMap = ({
           case ColonyActionType.VersionUpgrade:
           case ColonyActionType.VersionUpgradeMotion:
           case ColonyActionType.VersionUpgradeMultisig:
+          case ColonyActionType.ManageTokens:
+          case ColonyActionType.ManageTokensMotion:
+          case ColonyActionType.ManageTokensMultisig:
           case ExtendedColonyActionType.UpdateColonyObjective:
           case ExtendedColonyActionType.UpdateColonyObjectiveMotion:
           case ExtendedColonyActionType.UpdateColonyObjectiveMultisig:

--- a/src/components/shared/Fields/Form/Form.tsx
+++ b/src/components/shared/Fields/Form/Form.tsx
@@ -141,7 +141,7 @@ const Form = <FormData extends FieldValues>({
           : defaultValues;
 
       const currentValues = getValues();
-      const mergedValues = { ...currentValues, ...resolvedDefaultValues };
+      const mergedValues = { ...resolvedDefaultValues, ...currentValues };
 
       reset(mergedValues, { keepDirtyValues: true });
     };


### PR DESCRIPTION
## Description

![keep-values](https://github.com/user-attachments/assets/8505382b-1f19-4b82-94f1-73bdad97b279)

## Testing

**Testing Steps for #3871**

1. Bring up the manage tokens form
2. Add a token
3. Enter a title
4. Select a decision method
5. Submit the form
6. Verify the form is submitted
7. On the Colony Actions table, verify that there is no Redo option for the Manage Tokens action

**Testing Steps for #3860**

1. Make sure Andromeda has funds
2. Make sure the Reputation extension is enabled
3. Bring up the Transfer Funds from
4. Set the From field to Andromeda
5. Set the To field to General
6. Set the Decision method to Reputation
8. Verify that Created in is correctly set to the Root domain
9. Fill in all other required fields
10. Submit the form
11. Verify you are able to create the action successfully

Resolves #3871, #3860 