### PR TITLE
Fix: Automatically propagate user permission updates

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/SetUserRoles/SetUserRoles.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SetUserRoles/SetUserRoles.tsx
@@ -21,6 +21,7 @@ import {
   TEAM_FIELD_NAME,
   TITLE_FIELD_NAME,
 } from '~v5/common/ActionSidebar/consts.ts';
+import { UserRoleModifier } from '~v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/consts.ts';
 import { useDecisionMethod } from '~v5/common/CompletedAction/hooks.ts';
 import UserInfoPopover from '~v5/shared/UserInfoPopover/index.ts';
 import UserPopover from '~v5/shared/UserPopover/index.ts';
@@ -41,7 +42,10 @@ import {
   TeamFromRow,
 } from '../rows/index.ts';
 
-import { transformActionRolesToColonyRoles } from './utils.ts';
+import {
+  getIsPermissionsRemoval,
+  transformActionRolesToColonyRoles,
+} from './utils.ts';
 
 const displayName = 'v5.common.CompletedAction.partials.SetUserRoles';
 
@@ -71,6 +75,8 @@ const SetUserRoles = ({ action }: Props) => {
     blockNumber,
     colonyAddress,
     rolesAreMultiSig,
+    motionData,
+    multiSigData,
   } = action;
   const areRolesMultiSig = !!rolesAreMultiSig;
 
@@ -115,6 +121,9 @@ const SetUserRoles = ({ action }: Props) => {
 
   const dbPermissionsNew = transformActionRolesToColonyRoles(
     historicRoles?.getColonyHistoricRole || roles,
+    {
+      isMotion: !!motionData || !!multiSigData,
+    },
   );
 
   const { name: dbRoleNameNew, role: dbRoleForDomainNew } = getRole(
@@ -137,7 +146,9 @@ const SetUserRoles = ({ action }: Props) => {
             [ACTION_TYPE_FIELD_NAME]: Action.ManagePermissions,
             member: recipientAddress,
             authority: roleAuthority,
-            role: dbRoleForDomainNew,
+            role: getIsPermissionsRemoval(roles)
+              ? UserRoleModifier.Remove
+              : dbRoleForDomainNew,
             [TEAM_FIELD_NAME]: fromDomain?.nativeId,
             [DECISION_METHOD_FIELD_NAME]: decisionMethod,
             [DESCRIPTION_FIELD_NAME]: annotation?.message,

--- a/src/context/AppContext/AppContextProvider.tsx
+++ b/src/context/AppContext/AppContextProvider.tsx
@@ -7,11 +7,7 @@ import React, {
   useEffect,
 } from 'react';
 
-import {
-  GetUserByAddressDocument,
-  type GetUserByAddressQuery,
-  type GetUserByAddressQueryVariables,
-} from '~gql';
+import { useGetUserByAddressLazyQuery } from '~gql';
 import useAsyncFunction from '~hooks/useAsyncFunction.ts';
 import useJoinedColonies from '~hooks/useJoinedColonies.ts';
 import usePrevious from '~hooks/usePrevious.ts';
@@ -31,6 +27,8 @@ const AppContextProvider = ({ children }: { children: ReactNode }) => {
   // and the first render is important here
   const [walletConnecting, setWalletConnecting] = useState(true);
 
+  const [getUserByAddress] = useGetUserByAddressLazyQuery();
+
   const {
     joinedColonies,
     loading: joinedColoniesLoading,
@@ -44,13 +42,11 @@ const AppContextProvider = ({ children }: { children: ReactNode }) => {
           if (!shouldBackgroundUpdate) {
             setUserLoading(true);
           }
-          const apolloClient = getContext(ContextModule.ApolloClient);
-          const { data } = await apolloClient.query<
-            GetUserByAddressQuery,
-            GetUserByAddressQueryVariables
-          >({
-            query: GetUserByAddressDocument,
-            variables: { address: utils.getAddress(address) },
+
+          const { data } = await getUserByAddress({
+            variables: {
+              address: utils.getAddress(address),
+            },
             fetchPolicy: 'network-only',
           });
           const [currentUser] = data?.getUserByAddress?.items || [];
@@ -66,7 +62,7 @@ const AppContextProvider = ({ children }: { children: ReactNode }) => {
         }
       }
     },
-    [],
+    [getUserByAddress],
   );
 
   const updateWallet = useCallback(() => {

--- a/src/context/MemberContext/MemberContextProvider.tsx
+++ b/src/context/MemberContext/MemberContextProvider.tsx
@@ -18,6 +18,7 @@ import {
 import { useSearchContext } from '~context/SearchContext/SearchContext.ts';
 import {
   useOnCreateColonyContributorSubscription,
+  useOnUpdateColonyContributorSubscription,
   useOnUpdateColonySubscription,
   useSearchColonyContributorsQuery,
 } from '~gql';
@@ -160,17 +161,27 @@ const MemberContextProvider: FC<PropsWithChildren> = ({ children }) => {
     newColonyUpdateResult?.onUpdateColony
       ?.lastUpdatedContributorsWithReputation;
 
-  const { data: newColonyContributorResult } =
+  const { data: createColonyContributorSubscription } =
     useOnCreateColonyContributorSubscription();
 
-  const newColonyContributor =
-    newColonyContributorResult?.onCreateColonyContributor?.contributorAddress;
+  const newColonyContributorAdded =
+    createColonyContributorSubscription?.onCreateColonyContributor
+      ?.contributorAddress;
+
+  const { data: updateColonyContributorSubscription } =
+    useOnUpdateColonyContributorSubscription();
+
+  const newColonyContributorRolesUpdate =
+    updateColonyContributorSubscription?.onUpdateColonyContributor?.roles;
+
+  const newColonyContributorUpdate =
+    newColonyContributorAdded || newColonyContributorRolesUpdate;
 
   useEffect(() => {
     let timeout;
     // When the colony first loads, the reputation is updated asynchronously. This means that the currently
     // cached reputation might be out of date. If this is the case, we should refetch.
-    if (newColonyUpdate || newColonyContributor) {
+    if (newColonyUpdate || newColonyContributorUpdate) {
       // It looks hacky, but we need the timeout to ensure that opensearch has been updated before we refetch.
       timeout = setTimeout(refetchColonyContributors, 2000);
     }
@@ -180,7 +191,7 @@ const MemberContextProvider: FC<PropsWithChildren> = ({ children }) => {
         clearTimeout(timeout);
       }
     };
-  }, [newColonyUpdate, newColonyContributor, refetchColonyContributors]);
+  }, [newColonyContributorUpdate, newColonyUpdate, refetchColonyContributors]);
 
   const allMembers = useMemo(
     () =>

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -1156,13 +1156,6 @@ export type ColonyMultiSig = {
   executedBy?: Maybe<Scalars['ID']>;
   /** Extended user object for given executedBy */
   executedByUser?: Maybe<User>;
-  /**
-   * In case of multiple funding actions in a multisig, when funding an expenditure, array containing
-   * the details of tokens and amounts to be funded
-   */
-  expenditureFunding?: Maybe<Array<ExpenditureFundingItem>>;
-  /** Expenditure associated with the motion, if any */
-  expenditureId?: Maybe<Scalars['ID']>;
   /** Whether the underlying action completed */
   hasActionCompleted: Scalars['Boolean'];
   /**
@@ -1612,8 +1605,6 @@ export type CreateColonyMultiSigInput = {
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
   executedAt?: InputMaybe<Scalars['AWSDateTime']>;
   executedBy?: InputMaybe<Scalars['ID']>;
-  expenditureFunding?: InputMaybe<Array<ExpenditureFundingItemInput>>;
-  expenditureId?: InputMaybe<Scalars['ID']>;
   hasActionCompleted: Scalars['Boolean'];
   id?: InputMaybe<Scalars['ID']>;
   isDecision: Scalars['Boolean'];
@@ -3298,7 +3289,6 @@ export type ModelColonyMultiSigConditionInput = {
   createdAt?: InputMaybe<ModelStringInput>;
   executedAt?: InputMaybe<ModelStringInput>;
   executedBy?: InputMaybe<ModelIdInput>;
-  expenditureId?: InputMaybe<ModelIdInput>;
   hasActionCompleted?: InputMaybe<ModelBooleanInput>;
   isDecision?: InputMaybe<ModelBooleanInput>;
   isExecuted?: InputMaybe<ModelBooleanInput>;
@@ -3326,7 +3316,6 @@ export type ModelColonyMultiSigFilterInput = {
   createdAt?: InputMaybe<ModelStringInput>;
   executedAt?: InputMaybe<ModelStringInput>;
   executedBy?: InputMaybe<ModelIdInput>;
-  expenditureId?: InputMaybe<ModelIdInput>;
   hasActionCompleted?: InputMaybe<ModelBooleanInput>;
   id?: InputMaybe<ModelIdInput>;
   isDecision?: InputMaybe<ModelBooleanInput>;
@@ -4379,7 +4368,6 @@ export type ModelSubscriptionColonyMultiSigFilterInput = {
   createdAt?: InputMaybe<ModelSubscriptionStringInput>;
   executedAt?: InputMaybe<ModelSubscriptionStringInput>;
   executedBy?: InputMaybe<ModelSubscriptionIdInput>;
-  expenditureId?: InputMaybe<ModelSubscriptionIdInput>;
   hasActionCompleted?: InputMaybe<ModelSubscriptionBooleanInput>;
   id?: InputMaybe<ModelSubscriptionIdInput>;
   isDecision?: InputMaybe<ModelSubscriptionBooleanInput>;
@@ -6680,7 +6668,6 @@ export type Query = {
   getMotionTimeoutPeriods?: Maybe<GetMotionTimeoutPeriodsReturn>;
   getMotionVoterRewards?: Maybe<ModelVoterRewardsHistoryConnection>;
   getMultiSigByColonyAddress?: Maybe<ModelColonyMultiSigConnection>;
-  getMultiSigByExpenditureId?: Maybe<ModelColonyMultiSigConnection>;
   getMultiSigByTransactionHash?: Maybe<ModelColonyMultiSigConnection>;
   getMultiSigUserSignature?: Maybe<MultiSigUserSignature>;
   getMultiSigUserSignatureByMultiSigId?: Maybe<ModelMultiSigUserSignatureConnection>;
@@ -7254,16 +7241,6 @@ export type QueryGetMotionVoterRewardsArgs = {
 /** Root query type */
 export type QueryGetMultiSigByColonyAddressArgs = {
   colonyAddress: Scalars['ID'];
-  filter?: InputMaybe<ModelColonyMultiSigFilterInput>;
-  limit?: InputMaybe<Scalars['Int']>;
-  nextToken?: InputMaybe<Scalars['String']>;
-  sortDirection?: InputMaybe<ModelSortDirection>;
-};
-
-
-/** Root query type */
-export type QueryGetMultiSigByExpenditureIdArgs = {
-  expenditureId: Scalars['ID'];
   filter?: InputMaybe<ModelColonyMultiSigFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
   nextToken?: InputMaybe<Scalars['String']>;
@@ -9658,8 +9635,6 @@ export type UpdateColonyMultiSigInput = {
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
   executedAt?: InputMaybe<Scalars['AWSDateTime']>;
   executedBy?: InputMaybe<Scalars['ID']>;
-  expenditureFunding?: InputMaybe<Array<ExpenditureFundingItemInput>>;
-  expenditureId?: InputMaybe<Scalars['ID']>;
   hasActionCompleted?: InputMaybe<Scalars['Boolean']>;
   id: Scalars['ID'];
   isDecision?: InputMaybe<Scalars['Boolean']>;
@@ -10781,6 +10756,11 @@ export type OnCreateColonyContributorSubscriptionVariables = Exact<{ [key: strin
 
 
 export type OnCreateColonyContributorSubscription = { __typename?: 'Subscription', onCreateColonyContributor?: { __typename?: 'ColonyContributor', contributorAddress: string } | null };
+
+export type OnUpdateColonyContributorSubscriptionVariables = Exact<{ [key: string]: never; }>;
+
+
+export type OnUpdateColonyContributorSubscription = { __typename?: 'Subscription', onUpdateColonyContributor?: { __typename?: 'ColonyContributor', contributorAddress: string, roles?: { __typename?: 'ModelColonyRoleConnection', items: Array<{ __typename?: 'ColonyRole', domainId: string, role_0?: boolean | null, role_1?: boolean | null, role_2?: boolean | null, role_3?: boolean | null, role_5?: boolean | null, role_6?: boolean | null, isMultiSig?: boolean | null, id: string, domain: { __typename?: 'Domain', id: string, nativeId: number, metadata?: { __typename?: 'DomainMetadata', name: string, color: DomainColor } | null } } | null> } | null } | null };
 
 export type GetMembersCountQueryVariables = Exact<{
   filter: SearchableColonyContributorFilterInput;
@@ -14420,6 +14400,40 @@ export function useOnCreateColonyContributorSubscription(baseOptions?: Apollo.Su
       }
 export type OnCreateColonyContributorSubscriptionHookResult = ReturnType<typeof useOnCreateColonyContributorSubscription>;
 export type OnCreateColonyContributorSubscriptionResult = Apollo.SubscriptionResult<OnCreateColonyContributorSubscription>;
+export const OnUpdateColonyContributorDocument = gql`
+    subscription OnUpdateColonyContributor {
+  onUpdateColonyContributor {
+    contributorAddress
+    roles {
+      items {
+        ...ContributorRoles
+      }
+    }
+  }
+}
+    ${ContributorRolesFragmentDoc}`;
+
+/**
+ * __useOnUpdateColonyContributorSubscription__
+ *
+ * To run a query within a React component, call `useOnUpdateColonyContributorSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useOnUpdateColonyContributorSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useOnUpdateColonyContributorSubscription({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useOnUpdateColonyContributorSubscription(baseOptions?: Apollo.SubscriptionHookOptions<OnUpdateColonyContributorSubscription, OnUpdateColonyContributorSubscriptionVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useSubscription<OnUpdateColonyContributorSubscription, OnUpdateColonyContributorSubscriptionVariables>(OnUpdateColonyContributorDocument, options);
+      }
+export type OnUpdateColonyContributorSubscriptionHookResult = ReturnType<typeof useOnUpdateColonyContributorSubscription>;
+export type OnUpdateColonyContributorSubscriptionResult = Apollo.SubscriptionResult<OnUpdateColonyContributorSubscription>;
 export const GetMembersCountDocument = gql`
     query GetMembersCount($filter: SearchableColonyContributorFilterInput!, $nextToken: String) {
   searchColonyContributors(

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -1156,6 +1156,13 @@ export type ColonyMultiSig = {
   executedBy?: Maybe<Scalars['ID']>;
   /** Extended user object for given executedBy */
   executedByUser?: Maybe<User>;
+  /**
+   * In case of multiple funding actions in a multisig, when funding an expenditure, array containing
+   * the details of tokens and amounts to be funded
+   */
+  expenditureFunding?: Maybe<Array<ExpenditureFundingItem>>;
+  /** Expenditure associated with the motion, if any */
+  expenditureId?: Maybe<Scalars['ID']>;
   /** Whether the underlying action completed */
   hasActionCompleted: Scalars['Boolean'];
   /**
@@ -1605,6 +1612,8 @@ export type CreateColonyMultiSigInput = {
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
   executedAt?: InputMaybe<Scalars['AWSDateTime']>;
   executedBy?: InputMaybe<Scalars['ID']>;
+  expenditureFunding?: InputMaybe<Array<ExpenditureFundingItemInput>>;
+  expenditureId?: InputMaybe<Scalars['ID']>;
   hasActionCompleted: Scalars['Boolean'];
   id?: InputMaybe<Scalars['ID']>;
   isDecision: Scalars['Boolean'];
@@ -3289,6 +3298,7 @@ export type ModelColonyMultiSigConditionInput = {
   createdAt?: InputMaybe<ModelStringInput>;
   executedAt?: InputMaybe<ModelStringInput>;
   executedBy?: InputMaybe<ModelIdInput>;
+  expenditureId?: InputMaybe<ModelIdInput>;
   hasActionCompleted?: InputMaybe<ModelBooleanInput>;
   isDecision?: InputMaybe<ModelBooleanInput>;
   isExecuted?: InputMaybe<ModelBooleanInput>;
@@ -3316,6 +3326,7 @@ export type ModelColonyMultiSigFilterInput = {
   createdAt?: InputMaybe<ModelStringInput>;
   executedAt?: InputMaybe<ModelStringInput>;
   executedBy?: InputMaybe<ModelIdInput>;
+  expenditureId?: InputMaybe<ModelIdInput>;
   hasActionCompleted?: InputMaybe<ModelBooleanInput>;
   id?: InputMaybe<ModelIdInput>;
   isDecision?: InputMaybe<ModelBooleanInput>;
@@ -4368,6 +4379,7 @@ export type ModelSubscriptionColonyMultiSigFilterInput = {
   createdAt?: InputMaybe<ModelSubscriptionStringInput>;
   executedAt?: InputMaybe<ModelSubscriptionStringInput>;
   executedBy?: InputMaybe<ModelSubscriptionIdInput>;
+  expenditureId?: InputMaybe<ModelSubscriptionIdInput>;
   hasActionCompleted?: InputMaybe<ModelSubscriptionBooleanInput>;
   id?: InputMaybe<ModelSubscriptionIdInput>;
   isDecision?: InputMaybe<ModelSubscriptionBooleanInput>;
@@ -6668,6 +6680,7 @@ export type Query = {
   getMotionTimeoutPeriods?: Maybe<GetMotionTimeoutPeriodsReturn>;
   getMotionVoterRewards?: Maybe<ModelVoterRewardsHistoryConnection>;
   getMultiSigByColonyAddress?: Maybe<ModelColonyMultiSigConnection>;
+  getMultiSigByExpenditureId?: Maybe<ModelColonyMultiSigConnection>;
   getMultiSigByTransactionHash?: Maybe<ModelColonyMultiSigConnection>;
   getMultiSigUserSignature?: Maybe<MultiSigUserSignature>;
   getMultiSigUserSignatureByMultiSigId?: Maybe<ModelMultiSigUserSignatureConnection>;
@@ -7241,6 +7254,16 @@ export type QueryGetMotionVoterRewardsArgs = {
 /** Root query type */
 export type QueryGetMultiSigByColonyAddressArgs = {
   colonyAddress: Scalars['ID'];
+  filter?: InputMaybe<ModelColonyMultiSigFilterInput>;
+  limit?: InputMaybe<Scalars['Int']>;
+  nextToken?: InputMaybe<Scalars['String']>;
+  sortDirection?: InputMaybe<ModelSortDirection>;
+};
+
+
+/** Root query type */
+export type QueryGetMultiSigByExpenditureIdArgs = {
+  expenditureId: Scalars['ID'];
   filter?: InputMaybe<ModelColonyMultiSigFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
   nextToken?: InputMaybe<Scalars['String']>;
@@ -9635,6 +9658,8 @@ export type UpdateColonyMultiSigInput = {
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
   executedAt?: InputMaybe<Scalars['AWSDateTime']>;
   executedBy?: InputMaybe<Scalars['ID']>;
+  expenditureFunding?: InputMaybe<Array<ExpenditureFundingItemInput>>;
+  expenditureId?: InputMaybe<Scalars['ID']>;
   hasActionCompleted?: InputMaybe<Scalars['Boolean']>;
   id: Scalars['ID'];
   isDecision?: InputMaybe<Scalars['Boolean']>;

--- a/src/graphql/queries/contributors.graphql
+++ b/src/graphql/queries/contributors.graphql
@@ -55,6 +55,17 @@ subscription OnCreateColonyContributor {
   }
 }
 
+subscription OnUpdateColonyContributor {
+  onUpdateColonyContributor {
+    contributorAddress
+    roles {
+      items {
+        ...ContributorRoles
+      }
+    }
+  }
+}
+
 query GetMembersCount(
   $filter: SearchableColonyContributorFilterInput!
   $nextToken: String

--- a/src/utils/objects/index.ts
+++ b/src/utils/objects/index.ts
@@ -1,3 +1,5 @@
+import { type OptionalValue } from '~types';
+
 export const excludeTypenameKey = <T>(
   objectWithTypename: T & { __typename?: string },
 ) => {
@@ -16,4 +18,33 @@ export const getProperty = <T>(obj: T, key: string, defaultValue?: any) => {
 
 export const getObjectKeys = <T extends object>(obj: T): Array<keyof T> => {
   return Object.keys(obj) as Array<keyof T>;
+};
+
+/**
+ * Removes specified fields from an object and returns the updated object.
+ *
+ * @param {OptionalValue<T>} obj - The object to modify. Returns `null` if this is `null` or `undefined`.
+ * @param {K[]} fields - The fields to remove from the object.
+ *
+ * @example
+ * removeObjectFields({ a: 1, b: 2 }, ['b']); // { a: 1 }
+ */
+export const removeObjectFields = <
+  T extends Record<string, any>,
+  K extends keyof T,
+>(
+  obj: OptionalValue<T>,
+  fields: K[],
+) => {
+  if (!obj) {
+    return null;
+  }
+
+  const rest = { ...obj };
+
+  fields.forEach((field) => {
+    delete rest[field];
+  });
+
+  return rest as Omit<T, K>;
 };


### PR DESCRIPTION
## Description

> [!NOTE]
> Please note that there is an existing issue where the Permissions table on the Completed Action form is not correctly showing the permissions that were removed from the user after a Reputation or Multi-Sig motion has successfully been supported/approved and finalised. This is kind of a complex issue and **it will not be addressed on this PR**. 
>
> There is also an existing issue with reputation motions where the Finalise button has the possibility of getting stuck in a Pending state: https://github.com/JoinColony/colonyCDapp/issues/3859. You may or may not come across it but just know that this PR has nothing to do with it.

This PR makes use of subscriptions to automatically refresh member permissions information whenever it's updated.

**Out of scope yet relevant and manageable fixes**: You should also now be able to see the permissions that are marked for removal on the Completed Action component. BUT please note that this fix is only **limited to actions done via Permissions** as well as with motions that **have not been successfully supported/approved and finalised.** Please bear this in mind during testing 🙏 

Lastly, I did a wee refactor for setting the user data in our `AppContextProvider`.

![add-remove-permissions](https://github.com/user-attachments/assets/931012d9-b258-41c1-9444-bae5cdca54e4)

## Testing

> [!NOTE]
> Make sure that Fry doesn't not have any permissions to begin with

> [!IMPORTANT]
> - Please do not reload the page in between steps
> - Uninstall the Reputation and Multi-Sig extensions

1. Open an incognito window
2. Connect Fry's wallet
3. Bring up the Simple Payment form
4. Verify that you see this error banner:

<img width="685" alt="image" src="https://github.com/user-attachments/assets/74dd5b46-4088-4464-8954-bb19425387a1">

5. In the non-incognito window, connect Leela's wallet
6. Bring up the Manage Permissions form
7. Give Fry Payer permissions in General
8. Click the incognito window and verify that the error banner has disappeared
9. Click the Decision Method field and verify that you see Permissions in the options list
10. Click the non-incognito window
11. Remove Fry's permissions from General
12. Click the incognito window
13. Verify that you see the error banner again:

<img width="685" alt="image" src="https://github.com/user-attachments/assets/74dd5b46-4088-4464-8954-bb19425387a1">

**New stuff** ✨

* Added a new util `removeObjectFields` which allows you to remove a set of fields from a given object. It's strictly typed so you should be able to see auto-completed fields as you're selecting them:

<img width="552" alt="image" src="https://github.com/user-attachments/assets/a0485448-65de-401b-995b-30c54ea847bf">

Resolves #3635 