### PR TITLE
`classNames` should be `className`

### DIFF
--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/ActionsTableFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/ActionsTableFilters.tsx
@@ -118,7 +118,7 @@ const ActionsTableFilters: FC = () => {
                 hasShadow: true,
                 className: 'pt-6 pb-4 px-2',
               }}
-              classNames="sm:min-w-[20.375rem]"
+              className="sm:min-w-[20.375rem]"
             >
               <div className="mb-6 px-4">{searchInput}</div>
               {filtersContent}

--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/ActionTableFiltersItem/ActionTableFiltersItem.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/ActionTableFiltersItem/ActionTableFiltersItem.tsx
@@ -82,7 +82,7 @@ const ActionTableFiltersItem: FC<ActionTableFiltersItemProps> = ({
             hasShadow: true,
             className: 'pt-6 pb-4 px-2.5',
           }}
-          classNames="sm:min-w-[20.375rem]"
+          className="sm:min-w-[20.375rem]"
         >
           {children}
         </PopoverBase>

--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/ActionTypeFilters/ActionTypeFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/ActionTypeFilters/ActionTypeFilters.tsx
@@ -22,7 +22,7 @@ const ActionTypeFilters: FC = () => {
           return (
             <li key={name}>
               <Checkbox
-                classNames="subnav-button px-0 sm:px-3.5"
+                className="subnav-button px-0 sm:px-3.5"
                 name={name}
                 onChange={handleActionTypesFilterChange}
                 isChecked={isChecked}

--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/DateFilters/DateFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/DateFilters/DateFilters.tsx
@@ -28,7 +28,7 @@ const DateFilters: FC = () => {
           return (
             <li key={name}>
               <Checkbox
-                classNames="subnav-button px-0 sm:px-3.5"
+                className="subnav-button px-0 sm:px-3.5"
                 name={name}
                 isChecked={isChecked}
                 onChange={handleDateFilterChange}

--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/DecisionMethodFilters/DecisionMethodFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/DecisionMethodFilters/DecisionMethodFilters.tsx
@@ -22,7 +22,7 @@ const DecisionMethodFilters: FC = () => {
           return (
             <li key={name}>
               <Checkbox
-                classNames="subnav-button px-0 sm:px-3.5"
+                className="subnav-button px-0 sm:px-3.5"
                 name={name}
                 isChecked={isChecked}
                 onChange={handleDecisionMethodsFilterChange}

--- a/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/StatusFilters/StatusFilters.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionsTableFilters/partials/filters/StatusFilters/StatusFilters.tsx
@@ -21,7 +21,7 @@ const StatusFilters: FC = () => {
           return (
             <li key={name}>
               <Checkbox
-                classNames="subnav-button px-0 sm:px-3.5"
+                className="subnav-button px-0 sm:px-3.5"
                 name={name}
                 onChange={handleMotionStatesFilterChange}
                 isChecked={isChecked}

--- a/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
+++ b/src/components/common/Extensions/UserHubButton/UserHubButton.tsx
@@ -222,7 +222,7 @@ const UserHubButton: FC<Props> = ({ openTab, onOpen }) => {
         <PopoverBase
           setTooltipRef={setTooltipRef}
           tooltipProps={getTooltipProps}
-          classNames={clsx(
+          className={clsx(
             'w-full border-none bg-base-white p-0 shadow-none sm:w-auto sm:rounded-lg sm:border sm:border-solid sm:border-gray-200 sm:shadow-default',
             {
               '!top-[calc(var(--header-nav-section-height)-1.4rem)] h-[calc(100dvh-var(--top-content-height)+1.5rem)] !translate-x-0 !translate-y-0':

--- a/src/components/common/Extensions/UserNavigation/partials/UserMenu/UserMenu.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserMenu/UserMenu.tsx
@@ -67,7 +67,7 @@ const UserMenu: FC<UserMenuProps> = ({
       setTooltipRef={setTooltipRef}
       tooltipProps={tooltipProps}
       withTooltipStyles={!isTablet}
-      classNames={clsx(
+      className={clsx(
         'w-full overflow-hidden bg-base-white p-6 md:w-80 md:rounded-lg md:border md:border-gray-100 md:shadow-default',
         {
           '!top-[calc(var(--header-nav-section-height))] h-[calc(100vh-var(--top-content-height))] !translate-y-0':

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
@@ -161,7 +161,7 @@ const UninstallButton = ({
           label={MSG[extensionId].uninstallConfirmation}
           isChecked={isCheckboxChecked}
           onChange={() => setIsCheckboxChecked((prevState) => !prevState)}
-          classNames="mt-5"
+          className="mt-5"
         />
       </Modal>
     </>

--- a/src/components/frame/Extensions/pages/PermissionsPage/partials/FilterItem.tsx
+++ b/src/components/frame/Extensions/pages/PermissionsPage/partials/FilterItem.tsx
@@ -85,7 +85,7 @@ const RootFilter: FC<PermissionsPageFilterRootProps> = ({
 
                   onChange(updatedFilterValue);
                 }}
-                classNames="subnav-button px-0 sm:px-3.5"
+                className="subnav-button px-0 sm:px-3.5"
               >
                 {checkboxLabel}
               </Checkbox>
@@ -111,7 +111,7 @@ const RootFilter: FC<PermissionsPageFilterRootProps> = ({
                               [nestedValue]: !filterValue[nestedValue],
                             });
                           }}
-                          classNames="subnav-button px-0 sm:px-3.5"
+                          className="subnav-button px-0 sm:px-3.5"
                         >
                           {nestedCheckboxLabel}
                         </Checkbox>
@@ -143,7 +143,7 @@ const RootFilter: FC<PermissionsPageFilterRootProps> = ({
                 hasShadow: true,
                 className: 'py-6 px-2',
               }}
-              classNames="w-full sm:max-w-[13.25rem]"
+              className="w-full sm:max-w-[13.25rem]"
             >
               <span className="px-3.5 pb-2 uppercase text-gray-400 text-4">
                 {formatText({ id: 'permissions.type' })}
@@ -178,7 +178,7 @@ const RootFilter: FC<PermissionsPageFilterRootProps> = ({
 
                         onChange(updatedFilterValue);
                       }}
-                      classNames="subnav-button px-0 sm:px-3.5"
+                      className="subnav-button px-0 sm:px-3.5"
                     >
                       {checkboxLabel}
                     </Checkbox>
@@ -192,7 +192,7 @@ const RootFilter: FC<PermissionsPageFilterRootProps> = ({
                           hasShadow: true,
                           className: 'py-6 px-2',
                         }}
-                        classNames="w-full sm:max-w-[13.25rem]"
+                        className="w-full sm:max-w-[13.25rem]"
                       >
                         <span className="px-3.5 uppercase text-gray-400 text-4">
                           {formatText({ id: 'permissions.type' })}
@@ -211,7 +211,7 @@ const RootFilter: FC<PermissionsPageFilterRootProps> = ({
                                   [nestedValue]: !filterValue[nestedValue],
                                 });
                               }}
-                              classNames="subnav-button px-0 sm:px-3.5"
+                              className="subnav-button px-0 sm:px-3.5"
                             >
                               {nestedCheckboxLabel}
                             </Checkbox>

--- a/src/components/frame/Extensions/pages/PermissionsPage/partials/PermissionsPageFilter.tsx
+++ b/src/components/frame/Extensions/pages/PermissionsPage/partials/PermissionsPageFilter.tsx
@@ -129,7 +129,7 @@ const PermissionsPageFilter: FC<PermissionsPageFilterProps> = ({
             hasShadow: true,
             className: 'pt-6 pb-4 px-2.5',
           }}
-          classNames="w-full sm:max-w-[20.375rem]"
+          className="w-full sm:max-w-[20.375rem]"
         >
           <div className="mb-6 px-3.5">
             <SearchInputDesktop

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/AgreementsPageFilters.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/AgreementsPageFilters.tsx
@@ -123,7 +123,7 @@ const AgreementsPageFilters: FC = () => {
                 hasShadow: true,
                 className: 'pt-6 pb-4 px-2',
               }}
-              classNames="sm:min-w-[20.375rem]"
+              className="sm:min-w-[20.375rem]"
             >
               <div className="mb-6 px-4">{SearchInputComponent}</div>
               {FiltersContent}

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/partials/DateFilters/DateFilters.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/partials/DateFilters/DateFilters.tsx
@@ -28,7 +28,7 @@ const DateFilters: FC = () => {
           return (
             <li key={name}>
               <Checkbox
-                classNames="subnav-button px-0 sm:px-3.5"
+                className="subnav-button px-0 sm:px-3.5"
                 name={name}
                 isChecked={isChecked}
                 onChange={handleDateFilterChange}

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/partials/StatusFilters/StatusFilters.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFilters/partials/StatusFilters/StatusFilters.tsx
@@ -21,7 +21,7 @@ const StatusFilters: FC = () => {
           return (
             <li key={name}>
               <Checkbox
-                classNames="subnav-button px-0 sm:px-3.5"
+                className="subnav-button px-0 sm:px-3.5"
                 name={name}
                 onChange={handleMotionStatesFilterChange}
                 isChecked={isChecked}

--- a/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFiltersItem/AgreementsPageFiltersItem.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/partials/AgreementsPageFiltersItem/AgreementsPageFiltersItem.tsx
@@ -82,7 +82,7 @@ const AgreementsPageFiltersItem: FC<AgreementsPageFiltersItemProps> = ({
             hasShadow: true,
             className: 'pt-6 pb-4 px-2.5',
           }}
-          classNames="sm:min-w-[20.375rem]"
+          className="sm:min-w-[20.375rem]"
         >
           {children}
         </PopoverBase>

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/BalanceFilters/BalanceFilters.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/BalanceFilters/BalanceFilters.tsx
@@ -119,7 +119,7 @@ const BalanceFilters: FC = () => {
                 hasShadow: true,
                 className: 'pt-6 pb-4 px-2',
               }}
-              classNames="sm:min-w-[20.375rem]"
+              className="sm:min-w-[20.375rem]"
             >
               <div className="mb-6 px-4">{searchInput}</div>
               {filtersContent}

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/partials/BalanceTableFiltersItem/BalanceTableFiltersItem.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/partials/BalanceTableFiltersItem/BalanceTableFiltersItem.tsx
@@ -82,7 +82,7 @@ const BalanceTableFiltersItem: FC<BalanceTableFiltersItemProps> = ({
             hasShadow: true,
             className: 'pt-6 pb-4 px-2.5',
           }}
-          classNames="sm:min-w-[20.375rem]"
+          className="sm:min-w-[20.375rem]"
         >
           {children}
         </PopoverBase>

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/partials/filters/AttributeFilters/AttributeFilters.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/partials/filters/AttributeFilters/AttributeFilters.tsx
@@ -21,7 +21,7 @@ const AttributeFilters: FC = () => {
           return (
             <li key={name}>
               <Checkbox
-                classNames="subnav-button px-0 sm:px-3.5"
+                className="subnav-button px-0 sm:px-3.5"
                 name={name}
                 onChange={handleAttributeFilterChange}
                 isChecked={isChecked}

--- a/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/partials/filters/TokenFilters/TokenFilters.tsx
+++ b/src/components/frame/v5/pages/BalancePage/partials/BalanceTable/Filters/partials/filters/TokenFilters/TokenFilters.tsx
@@ -39,7 +39,7 @@ const TokenFilters: FC = () => {
           return (
             <li key={name}>
               <Checkbox
-                classNames="subnav-button px-0 sm:px-3.5"
+                className="subnav-button px-0 sm:px-3.5"
                 name={name}
                 onChange={handleTokenTypesFilterChange}
                 isChecked={isChecked}

--- a/src/components/frame/v5/pages/FundsPage/partials/Filter/Filter.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/Filter/Filter.tsx
@@ -137,7 +137,7 @@ function Filter<TValue extends FilterValue>({
             hasShadow: true,
             className: 'pt-6 pb-4 px-2.5',
           }}
-          classNames="w-full sm:max-w-[20.375rem]"
+          className="w-full sm:max-w-[20.375rem]"
         >
           <div className="mb-6 px-3.5">
             <SearchInputDesktop

--- a/src/components/frame/v5/pages/FundsPage/partials/Filter/FilterItem.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/Filter/FilterItem.tsx
@@ -77,7 +77,7 @@ function FilterItem<TValue extends FilterValue>({
                 hasShadow: true,
                 className: 'py-6 px-2',
               }}
-              classNames="w-full sm:max-w-[13.25rem] mr-2"
+              className="mr-2 w-full sm:max-w-[13.25rem]"
             >
               <>
                 <span className="px-3.5 pb-2 uppercase text-gray-400 text-4">

--- a/src/components/frame/v5/pages/FundsPage/partials/Filter/NestedFilterItem.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/Filter/NestedFilterItem.tsx
@@ -51,7 +51,7 @@ function NestedFilterItem<TValue extends FilterValue, TLevel extends number>({
             onChange={(e) => {
               onChange(set(cloneDeep(value), path, e.target.checked));
             }}
-            classNames="subnav-button px-0 sm:px-3.5"
+            className="subnav-button px-0 sm:px-3.5"
           >
             {label}
           </Checkbox>
@@ -81,7 +81,7 @@ function NestedFilterItem<TValue extends FilterValue, TLevel extends number>({
               onChange={(e) => {
                 onChange(set(cloneDeep(value), path, e.target.checked));
               }}
-              classNames="subnav-button px-0 sm:px-3.5"
+              className="subnav-button px-0 sm:px-3.5"
             >
               {label}
             </Checkbox>
@@ -96,7 +96,7 @@ function NestedFilterItem<TValue extends FilterValue, TLevel extends number>({
                 hasShadow: true,
                 className: 'py-6 px-2',
               }}
-              classNames="w-full sm:max-w-[13.25rem] mr-2"
+              className="mr-2 w-full sm:max-w-[13.25rem]"
             >
               {NestedItems}
             </PopoverBase>

--- a/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/FilterItem.tsx
+++ b/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/FilterItem.tsx
@@ -56,7 +56,7 @@ const FilterItem: FC<TeamsPageFilterRootProps> = ({
                   direction: value,
                 });
               }}
-              classNames="subnav-button px-0 sm:px-3.5"
+              className="subnav-button px-0 sm:px-3.5"
             >
               {checkboxLabel}
             </Checkbox>
@@ -82,7 +82,7 @@ const FilterItem: FC<TeamsPageFilterRootProps> = ({
                 hasShadow: true,
                 className: 'py-6 px-2',
               }}
-              classNames="w-full sm:max-w-[13.25rem] mr-2"
+              className="mr-2 w-full sm:max-w-[13.25rem]"
             >
               <>
                 <span className="px-3.5 pb-2 uppercase text-gray-400 text-4">
@@ -101,7 +101,7 @@ const FilterItem: FC<TeamsPageFilterRootProps> = ({
                         direction: value as ModelSortDirection,
                       });
                     }}
-                    classNames="subnav-button px-0 sm:px-3.5"
+                    className="subnav-button px-0 sm:px-3.5"
                   >
                     {checkboxLabel}
                   </Checkbox>

--- a/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/TeamsPageFilter.tsx
+++ b/src/components/frame/v5/pages/TeamsPage/partials/TeamsPageFilter/TeamsPageFilter.tsx
@@ -130,7 +130,7 @@ const TeamsPageFilter: FC<TeamsPageFilterProps> = ({
             hasShadow: true,
             className: 'pt-6 pb-4 px-2.5',
           }}
-          classNames="w-full sm:max-w-[20.375rem]"
+          className="w-full sm:max-w-[20.375rem]"
         >
           <div className="mb-6 px-3.5">
             <SearchInputDesktop

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/partials/PermissionsRemovalModal/PermissionsRemovalModal.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManagePermissionsForm/partials/PermissionsRemovalModal/PermissionsRemovalModal.tsx
@@ -91,7 +91,7 @@ const PermissionsRemovalModal: React.FC<PermissionsRemovalModalProps> = ({
           name="acknowledge"
           isChecked={isAcknowledged}
           onChange={() => setIsAcknowledged((state) => !state)}
-          classNames="mb-8"
+          className="mb-8"
           disabled={isFormSubmitting}
         >
           <p className="text-md">{formatText(MSG.acknowledge)}</p>

--- a/src/components/v5/common/Checkbox/Checkbox.tsx
+++ b/src/components/v5/common/Checkbox/Checkbox.tsx
@@ -15,7 +15,7 @@ const Checkbox: FC<PropsWithChildren<CheckboxProps>> = ({
   register,
   label = '',
   onChange,
-  classNames,
+  className,
   isChecked,
   children,
 }) => {
@@ -23,7 +23,7 @@ const Checkbox: FC<PropsWithChildren<CheckboxProps>> = ({
 
   return (
     <div
-      className={clsx(classNames, {
+      className={clsx(className, {
         'pointer-events-none opacity-50': disabled,
       })}
     >

--- a/src/components/v5/common/Checkbox/types.ts
+++ b/src/components/v5/common/Checkbox/types.ts
@@ -9,6 +9,6 @@ export interface CheckboxProps {
   name?: string;
   id?: string;
   disabled?: boolean;
-  classNames?: string;
+  className?: string;
   isChecked?: boolean;
 }

--- a/src/components/v5/common/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/v5/common/DropdownMenu/DropdownMenu.tsx
@@ -63,7 +63,7 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
             hasShadow: true,
             className: 'py-4 px-0',
           }}
-          classNames="overflow-hidden w-full px-6 sm:px-0 sm:w-auto"
+          className="w-full overflow-hidden px-6 sm:w-auto sm:px-0"
         >
           <ul
             className={clsx('w-full px-6 sm:w-[14.625rem]', {

--- a/src/components/v5/common/Filter/Filter.tsx
+++ b/src/components/v5/common/Filter/Filter.tsx
@@ -109,7 +109,7 @@ const Filter: FC<FilterProps> = ({
                 hasShadow: true,
                 className: 'pt-6 pb-4 px-2.5',
               }}
-              classNames="w-full sm:max-w-[17.375rem]"
+              className="w-full sm:max-w-[17.375rem]"
             >
               <div className="sm:mb-6 sm:px-3.5">
                 <SearchInput

--- a/src/components/v5/common/Table/types.ts
+++ b/src/components/v5/common/Table/types.ts
@@ -5,7 +5,7 @@ import { type MeatBallMenuProps } from '~v5/shared/MeatBallMenu/types.ts';
 import type React from 'react';
 
 export type RenderCellWrapper<T> = (
-  classNames: string,
+  className: string,
   content: React.ReactNode,
   context: {
     cell: Cell<T, unknown>;

--- a/src/components/v5/shared/CardWithBios/CardWithBios.tsx
+++ b/src/components/v5/shared/CardWithBios/CardWithBios.tsx
@@ -64,7 +64,7 @@ const CardWithBios: FC<CardWithBiosProps> = ({
                       hasShadow: true,
                       className: 'py-4 px-2',
                     }}
-                    classNames="w-full sm:max-w-[17.375rem]"
+                    className="w-full sm:max-w-[17.375rem]"
                   >
                     <SubNavigation user={user} />
                   </PopoverBase>

--- a/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesPopover/JoinedColoniesPopover.tsx
+++ b/src/components/v5/shared/Navigation/ColonySwitcher/partials/JoinedColoniesPopover/JoinedColoniesPopover.tsx
@@ -33,7 +33,7 @@ const JoinedColoniesPopover = ({
     <PopoverBase
       setTooltipRef={setTooltipRef}
       tooltipProps={getTooltipProps}
-      classNames={clsx(
+      className={clsx(
         'bg-white !left-[calc(100%+0.4rem)] z-top mt-4 max-h-[calc(100%-32px)] w-[252px] !transform-none rounded-lg border-gray-200 px-0 pb-4 pt-0 shadow-none',
         {
           '!bg-gray-100': isDarkMode,

--- a/src/components/v5/shared/PopoverBase/PopoverBase.tsx
+++ b/src/components/v5/shared/PopoverBase/PopoverBase.tsx
@@ -10,7 +10,7 @@ const displayName = 'v5.PopoverBase';
 const PopoverBase: FC<PropsWithChildren<PopoverBaseProps>> = ({
   tooltipProps,
   setTooltipRef,
-  classNames,
+  className,
   children,
   cardProps,
   withTooltipStyles = true,
@@ -19,7 +19,7 @@ const PopoverBase: FC<PropsWithChildren<PopoverBaseProps>> = ({
   <div
     ref={setTooltipRef}
     {...tooltipProps({
-      className: clsx(classNames, 'z-header', {
+      className: clsx(className, 'z-header', {
         'tooltip-container': withTooltipStyles,
       }),
     })}

--- a/src/components/v5/shared/PopoverBase/types.ts
+++ b/src/components/v5/shared/PopoverBase/types.ts
@@ -8,7 +8,7 @@ export interface PopoverBaseProps {
     style: React.CSSProperties;
   };
   setTooltipRef: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
-  classNames?: string;
+  className?: string;
   cardProps?: CardProps;
   withTooltipStyles?: boolean;
   isTopSectionWithBackground?: boolean;

--- a/src/components/v5/shared/SubNavigationItem/SubNavigationItem.tsx
+++ b/src/components/v5/shared/SubNavigationItem/SubNavigationItem.tsx
@@ -76,7 +76,7 @@ const SubNavigationItem: FC<SubNavigationItemProps> = ({
             hasShadow: true,
             className: 'py-4 sm:pt-6 sm:pb-4 px-2',
           }}
-          classNames="w-full sm:max-w-[17.375rem]"
+          className="w-full sm:max-w-[17.375rem]"
         >
           {option && nestedFilters && (
             <NestedOptions

--- a/src/components/v5/shared/SubNavigationItem/partials/NestedOptions.tsx
+++ b/src/components/v5/shared/SubNavigationItem/partials/NestedOptions.tsx
@@ -92,7 +92,7 @@ const NestedOptions: FC<NestedOptionsProps> = ({
                       onChange({ hasNestedOptions, id, isChecked, event })
                     }
                     isChecked={isChecked || isNestedOptionsChecked}
-                    classNames="w-full"
+                    className="w-full"
                   >
                     {Icon ? <Icon size={14} /> : null}
                   </Checkbox>
@@ -128,7 +128,7 @@ const NestedOptions: FC<NestedOptionsProps> = ({
                           hasShadow: true,
                           className: 'py-4 px-2',
                         }}
-                        classNames="w-full sm:max-w-[17.375rem]"
+                        className="w-full sm:max-w-[17.375rem]"
                       >
                         <NestedOptions
                           parentOption={`custom.${parentOption}`}

--- a/src/components/v5/shared/UserInfoPopover/UserInfoPopover.tsx
+++ b/src/components/v5/shared/UserInfoPopover/UserInfoPopover.tsx
@@ -140,7 +140,7 @@ const UserInfoPopover: FC<UserInfoPopoverProps> = ({
             <PopoverBase
               setTooltipRef={setTooltipRef}
               tooltipProps={getTooltipProps}
-              classNames="sm:w-[21.875rem]"
+              className="sm:w-[21.875rem]"
               withTooltipStyles={false}
               cardProps={{
                 rounded: 's',


### PR DESCRIPTION
## Description

Otherwise our linter and tailwind won't pick it up properly.

## Testing

Everything should look the same I guess?

## Diffs

**Changes** 🏗

* `classNames` is now `className` except when there's actually a different use case for it (e.g. `ReactSelect`)