### PR TITLE
test: advanced payment e2e tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,7 @@
         "@jackfranklin/test-data-bot": "^1.4.0",
         "@jest/globals": "^29.0.2",
         "@limegrass/eslint-plugin-import-alias": "^1.4.1",
-        "@playwright/test": "^1.48.0",
+        "@playwright/test": "^1.49.1",
         "@storybook/addon-essentials": "^8.0.0",
         "@storybook/addon-interactions": "^8.0.0",
         "@storybook/addon-links": "^8.0.0",
@@ -7400,12 +7400,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.0.tgz",
-      "integrity": "sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==",
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.48.0"
+        "playwright": "1.49.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -45566,12 +45566,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.0.tgz",
-      "integrity": "sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==",
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.48.0"
+        "playwright-core": "1.49.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -45584,9 +45584,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.0.tgz",
-      "integrity": "sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==",
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@jackfranklin/test-data-bot": "^1.4.0",
     "@jest/globals": "^29.0.2",
     "@limegrass/eslint-plugin-import-alias": "^1.4.1",
-    "@playwright/test": "^1.48.0",
+    "@playwright/test": "^1.49.1",
     "@storybook/addon-essentials": "^8.0.0",
     "@storybook/addon-interactions": "^8.0.0",
     "@storybook/addon-links": "^8.0.0",

--- a/playwright/e2e/advanced-payment.spec.ts
+++ b/playwright/e2e/advanced-payment.spec.ts
@@ -1,0 +1,414 @@
+import { type BrowserContext, expect, type Page, test } from '@playwright/test';
+
+import { expendituresBatchRecipients } from '../fixtures/test-data.ts';
+import { AdvancedPayment } from '../models/advanced-payment.ts';
+import {
+  forwardTime,
+  setCookieConsent,
+  signInAndNavigateToColony,
+} from '../utils/common.ts';
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Advanced payment', () => {
+  let page: Page;
+  let context: BrowserContext;
+  let advancedPayment: AdvancedPayment;
+
+  test.beforeAll(async ({ browser, baseURL }) => {
+    context = await browser.newContext();
+    page = await context.newPage();
+    advancedPayment = new AdvancedPayment(page);
+
+    await setCookieConsent(context, baseURL);
+    await signInAndNavigateToColony(page, {
+      colonyUrl: '/planex',
+      wallet: /dev wallet 1$/i,
+    });
+  });
+
+  test.afterAll(async () => {
+    await context?.close();
+  });
+
+  test.beforeEach(async () => {
+    await advancedPayment.open();
+  });
+
+  test('Should be able to create an advanced payment (Permissions method)', async () => {
+    const recipient = '0x27fF0C145E191C22C75cD123C679C3e1F58a4469';
+    const recipient2 = '0x9dF24e73f40b2a911Eb254A8825103723E13209C';
+    const claimDelay = 1;
+
+    await advancedPayment.fillForm({
+      title: 'Test advanced payment',
+      team: 'General',
+      decisionMethod: 'Permissions',
+      recipients: [
+        { amount: '1', claimDelay: claimDelay.toString(), recipient },
+        {
+          amount: '2',
+          claimDelay: claimDelay.toString(),
+          recipient: recipient2,
+        },
+      ],
+    });
+    await advancedPayment.submitButton.click();
+    await advancedPayment.waitForPending();
+    await advancedPayment.waitForTransaction();
+    await expect(advancedPayment.completedAction).toBeVisible();
+    await expect(advancedPayment.stepper).toBeVisible();
+    await expect(advancedPayment.expenditureActionStatusBadge).toHaveText(
+      'Review',
+    );
+    await advancedPayment.confirmPayment();
+
+    await advancedPayment.fundPayment();
+
+    await advancedPayment.releasePayment();
+    await expect(
+      advancedPayment.completedAction.getByText('Payment overview'),
+    ).toBeVisible();
+
+    await expect(
+      advancedPayment.completedAction.getByRole('button', {
+        name: 'Make payment',
+      }),
+    ).toBeDisabled();
+
+    await expect(
+      advancedPayment.completedAction.getByText('Claim in'),
+    ).toHaveCount(3);
+
+    await forwardTime(claimDelay);
+
+    await advancedPayment.reloadPage();
+
+    await expect(advancedPayment.expenditureActionStatusBadge).toHaveText(
+      'Payable',
+    );
+
+    await expect(
+      advancedPayment.completedAction.getByText('Claim now'),
+    ).toHaveCount(2);
+
+    await advancedPayment.makePayment();
+
+    await expect(
+      advancedPayment.completedAction.getByText('Claimed'),
+    ).toHaveCount(2);
+  });
+
+  test('Should be able to create an advanced payment (Staking method)', async () => {
+    const recipient = '0x27fF0C145E191C22C75cD123C679C3e1F58a4469';
+    const recipient2 = '0x9dF24e73f40b2a911Eb254A8825103723E13209C';
+    const claimDelay = 1;
+
+    await advancedPayment.fillForm({
+      title: 'Test advanced payment',
+      team: 'General',
+      decisionMethod: 'Staking',
+      recipients: [
+        { amount: '3', claimDelay: claimDelay.toString(), recipient },
+        {
+          amount: '2',
+          claimDelay: claimDelay.toString(),
+          recipient: recipient2,
+        },
+      ],
+    });
+
+    await advancedPayment.submitButton.click();
+    await advancedPayment.confirmRequiredStakeDialog();
+    await advancedPayment.waitForTransaction();
+    await expect(advancedPayment.completedAction).toBeVisible();
+    await expect(advancedPayment.stepper).toBeVisible();
+    await expect(advancedPayment.expenditureActionStatusBadge).toHaveText(
+      'Review',
+    );
+    await advancedPayment.confirmPayment();
+
+    await advancedPayment.fundPayment();
+
+    await advancedPayment.releasePayment();
+
+    await expect(
+      advancedPayment.completedAction.getByText('Payment overview'),
+    ).toBeVisible();
+
+    await expect(
+      advancedPayment.completedAction.getByRole('button', {
+        name: 'Make payment',
+      }),
+    ).toBeDisabled();
+
+    await expect(
+      advancedPayment.completedAction.getByText('Claim in'),
+    ).toHaveCount(3);
+
+    await forwardTime(claimDelay);
+
+    await advancedPayment.reloadPage();
+
+    await expect(advancedPayment.expenditureActionStatusBadge).toHaveText(
+      'Payable',
+    );
+
+    await expect(
+      advancedPayment.completedAction.getByText('Claim now'),
+    ).toHaveCount(2);
+
+    await advancedPayment.makePayment();
+
+    await expect(
+      advancedPayment.completedAction.getByText('Claimed'),
+    ).toHaveCount(2);
+  });
+
+  test('Should be able to cancel an advanced payment', async () => {
+    const recipient = '0x27fF0C145E191C22C75cD123C679C3e1F58a4469';
+    const recipient2 = '0x9dF24e73f40b2a911Eb254A8825103723E13209C';
+    const claimDelay = 1;
+
+    await advancedPayment.fillForm({
+      title: 'Test advanced payment',
+      team: 'General',
+      decisionMethod: 'Staking',
+      recipients: [
+        { amount: '1', claimDelay: claimDelay.toString(), recipient },
+        {
+          amount: '1',
+          claimDelay: claimDelay.toString(),
+          recipient: recipient2,
+        },
+      ],
+    });
+
+    await advancedPayment.submitButton.click();
+    await advancedPayment.confirmRequiredStakeDialog();
+    await advancedPayment.waitForTransaction();
+    await expect(advancedPayment.completedAction).toBeVisible();
+    await expect(advancedPayment.stepper).toBeVisible();
+    await expect(advancedPayment.expenditureActionStatusBadge).toHaveText(
+      'Review',
+    );
+    await advancedPayment.confirmPayment();
+
+    await advancedPayment.cancelAction();
+
+    await advancedPayment.expenditureActionStatusBadge
+      .filter({
+        hasText: 'Canceled',
+      })
+      .waitFor({ state: 'visible' });
+  });
+
+  test('Should validate advanced payment form fields', async () => {
+    await advancedPayment.submit();
+
+    // Verify validation messages for required fields
+    for (const message of AdvancedPayment.validationMessages
+      .allRequiredFields) {
+      await expect(advancedPayment.getValidationMessage(message)).toBeVisible();
+    }
+    // Verify validation message for title field when it exceeds the maximum character limit
+    await advancedPayment.setTitle(
+      'This is a test title that exceeds the maximum character limit of sixty.',
+    );
+
+    await advancedPayment.submit();
+
+    await expect(
+      advancedPayment.getValidationMessage(
+        AdvancedPayment.validationMessages.title.maxLengthExceeded,
+      ),
+    ).toBeVisible();
+
+    await advancedPayment.close();
+  });
+
+  test('Should handle recipient table operations - add new row, remove row, and duplicate row correctly', async () => {
+    await advancedPayment.fillForm({
+      title: 'Test advanced payment',
+      team: 'General',
+      decisionMethod: 'Staking',
+      recipients: [
+        {
+          amount: '1',
+          claimDelay: '1',
+          recipient: '0x27fF0C145E191C22C75cD123C679C3e1F58a4469',
+        },
+      ],
+    });
+
+    await advancedPayment.recipientsTable.getByLabel('Open menu').click();
+
+    await advancedPayment.recipientsTable
+      .getByRole('button', { name: 'Duplicate row' })
+      .click();
+
+    // Verify two rows exist
+    const recipients = await advancedPayment.recipientsTable
+      .locator('tbody')
+      .getByRole('row')
+      .all();
+    expect(recipients).toHaveLength(2);
+
+    await expect(
+      advancedPayment.recipientsTable.getByLabel('Select User'),
+    ).toHaveCount(2);
+
+    // Verify the content of both rows is identical
+    await expect(recipients[0]).toHaveText(
+      (await recipients[1].textContent()) || '',
+    );
+
+    await expect(
+      recipients[0]
+        .getByRole('cell')
+        .filter({ hasNotText: 'Hour' })
+        .getByPlaceholder('Enter amount'),
+    ).toHaveValue(
+      await recipients[1]
+        .getByRole('cell')
+        .filter({ hasNotText: 'Hour' })
+        .getByPlaceholder('Enter amount')
+
+        .inputValue(),
+    );
+
+    await expect(
+      recipients[0]
+        .getByRole('cell')
+        .filter({ hasText: 'Hour' })
+        .getByPlaceholder('Enter amount'),
+    ).toHaveValue(
+      await recipients[1]
+        .getByRole('cell')
+        .filter({ hasText: 'Hour' })
+        .getByPlaceholder('Enter amount')
+        .inputValue(),
+    );
+
+    // Removing a row
+    await advancedPayment.recipientsTable
+      .getByLabel('Open menu')
+      .last()
+      .click();
+
+    await advancedPayment.recipientsTable
+      .getByRole('button', { name: 'Remove row' })
+      .click();
+
+    await expect(
+      advancedPayment.recipientsTable.getByLabel('Open menu').nth(1),
+    ).toBeHidden();
+
+    await advancedPayment.close();
+  });
+
+  test('Should be able to load recipients from CSV file', async () => {
+    await advancedPayment.fillForm({
+      title: 'Test CSV payment',
+      team: 'General',
+      decisionMethod: 'Permissions',
+    });
+
+    const dialog = await advancedPayment.uploadRecipientsCSV(
+      'playwright/fixtures/expenditures_batch.csv',
+    );
+
+    await dialog.waitFor({ state: 'hidden' });
+
+    // Verify recipients were loaded correctly
+    const recipients = await advancedPayment.recipientsTable
+      .locator('tbody')
+      .getByRole('row')
+      .all();
+
+    // Verify number of rows matches CSV
+    expect(recipients).toHaveLength(expendituresBatchRecipients.length);
+
+    // Verify each row matches CSV data
+    for (const [
+      index,
+      expectedRecipient,
+    ] of expendituresBatchRecipients.entries()) {
+      await expect(recipients[index].getByLabel('Select User')).toHaveText(
+        expectedRecipient.username,
+      );
+      await expect(
+        recipients[index]
+          .getByRole('cell')
+          .filter({ hasNotText: 'Hour' })
+          .getByPlaceholder('Enter amount'),
+      ).toHaveValue(expectedRecipient.amount);
+      await expect(
+        recipients[index]
+          .getByRole('cell')
+          .filter({ hasText: 'Hour' })
+          .getByPlaceholder('Enter amount'),
+      ).toHaveValue(expectedRecipient.claimDelay);
+    }
+
+    // Verify total amount
+    const totalAmount = expendituresBatchRecipients.reduce(
+      (sum, recipient) => sum + Number(recipient.amount),
+      0,
+    );
+    // We assume that the token symbol is the same for all recipients
+    await expect(advancedPayment.totalAmount).toHaveText(
+      `${totalAmount}${expendituresBatchRecipients[0].tokenSymbol}`,
+    );
+
+    await advancedPayment.close();
+  });
+
+  test('Should provide feedback when submitting a CSV file with missing or invalid data', async () => {
+    await advancedPayment.fillForm({
+      title: 'Test CSV payment',
+      team: 'General',
+      decisionMethod: 'Permissions',
+    });
+
+    const firstRow = advancedPayment.recipientsTable
+      .locator('tbody')
+      .getByRole('row')
+      .first();
+
+    await advancedPayment.uploadRecipientsCSV(
+      'playwright/fixtures/expenditures_batch_invalid.csv',
+    );
+
+    await expect(firstRow.getByText('Address error')).toBeVisible();
+
+    await expect(firstRow.getByText('Token error')).toBeVisible();
+
+    await advancedPayment.close();
+  });
+
+  test('Should provide feedback when loading invalid CSV content', async () => {
+    await advancedPayment.fillForm({
+      title: 'Test CSV payment',
+      team: 'General',
+      decisionMethod: 'Permissions',
+    });
+
+    // Create invalid CSV content
+    const invalidCSVContent = Buffer.from(`
+Username (for reference);Address;Token Symbol (for reference);Token Contract Address;Amount;Claim delay (hours)
+fry;;INVALID_TOKEN;;not_a_number;invalid_delay
+amy;invalid_address;;;;;
+`);
+
+    await advancedPayment.uploadRecipientsCSV({
+      buffer: invalidCSVContent,
+      name: 'invalid.csv',
+      mimeType: 'text/csv',
+    });
+
+    await expect(
+      page.getByText('File structure is incorrect, please try again'),
+    ).toBeVisible();
+  });
+});

--- a/playwright/fixtures/expenditures_batch.csv
+++ b/playwright/fixtures/expenditures_batch.csv
@@ -1,0 +1,22 @@
+;;;;;
+Instructions here: https://go.clny.io/csv;;;;;
+;;;;;
+Address Book;;;;;
+;;;;;
+Username (for reference);Address (for reference);;;;
+leela;0xb77D57F4959eAfA0339424b83FcFaf9c15407461;;;;
+fry;0x27fF0C145E191C22C75cD123C679C3e1F58a4469;;;;
+amy;0x9dF24e73f40b2a911Eb254A8825103723E13209C;;;;
+;;;;;
+Token List;;;;;
+;;;;;
+Symbol (for reference);Token Contract Address (for reference);;;;
+CREDS;0xBaE2cc298449726064F39DED7eA84E51742130d5;;;;
+ƓƓƓ;0x273E0D4AB412194d018C40fE6EdBDc7d7Df8f34e;;;;
+ETH;0x0000000000000000000000000000000000000000;;;;
+;;;;;
+Payment Details;;;;;
+;;;;;
+Username (for reference);Address;Token Symbol (for reference);Token Contract Address;Amount;Claim delay (hours)
+fry;0x27fF0C145E191C22C75cD123C679C3e1F58a4469;CREDS;0x0000000000000000000000000000000000000000;2;24
+amy;0x9dF24e73f40b2a911Eb254A8825103723E13209C;CREDS;0x0000000000000000000000000000000000000000;3;12

--- a/playwright/fixtures/expenditures_batch_invalid.csv
+++ b/playwright/fixtures/expenditures_batch_invalid.csv
@@ -1,0 +1,24 @@
+;;;;;
+Instructions here: https://go.clny.io/csv;;;;;
+;;;;;
+Address Book;;;;;
+;;;;;
+Username (for reference);Address (for reference);;;;
+leela;0xb77D57F4959eAfA0339424b83FcFaf9c15407461;;;;
+fry;0x27fF0C145E191C22C75cD123C679C3e1F58a4469;;;;
+amy;0x9dF24e73f40b2a911Eb254A8825103723E13209C;;;;
+ulysses-ultimate;0x2da1037D928b395D118f5C72B23C93Ea43892DF0;;;;
+;;;;;
+Token List;;;;;
+;;;;;
+Symbol (for reference);Token Contract Address (for reference);;;;
+CREDS;0xBaE2cc298449726064F39DED7eA84E51742130d5;;;;
+ƓƓƓ;0x273E0D4AB412194d018C40fE6EdBDc7d7Df8f34e;;;;
+ETH;0x0000000000000000000000000000000000000000;;;;
+;;;;;
+Payment Details;;;;;
+;;;;;
+Username (for reference);Address;Token Symbol (for reference);Token Contract Address;Amount;Claim delay (hours)
+fry;Ddcdc;CREDS;;1;
+amy;0x9dF24e73f40b2a911Eb254A8825103723E13209C;CREDS;0xBaE2cc298449726064F39DED7eA84E51742130d5;3;12
+ulysses-ultimate;0x2da1037D928b395D118f5C72B23C93Ea43892DF0;CREDS;0xBaE2cc298449726064F39DED7eA84E51742130d5;5;6

--- a/playwright/fixtures/test-data.ts
+++ b/playwright/fixtures/test-data.ts
@@ -1,20 +1,17 @@
+// Represents content of the expenditures_batch.csv
 export const expendituresBatchRecipients = [
   {
     username: 'fry',
     address: '0x27fF0C145E191C22C75cD123C679C3e1F58a4469',
     amount: '2',
     claimDelay: '24',
+    tokenSymbol: 'ETH',
   },
   {
     username: 'amy',
     address: '0x9dF24e73f40b2a911Eb254A8825103723E13209C',
     amount: '3',
     claimDelay: '12',
-  },
-  {
-    username: 'ulysses-ultimate',
-    address: '0x2da1037D928b395D118f5C72B23C93Ea43892DF0',
-    amount: '5',
-    claimDelay: '6',
+    tokenSymbol: 'ETH',
   },
 ];

--- a/playwright/models/advanced-payment.ts
+++ b/playwright/models/advanced-payment.ts
@@ -1,0 +1,437 @@
+import type { Locator, Page } from '@playwright/test';
+
+type Recipient = {
+  amount: string;
+  claimDelay: string;
+  recipient: string;
+};
+
+type CSVFileInput =
+  | string
+  | {
+      name: string;
+      mimeType: string;
+      buffer: Buffer;
+    };
+
+export class AdvancedPayment {
+  static readonly validationMessages = {
+    title: {
+      maxLengthExceeded: 'Title must not exceed 60 characters',
+      isRequired: 'Title is required',
+    },
+    allRequiredFields: [
+      // This one should be changed to a human readable message
+      'from must be a `number` type, but the final value was: `NaN` (cast from the value `""`)',
+      'decisionMethod must be defined',
+      'Recipient is required in 1st payment',
+      'Amount must be greater than zero',
+      "Claim delay can't be empty in 1st payment",
+      'Title is required',
+    ],
+    amount: {
+      isRequired: 'Amount is required',
+      mustBeGreaterThanZero: 'Amount must be greater than zero',
+      maxExceeded: 'Not enough funds to cover the payment and network fees',
+    },
+    permissions:
+      "You don't have the right permissions to create this action. Try another action type.",
+    token: {
+      locked:
+        'This token is locked and is not able to be used for payments. Check with the token creator for details.',
+    },
+  };
+
+  static readonly tooltipMessages = {
+    From: /Team source of the funds/i,
+    Recipient: /Member or address designated to receive the funds/i,
+    Amount: /Quantity and type of funds of the payment/i,
+    'Decision method': /Mechanism behind the decision-making process/i,
+  };
+
+  drawer: Locator;
+
+  form: Locator;
+
+  selectDrowdown: Locator;
+
+  decisionMethodDropdown: Locator;
+
+  sidebar: Locator;
+
+  stepper: Locator;
+
+  closeButton: Locator;
+
+  userInfo: Locator;
+
+  submitButton: Locator;
+
+  completedAction: Locator;
+
+  recipientsTable: Locator;
+
+  addPaymentButton: Locator;
+
+  uploadCSVButton: Locator;
+
+  openMenuButton: Locator;
+
+  totalAmount: Locator;
+
+  expenditureActionStatusBadge: Locator;
+
+  menuButton: Locator;
+
+  constructor(private page: Page) {
+    this.drawer = page.getByTestId('action-drawer');
+    this.form = page.getByTestId('action-form');
+    this.selectDrowdown = page.getByTestId('search-select-menu');
+    this.decisionMethodDropdown = page
+      .getByRole('list')
+      .filter({ hasText: /Available decision methods/i });
+    this.sidebar = page.getByTestId('colony-page-sidebar');
+    this.stepper = page.getByTestId('stepper');
+    this.closeButton = page.getByRole('button', { name: /close the modal/i });
+    this.userInfo = page.getByTestId('user-info');
+    this.submitButton = page.getByRole('button', { name: 'Create payment' });
+    this.completedAction = page.getByTestId('completed-action');
+    this.recipientsTable = page.getByTestId('payment-builder-recipients-field');
+    this.addPaymentButton = page.getByRole('button', { name: 'Add payment' });
+    this.uploadCSVButton = page.getByRole('button', {
+      name: 'Upload CSV',
+    });
+    this.openMenuButton = this.form.getByRole('button', { name: 'Open menu' });
+    this.totalAmount = page.getByTestId('payment-builder-payouts-total');
+    this.expenditureActionStatusBadge = this.drawer.getByTestId(
+      'expenditure-action-status-badge',
+    );
+    this.menuButton = this.completedAction.getByLabel('Open menu');
+  }
+
+  async open() {
+    await this.sidebar.getByLabel('Start the payment group action').click();
+    await this.drawer.waitFor({ state: 'visible' });
+    await this.drawer
+      .getByRole('button', {
+        name: /New Advanced Payment Multiple recipients/i,
+      })
+      .click();
+    await this.form.waitFor({ state: 'visible' });
+    await this.drawer
+      .getByTestId('action-sidebar-description')
+      .waitFor({ state: 'visible' });
+  }
+
+  async close() {
+    await this.closeButton.click();
+
+    const dialog = this.getConfirmationDialog();
+    if (await dialog.isVisible()) {
+      await dialog
+        .getByRole('button', { name: 'Yes, cancel the action' })
+        .click();
+    }
+  }
+
+  async setTitle(title: string) {
+    await this.form.getByPlaceholder('Enter title').fill(title);
+  }
+
+  async selectTeam(teamName: string) {
+    await this.form.getByRole('button', { name: 'Select team' }).click();
+    await this.selectDrowdown.getByRole('button', { name: teamName }).click();
+  }
+
+  async setRecipient({ address, row = 0 }: { address: string; row: number }) {
+    await this.recipientsTable
+      .getByRole('row')
+      .nth(row)
+      .getByLabel('Select user')
+      .click();
+    await this.page.getByPlaceholder('Search or add wallet address').click();
+    await this.page
+      .getByPlaceholder('Search or add wallet address')
+      .fill(address);
+    await this.page
+      .getByRole('button', {
+        name: address,
+      })
+      .click();
+  }
+
+  async setAmount({ amount, row = 0 }: { amount: string; row: number }) {
+    await this.recipientsTable
+      .getByRole('row')
+      .nth(row)
+      .getByRole('cell', { name: 'Select Token' })
+      .getByPlaceholder('Enter amount')
+      .fill(amount);
+  }
+
+  async setClaimDelay({ delay, row = 0 }: { delay: string; row: number }) {
+    await this.recipientsTable
+      .getByRole('row')
+      .nth(row)
+      .getByRole('cell', { name: 'Hours' })
+      .getByPlaceholder('Enter amount')
+      .fill(delay);
+  }
+
+  async selectToken(tokenName: string) {
+    await this.form.getByRole('button', { name: 'Select token' }).click();
+    await this.page
+      .getByTestId('token-list-item')
+      .getByText(tokenName)
+      .first()
+      .click();
+  }
+
+  async selectDecisionMethod(method: string) {
+    await this.form.getByRole('button', { name: 'Select method' }).click();
+
+    await this.decisionMethodDropdown
+      .getByRole('button', { name: method })
+      .click();
+  }
+
+  async submit() {
+    await this.submitButton.click();
+  }
+
+  async waitForPending() {
+    await this.form
+      .getByRole('button', { name: 'Pending' })
+      .first()
+      .waitFor({ state: 'visible' });
+  }
+
+  async waitForTransaction() {
+    await this.page.waitForURL(/\?tx=/);
+    await this.page
+      .getByTestId('loading-skeleton')
+      .last()
+      .waitFor({ state: 'hidden' });
+  }
+
+  async verifyStepperUI() {
+    await this.stepper.waitFor({ state: 'visible' });
+    await this.stepper
+      .getByRole('button', { name: 'Staking' })
+      .waitFor({ state: 'visible' });
+    await this.stepper
+      .getByRole('button', { name: 'Voting' })
+      .waitFor({ state: 'visible' });
+
+    await this.stepper.getByRole('button', { name: 'Reveal' }).waitFor({
+      state: 'visible',
+    });
+
+    await this.stepper.getByRole('button', { name: 'Outcome' }).waitFor({
+      state: 'visible',
+    });
+
+    await this.stepper.getByRole('button', { name: 'Finalize' }).waitFor({
+      state: 'visible',
+    });
+  }
+
+  async openUserInfo() {
+    await this.form
+      .getByTestId('action-sidebar-description')
+      .getByRole('button')
+      .click();
+  }
+
+  async changeActionType(newType: string) {
+    await this.form.getByRole('button', { name: 'Advanced payment' }).click();
+    await this.selectDrowdown.getByRole('button', { name: newType }).click();
+  }
+
+  getValidationMessage(message: string) {
+    return this.drawer.getByText(message);
+  }
+
+  getTooltip(text: RegExp) {
+    return this.page.getByText(text);
+  }
+
+  getConfirmationDialog() {
+    return this.page
+      .getByRole('dialog')
+      .filter({ hasText: 'Do you wish to cancel the action creation?' });
+  }
+
+  async confirmPayment() {
+    await this.completedAction
+      .getByRole('button', { name: 'Confirm details' })
+      .click();
+
+    await this.completedAction
+      .getByRole('button', { name: 'Pending' })
+      .waitFor({ state: 'hidden' });
+
+    await this.expenditureActionStatusBadge
+      .filter({
+        hasText: 'Funding',
+      })
+      .waitFor();
+  }
+
+  async fundPayment() {
+    await this.completedAction
+      .getByRole('button', { name: 'Fund', exact: true })
+      .click();
+
+    const fundDialog = this.page
+      .getByRole('dialog')
+      .filter({ hasText: 'Payment funding' });
+    await fundDialog.waitFor({ state: 'visible' });
+    await fundDialog.getByText('Select Method').click();
+    await this.page.getByRole('option', { name: 'Permissions' }).click();
+    await fundDialog.getByRole('button', { name: 'Fund Payment' }).click();
+    await fundDialog.waitFor({ state: 'hidden' });
+    await this.completedAction
+      .getByRole('button', { name: 'Pending' })
+      .waitFor({ state: 'hidden' });
+
+    await this.expenditureActionStatusBadge
+      .filter({
+        hasText: 'Release',
+      })
+      .waitFor();
+  }
+
+  async releasePayment() {
+    await this.completedAction
+      .getByRole('button', { name: 'Release' })
+      .nth(1)
+      .click();
+    const releaseDialog = this.page
+      .getByRole('dialog')
+      .filter({ hasText: 'Release payment' });
+
+    await releaseDialog.waitFor({ state: 'visible' });
+    await releaseDialog.getByText('Select Method').click();
+    await this.page.getByRole('option', { name: 'Permissions' }).click();
+    await releaseDialog
+      .getByRole('button', { name: 'Release Payment' })
+      .click();
+    await releaseDialog.waitFor({ state: 'hidden' });
+    await this.completedAction
+      .getByRole('button', { name: 'Pending' })
+      .waitFor({ state: 'hidden' });
+
+    await this.expenditureActionStatusBadge
+      .filter({
+        hasText: 'Payable',
+      })
+      .waitFor();
+  }
+
+  async makePayment() {
+    await this.completedAction
+      .getByRole('button', { name: 'Make payment' })
+      .click();
+
+    await this.page.getByRole('button', { name: 'Pending' }).last().waitFor({
+      state: 'hidden',
+    });
+
+    await this.completedAction
+      .getByRole('button', { name: 'Make payment' })
+      .waitFor({ state: 'hidden' });
+
+    await this.expenditureActionStatusBadge
+      .filter({
+        hasText: 'Paid',
+      })
+      .waitFor();
+  }
+
+  async confirmRequiredStakeDialog() {
+    await this.page
+      .getByRole('dialog')
+      .filter({ hasText: 'Required stake amount' })
+      .getByRole('button', { name: 'Create payment' })
+      .click();
+
+    await this.page
+      .getByRole('dialog')
+      .filter({ hasText: 'Required stake amount' })
+      .waitFor({ state: 'hidden' });
+  }
+
+  async fillForm({
+    title,
+    team,
+    decisionMethod,
+    recipients,
+  }: {
+    title: string;
+    team: string;
+    decisionMethod: string;
+    recipients?: Recipient[];
+  }) {
+    await this.setTitle(title);
+    await this.selectTeam(team);
+    await this.selectDecisionMethod(decisionMethod);
+
+    if (recipients) {
+      for (const [
+        index,
+        { amount, claimDelay, recipient },
+      ] of recipients.entries()) {
+        const row = index + 1;
+        await this.setAmount({ amount, row });
+        await this.setClaimDelay({ delay: claimDelay, row });
+        await this.setRecipient({ address: recipient, row });
+        if (row !== recipients.length) {
+          await this.addPaymentButton.click();
+        }
+      }
+    }
+  }
+
+  async reloadPage() {
+    await this.page.reload();
+
+    await this.page.getByText(/loading colon/i).waitFor({ state: 'hidden' });
+
+    await this.page
+      .getByTestId('loading-skeleton')
+      .last()
+      .waitFor({ state: 'hidden' });
+  }
+
+  async cancelAction() {
+    const cancelDialog = this.page.getByRole('dialog').filter({
+      has: this.page.getByRole('heading', { name: 'Cancel the payment' }),
+    });
+
+    await this.menuButton.click();
+    await this.page.getByRole('button', { name: 'Cancel payment' }).click();
+    await cancelDialog.waitFor({ state: 'visible' });
+
+    await cancelDialog.getByText('Select method').click();
+    await this.page.getByRole('option', { name: 'Permissions' }).click();
+    await cancelDialog
+      .getByRole('button', { name: 'Confirm cancelation' })
+      .click();
+
+    await cancelDialog.waitFor({ state: 'hidden' });
+  }
+
+  async uploadRecipientsCSV(csvInput: CSVFileInput) {
+    await this.uploadCSVButton.click();
+
+    const dialog = this.page
+      .getByRole('dialog')
+      .filter({ hasText: 'Upload CSV' });
+    await dialog.waitFor({ state: 'visible' });
+
+    await dialog.locator('input[type="file"]').setInputFiles(csvInput);
+
+    return dialog;
+  }
+}

--- a/playwright/setup/index.ts
+++ b/playwright/setup/index.ts
@@ -1,0 +1,26 @@
+import { test as baseTest } from '@playwright/test';
+
+import { AdvancedPayment } from '../models/advanced-payment.ts';
+import { SimplePayment } from '../models/simple-payment.ts';
+
+// Extend the test context to include page objects
+type ModelFixtures = {
+  simplePayment: SimplePayment;
+  advancedPayment: AdvancedPayment;
+};
+
+const test = baseTest.extend<ModelFixtures>({
+  simplePayment: async ({ page }, use) => {
+    const simplePayment = new SimplePayment(page);
+
+    await use(simplePayment);
+  },
+  advancedPayment: async ({ page }, use) => {
+    const advancedPayment = new AdvancedPayment(page);
+    await use(advancedPayment);
+  },
+});
+
+export * from '@playwright/test';
+
+export { test };

--- a/src/components/v5/common/ActionSidebar/partials/ExpenditureActionStatusBadge/ExpenditureActionStatusBadge.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ExpenditureActionStatusBadge/ExpenditureActionStatusBadge.tsx
@@ -62,6 +62,7 @@ const ExpenditureActionStatusBadge: FC<ExpenditureActionStatusBadgeProps> = ({
 
   const pill = (
     <PillsBase
+      testId="expenditure-action-status-badge"
       className={clsx(
         className,
         EXPENDITURE_STATUS_TO_CLASSNAME_MAP[activeStatus],
@@ -78,7 +79,10 @@ const ExpenditureActionStatusBadge: FC<ExpenditureActionStatusBadgeProps> = ({
     ExpenditureActionStatus.Changes,
     ExpenditureActionStatus.Edit,
   ].includes(activeStatus) ? (
-    <Tooltip tooltipContent={formatText(MSG.tooltipText, { activeStatus })}>
+    <Tooltip
+      testId="expenditure-action-status-badge-tooltip"
+      tooltipContent={formatText(MSG.tooltipText, { activeStatus })}
+    >
       {pill}
     </Tooltip>
   ) : (

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderPayoutsTotal/PaymentBuilderPayoutsTotal.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderPayoutsTotal/PaymentBuilderPayoutsTotal.tsx
@@ -108,7 +108,7 @@ const PaymentBuilderTokensTotal: FC<PaymentBuilderPayoutsTotalProps> = ({
   }
 
   return (
-    <div className="w-full">
+    <div className="w-full" data-testid="payment-builder-payouts-total">
       {sortedTokens.length > 1 ? (
         <>
           <button

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/PaymentBuilderRecipientsField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/PaymentBuilderRecipientsField/PaymentBuilderRecipientsField.tsx
@@ -136,7 +136,7 @@ const PaymentBuilderRecipientsField: FC<PaymentBuilderRecipientsFieldProps> = ({
   );
 
   return (
-    <div>
+    <div data-testid="payment-builder-recipients-field">
       <h5 className="mb-3 mt-6 text-2">
         {formatText({ id: 'actionSidebar.payments' })}
       </h5>

--- a/src/components/v5/common/AvatarUploader/partials/ErrorContent.tsx
+++ b/src/components/v5/common/AvatarUploader/partials/ErrorContent.tsx
@@ -20,7 +20,10 @@ const ErrorContent: FC<ErrorContentProps> = ({
   const errorMessage = getErrorMessage(errorCode || DropzoneErrors.DEFAULT);
 
   return (
-    <div className="flex w-full gap-3 rounded border border-negative-400 bg-base-white px-6 py-4">
+    <div
+      data-testid="avatar-uploader-error-content"
+      className="flex w-full gap-3 rounded border border-negative-400 bg-base-white px-6 py-4"
+    >
       <div className="mb-2 w-10">
         <div className="flex items-start justify-center rounded-full bg-negative-100 p-[0.25rem]">
           <div className="flex items-start justify-center rounded-full bg-negative-200 p-[0.25rem] text-negative-400">

--- a/src/components/v5/common/Pills/PillsBase.tsx
+++ b/src/components/v5/common/Pills/PillsBase.tsx
@@ -15,11 +15,13 @@ const PillsBase: FC<PropsWithChildren<PillsProps>> = ({
   pillSize = 'medium',
   isCapitalized = true,
   textClassName,
+  testId,
 }) => {
   const content = text || children;
 
   return (
     <span
+      data-testid={testId}
       className={clsx(
         'inline-flex shrink-0 items-center rounded-3xl px-[9px] py-1.5 text-center',
         className,

--- a/src/components/v5/common/Pills/types.ts
+++ b/src/components/v5/common/Pills/types.ts
@@ -47,6 +47,7 @@ export interface PillsProps {
   textClassName?: string;
   isIconVisible?: boolean;
   isCapitalized?: boolean;
+  testId?: string;
 }
 
 export interface UserStakeStatusBadgeProps extends Omit<PillsProps, 'mode'> {


### PR DESCRIPTION
## Description

E2e tests for Advanced Payment. Also updated playwright to the latest version. 
Test cases included in the PR:
- Happy path of Advanced payment (Permissions and Staking method)
- Canceling the Advanced payment 
- Form fields validation
- Recipients table actions - Add/Remove/Duplicate row
- Uploading CSV - Happy path
- Uploading CSV - invalid field values/missing values 
- Uploading CSV of invalid format

The playwright package version has been upgraded in this PR. 
Please run `npm run e2e:install` and `npm install`. 

## Testing

**Step 1**. Spin up the dev env and seed the test data 

`npm run dev`  followed by `node scripts/create-data.js`

**Step 2 (optional)**. Remove your local playwright trace files

 `rm -rf playwright-report/` (from the root of the project )

**Step 3**. Build and start the frontend in preview mode

`npm run preview` 

**Step 4.** Run the tests in a separate terminal 

`npm run e2e advanced-payment`

**Step 5**. The tests should pass ( if any failures - please send me .zip files from `/playwright-report/data` directory)



(Resolves | Contributes to) #31415
