### PR TITLE
Fix: Clear invalid decision method and prevent Staged Payment form crash

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/StagedPaymentsDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/StagedPaymentsDescription.tsx
@@ -20,7 +20,7 @@ const displayName =
 export const StagedPaymentsDescription = () => {
   const allTokens = useGetAllTokens();
   const formValues = useFormContext<StagedPaymentFormValues>().getValues();
-  const { recipient, stages } = formValues;
+  const { recipient, stages = [] } = formValues;
 
   if (!recipient) {
     return (
@@ -46,12 +46,13 @@ export const StagedPaymentsDescription = () => {
   }, BigNumber.from('0'));
 
   const tokensCount = stages.reduce((acc, { tokenAddress }) => {
-    return acc + (tokenAddress !== stages[0].tokenAddress ? 1 : 0);
+    return acc + (tokenAddress !== stages[0]?.tokenAddress ? 1 : 0);
   }, 1);
   const stagedPaymentTokenSymbol =
     tokensCount === 1 &&
-    allTokens.find(({ token }) => token.tokenAddress === stages[0].tokenAddress)
-      ?.token.symbol;
+    allTokens.find(
+      ({ token }) => token.tokenAddress === stages[0]?.tokenAddress,
+    )?.token.symbol;
 
   return (
     <FormattedMessage

--- a/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx
@@ -1,6 +1,6 @@
 import { Scales } from '@phosphor-icons/react';
-import React from 'react';
-import { useWatch } from 'react-hook-form';
+import React, { useEffect } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
@@ -10,7 +10,10 @@ import { DecisionMethod } from '~types/actions.ts';
 import { extractColonyRoles } from '~utils/colonyRoles.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
-import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
+import {
+  ACTION_TYPE_FIELD_NAME,
+  DECISION_METHOD_FIELD_NAME,
+} from '~v5/common/ActionSidebar/consts.ts';
 import { actionsWithStakingDecisionMethod } from '~v5/common/ActionSidebar/hooks/permissions/consts.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import { FormCardSelect } from '~v5/common/Fields/CardSelect/index.ts';
@@ -41,6 +44,10 @@ const DecisionMethodField = ({
   );
 
   const hasNoDecisionMethods = useHasNoDecisionMethods();
+
+  const decisionMethod = useWatch({ name: DECISION_METHOD_FIELD_NAME });
+
+  const { setValue } = useFormContext();
 
   const {
     isVotingReputationEnabled,
@@ -99,6 +106,18 @@ const DecisionMethodField = ({
     return decisionMethods;
   };
 
+  const isDecisionMethodAvailable = getDecisionMethods()
+    .map((decision) => decision.value)
+    .includes(decisionMethod);
+
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      if (!isDecisionMethodAvailable) {
+        setValue(DECISION_METHOD_FIELD_NAME, undefined);
+      }
+    });
+  }, [isDecisionMethodAvailable, setValue]);
+
   return (
     <ActionFormRow
       icon={Scales}
@@ -122,6 +141,9 @@ const DecisionMethodField = ({
         })}
         disabled={disabled || hasNoDecisionMethods}
         cardClassName="sm:min-w-[12.875rem]"
+        {...(!isDecisionMethodAvailable && {
+          valueOverride: undefined,
+        })}
       />
     </ActionFormRow>
   );

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/PaymentBuilderForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/PaymentBuilderForm.tsx
@@ -5,8 +5,6 @@ import { DecisionMethod } from '~types/actions.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
-import useFilterCreatedInField from '~v5/common/ActionSidebar/hooks/useFilterCreatedInField.ts';
-import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
 import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
 import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
 import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/index.ts';
@@ -20,8 +18,6 @@ const displayName = 'v5.common.ActionSidebar.partials.PaymentBuilderForm';
 const PaymentBuilderForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
   const { renderStakedExpenditureModal } = usePaymentBuilder(getFormOptions);
   const hasNoDecisionMethods = useHasNoDecisionMethods();
-
-  const createdInFilterFn = useFilterCreatedInField('from');
 
   return (
     <>
@@ -46,7 +42,6 @@ const PaymentBuilderForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
           ![DecisionMethod.Reputation, DecisionMethod.MultiSig].includes(value)
         }
       />
-      <CreatedIn filterOptionsFn={createdInFilterFn} />
       <Description />
       <PaymentBuilderRecipientsField name="payments" />
       {renderStakedExpenditureModal()}

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/SplitPaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/SplitPaymentForm.tsx
@@ -6,10 +6,8 @@ import { DecisionMethod } from '~types/actions.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
-import useFilterCreatedInField from '~v5/common/ActionSidebar/hooks/useFilterCreatedInField.ts';
 import AmountRow from '~v5/common/ActionSidebar/partials/AmountRow/AmountRow.tsx';
 import { distributionMethodOptions } from '~v5/common/ActionSidebar/partials/consts.tsx';
-import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/index.ts';
 import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/index.ts';
 import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
 import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/index.ts';
@@ -30,7 +28,6 @@ const SplitPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
   const { watch, trigger } = useFormContext();
   const selectedTeam = watch('team');
 
-  const createdInFilterFn = useFilterCreatedInField('team');
   const decisionMethodFilterFn = createUnsupportedDecisionMethodFilter([
     DecisionMethod.Reputation,
     DecisionMethod.MultiSig,
@@ -103,7 +100,6 @@ const SplitPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
         <TeamsSelect name="team" disabled={hasNoDecisionMethods} />
       </ActionFormRow>
       <DecisionMethodField filterOptionsFn={decisionMethodFilterFn} />
-      <CreatedIn filterOptionsFn={createdInFilterFn} />
       <Description />
       {currentToken && (
         <SplitPaymentRecipientsField

--- a/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/StagedPaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/StagedPaymentForm.tsx
@@ -9,7 +9,6 @@ import {
   RECIPIENT_FIELD_NAME,
 } from '~v5/common/ActionSidebar/consts.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
-import CreatedIn from '~v5/common/ActionSidebar/partials/CreatedIn/CreatedIn.tsx';
 import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx';
 import Description from '~v5/common/ActionSidebar/partials/Description/Description.tsx';
 import { useIsFieldDisabled } from '~v5/common/ActionSidebar/partials/hooks.ts';
@@ -77,7 +76,6 @@ const StagedPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
         filterOptionsFn={decisionMethodFilterFn}
         disabled={isFieldDisabled}
       />
-      <CreatedIn disabled={isFieldDisabled} />
       <Description disabled={isFieldDisabled} />
       <StagedPaymentRecipientsField name="stages" />
       {renderStakedExpenditureModal()}


### PR DESCRIPTION
## Description

The issue was that the Reputation decision method isn't available for the Advanced, Split & Staged payment forms. So this PR clears the decision method field if the form attempts to set it to an unavailable decision method.

I also took the liberty of removing the `<CreatedIn />` component from the aforementioned forms because I thought they were redundant. But if I'm wrong in my assumption, do let me know and I'll bring them back.

This PR also includes a crash fix raised in #3892.

![decision-method-reset](https://github.com/user-attachments/assets/d3790591-2382-49c3-8330-97b249babb95)

## Testing

1. Enable the Reputation extension
2. Create a Simple Payment action via the Reputation decision method
3. Redo this action
4. Change the action to Advanced payments/Split payments/Staged payments
5. Submit the form
6. Verify that you see the validation error for the decision method field

Resolves #3889 , #3892