### PR TITLE
Fix: Solve fetchDomainBalance lambda issues

### DIFF
--- a/amplify/backend/api/colonycdapp/schema/balance.graphql
+++ b/amplify/backend/api/colonycdapp/schema/balance.graphql
@@ -15,13 +15,9 @@ input DomainBalanceArguments {
   """
   domainId: String
   """
-  The chain id the colony is on
-  """
-  chainId: String
-  """
   The currency in which we want to exchange the in/out token balance
   """
-  selectedCurrency: ExtendedSupportedCurrencies 
+  selectedCurrency: ExtendedSupportedCurrencies
   """
   The timeframe type (day/week/month/total) for which we want to get the in/out token balance
   Defaults to TimeframeType.MONTHLY
@@ -56,7 +52,7 @@ Return type for domain balance for a timeframe item
 type TimeframeDomainBalanceInOut {
   """
   The timeframe item key representing a day/week/month based on the selected timeframeType
-  """  
+  """
   key: String!
   """
   The timeframe item value holding the computed values
@@ -65,7 +61,7 @@ type TimeframeDomainBalanceInOut {
 }
 
 """
-Return type for domain balance 
+Return type for domain balance
 """
 type DomainBalanceReturn {
   """
@@ -109,7 +105,12 @@ type TokenExchangeRate @model {
   """
   Unique identifier for the token id
   """
-  tokenId: String! @index(name: "byTokenId", queryField: "tokenExhangeRateByTokenId", sortKeyFields: ["date"], )
+  tokenId: String!
+    @index(
+      name: "byTokenId"
+      queryField: "tokenExhangeRateByTokenId"
+      sortKeyFields: ["date"]
+    )
   """
   Exchange timestamp
   """
@@ -131,7 +132,12 @@ type CacheTotalBalance @model {
   """
   Address of the colony on the blockchain
   """
-  colonyAddress: ID! @index(name: "byColonyAddress", queryField: "cacheTotalBalanceByColonyAddress", sortKeyFields: ["date"] )
+  colonyAddress: ID!
+    @index(
+      name: "byColonyAddress"
+      queryField: "cacheTotalBalanceByColonyAddress"
+      sortKeyFields: ["date"]
+    )
   """
   Domain id within a colony
   """

--- a/amplify/backend/function/fetchDomainBalance/src/api/graphql/operations.js
+++ b/amplify/backend/function/fetchDomainBalance/src/api/graphql/operations.js
@@ -207,7 +207,8 @@ const getTokensDecimalsFor = async (tokenAddresses) => {
   );
 
   tokenResponses.forEach((tokenResponse) => {
-    const { id, decimals } = tokenResponse?.data?.getToken || {};
+    const { id, decimals } =
+      tokenResponse?.data?.getTokenFromEverywhere?.items?.[0] || {};
     tokenDecimals[id] = decimals;
   });
 

--- a/amplify/backend/function/fetchDomainBalance/src/api/graphql/schemas.js
+++ b/amplify/backend/function/fetchDomainBalance/src/api/graphql/schemas.js
@@ -218,10 +218,12 @@ module.exports = {
     }
   `,
   getToken: /* GraphQL */ `
-    query GetToken($tokenAddress: ID!) {
-      getToken(id: $tokenAddress) {
-        id
-        decimals
+    query GetTokenFromEverywhere($tokenAddress: String!) {
+      getTokenFromEverywhere(input: { tokenAddress: $tokenAddress }) {
+        items {
+          id
+          decimals
+        }
       }
     }
   `,

--- a/amplify/backend/function/fetchDomainBalance/src/config/networkConfig.js
+++ b/amplify/backend/function/fetchDomainBalance/src/config/networkConfig.js
@@ -7,18 +7,23 @@ const {
   NETWORK_DATA,
 } = require('../consts');
 
+const DEFAULT_NETWORK = SupportedNetwork.ArbitrumOne;
+
 const NetworkConfig = (() => {
   return {
     getConfig: async () => {
       const { network } = await EnvVarsConfig.getEnvVars();
-      const supportedNetwork = ColonyJSNetworkMapping[network] || network;
+      const resolvedNetwork = ColonyJSNetworkMapping[network] || network;
+
+      const DEFAULT_NETWORK_TOKEN =
+        TOKEN_DATA[resolvedNetwork] || TOKEN_DATA[DEFAULT_NETWORK];
+      const DEFAULT_NETWORK_INFO =
+        NETWORK_DATA[resolvedNetwork] || NETWORK_DATA[DEFAULT_NETWORK];
 
       return {
-        DEFAULT_NETWORK_TOKEN:
-          TOKEN_DATA[supportedNetwork] ?? TOKEN_DATA[SupportedNetwork.Ganache],
-        DEFAULT_NETWORK_INFO:
-          NETWORK_DATA[supportedNetwork] ??
-          NETWORK_DATA[SupportedNetwork.Ganache],
+        DEFAULT_NETWORK_TOKEN,
+        DEFAULT_NETWORK_INFO,
+        supportedNetwork: resolvedNetwork || DEFAULT_NETWORK,
       };
     },
   };

--- a/amplify/backend/function/fetchDomainBalance/src/index.js
+++ b/amplify/backend/function/fetchDomainBalance/src/index.js
@@ -26,7 +26,6 @@ exports.handler = async (event) => {
     const {
       colonyAddress,
       domainId,
-      chainId,
       selectedCurrency,
       timeframePeriod = 4,
       timeframeType,
@@ -74,7 +73,6 @@ exports.handler = async (event) => {
     const exchangeRates = await ExchangeRatesService.getExchangeRates(
       getTokensDatesMap(inOutActionsWithinTimeframe),
       selectedCurrency,
-      chainId,
     );
 
     const inOutPeriodBalance = {};
@@ -104,7 +102,6 @@ exports.handler = async (event) => {
         timeframePeriodEndDate,
         domainId,
         selectedCurrency,
-        chainId,
       });
       return {
         totalIn: timeframeTotalIn.toString(),

--- a/amplify/backend/function/fetchDomainBalance/src/services/networkBalance.js
+++ b/amplify/backend/function/fetchDomainBalance/src/services/networkBalance.js
@@ -169,7 +169,6 @@ const getNetworkTotalBalance = async ({
   domainId,
   timeframePeriodEndDate,
   selectedCurrency,
-  chainId,
 }) => {
   const { DEFAULT_NETWORK_INFO } = await NetworkConfig.getConfig();
   const averageBlockTime = DEFAULT_NETWORK_INFO.blockTime;
@@ -222,7 +221,6 @@ const getNetworkTotalBalance = async ({
   const exchangeRates = await ExchangeRatesService.getExchangeRates(
     getTokensDatesMap(balances),
     selectedCurrency,
-    chainId,
   );
 
   return getTotalFiatAmountFor(balances, exchangeRates);

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -2195,8 +2195,6 @@ export type Domain = {
 
 /** Input data for fetching domain balance in/out values within a specific timeframe */
 export type DomainBalanceArguments = {
-  /** The chain id the colony is on */
-  chainId?: InputMaybe<Scalars['String']>;
   /** Address of the colony on the blockchain */
   colonyAddress: Scalars['String'];
   /** Domain id within a colony */
@@ -2228,7 +2226,7 @@ export type DomainBalanceInOut = {
   totalOut?: Maybe<Scalars['String']>;
 };
 
-/** Return type for domain balance  */
+/** Return type for domain balance */
 export type DomainBalanceReturn = {
   __typename?: 'DomainBalanceReturn';
   timeframe?: Maybe<Array<Maybe<TimeframeDomainBalanceInOut>>>;


### PR DESCRIPTION
## Description

There were some issues discovered while doing the prod deployment, causing for the displayed values to be always `0`.
The main one was due to the used fallback value for the `chainId` property. Given we don't really want to be a parametrisable property, this value has been removed from the lambda's input values. Also, given we want to use this value to filter out the coins list from `CoinGecko` this value has been renamed to `supportedNetwork` and will be set in `NetworkConfig`.

Another issue we might face is not having the token used for an action already stored in the DB - which we need to determine the number of decimals - so, we should use the `getTokenFromEverywhere`. This query relies on the `fetchTokenFromChain` lambda that will try to find the token if it is not already stored and then save it in the `DB`.

Introduced `apiTokenIdsData` in `ExchangeRatesService` only for optimisation, in order not to make extra calls for getting the whole coins list from `CoinGecko`.

Added the usage of the checksummed token address only to prevent some errors. 

As a summary, the following issues for the **fetchDomainBalance** lambda were fixed in this PR

- Remove chainId argument
- Use checksummed token address
- Replace chainId usage with the resolved network variable 
- Replace getToken with getTokenFromEverywhere query

## Testing

TODO: Just make sure the values shown for the `Total` cards and the `Total in and out` cards are still properly shown. 
You can also try running this query 

```
query MyQuery {
  getDomainBalance(
    input: {colonyAddress: "<COLONY_ADDRESS_HERE>", timeframePeriod: 4, timeframeType: DAILY}
  ) {
    total
    totalIn
    totalOut
    timeframe {
      key
      value {
        total
        totalIn
        totalOut
      }
    }
  }
}
```

Please also try changing the `query`'s input values and make sure everything still works as expected ✨ 
