### PR TITLE
Fix: Styling when only 1 funding motion

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingRequests/FundingRequestItem.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingRequests/FundingRequestItem.tsx
@@ -9,7 +9,10 @@ import useGetColonyAction from '~v5/common/ActionSidebar/hooks/useGetColonyActio
 
 import { type FundingRequestItemProps } from './types.ts';
 
-const FundingRequestItem: FC<FundingRequestItemProps> = ({ action }) => {
+const FundingRequestItem: FC<FundingRequestItemProps> = ({
+  action,
+  isOnlyItem,
+}) => {
   const { motionState, loadingAction } = useGetColonyAction(
     action.transactionHash,
   );
@@ -27,8 +30,9 @@ const FundingRequestItem: FC<FundingRequestItemProps> = ({ action }) => {
       className={clsx(
         'group flex w-full items-center justify-between outline-none transition-all',
         {
-          'text-blue-400': isSelected,
-          'text-gray-600': !isSelected,
+          'text-blue-400': isSelected && !isOnlyItem,
+          'text-gray-600 hover:text-blue-400': !isSelected || isOnlyItem,
+          'cursor-default': isOnlyItem,
         },
       )}
       onClick={() => {
@@ -37,7 +41,7 @@ const FundingRequestItem: FC<FundingRequestItemProps> = ({ action }) => {
     >
       <span
         className={clsx('text-sm', {
-          underline: isSelected,
+          underline: isSelected && !isOnlyItem,
         })}
       >
         <FormattedDate

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingRequests/FundingRequests.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingRequests/FundingRequests.tsx
@@ -20,7 +20,10 @@ const FundingRequests: FC<FundingRequestsProps> = ({ actions }) => {
       <ul className="max-h-[6.25rem] overflow-y-auto overflow-x-hidden">
         {actions.map((action) => (
           <li className="mb-2 w-full last:mb-0" key={action.transactionHash}>
-            <FundingRequestItem action={action} />
+            <FundingRequestItem
+              action={action}
+              isOnlyItem={actions.length === 1}
+            />
           </li>
         ))}
       </ul>

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingRequests/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FundingRequests/types.ts
@@ -6,4 +6,5 @@ export interface FundingRequestsProps {
 
 export interface FundingRequestItemProps {
   action: ExpenditureAction;
+  isOnlyItem: boolean;
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where the FundingRequestItem would appear as though it were a link when there is only 1 item in the list.

## Testing

* Step 1 - Install the weighted voting reputation extension
* Step 2 - Create an advanced payment
* Step 3 - Proceed to the funding stage and create a motion to fund the payment
* Step 4 - Check the date is styled with grey text and no underline
 
![Screenshot 2024-12-11 at 18 40 22](https://github.com/user-attachments/assets/c65b3fa2-0121-488d-9d65-090ecc6c2a1f)

* Step 5 - Stake both sides, then reject the motion
* Step 6 - Start a second funding motion (note if the funding button gets stuck after finalizing the first motion, it is unrelated to this PR and will required a refresh to fix)
* Step 7 - Check the date for the new selected motion is styled with blue text and an underline, and that the old motion is styled with grey text and changes to blue hovered.

![Screenshot 2024-12-11 at 18 45 16](https://github.com/user-attachments/assets/4a3ab55b-f990-4723-920d-eb74ed768a8d)

## Diffs

**Changes** 🏗

* Added new `isOnlyItem` prop to FundingItem and changed styling

Resolves #3776
