### PR TITLE
Fix: Show no permissions validation for expenditures without multisig

### DIFF
--- a/src/components/v5/common/ActionSidebar/hooks/permissions/consts.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/consts.ts
@@ -6,6 +6,12 @@ export const actionsWithoutReputationDecisionMethod = [
   Action.SplitPayment,
 ];
 
+export const actionsWithoutMultiSigDecisionMethod = [
+  Action.PaymentBuilder,
+  Action.StagedPayment,
+  Action.SplitPayment,
+];
+
 export const actionsWithStakingDecisionMethod = [
   Action.PaymentBuilder,
   Action.StagedPayment,

--- a/src/components/v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts
@@ -11,6 +11,7 @@ import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 
 import {
   actionsWithStakingDecisionMethod,
+  actionsWithoutMultiSigDecisionMethod,
   actionsWithoutReputationDecisionMethod,
 } from './consts.ts';
 import {
@@ -46,7 +47,7 @@ const useHasNoDecisionMethods = () => {
     return true;
   }
 
-  // User can't use reputation to create Payment builder or split payment action
+  // User can't use reputation to create certain actions
   if (
     isVotingReputationEnabled &&
     !actionsWithoutReputationDecisionMethod.includes(actionType)
@@ -65,6 +66,9 @@ const useHasNoDecisionMethods = () => {
   if (!requiredPermissions) {
     return false;
   }
+
+  const actionSupportsMultisig =
+    !actionsWithoutMultiSigDecisionMethod.includes(actionType);
 
   const requiredRolesDomain = getPermissionsDomainIdForAction(actionType, {});
 
@@ -120,14 +124,16 @@ const useHasNoDecisionMethods = () => {
           };
         }
 
+        // Check if the user has the role or multisig role in any domain
         // @TODO: If an action requires multiple permissions (Simple Payment) then all the roles need to be in the same domain
         // This would require reworking `userRoles` and `userMultiSigRoles` to group roles by domain
+        const userHasRole = rolesToCheck.userRoles.includes(role);
+        const userHasMultiSigRole =
+          isMultiSigEnabled &&
+          actionSupportsMultisig &&
+          rolesToCheck.userMultiSigRoles.includes(role);
 
-        // Check if the user has the role in any domain
-        return (
-          rolesToCheck.userRoles.includes(role) ||
-          (isMultiSigEnabled && rolesToCheck.userMultiSigRoles.includes(role))
-        );
+        return userHasRole || userHasMultiSigRole;
       });
     })
   ) {

--- a/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx
@@ -14,7 +14,11 @@ import {
   ACTION_TYPE_FIELD_NAME,
   DECISION_METHOD_FIELD_NAME,
 } from '~v5/common/ActionSidebar/consts.ts';
-import { actionsWithStakingDecisionMethod } from '~v5/common/ActionSidebar/hooks/permissions/consts.ts';
+import {
+  actionsWithStakingDecisionMethod,
+  actionsWithoutMultiSigDecisionMethod,
+  actionsWithoutReputationDecisionMethod,
+} from '~v5/common/ActionSidebar/hooks/permissions/consts.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import { FormCardSelect } from '~v5/common/Fields/CardSelect/index.ts';
 
@@ -29,7 +33,6 @@ const DecisionMethodField = ({
   reputationOnly,
   disabled,
   tooltipContent = 'actionSidebar.tooltip.decisionMethod',
-  filterOptionsFn,
 }: DecisionMethodFieldProps) => {
   const { colony } = useColonyContext();
   const { user } = useAppContext();
@@ -57,11 +60,20 @@ const DecisionMethodField = ({
   const actionType = useWatch({ name: ACTION_TYPE_FIELD_NAME });
 
   const shouldShowPermissions = !reputationOnly && userRoles.length > 0;
+
+  const shouldShowReputation =
+    isVotingReputationEnabled &&
+    !actionsWithoutReputationDecisionMethod.includes(actionType);
+
   const shouldShowStaking =
     isStakedExpenditureEnabled &&
     actionsWithStakingDecisionMethod.includes(actionType);
+
   const shouldShowMultiSig =
-    !reputationOnly && isMultiSigEnabled && userMultiSigRoles.length > 0;
+    !reputationOnly &&
+    isMultiSigEnabled &&
+    !actionsWithoutMultiSigDecisionMethod.includes(actionType) &&
+    userMultiSigRoles.length > 0;
 
   const getDecisionMethods = () => {
     const decisionMethods: DecisionMethodOption[] = [
@@ -73,7 +85,7 @@ const DecisionMethodField = ({
             },
           ]
         : []),
-      ...(isVotingReputationEnabled
+      ...(shouldShowReputation
         ? [
             {
               label: formatText({ id: 'decisionMethod.reputation' }),
@@ -98,10 +110,6 @@ const DecisionMethodField = ({
           ]
         : []),
     ];
-
-    if (filterOptionsFn) {
-      return decisionMethods?.filter(filterOptionsFn);
-    }
 
     return decisionMethods;
   };

--- a/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/types.ts
+++ b/src/components/v5/common/ActionSidebar/partials/DecisionMethodField/types.ts
@@ -9,5 +9,4 @@ export interface DecisionMethodFieldProps {
   reputationOnly?: boolean;
   disabled?: boolean;
   tooltipContent?: string;
-  filterOptionsFn?: (option: DecisionMethodOption) => boolean;
 }

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/PaymentBuilderForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/PaymentBuilderForm.tsx
@@ -1,7 +1,6 @@
 import { UsersThree } from '@phosphor-icons/react';
 import React, { type FC } from 'react';
 
-import { DecisionMethod } from '~types/actions.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
@@ -36,12 +35,7 @@ const PaymentBuilderForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       >
         <TeamsSelect name="from" disabled={hasNoDecisionMethods} />
       </ActionFormRow>
-      <DecisionMethodField
-        // @TODO remove MultiSig once we add support for multisig advanced payments
-        filterOptionsFn={({ value }) =>
-          ![DecisionMethod.Reputation, DecisionMethod.MultiSig].includes(value)
-        }
-      />
+      <DecisionMethodField />
       <Description />
       <PaymentBuilderRecipientsField name="payments" />
       {renderStakedExpenditureModal()}

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/SplitPaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/SplitPaymentForm.tsx
@@ -2,7 +2,6 @@ import { ChartPieSlice, UsersThree } from '@phosphor-icons/react';
 import React, { useEffect, type FC } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { DecisionMethod } from '~types/actions.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
@@ -12,7 +11,6 @@ import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMetho
 import Description from '~v5/common/ActionSidebar/partials/Description/index.ts';
 import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/index.ts';
 import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
-import { createUnsupportedDecisionMethodFilter } from '~v5/common/ActionSidebar/utils.ts';
 import { FormCardSelect } from '~v5/common/Fields/CardSelect/index.ts';
 
 import { useSplitPayment } from './hooks.ts';
@@ -27,11 +25,6 @@ const SplitPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
 
   const { watch, trigger } = useFormContext();
   const selectedTeam = watch('team');
-
-  const decisionMethodFilterFn = createUnsupportedDecisionMethodFilter([
-    DecisionMethod.Reputation,
-    DecisionMethod.MultiSig,
-  ]);
 
   useEffect(() => {
     const subscription = watch((_, { name: fieldName = '', type }) => {
@@ -99,7 +92,7 @@ const SplitPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       >
         <TeamsSelect name="team" disabled={hasNoDecisionMethods} />
       </ActionFormRow>
-      <DecisionMethodField filterOptionsFn={decisionMethodFilterFn} />
+      <DecisionMethodField />
       <Description />
       {currentToken && (
         <SplitPaymentRecipientsField

--- a/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/StagedPaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/StagedPaymentForm.tsx
@@ -1,7 +1,6 @@
 import { UserFocus, UsersThree } from '@phosphor-icons/react';
 import React, { type FC } from 'react';
 
-import { DecisionMethod } from '~types/actions.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/ActionFormRow.tsx';
 import {
@@ -15,7 +14,6 @@ import { useIsFieldDisabled } from '~v5/common/ActionSidebar/partials/hooks.ts';
 import TeamsSelect from '~v5/common/ActionSidebar/partials/TeamsSelect/TeamsSelect.tsx';
 import UserSelect from '~v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx';
 import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
-import { createUnsupportedDecisionMethodFilter } from '~v5/common/ActionSidebar/utils.ts';
 
 import { useStagePayment } from './hooks.ts';
 import StagedPaymentRecipientsField from './partials/StagedPaymentRecipientsField/StagedPaymentRecipientField.tsx';
@@ -28,11 +26,6 @@ const StagedPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
   const { renderStakedExpenditureModal } = useStagePayment(getFormOptions);
 
   const isFieldDisabled = useIsFieldDisabled();
-
-  const decisionMethodFilterFn = createUnsupportedDecisionMethodFilter([
-    DecisionMethod.MultiSig,
-    DecisionMethod.Reputation,
-  ]);
 
   return (
     <>
@@ -72,10 +65,7 @@ const StagedPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
           disabled={hasNoDecisionMethods || isFieldDisabled}
         />
       </ActionFormRow>
-      <DecisionMethodField
-        filterOptionsFn={decisionMethodFilterFn}
-        disabled={isFieldDisabled}
-      />
+      <DecisionMethodField disabled={isFieldDisabled} />
       <Description disabled={isFieldDisabled} />
       <StagedPaymentRecipientsField name="stages" />
       {renderStakedExpenditureModal()}

--- a/src/components/v5/common/ActionSidebar/utils.ts
+++ b/src/components/v5/common/ActionSidebar/utils.ts
@@ -1,7 +1,6 @@
 import { apolloClient } from '~apollo';
 import { type Action } from '~constants/actions.ts';
 import { SearchActionsDocument } from '~gql';
-import { type DecisionMethod } from '~types/actions.ts';
 import { type ColonyAction, ColonyActionType } from '~types/graphql.ts';
 import { isQueryActive } from '~utils/isQueryActive.ts';
 import {
@@ -79,8 +78,3 @@ export const handleMotionCompleted = (action: ColonyAction) => {
     }
   }
 };
-
-export const createUnsupportedDecisionMethodFilter =
-  (unsupportedDecisionMethods: DecisionMethod[] = []) =>
-  ({ value }: { value: DecisionMethod }) =>
-    !unsupportedDecisionMethods.includes(value);


### PR DESCRIPTION
## Description

This PR fixes an edge case issue where users with multi-sig permissions would be able to access the expenditure actions when the staking advanced payments is uninstalled and there are no decision methods available.

## Testing

* Step 1 - Uninstall the staking advanced payments extension
* Step 2 - Install the staged payments extension
* Step 3 - Install the multi-sig extension
* Step 4 - Assign Owner multisig permissions to Fry
* Step 5 - Switch to the Fry wallet
* Step 6 - Create an advanced payment action, observe the "no permissions" validation error

![Screenshot 2024-12-11 at 20 00 51](https://github.com/user-attachments/assets/03e9d4f6-2af9-4956-a23d-b7382306b16e)

* Step 7 - Check the same is true for split payments and staged payments

![Screenshot 2024-12-11 at 20 01 01](https://github.com/user-attachments/assets/2ffa316e-4446-4007-8e77-779879d535fe)

![Screenshot 2024-12-11 at 20 01 13](https://github.com/user-attachments/assets/d72c4233-ae0d-45f0-86a3-1bc20d5e1cd4)

* Step 8 - Reinstall the staking advanced payments extension and check the decision method is available

![Screenshot 2024-12-11 at 20 02 33](https://github.com/user-attachments/assets/fcbe2f5a-06e8-4dc0-81e3-71fe9659b53f)


## Diffs

**New stuff** ✨

* Added an `actionsWithoutMultiSigDecisionMethod` const

**Changes** 🏗

* Added check for if action supports multisig in useHasNoDecisionMethods hook

**Deletions** ⚰️

* Removed filterOptionFn from DecisionMethodField in favour of using the "actionsWithout" consts as the source of truth

Resolves #3771
