### PR TITLE
Fix: Username change is not reflected in colony

### DIFF
--- a/src/utils/members.ts
+++ b/src/utils/members.ts
@@ -59,7 +59,7 @@ const updateContributorQueries = (
       const modifiedContributors = data.searchColonyContributors.items.map(
         (contributor) => {
           if (!contributor) {
-            return contributor;
+            return null;
           }
 
           const contributorData = updatedContributors.find(
@@ -67,11 +67,24 @@ const updateContributorQueries = (
               contributorEntry.userAddress === contributor.contributorAddress,
           );
 
-          if (!contributorData) {
+          if (!contributorData || !contributor.user) {
             return contributor;
           }
 
-          return merge({ ...contributor }, contributorData.newData);
+          const mergedProfile = merge(
+            { ...contributor.user.profile },
+            contributorData.newData.user?.profile,
+          );
+
+          const updatedContributor = {
+            ...contributor,
+            user: {
+              ...contributor.user,
+              profile: mergedProfile,
+            },
+          };
+
+          return updatedContributor;
         },
       );
 
@@ -97,16 +110,26 @@ const updateContributorQueries = (
       (
         data: GetColonyContributorQuery | null,
       ): GetColonyContributorQuery | null => {
-        if (!data?.getColonyContributor) {
+        if (!data?.getColonyContributor || !data.getColonyContributor.user) {
           return null;
         }
 
+        const mergedProfile = merge(
+          { ...data.getColonyContributor.user.profile },
+          newData.user?.profile,
+        );
+
+        const updatedContributor = {
+          ...data.getColonyContributor,
+          user: {
+            ...data.getColonyContributor.user,
+            profile: mergedProfile,
+          },
+        };
+
         return {
           ...data,
-          getColonyContributor: merge(
-            { ...data.getColonyContributor },
-            newData,
-          ),
+          getColonyContributor: updatedContributor,
         };
       },
     );


### PR DESCRIPTION
## Description

This PR fixes an issue with the username not correctly updating within a colony if you had previously loaded that colony.

## Testing

Before testing, we need to adjust the code to work around the 90 day username change restriction. Open up this file: `src/components/frame/v5/pages/UserProfilePage/partials/UserAccountPage/hooks.tsx` and change line 31 to `return { canChangeUsername: true, daysTillUsernameChange };`.

* Step 1 - Navigate to the planex dashboard: http://localhost:9091/planex
* Step 2 - Without refreshing, navigate to the manage account page

![Screenshot 2024-12-12 at 16 25 14](https://github.com/user-attachments/assets/68bf10e0-3147-415c-9edb-1dfcd5d2e5e0)

* Step 3 - Change the username to something new and click save changes. Notice the success toast.

![Screenshot 2024-12-12 at 16 27 43](https://github.com/user-attachments/assets/d94862f8-8a05-47d5-a94a-9832bd7fba68)

* Step 4 - Without refreshing, navigate back to the colony and go to the members page. Check the name has changed.

![Screenshot 2024-12-12 at 16 28 49](https://github.com/user-attachments/assets/7baf6c29-d026-44d6-b97e-b64474ba4911)

## Diffs

**Changes** 🏗

* Fixed issue with the object merge

Resolves #3735
