### PR TITLE
Fix: Staged payments with locked tokens

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/MilestoneReleaseModal.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/MilestoneReleaseModal.tsx
@@ -208,6 +208,14 @@ const MilestoneReleaseModal: FC<MilestoneReleaseModalProps> = ({
   });
 
   const onSubmit = async ({ decisionMethod }) => {
+    const tokenAddresses: string[] = [];
+
+    items.forEach((item) => {
+      if (!tokenAddresses.includes(item.tokenAddress)) {
+        tokenAddresses.push(item.tokenAddress);
+      }
+    });
+
     try {
       const motionPayload: ReleaseExpenditureStagesMotionPayload = {
         colonyAddress: colony.colonyAddress,
@@ -217,12 +225,12 @@ const MilestoneReleaseModal: FC<MilestoneReleaseModalProps> = ({
         expenditure,
         slotIds: items.map(({ slotId }) => slotId),
         motionDomainId: expenditure.nativeDomainId,
-        tokenAddresses: [colony.nativeToken.tokenAddress],
+        tokenAddresses,
       };
       const payload: ReleaseExpenditureStagesPayload = {
         colonyAddress: colony.colonyAddress,
         expenditure,
-        tokenAddresses: [colony.nativeToken.tokenAddress],
+        tokenAddresses,
         stagedExpenditureAddress: stagedExpenditureAddress || '',
         slotIds: items.map(({ slotId }) => slotId),
         userAddress: user?.walletAddress || '',

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/ReleaseActions/ReleaseActionItem.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/ReleaseActions/ReleaseActionItem.tsx
@@ -40,6 +40,10 @@ const ReleaseActionItem: FC<ReleaseActionItemProps> = ({
 
   const isReleasingMultipleMilestones = releasedSlotIds.length > 1;
 
+  const wasSuccessful = expenditure.slots
+    .filter((slot) => releasedSlotIds.includes(slot.id))
+    .every((slot) => slot.payouts?.every((payout) => payout.isClaimed));
+
   return (
     <button
       className="group flex w-full items-center justify-between gap-2"
@@ -63,10 +67,15 @@ const ReleaseActionItem: FC<ReleaseActionItemProps> = ({
       </span>
       {!action.motionData ? (
         <PillsBase
-          className="bg-success-100 text-success-400"
+          className={clsx({
+            'bg-success-100 text-success-400': wasSuccessful,
+            'bg-negative-100 text-negative-400': !wasSuccessful,
+          })}
           isCapitalized={false}
         >
-          {formatText({ id: 'action.passed' })}
+          {wasSuccessful
+            ? formatText({ id: 'action.passed' })
+            : formatText({ id: 'action.failed' })}
         </PillsBase>
       ) : (
         <>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1412,6 +1412,7 @@
     "motion.staking.button.submit": "Stake",
     "motion.staking.chart.thresholdLabel": "Not public until min {value} is staked",
     "action.passed": "Passed",
+    "action.failed": "Failed",
     "motion.voting.label": "Voting",
     "motion.reveal.label": "Reveal",
     "motion.outcome.label": "Outcome",


### PR DESCRIPTION
## Description

- Fix issues with making staged payment using tokens which are not native to your colony.
- Four issues are fixed here:
  - You should not be able to make a staged payment milestone using a token which is locked
  - When using a token for a milestone which is not your colonies native token, it needs to be passed to the transaction for it to be claimed properly (previously only the colony native token was being sent)
  - If a milestone payment failed for whatever reason, the status pill should not show as 'passed'
  - Duplicate milestones were appearing in the sidebar (related to them silently failing)


## Testing

* Open Wayne Enterprises colony and check that the native token (GGG) is locked (this is the default state from the create-data script)
<img width="547" alt="Screenshot 2024-12-12 at 16 35 12" src="https://github.com/user-attachments/assets/1f957e76-244d-4ac5-85a5-b582a4f652a9" />

* Go to the Planet Express colony

* Open the incoming funds table and claim all incoming funds (there should by default be some GGG in there)
<img width="1969" alt="Screenshot 2024-12-12 at 16 46 06" src="https://github.com/user-attachments/assets/ffdc90fb-643e-4809-8364-cd6e32d8390f" />

* Install the staged payments extension

* Make a staged payment, and for at least one of the milestones try to use GGG as the token. You should not be able to create the staged payment and a correct error should be shown.
<img width="671" alt="Screenshot 2024-12-12 at 16 41 53" src="https://github.com/user-attachments/assets/4089b86a-88a6-4117-892f-2d5edae1def4" />

* Go back to Wayne Enterprises and unlock the token using an unlock token action.
<img width="1055" alt="Screenshot 2024-12-12 at 16 44 48" src="https://github.com/user-attachments/assets/75bd7393-b384-4a42-b101-fff38f919087" />

* Return to the Planet Express colony

* Make another staged payment, and again for at least one of the milestones try to use GGG as the token. You should now be able to create the staged payment and no error should be shown.
<img width="1052" alt="Screenshot 2024-12-12 at 16 49 54" src="https://github.com/user-attachments/assets/f88ef71c-ca47-4df9-98e3-1b3e3a1291ab" />

* Go through all the steps in the sidebar of the completed action panel for this staged payment and release all of the milestones (either one by one, or all at once, it shouldn't matter). There should be no issues with this, and no duplicate milestones being shown in the sidebar. 
<img width="1055" alt="Screenshot 2024-12-12 at 16 57 45" src="https://github.com/user-attachments/assets/512afb01-73fa-4f6e-81c6-6ff2d8229f78" />


## Diffs

**Changes** 🏗

* Fixed form validation of staged payments
* Fixed token addresses being passed in the payload to the staged payment saga
* Fixed styling of failed milestone claims for staged payments

Resolves #3899
