### PR TITLE
Fix: Input field should hover to blue

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/AmountField/AmountField.tsx
@@ -169,7 +169,8 @@ const AmountField: FC<AmountFieldProps> = ({
         className={clsx(
           'col-start-1 row-start-1 w-auto min-w-[0.5em] flex-shrink resize-none appearance-none bg-base-white text-md outline-none outline-0',
           {
-            'text-gray-900 placeholder:text-gray-400': !isError && !isDisabled,
+            'text-gray-900 transition-colors placeholder:text-gray-400 md:hover:text-blue-400 md:placeholder:hover:text-blue-400':
+              !isError && !isDisabled,
             'text-gray-400 placeholder:text-gray-300':
               isDisabled && !isTokenSelectionDisabled,
             'text-gray-500 placeholder:text-gray-300':

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/ManageReputationTable.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageReputationForm/partials/ManageReputationTable/ManageReputationTable.tsx
@@ -81,10 +81,10 @@ const ManageReputationTable: FC = () => {
         }}
         disabled={isChangeFieldDisabled}
         name="amount"
-        className={clsx('flex-shrink outline-none outline-0', {
+        className={clsx('flex-shrink bg-transparent outline-none outline-0', {
           'placeholder:text-negative-400': !!error,
-          'bg-transparent placeholder:text-gray-300': isChangeFieldDisabled,
-          'bg-base-white placeholder:text-gray-400':
+          'placeholder:text-gray-300': isChangeFieldDisabled,
+          'transition-colors placeholder:text-gray-400 md:hover:text-blue-400 md:placeholder:hover:text-blue-400':
             !isChangeFieldDisabled && !error,
         })}
         placeholder={formatText({ id: 'actionSidebar.enterValue' })}

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/ClaimDelayField/ClaimDelayField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/partials/ClaimDelayField/ClaimDelayField.tsx
@@ -73,7 +73,8 @@ const ClaimDelayField: FC<ClaimDelayFieldProps> = ({
         className={clsx(
           'col-start-1 row-start-1 w-auto min-w-[0.5em] flex-shrink resize-none appearance-none bg-base-white text-md outline-none outline-0',
           {
-            'text-gray-900 placeholder:text-gray-400': !isError && !disabled,
+            'text-gray-900 transition-colors placeholder:text-gray-400 md:hover:text-blue-400 md:placeholder:hover:text-blue-400':
+              !isError && !disabled,
             'bg-transparent text-gray-400 placeholder:text-gray-300': disabled,
             'text-negative-400 placeholder:text-negative-400':
               !disabled && isError,

--- a/src/components/v5/common/Fields/InputBase/InputBase.tsx
+++ b/src/components/v5/common/Fields/InputBase/InputBase.tsx
@@ -68,6 +68,8 @@ const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
           'w-full bg-transparent text-md outline-0 focus:outline-none',
           {
             'text-gray-900 placeholder:text-gray-400': !disabled,
+            'transition-colors md:hover:text-blue-400 md:placeholder:hover:text-blue-400':
+              state !== FieldState.Error && !disabled,
             'pointer-events-none bg-transparent text-gray-400 placeholder:text-gray-300':
               disabled,
             'rounded border border-gray-300 bg-base-white px-3.5 py-2 focus:border-blue-200 focus:shadow-light-blue':

--- a/src/components/v5/common/Fields/TextareaBase/TextareaBase.tsx
+++ b/src/components/v5/common/Fields/TextareaBase/TextareaBase.tsx
@@ -54,6 +54,8 @@ const TextareaBase = React.forwardRef<HTMLTextAreaElement, TextareaBaseProps>(
             'w-full resize-none bg-base-white text-md outline-none',
             {
               'placeholder:text-gray-400': !disabled,
+              'transition-colors md:hover:text-blue-400 md:placeholder:hover:text-blue-400':
+                state !== FieldState.Error && !disabled,
               'pointer-events-none text-gray-300 placeholder:text-gray-300':
                 disabled,
             },


### PR DESCRIPTION
## Description

What it says on the tin. This PR adds a blue hover state to input fields in the action form.

## Testing

Check the text input fields on all the various actions, check the placeholder hovers to blue and that the text hovers to blue.

This PR does change both the InputBase component and the TextareaBase component, so feels like there could be unintended changes elsewhere in the app, but I could not find any during my testing.

![Screenshot 2024-12-12 at 17 05 27](https://github.com/user-attachments/assets/f9f8fde9-6dd0-42fa-8407-452f351a61a8)

![Screenshot 2024-12-12 at 17 05 39](https://github.com/user-attachments/assets/54891613-78ee-4449-88d1-61d1adbb5510)

![Screenshot 2024-12-12 at 17 06 27](https://github.com/user-attachments/assets/4ec502f2-9627-4f7e-a113-83e5eac7cedd)


## Diffs

**Changes** 🏗

* Add hover state to inputs

Resolves #3740