### PR TITLE
fix: refresh available funds

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/StreamingPayment/partials/StreamingPaymentWidget/StreamingPaymentWidget.tsx
+++ b/src/components/v5/common/CompletedAction/partials/StreamingPayment/partials/StreamingPaymentWidget/StreamingPaymentWidget.tsx
@@ -97,6 +97,14 @@ const StreamingPaymentWidget: FC<StreamingPaymentWidgetProps> = ({
 
   const [hasEnoughFunds, setHasEnoughFunds] = useState(checkIfHasEnoughFunds());
 
+  useEffect(() => {
+    setHasEnoughFunds(checkIfHasEnoughFunds());
+  }, [
+    checkIfHasEnoughFunds,
+    amounts.amountAvailableToClaim,
+    streamingPaymentData,
+  ]);
+
   const claim = useAsyncFunction({
     submit: ActionTypes.STREAMING_PAYMENT_CLAIM,
     error: ActionTypes.STREAMING_PAYMENT_CLAIM_ERROR,

--- a/src/components/v5/common/CompletedAction/partials/StreamingPayment/partials/StreamingPaymentWidget/StreamingPaymentWidget.tsx
+++ b/src/components/v5/common/CompletedAction/partials/StreamingPayment/partials/StreamingPaymentWidget/StreamingPaymentWidget.tsx
@@ -99,11 +99,7 @@ const StreamingPaymentWidget: FC<StreamingPaymentWidgetProps> = ({
 
   useEffect(() => {
     setHasEnoughFunds(checkIfHasEnoughFunds());
-  }, [
-    checkIfHasEnoughFunds,
-    amounts.amountAvailableToClaim,
-    streamingPaymentData,
-  ]);
+  }, [checkIfHasEnoughFunds]);
 
   const claim = useAsyncFunction({
     submit: ActionTypes.STREAMING_PAYMENT_CLAIM,


### PR DESCRIPTION
## Description

- An error appeared about funds even though there are funds in the colony
<img width="310" alt="image" src="https://github.com/user-attachments/assets/d6eeaa5c-6dc2-4010-8c76-05b4b3418858" />

## Testing

* Install Streaming Payments extension
* Create a stream with a Start immediately option and with a relatively low (compared to your colony balance) amount
* Watch the completed action view


https://github.com/user-attachments/assets/0c7a298c-de79-457e-b765-6471cbcd6537

Resolves https://github.com/JoinColony/colonyCDapp/issues/3901
