### PR TITLE
Fix: Do not overscroll the Teams filter

### DIFF
--- a/src/components/v5/common/ArrowScroller/ArrowScroller.tsx
+++ b/src/components/v5/common/ArrowScroller/ArrowScroller.tsx
@@ -55,9 +55,10 @@ const ArrowScroller: FC<ArrowScrollerProps> = ({
       return;
     }
 
-    const { clientWidth } = containerRef.current;
+    const { clientWidth, scrollLeft: currentScrollLeft } = containerRef.current;
+    const boundedScrollLeft = Math.min(clientWidth * 0.5, currentScrollLeft);
     containerRef?.current.scrollBy({
-      left: -clientWidth * 0.75,
+      left: -boundedScrollLeft,
       behavior: 'smooth',
     });
   };
@@ -67,9 +68,15 @@ const ArrowScroller: FC<ArrowScrollerProps> = ({
       return;
     }
 
-    const { clientWidth } = containerRef.current;
+    const {
+      clientWidth,
+      scrollLeft: currentScrollLeft,
+      scrollWidth,
+    } = containerRef.current;
+    const remainingScroll = scrollWidth - currentScrollLeft - clientWidth;
+    const boundedScrollLeft = Math.min(clientWidth * 0.5, remainingScroll);
     containerRef?.current.scrollBy({
-      left: clientWidth * 0.5,
+      left: boundedScrollLeft,
       behavior: 'smooth',
     });
   };


### PR DESCRIPTION
## Description

The left scroll's distance multiplier was somehow causing the team filter to shift way beyond the boundaries so I set it to match the right scroll's distance multiplier, `0.5`.

| Before | After |
| ---- | ---- |
| ![team-filter-scroll-bug](https://github.com/user-attachments/assets/7fa86a75-2e5c-4bd5-8796-8b6e7804b7cd) | ![team-filter-scroll-fix](https://github.com/user-attachments/assets/6f779f6c-bafc-450b-aa1b-39eaf269e3b9) |

## Testing

> [!NOTE]
> I don't know any other way for anyone to test this apart from doing this in a Simulator

1. Open the app on an iOS simulator
2. Go to the Planex colony dashboard
3. Click the right arrow for the Teams filter
4. Click the left arrow for the Teams filter
5. Verify that the Team filter is not overly scrolled to the point that there is an empty space to its left
6. To compare, simply checkout to the `master` branch and redo steps 2 to 4

Resolves #3540