### PR TITLE
Fix: Prevent form reset on submit when errors are present

### DIFF
--- a/src/components/shared/Fields/Form/Form.tsx
+++ b/src/components/shared/Fields/Form/Form.tsx
@@ -103,7 +103,7 @@ const Form = <FormData extends FieldValues>({
     watch,
     reset,
     getValues,
-    formState: { isSubmitting },
+    formState: { isSubmitting, errors: formErrors },
   } = formHelpers;
   const values = watch();
 
@@ -112,10 +112,10 @@ const Form = <FormData extends FieldValues>({
    * Useful in user settings.
    */
   useEffect(() => {
-    if (isSubmitting && resetOnSubmit) {
+    if (isSubmitting && resetOnSubmit && !Object.keys(formErrors)) {
       reset(values);
     }
-  }, [isSubmitting, values, resetOnSubmit, reset]);
+  }, [isSubmitting, values, resetOnSubmit, reset, formErrors]);
 
   const submitHandler = useCallback<React.FormEventHandler<HTMLFormElement>>(
     (event) => {


### PR DESCRIPTION
## Description

The problem is that the form was being reset when submitted even though errors are present. We don't want that to happen.

![form-error-reset](https://github.com/user-attachments/assets/ba0330b1-75c9-4d9b-bb0e-126a278e7ac7)

## Testing

1. Open the `UserAccountPage/hooks.tsx` file and update line 31 to:

```js
return { canChangeUsername: true, daysTillUsernameChange };
```
2. Connect Amy's wallet (Wallet 2)
3. Go to the profile page: http://localhost:9091/account/profile
4. Enter "leela" in the Username field
5. Click the Save changes button repeatedly
6. Verify that the form doesn't submit

Resolves #3730 