### PR TITLE
Fix: Wrap long descriptions

### DIFF
--- a/src/components/v5/shared/RichText/RichText.tsx
+++ b/src/components/v5/shared/RichText/RichText.tsx
@@ -133,7 +133,7 @@ const RichText: FC<RichTextProps> = ({
 
                     setIsTextTruncated(ref.scrollHeight > ref.offsetHeight);
                   }}
-                  className="line-clamp-2 text-left"
+                  className="line-clamp-2 text-left break-word"
                 >
                   {notFormattedContent}
                 </span>


### PR DESCRIPTION
## Description

![wrap](https://github.com/user-attachments/assets/b922ed9b-a129-4c75-8692-902f06730df8)

## Testing

1. Bring up the Simple Payment form
2. Enter the following text on the Description field:

```
jfkladfjkladfkldjlk;ajflkjadkl;fjadlk;fjadlk;fjkladsjflk;adjfkljadklfjadlkfjadkl;jflk;ajfkladjlf;jalk;fjadkl;fjakld;jfkladjl;adjlkdajflkadjfkljadklfjadlkfjkladjflk;adsjflkadsjflkadjfkladjfal;kfjklajfl;kadjflkadjflkadjfl;kajfl;kadjflk;adjfl;kadjfl;kdajflk;adjflkadjfkladjkfjadlk;fjlka;djfjadlk;jfkladjf;la
```

3. Collapse the Description field
4. Verify that the description is properly clamped to 2 lines and truncated
5. Change the viewport to mobile
6. Verify that it's still properly clamped and truncated

Resolves #2985 