### PR TITLE
fix: show description tooltip in action form and completed action

### DIFF
--- a/src/components/v5/common/ActionFormRow/ActionFormRow.tsx
+++ b/src/components/v5/common/ActionFormRow/ActionFormRow.tsx
@@ -118,6 +118,7 @@ const ActionFormRow = <T,>(
       >
         {label ? (
           <Tooltip
+            placement="top"
             {...label}
             tooltipContent={<span>{label.tooltipContent}</span>}
             selectTriggerRef={(triggerRef) => {
@@ -127,7 +128,6 @@ const ActionFormRow = <T,>(
 
               return triggerRef.querySelector(`.${LABEL_CLASSNAME}`);
             }}
-            placement="top"
           >
             {tooltipContent}
           </Tooltip>

--- a/src/components/v5/common/ActionSidebar/partials/Description/Description.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Description/Description.tsx
@@ -24,14 +24,14 @@ const Description: FC<DescriptionProps> = ({
     <ActionFormRow
       icon={Pencil}
       fieldName={DESCRIPTION_FIELD_NAME}
-      // Tooltip disabled to experiment with improving user experience
-      // tooltips={{
-      //   label: {
-      //     tooltipContent: formatMessage({
-      //       id: 'actionSidebar.tooltip.description',
-      //     }),
-      //   },
-      // }}
+      tooltips={{
+        label: {
+          placement: 'bottom-start',
+          tooltipContent: formatText({
+            id: 'actionSidebar.tooltip.description',
+          }),
+        },
+      }}
       title={formatText({ id: 'actionSidebar.description' })}
       isExpandable={!(disabled || hasNoDecisionMethods)}
       isDisabled={disabled || hasNoDecisionMethods}

--- a/src/components/v5/common/CompletedAction/partials/rows/Description.tsx
+++ b/src/components/v5/common/CompletedAction/partials/rows/Description.tsx
@@ -2,7 +2,9 @@ import { CaretRight, Pencil } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import DOMPurify from 'dompurify';
 import React, { useState } from 'react';
+import { defineMessages } from 'react-intl';
 
+import Tooltip from '~shared/Extensions/Tooltip/index.ts';
 import { formatText } from '~utils/intl.ts';
 import { ICON_SIZE } from '~v5/common/CompletedAction/consts.ts';
 import RichTextDisplay from '~v5/shared/RichTextDisplay/index.ts';
@@ -14,6 +16,14 @@ interface DescriptionRowProps {
 }
 
 const SHORT_DESCRIPTION_CHAR_LIMIT = 180;
+
+const MSG = defineMessages({
+  descriptionTooltip: {
+    id: `${displayName}.descriptionTooltip`,
+    defaultMessage:
+      'The description for why this action is being performed including any relevant details.',
+  },
+});
 
 // @NOTE this is pretty hacky with the arbitrary limit and DOMPurify sanitization
 // it's also outside the grid, since it changes from a row to a column
@@ -40,29 +50,34 @@ const DescriptionRow = ({ description }: DescriptionRowProps) => {
         'flex-col': isExpanded,
       })}
     >
-      <div className="w-40 flex-shrink-0 sm:w-[12.5rem]">
-        <button
-          className="flex items-center hover:text-blue-400"
-          type="button"
-          onClick={() => {
-            setIsExpanded((previousExpanded) => !previousExpanded);
-          }}
-        >
-          <Pencil size={ICON_SIZE} />
-          <span className="ml-2 mr-1">
-            {formatText({ id: 'actionSidebar.description' })}
-          </span>
-          <CaretRight
-            size={12}
-            className={clsx(
-              'rotate-0 transition-transform duration-300 ease-in-out',
-              {
-                'rotate-90': isExpanded,
-              },
-            )}
-          />
-        </button>
-      </div>
+      <Tooltip
+        placement="bottom-start"
+        tooltipContent={formatText(MSG.descriptionTooltip)}
+      >
+        <div className="w-40 flex-shrink-0 sm:w-[12.5rem]">
+          <button
+            className="flex items-center hover:text-blue-400"
+            type="button"
+            onClick={() => {
+              setIsExpanded((previousExpanded) => !previousExpanded);
+            }}
+          >
+            <Pencil size={ICON_SIZE} />
+            <span className="ml-2 mr-1">
+              {formatText({ id: 'actionSidebar.description' })}
+            </span>
+            <CaretRight
+              size={12}
+              className={clsx(
+                'rotate-0 transition-transform duration-300 ease-in-out',
+                {
+                  'rotate-90': isExpanded,
+                },
+              )}
+            />
+          </button>
+        </div>
+      </Tooltip>
       <div
         className={clsx('flex items-start', {
           'h-10 flex-1 cursor-pointer': !isExpanded,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1197,7 +1197,7 @@
     "actionSidebar.tooltip.decisionMethod": "Mechanism behind the decision-making process.",
     "actionSidebar.tooltip.manageMembers": "Whether members are being added or removed.",
     "actionSidebar.tooltip.createdIn": "Team responsible for decision-making and action execution.",
-    "actionSidebar.tooltip.description": "Rationale and context behind the action.",
+    "actionSidebar.tooltip.description": "Provide a description for why this action is being performed including any relevant details.",
     "actionSidebar.tooltip.simplePayment.from": "Team source of the funds.",
     "actionSidebar.tooltip.simplePayment.recipient": "Member or address designated to receive the funds.",
     "actionSidebar.tooltip.simplePayment.amount": "Quantity and type of funds of the payment.",


### PR DESCRIPTION
## Description

This PR adds back tooltips to the description field.

## Testing

I took some creative liberty to reword the tooltip in the completed action from:
```
Provide a description for why this action is being performed including any relevant details.
```

to

```
The description for why this action is being performed including any relevant details.
```
since it makes no sense grammatically otherwise :shrug: 

1. Try to create any action and hover the description field. Verify that the tooltip appears :eyes: 
![image](https://github.com/user-attachments/assets/56c385e7-3ad3-4c28-8588-5db65b6b18f9)
2. Create the action and verify that the tooltip appears, but with slightly different text
![image](https://github.com/user-attachments/assets/d2ad4803-8dc6-48da-b8a5-b1383802de7c)

## Diffs

**Changes** 🏗

* The ActionForm `DescriptionField` now renders the tooltip
* The completed action's `Description` row now render a slightly different tooltip

Resolves  #3739 
