### PR TITLE
Fix: Remove CLNY from currency list and add try catch for CoinGecko errors

### DIFF
--- a/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Currency/Currency.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Currency/Currency.tsx
@@ -30,6 +30,13 @@ const Currency = ({ closeSubmenu }: CurrencyProps) => {
     <>
       <MenuList className="grid w-[calc(100%+2rem)] grid-cols-2">
         {Object.values(SupportedCurrencies)
+          /**
+           * @Note This filter needs to be removed once we re-enable SupportedCurrencies.Clny
+           */
+          .filter(
+            (supportedCurrency) =>
+              supportedCurrency !== SupportedCurrencies.Clny,
+          )
           .reverse()
           .map((currency) => {
             const CurrencyIcon = currencyIcons[currency] || ClnyTokenIcon;

--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -18,12 +18,16 @@ const useCurrency = ({
     if (!contractAddress) return;
 
     const getPrice = async () => {
-      const currentPrice = await fetchCurrentPrice({
-        contractAddress,
-        chainId,
-        conversionDenomination,
-      });
-      setPrice(currentPrice);
+      try {
+        const currentPrice = await fetchCurrentPrice({
+          contractAddress,
+          chainId,
+          conversionDenomination,
+        });
+        setPrice(currentPrice);
+      } catch {
+        console.warn(`Failed to fetch current price for ${contractAddress}`);
+      }
     };
 
     getPrice();

--- a/src/utils/currency/tokenPriceByAddress.ts
+++ b/src/utils/currency/tokenPriceByAddress.ts
@@ -70,27 +70,34 @@ export const fetchTokenPriceByAddress = async ({
 }: Pick<FetchCurrentPriceArgs, 'chainId' | 'contractAddress'> & {
   conversionDenomination: CoinGeckoSupportedCurrencies;
 }) => {
-  const url = buildTokenAddressCoinGeckoURL(
-    contractAddress,
-    chainId,
-    conversionDenomination,
-  );
-
-  return fetchJsonData<TokenAddressPriceResponse>(
-    url,
-    `Api called failed at ${url}.`,
-  ).then((data) => {
-    if (isAddressPriceSuccessResponse(data)) {
-      return extractAddressPriceFromResponse(
-        data,
-        contractAddress,
-        conversionDenomination,
-      );
-    }
-
-    console.error(
-      `Unable to get price for ${contractAddress}. It probably doesn't have a listed exchange value.`,
+  try {
+    const url = buildTokenAddressCoinGeckoURL(
+      contractAddress,
+      chainId,
+      conversionDenomination,
     );
+
+    return fetchJsonData<TokenAddressPriceResponse>(
+      url,
+      `Api called failed at ${url}.`,
+    ).then((data) => {
+      if (isAddressPriceSuccessResponse(data)) {
+        return extractAddressPriceFromResponse(
+          data,
+          contractAddress,
+          conversionDenomination,
+        );
+      }
+
+      console.error(
+        `Unable to get price for ${contractAddress}. It probably doesn't have a listed exchange value.`,
+      );
+      return 0;
+    });
+  } catch (e) {
+    if (import.meta.env.DEV) {
+      console.error(e);
+    }
     return 0;
-  });
+  }
 };


### PR DESCRIPTION
## Description

This PR addresses mainly the problem of having the `CLNY` token migrated to another address on `Arbitrum One`.
This caused the `fetchTokenPriceByAddress` to throw an error and render the `Balances` page blank, due to a missing `try...catch` block.
Also given that for the moment we don't have data based on which to convert amounts to `CLNY`, we'll hide the option from the user menu, while also refreshing the `preferredCurrency` stored in the user profile.
![Screenshot 2024-12-17 at 19 13 18](https://github.com/user-attachments/assets/fc9144d7-ff72-4a58-86c8-c5f5a9d16fba)
![Screenshot 2024-12-17 at 19 13 21](https://github.com/user-attachments/assets/bb8835d0-557a-43e7-a392-fd16132a86e9)


## Testing

TODO: Let's test our changes do work as expected. 

* Step 1. Please add this at `line 55` in `src/components/shared/CurrencyConversion/CurrencyConversion.tsx`
```
const conversionRate = useCurrency({
    contractAddress: '0xd611b29dc327723269bd1e53fe987ee71a24b234',
    chainId: Network.ArbitrumOne,
    conversionDenomination: SupportedCurrencies.Clny,
  });
```
and comment also `line 79` in `src/utils/currency/currency.ts`
`// if (isDev) return 1;`
* Step 2. Now go to http://localhost:9091/planex/balances
You should see this error in the console, but the page should have no issue rendering.
![Screenshot 2024-12-17 at 19 25 30](https://github.com/user-attachments/assets/ad038ffa-834c-4b62-87fd-8eedc9f1f5d4)

* Step 3. Awesome ✨ Now let's test the `CLNY` currency selection. Please comment the `36-39 lines` in `src/components/common/Extensions/UserNavigation/partials/UserSubmenu/partials/Currency/Currency.tsx`
```
         .filter(
            (supportedCurrency) =>
              supportedCurrency !== SupportedCurrencies.Clny,
          )
```
* Step 4. The `CLNY` token should be again visible in the user menu list 
![Screenshot 2024-12-17 at 19 28 56](https://github.com/user-attachments/assets/055f3383-3eaa-4763-88d9-16ec929c424c)
* Step 5. Select it and open the user menu again. The value should not update to `CLNY` but remain as previously selected.

https://github.com/user-attachments/assets/567abae4-52d8-4bac-a302-181f3f0039f5

* Step 6. You can also run this query to confirm the preferredCurrency is not updating to `CLNY`
```
query MyQuery {
 # Note: I have used leela's wallet address
  getUserByAddress(id: "0xb77D57F4959eAfA0339424b83FcFaf9c15407461") { 
    items {
      profile {
        preferredCurrency
      }
    }
  }
}
```
* Step 7. Now let's try to have the `CLNY` already stored in the user profile's preferredCurrency. 
First, let's manually update the localStorage `preferredCurrency` entry to `CLNY`
![Screenshot 2024-12-17 at 19 37 17](https://github.com/user-attachments/assets/3274355d-6b13-4471-9c44-4906b8080fe2)

Now, please run the following mutation
```
mutation MyMutation {
  updateProfile(
    input: {
      id: "0xb77D57F4959eAfA0339424b83FcFaf9c15407461", 
      preferredCurrency: CLNY
    }
  ) {
    preferredCurrency
    id
    displayName
  }
}
```

* Step 8. Refresh the page and the selected currency should be based on the user's location

https://github.com/user-attachments/assets/55dcfbcf-c84f-444b-b81f-30c3b405fdc8

* Step 9. You can run this query again and check the `preferredCurrency` is set to another value than `CLNY`
```
query MyQuery {
 # Note: I have used leela's wallet address
  getUserByAddress(id: "0xb77D57F4959eAfA0339424b83FcFaf9c15407461") { 
    items {
      profile {
        preferredCurrency
      }
    }
  }
}
```

* Step 10. Now please select from the currencies list another one to test possible regressions

https://github.com/user-attachments/assets/57ad2300-e4c4-4f39-b3cb-8f872cf47aa6


If you've reached so far, I can confirm your testing is completed, though feel free to explore any other scenario that comes in mind.  🎉 

## Diffs

**Changes** 🏗

* `SupportedCurrencies.Clny` is not used ftm.
* One more missing `try...catch`

Resolves #3965 
