### PR TITLE
fix: if split payment uses split by reputation, filter out if reputatation in that team is 0

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/hooks.ts
@@ -25,9 +25,7 @@ export const useUserSelect = ({
         const { reputation, user } = member;
         const reputationItems = reputation?.items ?? [];
         const userReputation = reputationItems?.find(
-          (item) =>
-            item?.domain.nativeId === domainId ||
-            item?.domain.nativeId === Id.RootDomain,
+          (item) => item?.domain.nativeId === domainId,
         )?.reputationRaw;
 
         const { walletAddress, profile } = user || {};

--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/index.ts
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/index.ts
@@ -1,1 +1,2 @@
 export { default } from './UserSelect.tsx';
+export * from './types.ts';

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/SplitPaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/SplitPaymentForm.tsx
@@ -4,6 +4,7 @@ import { useFormContext } from 'react-hook-form';
 
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
+import { TEAM_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 import AmountRow from '~v5/common/ActionSidebar/partials/AmountRow/AmountRow.tsx';
 import { distributionMethodOptions } from '~v5/common/ActionSidebar/partials/consts.tsx';
@@ -24,7 +25,7 @@ const SplitPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
   const hasNoDecisionMethods = useHasNoDecisionMethods();
 
   const { watch, trigger } = useFormContext();
-  const selectedTeam = watch('team');
+  const selectedTeam = watch(TEAM_FIELD_NAME);
 
   useEffect(() => {
     const subscription = watch((_, { name: fieldName = '', type }) => {

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/SplitPaymentRecipientsField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/SplitPaymentRecipientsField.tsx
@@ -8,6 +8,7 @@ import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { SplitPaymentDistributionType } from '~gql';
 import { useTablet } from '~hooks/index.ts';
 import { formatText } from '~utils/intl.ts';
+import { TEAM_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import { MEATBALL_MENU_COLUMN_ID } from '~v5/common/Table/consts.ts';
 import { Table } from '~v5/common/Table/Table.tsx';
 import {
@@ -45,6 +46,9 @@ const SplitPaymentRecipientsField: FC<SplitPaymentRecipientsFieldProps> = ({
     }),
   );
   const value: SplitPaymentRecipientsFieldModel[] = useWatch({ name }) || [];
+  const domainId = useWatch({
+    name: TEAM_FIELD_NAME,
+  });
   const amount: string | undefined = useWatch({ name: 'amount' });
   const isTablet = useTablet();
   const getMenuProps = ({ index }) => ({
@@ -85,6 +89,7 @@ const SplitPaymentRecipientsField: FC<SplitPaymentRecipientsFieldProps> = ({
     disabled,
     distributionMethod,
     getMenuProps,
+    domainId,
   });
   const { getFieldState, watch } = useFormContext();
   const fieldState = getFieldState(name);


### PR DESCRIPTION
## Description

Basically I started propagating the `domainId` on to `UserSelect` and fixed a `find` statement.
Not sure if we should do this for form validation too? Seems a bit overkill for now.

## Testing

Right so it may be tricky with create data being semi-flaky and all, but let's go
1. After running the `create-data` script, open up `Wayne` (`Planex` would work too, just use a member with no reputation in a child team
![image](https://github.com/user-attachments/assets/abe7aeeb-fe84-48da-91a9-af68b2b1f754)
![image](https://github.com/user-attachments/assets/6c6b0cdc-95fe-435a-97d4-9f97680d9152)
2. Create a `Split payment` action, use `Reputation percentage` for `Distribution`. 
![image](https://github.com/user-attachments/assets/20117baa-b8fc-4060-8b5d-22263b62cc6f)
3. Verify that the member select has all the members when `General` is selected as the team
![image](https://github.com/user-attachments/assets/4aa5617b-10fb-4ca8-b0e6-02bca2324055)
4. Verify that the members with 0 reputation in `Advanced technologies` are filtered out when choosing that as the `Team`
![image](https://github.com/user-attachments/assets/2796d66d-76a2-4964-a140-9dea8b004c9c)


## Diffs

**Changes** 🏗

* `UserSelect` now doesn't fallback to reputation in `General`
* `SpliPaymentRecipientField` now passes the form's domainId to `UserSelect` and filters out 0 reputation members if decision method is `SplitPaymentDistributionType.Reputation`

Resolves  #3717
