### PR TITLE
fix: changed supported state copy

### DIFF
--- a/src/i18n/en-motion-states.ts
+++ b/src/i18n/en-motion-states.ts
@@ -2,7 +2,7 @@ import { MotionState } from '~utils/colonyMotions.ts';
 
 const motionStatesMessageDescriptors = {
   'motion.state': `{state, select,
-      ${MotionState.Supported} {Staked}
+      ${MotionState.Supported} {Supported}
       ${MotionState.Staking} {Staking}
       ${MotionState.Voting} {Voting}
       ${MotionState.Reveal} {Reveal}


### PR DESCRIPTION
## Description

- Changed `Staked` motion text to `Supported`

<img width="857" alt="image" src="https://github.com/user-attachments/assets/02762de0-bde2-46e4-b017-80e4d5de6b29" />


## Testing

**Simple payment**
1. Ensure you have Reputation extension enabled.
2. Create a Simple payment action.
3. Use the Reputation decision method.
4. Fully stake the motion.
6. Check the status of the motion in the activity feed.

**Advanced payment**
1. Ensure you have Reputation extension enabled.
2. Create an Advanced payment action.
3. Perform any step with the Reputation decision method. e.g. Funding.
5. Check the status of the motion in the motion widget.

Resolves https://github.com/JoinColony/colonyCDapp/issues/3971
