### PR TITLE
test: split payment e2e tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,11 +23,10 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: 'http://localhost:9091',
 
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    /* Collect trace for failed tests. See https://playwright.dev/docs/trace-viewer */
     trace: 'retain-on-failure',
   },
-  // Needed for running tests against the app in development mode
-  timeout: !process.env.CI ? 90000 : undefined,
+  timeout: !process.env.CI ? 60000 : undefined,
   /* Configure projects for major browsers */
   projects: [
     {

--- a/playwright/e2e/manage-account-advanced-settings.spec.ts
+++ b/playwright/e2e/manage-account-advanced-settings.spec.ts
@@ -10,7 +10,10 @@ test.describe('Advanced Settings section', () => {
 
     await selectWallet(page);
 
-    await page.getByTestId('user-navigation-hamburger').click();
+    await page
+      .getByRole('banner')
+      .getByTestId('user-navigation-hamburger')
+      .click();
 
     await page.getByTestId('user-menu').waitFor({ state: 'visible' });
 

--- a/playwright/e2e/manage-account-avatar.spec.ts
+++ b/playwright/e2e/manage-account-avatar.spec.ts
@@ -9,7 +9,10 @@ test.describe('Avatar Uploader on Manage Account page', () => {
     await setCookieConsent(context, baseURL);
     await page.goto('/');
     await selectWallet(page);
-    await page.getByTestId('user-navigation-hamburger').click();
+    await page
+      .getByRole('banner')
+      .getByTestId('user-navigation-hamburger')
+      .click();
     await page.getByTestId('user-menu').waitFor({ state: 'visible' });
     await page
       .getByTestId('user-menu')

--- a/playwright/e2e/manage-account-preferences.spec.ts
+++ b/playwright/e2e/manage-account-preferences.spec.ts
@@ -16,7 +16,10 @@ test.describe('Preferences section', () => {
 
     await selectWallet(page);
 
-    await page.getByTestId('user-navigation-hamburger').click();
+    await page
+      .getByRole('banner')
+      .getByTestId('user-navigation-hamburger')
+      .click();
 
     await page.getByTestId('user-menu').waitFor({ state: 'visible' });
 

--- a/playwright/e2e/manage-account-profile.spec.ts
+++ b/playwright/e2e/manage-account-profile.spec.ts
@@ -10,7 +10,10 @@ test.describe('Manage Account', () => {
 
     await selectWallet(page);
 
-    await page.getByTestId('user-navigation-hamburger').click();
+    await page
+      .getByRole('banner')
+      .getByTestId('user-navigation-hamburger')
+      .click();
 
     await page.getByTestId('user-menu').waitFor({ state: 'visible' });
 

--- a/playwright/e2e/split-payment.spec.ts
+++ b/playwright/e2e/split-payment.spec.ts
@@ -1,0 +1,290 @@
+import { type BrowserContext, expect, type Page, test } from '@playwright/test';
+
+import { SplitPayment } from '../models/split-payment.ts';
+import {
+  setCookieConsent,
+  signInAndNavigateToColony,
+} from '../utils/common.ts';
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Split payment', () => {
+  let page: Page;
+  let context: BrowserContext;
+  let splitPayment: SplitPayment;
+  const recipient = '0x27fF0C145E191C22C75cD123C679C3e1F58a4469';
+  const recipient2 = '0x9dF24e73f40b2a911Eb254A8825103723E13209C';
+
+  test.beforeAll(async ({ browser, baseURL }) => {
+    context = await browser.newContext();
+    page = await context.newPage();
+    splitPayment = new SplitPayment(page);
+
+    await setCookieConsent(context, baseURL);
+    await signInAndNavigateToColony(page, {
+      colonyUrl: '/planex',
+      wallet: /dev wallet 1$/i,
+    });
+  });
+
+  test.afterAll(async () => {
+    await context?.close();
+  });
+
+  test.beforeEach(async () => {
+    await splitPayment.open();
+  });
+
+  test.afterEach(async () => {
+    await splitPayment.close();
+  });
+
+  test('Happy path (Unequal distribution/Staking decision method)', async () => {
+    await splitPayment.fillForm({
+      title: 'Test Split Payment',
+      team: 'General',
+      decisionMethod: 'Staking',
+      distribution: 'Unequal',
+      totalAmount: '5',
+      recipients: [
+        {
+          amount: '2.5',
+          recipient,
+          percentage: '50%',
+        },
+        {
+          amount: '2.5',
+          recipient: recipient2,
+          percentage: '50%',
+        },
+      ],
+    });
+
+    await splitPayment.submitButton.click();
+
+    await splitPayment.confirmRequiredStakeDialog();
+    await splitPayment.waitForTransaction();
+
+    await expect(splitPayment.completedAction).toBeVisible();
+    await expect(splitPayment.stepper).toBeVisible();
+    await expect(splitPayment.expenditureActionStatusBadge).toHaveText(
+      'Review',
+    );
+
+    await splitPayment.confirmPayment();
+    await splitPayment.fundPayment();
+    await splitPayment.releasePayment({ releaseMethod: 'Permissions' });
+
+    await expect(splitPayment.expenditureActionStatusBadge).toHaveText('Paid');
+    for (const [index, row] of [
+      /fry\s*2.5CREDS\s*50%/i,
+      /amy\s*2.5CREDS\s*50%/i,
+      /Total payments5 CREDS/i,
+    ].entries()) {
+      await expect(
+        splitPayment.completedActionTable.locator('tbody tr').nth(index),
+      ).toContainText(row, {
+        ignoreCase: true,
+      });
+    }
+  });
+
+  test('Happy path (Equal distribution/Permissions decision method)', async () => {
+    await splitPayment.fillForm({
+      title: 'Test Split Payment',
+      team: 'General',
+      decisionMethod: 'Permissions',
+      distribution: 'Equal',
+      totalAmount: '2',
+      recipients: [
+        {
+          amount: '1',
+          recipient,
+          percentage: '50%',
+        },
+        {
+          amount: '1',
+          recipient: recipient2,
+          percentage: '50%',
+        },
+      ],
+    });
+
+    await splitPayment.submitButton.click();
+    await splitPayment.waitForTransaction();
+
+    await expect(splitPayment.completedAction).toBeVisible();
+    await expect(splitPayment.stepper).toBeVisible();
+    await expect(splitPayment.expenditureActionStatusBadge).toHaveText(
+      'Review',
+    );
+
+    await splitPayment.confirmPayment();
+    await splitPayment.fundPayment();
+    await splitPayment.releasePayment({ releaseMethod: 'Permissions' });
+
+    await expect(splitPayment.expenditureActionStatusBadge).toHaveText('Paid');
+    for (const [index, row] of [
+      /fry\s*1CREDS\s*50%/i,
+      /amy\s*1CREDS\s*50%/i,
+      /Total payments2 CREDS/i,
+    ].entries()) {
+      await expect(
+        splitPayment.completedActionTable.locator('tbody tr').nth(index),
+      ).toContainText(row);
+    }
+  });
+
+  test('Redo payment (Permissions decision method/Payment Creator release method)', async () => {
+    await splitPayment.fillForm({
+      title: 'Test Split Payment',
+      team: 'General',
+      decisionMethod: 'Permissions',
+      distribution: 'Unequal',
+      totalAmount: '5',
+      recipients: [
+        {
+          amount: '2.5',
+          recipient,
+          percentage: '50%',
+        },
+        {
+          amount: '2.5',
+          recipient: recipient2,
+          percentage: '50%',
+        },
+      ],
+    });
+
+    await splitPayment.submitButton.click();
+    await splitPayment.waitForTransaction();
+    await splitPayment.confirmPayment();
+    await splitPayment.fundPayment();
+    await splitPayment.releasePayment({ releaseMethod: 'Payment creator' });
+
+    await splitPayment.threeDotButton.click();
+    await splitPayment.redoActionButton.click();
+    await splitPayment.waitForLoadingComplete();
+    // The Form should be pre-filled with the previous values
+    await expect(splitPayment.titleInput).toHaveValue('Test Split Payment');
+    await expect(
+      splitPayment.form.getByRole('button', { name: 'Split payment' }),
+    ).toBeVisible();
+    await expect(splitPayment.form.getByLabel('Select token')).toContainText(
+      'CREDS',
+    );
+    await expect(splitPayment.totalAmountInput).toHaveValue('5');
+    await expect(
+      splitPayment.form.getByRole('button', {
+        name: 'General',
+      }),
+    ).toBeVisible();
+    // Recipients table should be present and filled with th expected data
+    const row1 = splitPayment.recipientsTable.locator('tbody tr').nth(0);
+    const row2 = splitPayment.recipientsTable.locator('tbody tr').nth(1);
+    await expect(row1.getByPlaceholder('Enter value')).toHaveValue('50');
+    await expect(row2.getByPlaceholder('Enter value')).toHaveValue('50');
+    await expect(row1.getByText('CREDS')).toBeVisible();
+    await expect(row2.getByText('CREDS')).toBeVisible();
+    await expect(row1.getByPlaceholder('Enter amount')).toHaveValue('2.5');
+    await expect(row2.getByPlaceholder('Enter amount')).toHaveValue('2.5');
+
+    await splitPayment.submitButton.click();
+
+    await splitPayment.waitForTransaction();
+
+    await expect(splitPayment.expenditureActionStatusBadge).toHaveText(
+      'Review',
+    );
+  });
+
+  test('Form validation', async () => {
+    await splitPayment.submitButton.click();
+
+    // Verify validation messages
+    for (const message of SplitPayment.validationMessages.allRequiredFields) {
+      await expect(splitPayment.drawer.getByText(message)).toBeVisible();
+    }
+
+    await splitPayment.setTitle(
+      'This is a test title that exceeds the maximum character limit of sixty.',
+    );
+    await expect(
+      splitPayment.drawer.getByText(
+        SplitPayment.validationMessages.title.maxLengthExceeded,
+      ),
+    ).toBeVisible();
+
+    await splitPayment.fillForm({
+      title: 'Test Split Payment',
+      team: 'General',
+      decisionMethod: 'Staking',
+      distribution: 'Unequal',
+      totalAmount: '5',
+      recipients: [
+        {
+          amount: '1',
+          recipient,
+          percentage: '50%',
+        },
+        {
+          amount: '1',
+          recipient: recipient2,
+          percentage: '50%',
+        },
+      ],
+    });
+
+    await splitPayment.submitButton.click();
+
+    await expect(
+      splitPayment.drawer.getByText(
+        SplitPayment.validationMessages.percentage.mustBe100,
+      ),
+    ).toBeVisible();
+  });
+
+  test('Recipients table actions', async () => {
+    await splitPayment.fillForm({
+      title: 'Test Split Payment',
+      team: 'General',
+      decisionMethod: 'Staking',
+      distribution: 'Equal',
+      totalAmount: '2',
+      recipients: [
+        {
+          amount: '1',
+          recipient,
+          percentage: '50%',
+        },
+      ],
+    });
+
+    await splitPayment.form.getByLabel('Open menu').first().click();
+    await splitPayment.form.getByRole('button', { name: 'Duplicate' }).click();
+
+    await expect(
+      splitPayment.drawer.getByText(
+        SplitPayment.validationMessages.percentage.mustBe100,
+      ),
+    ).toBeHidden();
+    await expect(splitPayment.form.getByText('100%')).toBeVisible();
+
+    await splitPayment.form.getByLabel('Open menu').nth(1).click();
+    await splitPayment.form.getByRole('button', { name: 'Remove row' }).click();
+
+    await expect(splitPayment.recipientsTable.locator('tbody tr')).toHaveCount(
+      1,
+    );
+
+    await expect(
+      splitPayment.recipientsTable.locator('tfoot tr').first(),
+    ).toContainText('50%');
+
+    await expect(
+      splitPayment.drawer.getByText(
+        SplitPayment.validationMessages.percentage.mustBe100,
+      ),
+    ).toBeVisible();
+  });
+});

--- a/playwright/models/simple-payment.ts
+++ b/playwright/models/simple-payment.ts
@@ -193,7 +193,6 @@ export class SimplePayment {
     await this.selectDropdown.getByRole('button', { name: newType }).click();
   }
 
-  // Locator getters for assertions in test files
   getValidationMessage(message: string) {
     return this.drawer.getByText(message);
   }

--- a/playwright/models/split-payment.ts
+++ b/playwright/models/split-payment.ts
@@ -180,12 +180,13 @@ export class SplitPayment {
       ] of recipients.entries()) {
         const row = index + 1;
         await this.setRecipient({ address: recipient, row });
-
-        await this.recipientsTable
-          .getByRole('row')
-          .nth(row)
-          .getByPlaceholder('Enter amount')
-          .fill(amount);
+        if (amount) {
+          await this.recipientsTable
+            .getByRole('row')
+            .nth(row)
+            .getByPlaceholder('Enter amount')
+            .fill(amount);
+        }
         if (percentage) {
           await this.recipientsTable
             .getByRole('row')
@@ -303,7 +304,7 @@ export class SplitPayment {
 
 type Distribution = 'Equal' | 'Unequal' | 'Reputation percentage';
 type Recipient = {
-  amount: string;
+  amount?: string;
   recipient: string;
   percentage?: string;
 };

--- a/playwright/models/split-payment.ts
+++ b/playwright/models/split-payment.ts
@@ -1,0 +1,310 @@
+import type { Page, Locator } from '@playwright/test';
+
+export class SplitPayment {
+  static readonly validationMessages = {
+    title: {
+      maxLengthExceeded: 'Title must not exceed 60 characters',
+      isRequired: 'Title is required',
+    },
+    allRequiredFields: [
+      'decisionMethod must be defined',
+      'distributionMethod must be defined',
+      'team must be a `number` type, but the final value was: `NaN` (cast from the value `""`).',
+      'Percent is required in 1st payment',
+      'Amount must be greater than zero',
+      'Title is required',
+      'Recipient is required',
+    ],
+    percentage: {
+      mustBe100: 'The sum of percentages must be 100.',
+    },
+  };
+
+  drawer: Locator;
+
+  form: Locator;
+
+  selectDropdown: Locator;
+
+  decisionMethodDropdown: Locator;
+
+  sidebar: Locator;
+
+  stepper: Locator;
+
+  closeButton: Locator;
+
+  submitButton: Locator;
+
+  completedAction: Locator;
+
+  confirmationDialog: Locator;
+
+  recipientsTable: Locator;
+
+  addRecipientButton: Locator;
+
+  expenditureActionStatusBadge: Locator;
+
+  completedActionTable: Locator;
+
+  threeDotButton: Locator;
+
+  redoActionButton: Locator;
+
+  titleInput: Locator;
+
+  totalAmountInput: Locator;
+
+  constructor(private page: Page) {
+    this.drawer = page.getByTestId('action-drawer');
+    this.form = page.getByTestId('action-form');
+    this.selectDropdown = page.getByTestId('search-select-menu');
+    this.decisionMethodDropdown = page
+      .getByRole('list')
+      .filter({ hasText: /Available decision methods/i });
+    this.sidebar = page.getByTestId('colony-page-sidebar');
+    this.stepper = page.getByTestId('stepper');
+    this.closeButton = page.getByRole('button', { name: /close the modal/i });
+    this.submitButton = page.getByRole('button', { name: 'Create payment' });
+    this.completedAction = page.getByTestId('completed-action');
+    this.confirmationDialog = page
+      .getByRole('dialog')
+      .filter({ hasText: 'Do you wish to cancel the action creation?' });
+    this.recipientsTable = this.form.getByRole('table');
+    this.addRecipientButton = this.form.getByRole('button', {
+      name: 'Add recipient',
+    });
+    this.expenditureActionStatusBadge = this.drawer.getByTestId(
+      'expenditure-action-status-badge',
+    );
+
+    this.completedActionTable = this.completedAction.getByRole('table');
+    this.threeDotButton = this.completedAction.getByLabel('Open menu');
+    this.redoActionButton = this.page.getByRole('button', {
+      name: 'Redo action',
+    });
+    this.titleInput = this.form.getByPlaceholder('Enter title');
+    this.totalAmountInput = this.form.locator('input[name="amount"]');
+  }
+
+  async open() {
+    await this.sidebar.getByLabel('Start the payment group action').click();
+    await this.drawer.waitFor({ state: 'visible' });
+    await this.drawer
+      .getByRole('button', { name: 'New Split payment' })
+      .click();
+    await this.form.waitFor({ state: 'visible' });
+    await this.drawer
+      .getByTestId('action-sidebar-description')
+      .waitFor({ state: 'visible' });
+  }
+
+  async close() {
+    await this.closeButton.click();
+
+    if (await this.confirmationDialog.isVisible()) {
+      await this.confirmationDialog
+        .getByRole('button', { name: 'Yes, cancel the action' })
+        .click();
+    }
+  }
+
+  async setTitle(title: string) {
+    await this.titleInput.fill(title);
+  }
+
+  async setRecipient({ address, row = 0 }: { address: string; row: number }) {
+    await this.recipientsTable
+      .getByRole('row')
+      .nth(row)
+      .getByLabel('Select user')
+      .click();
+
+    await this.page
+      .getByPlaceholder('Search or add wallet address')
+      .fill(address);
+
+    await this.page
+      .getByRole('button', {
+        name: address,
+      })
+      .click();
+  }
+
+  async fillForm({
+    title,
+    team,
+    decisionMethod,
+    totalAmount,
+    distribution,
+    recipients,
+  }: {
+    title?: string;
+    team?: string;
+    decisionMethod?: string;
+    totalAmount?: string;
+    distribution?: Distribution;
+    recipients?: Recipient[];
+  }) {
+    if (title) {
+      await this.setTitle(title);
+    }
+    if (team) {
+      await this.form.getByRole('button', { name: 'Select team' }).click();
+      await this.selectDropdown.getByRole('button', { name: team }).click();
+    }
+    if (decisionMethod) {
+      await this.form.getByRole('button', { name: 'Select method' }).click();
+
+      await this.decisionMethodDropdown
+        .getByRole('button', { name: decisionMethod })
+        .click();
+    }
+    if (totalAmount) {
+      await this.totalAmountInput.fill(totalAmount);
+    }
+    if (distribution) {
+      await this.form
+        .getByRole('button', { name: 'Select split type' })
+        .click();
+      await this.page
+        .getByRole('button', { name: distribution, exact: true })
+        .click();
+    }
+
+    if (recipients) {
+      for (const [
+        index,
+        { amount, recipient, percentage },
+      ] of recipients.entries()) {
+        const row = index + 1;
+        await this.setRecipient({ address: recipient, row });
+
+        await this.recipientsTable
+          .getByRole('row')
+          .nth(row)
+          .getByPlaceholder('Enter amount')
+          .fill(amount);
+        if (percentage) {
+          await this.recipientsTable
+            .getByRole('row')
+            .nth(row)
+            .getByPlaceholder('Enter value')
+            .fill(percentage);
+        }
+        if (row !== recipients.length) {
+          await this.addRecipientButton.click();
+        }
+      }
+    }
+  }
+
+  async waitForLoadingComplete() {
+    await this.page
+      .getByTestId('loading-skeleton')
+      .last()
+      .waitFor({ state: 'hidden' });
+  }
+
+  async waitForTransaction() {
+    await this.page.waitForURL(/\?tx=/);
+    await this.page
+      .getByTestId('loading-skeleton')
+      .last()
+      .waitFor({ state: 'hidden' });
+  }
+
+  async confirmPayment() {
+    await this.completedAction
+      .getByRole('button', { name: 'Confirm details' })
+      .click();
+
+    await this.completedAction
+      .getByRole('button', { name: 'Pending' })
+      .waitFor({ state: 'hidden' });
+
+    await this.expenditureActionStatusBadge
+      .filter({
+        hasText: 'Funding',
+      })
+      .waitFor();
+  }
+
+  async fundPayment() {
+    await this.completedAction
+      .getByRole('button', { name: 'Fund', exact: true })
+      .click();
+
+    const fundDialog = this.page
+      .getByRole('dialog')
+      .filter({ hasText: 'Payment funding' });
+    await fundDialog.waitFor({ state: 'visible' });
+    await fundDialog.getByText('Select Method').click();
+    await this.page.getByRole('option', { name: 'Permissions' }).click();
+    await fundDialog.getByRole('button', { name: 'Fund Payment' }).click();
+    await fundDialog.waitFor({ state: 'hidden' });
+    await this.completedAction
+      .getByRole('button', { name: 'Pending' })
+      .waitFor({ state: 'hidden' });
+
+    await this.expenditureActionStatusBadge
+      .filter({
+        hasText: 'Release',
+      })
+      .waitFor();
+  }
+
+  async releasePayment({ releaseMethod }: { releaseMethod: ReleaseMethod }) {
+    await this.completedAction
+      .getByRole('button', { name: 'Release' })
+      .nth(1)
+      .click();
+    const releaseDialog = this.page
+      .getByRole('dialog')
+      .filter({ hasText: 'Release payment' });
+
+    await releaseDialog.waitFor({ state: 'visible' });
+    await releaseDialog.getByText('Select Method').click();
+    await this.page.getByRole('option', { name: releaseMethod }).click();
+    await releaseDialog
+      .getByRole('button', { name: 'Release Payment' })
+      .click();
+    await releaseDialog.waitFor({ state: 'hidden' });
+    await this.completedAction
+      .getByRole('button', { name: 'Pending' })
+      .waitFor({ state: 'hidden' });
+
+    await this.expenditureActionStatusBadge
+      .filter({
+        hasText: 'Paid',
+      })
+      .waitFor();
+  }
+
+  async confirmRequiredStakeDialog() {
+    const requiredStakeDialog = this.page.getByRole('dialog').filter({
+      hasText: 'Create the payment',
+    });
+
+    await requiredStakeDialog.waitFor({ state: 'visible' });
+
+    await requiredStakeDialog.getByTestId('spinner-loader').waitFor({
+      state: 'hidden',
+    });
+
+    await requiredStakeDialog
+      .getByRole('button', { name: 'Create payment' })
+      .click();
+
+    await requiredStakeDialog.waitFor({ state: 'hidden' });
+  }
+}
+
+type Distribution = 'Equal' | 'Unequal' | 'Reputation percentage';
+type Recipient = {
+  amount: string;
+  recipient: string;
+  percentage?: string;
+};
+type ReleaseMethod = 'Payment creator' | 'Permissions' | 'Reputation';

--- a/playwright/utils/common.ts
+++ b/playwright/utils/common.ts
@@ -79,8 +79,6 @@ export const selectWallet = async (
 
   await page.getByText(wallet).click();
 
-  await page.getByText(/Local Ganache Instance/i).waitFor({ state: 'visible' });
-
   const loadingIndicator = page.getByText(/Checking your access.../i);
   const loadingIndicatorVisible = await loadingIndicator.isVisible();
 

--- a/src/components/shared/Preloaders/SpinnerLoader.tsx
+++ b/src/components/shared/Preloaders/SpinnerLoader.tsx
@@ -29,7 +29,10 @@ const SpinnerLoader = ({
   textValues,
 }: Props) => {
   return (
-    <div className={getMainClasses(appearance, styles)}>
+    <div
+      data-testid="spinner-loader"
+      className={getMainClasses(appearance, styles)}
+    >
       <div className={styles.loader} />
       {loadingText && (
         <div className={styles.loadingTextContainer}>


### PR DESCRIPTION
## Description

Initiatal set of E2E tests for the Split Payment motion. Also, I updated some selectors related to the `selectWallet` test helper to fix tests that began failing after the homepage redesign. 
Test cases included in the PR:
- Happy path of Split payment (Permissions/Staking method of create motion, Equal/Unequal distribution, Permissions release method)
- Form fields validation
- Recipients table actions: Add/Remove/Duplicate a row
- Redo a payment



## Testing

**Step 1**. Spin up the dev env and seed the test data 

`npm run dev`  followed by `node scripts/create-data.js`

**Step 2**. Build and start the frontend in preview mode

`npm run preview` 

**Step 3.** Run the tests in a separate terminal 

`npm run e2e split-payment`

**Step 4**. The tests should pass ( if any failures - please send me .zip files from `/playwright-report/data` directory)

