### PR TITLE
Fix: Disable accept incoming funds button until updated data

### DIFF
--- a/src/components/frame/v5/pages/FundsPage/context/IncomingFundsLoadingContext.ts
+++ b/src/components/frame/v5/pages/FundsPage/context/IncomingFundsLoadingContext.ts
@@ -4,15 +4,20 @@ import noop from '~utils/noop.ts';
 
 interface IncomingFundsLoadingContextValues {
   isAcceptLoading: boolean;
-  enableAcceptLoading: () => void;
-  disableAcceptLoading: () => void;
+  enableAcceptLoading: VoidFunction;
+  setPendingFundsTokenAddresses: (tokenAddresses: string[]) => void;
+  /**
+   * Resets the loading state (`isAcceptLoading`) and the list of token addresses awaiting fund claims to their initial values.
+   */
+  reset: VoidFunction;
 }
 
 export const IncomingFundsLoadingContext =
   createContext<IncomingFundsLoadingContextValues>({
     isAcceptLoading: false,
     enableAcceptLoading: noop,
-    disableAcceptLoading: noop,
+    setPendingFundsTokenAddresses: noop,
+    reset: noop,
   });
 
 export const useIncomingFundsLoadingContext = () => {

--- a/src/components/frame/v5/pages/FundsPage/context/IncomingFundsLoadingContextProvider.tsx
+++ b/src/components/frame/v5/pages/FundsPage/context/IncomingFundsLoadingContextProvider.tsx
@@ -6,23 +6,43 @@ import React, {
   type PropsWithChildren,
 } from 'react';
 
+import { useRefetchColonyData, useFundsStateUpdater } from './hooks.ts';
 import { IncomingFundsLoadingContext } from './IncomingFundsLoadingContext.ts';
 
 export const IncomingFundsLoadingContextProvider: FC<PropsWithChildren> = ({
   children,
 }) => {
   const [isAcceptLoading, setIsAcceptLoading] = useState(false);
+  const [pendingFundsTokenAddresses, setPendingFundsTokenAddresses] = useState<
+    string[]
+  >([]);
 
   const enableAcceptLoading = useCallback(() => setIsAcceptLoading(true), []);
-  const disableAcceptLoading = useCallback(() => setIsAcceptLoading(false), []);
+
+  const reset = useCallback(() => {
+    setPendingFundsTokenAddresses([]);
+    setIsAcceptLoading(false);
+  }, []);
+
+  useFundsStateUpdater(pendingFundsTokenAddresses, reset);
+  useRefetchColonyData(
+    isAcceptLoading && !!pendingFundsTokenAddresses.length,
+    reset,
+  );
 
   const value = useMemo(
     () => ({
       isAcceptLoading,
       enableAcceptLoading,
-      disableAcceptLoading,
+      setPendingFundsTokenAddresses,
+      reset,
     }),
-    [isAcceptLoading, enableAcceptLoading, disableAcceptLoading],
+    [
+      isAcceptLoading,
+      enableAcceptLoading,
+      setPendingFundsTokenAddresses,
+      reset,
+    ],
   );
 
   return (

--- a/src/components/frame/v5/pages/FundsPage/context/hooks.ts
+++ b/src/components/frame/v5/pages/FundsPage/context/hooks.ts
@@ -1,0 +1,64 @@
+import { useEffect } from 'react';
+
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import useColonyFundsClaims from '~hooks/useColonyFundsClaims.ts';
+import usePrevious from '~hooks/usePrevious.ts';
+
+export const useRefetchColonyData = (
+  shouldRefetchColonyData: boolean,
+  reset: () => void,
+) => {
+  const { startPollingColonyData, stopPollingColonyData } = useColonyContext();
+
+  useEffect(() => {
+    let timeoutId;
+    if (shouldRefetchColonyData) {
+      startPollingColonyData(1_000);
+      timeoutId = setTimeout(() => {
+        stopPollingColonyData();
+        /**
+         * Resets the context state if no incoming funds state update occurs
+         * after colony polling is completed.
+         */
+        reset();
+      }, 10_000);
+    }
+
+    return () => {
+      if (timeoutId) {
+        stopPollingColonyData();
+        reset();
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [
+    shouldRefetchColonyData,
+    reset,
+    startPollingColonyData,
+    stopPollingColonyData,
+  ]);
+};
+
+export const useFundsStateUpdater = (
+  pendingFundsTokenAddresses: string[],
+  reset: () => void,
+) => {
+  const fundsClaims = useColonyFundsClaims();
+  const unclaimedFundsClaims = fundsClaims.filter(
+    (claim) =>
+      claim.amount !== '0' &&
+      !claim.isClaimed &&
+      claim.token?.tokenAddress &&
+      pendingFundsTokenAddresses.includes(claim.token?.tokenAddress),
+  );
+  const previousUnclaimedFundsClaims = usePrevious(unclaimedFundsClaims);
+
+  const hasFundsClaimsStateChanged =
+    !unclaimedFundsClaims?.length && !!previousUnclaimedFundsClaims?.length;
+
+  useEffect(() => {
+    if (hasFundsClaimsStateChanged) {
+      reset();
+    }
+  }, [hasFundsClaimsStateChanged, reset]);
+};

--- a/src/components/frame/v5/pages/FundsPage/partials/AcceptButton/AcceptButton.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/AcceptButton/AcceptButton.tsx
@@ -15,16 +15,15 @@ const AcceptButton: FC<AcceptButtonProps> = ({
   disabled,
   ...rest
 }) => {
-  const {
-    colony,
-    canInteractWithColony,
-    startPollingColonyData,
-    stopPollingColonyData,
-  } = useColonyContext();
+  const { colony, canInteractWithColony } = useColonyContext();
   const [isClaimed, setIsClaimed] = useState(false);
 
-  const { isAcceptLoading, enableAcceptLoading, disableAcceptLoading } =
-    useIncomingFundsLoadingContext();
+  const {
+    isAcceptLoading,
+    enableAcceptLoading,
+    setPendingFundsTokenAddresses,
+    reset,
+  } = useIncomingFundsLoadingContext();
 
   // Used to set acceptLoading in the context whilst transaction is processed
   const getPayload = () => {
@@ -38,9 +37,7 @@ const AcceptButton: FC<AcceptButtonProps> = ({
 
   const handleClaimSuccess = () => {
     setIsClaimed(true);
-    startPollingColonyData(1_000);
-    setTimeout(stopPollingColonyData, 10_000);
-    disableAcceptLoading();
+    setPendingFundsTokenAddresses(tokenAddresses);
   };
 
   const isBtnDisabled =
@@ -50,7 +47,7 @@ const AcceptButton: FC<AcceptButtonProps> = ({
       {...rest}
       actionType={ActionTypes.CLAIM_TOKEN}
       onSuccess={handleClaimSuccess}
-      onError={disableAcceptLoading}
+      onError={reset}
       disabled={isBtnDisabled}
       mode="primarySolid"
       size="small"


### PR DESCRIPTION
## Description

- This PR aims to keep the `Accept` buttons on the `Incoming funds` page disabled until the funds claims data is refetched and their `isClaimed` state has updated.

> [!NOTE]
> I have considered using subscriptions, however setting a subscription on the `Colony` model would not get triggered when updating the `fundsClaims`, while setting subscriptions for all unclaimed funds claims seems like a too-big of a performance overhead for what we want to achieve. Thus, I have introduced a new `isFundsUpdatePending` state on the `IncomingFundsLoadingContext` and make use of two new hooks, one for refreshing the colony data and one for checking the funds claims state.

## Testing

TODO: Now let's proceed to testing these changes behave accordingly.

* Step 1. Visit http://localhost:9091/planex and copy the colony address
* Step 2. Go to http://localhost:9091/wayne
* Step 3. Create a `Simple payment` using the copied colony address for the `Recipient` field
![Screenshot 2024-12-23 at 12 23 28](https://github.com/user-attachments/assets/2273fdf2-0f64-43c0-8991-5ca8b72c0f2c)

* Step 4. Go back to planex http://localhost:9091/planex
* Step 5. Please save this in a new file - you can call it `.diff`
```
diff --git a/src/redux/sagas/actions/mintTokens.ts b/src/redux/sagas/actions/mintTokens.ts
index 7f68b83f1..6ead99ee8 100644
--- a/src/redux/sagas/actions/mintTokens.ts
+++ b/src/redux/sagas/actions/mintTokens.ts
@@ -61,18 +61,18 @@ function* createMintTokensAction({
       ready: false,
     });
 
-    yield fork(createTransaction, claimColonyFunds.id, {
-      context: ClientType.ColonyClient,
-      methodName: 'claimColonyFunds',
-      identifier: colonyAddress,
-      params: [nativeTokenAddress],
-      group: {
-        key: batchKey,
-        id: metaId,
-        index: 1,
-      },
-      ready: false,
-    });
+    // yield fork(createTransaction, claimColonyFunds.id, {
+    //   context: ClientType.ColonyClient,
+    //   methodName: 'claimColonyFunds',
+    //   identifier: colonyAddress,
+    //   params: [nativeTokenAddress],
+    //   group: {
+    //     key: batchKey,
+    //     id: metaId,
+    //     index: 1,
+    //   },
+    //   ready: false,
+    // });
 
     if (annotationMessage) {
       yield fork(createTransaction, annotateMintTokens.id, {
@@ -90,7 +90,7 @@ function* createMintTokensAction({
     }
 
     yield takeFrom(mintTokens.channel, ActionTypes.TRANSACTION_CREATED);
-    yield takeFrom(claimColonyFunds.channel, ActionTypes.TRANSACTION_CREATED);
+    // yield takeFrom(claimColonyFunds.channel, ActionTypes.TRANSACTION_CREATED);
 
     if (annotationMessage) {
       yield takeFrom(
@@ -107,9 +107,9 @@ function* createMintTokensAction({
       },
     } = yield waitForTxResult(mintTokens.channel);
 
-    yield initiateTransaction(claimColonyFunds.id);
+    // yield initiateTransaction(claimColonyFunds.id);
 
-    yield waitForTxResult(claimColonyFunds.channel);
+    // yield waitForTxResult(claimColonyFunds.channel);
 
     yield createActionMetadataInDB(txHash, { customTitle: customActionTitle });
 

```

* Step 6. Run `git apply .diff` - or however you decided to name the file with the above-mentioned content

> [!NOTE]
> These changes will disable the funds claiming when minting tokens, as we'll need to have some data on which to check the buttons on the `Incoming funds` page behave properly

* Step 7. Let's create a couple of `Mint tokens` actions
![Screenshot 2024-12-23 at 12 23 36](https://github.com/user-attachments/assets/a6cc63ab-75f1-48df-9401-048af989e154)

* Step 8. Head to http://localhost:9091/planex/incoming
* Step 9. Play around with the `Accept` or `Accept all incoming funds` buttons and check the buttons are not re-enabled before the `Accepted` status is shown

https://github.com/user-attachments/assets/73889798-9f6a-46b0-9a35-4377acccb100


**Repeat step 3. and/or steps 7-9. as much as wanted. If you have any other testing ideas, do not stop these testing steps from checking them out**

> [!NOTE]
> Even after accepting all incoming funds, if you refresh the page, the `Accept all incoming funds` button will be enabled as there are `chainFundsClaim` that still remain unclaimed

## Diffs

**New stuff** ✨

* `useRefetchColonyData` and `useFundsStateUpdater` hooks
* `setPendingFundsTokenAddresses` and `reset` props for `IncomingFundsLoadingContext`

**Deletions** ⚰️

* `disableAcceptLoading` prop for `IncomingFundsLoadingContext`

Resolves #3502 
