### PR TITLE
fix: split payment ui/ux

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/SplitPaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/SplitPaymentForm.tsx
@@ -67,16 +67,6 @@ const SplitPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
           disabled={hasNoDecisionMethods}
         />
       </ActionFormRow>
-      <AmountRow
-        domainId={selectedTeam}
-        tooltips={{
-          label: {
-            tooltipContent: formatText({
-              id: 'actionSidebar.tooltip.simplePayment.amount',
-            }),
-          },
-        }}
-      />
       <ActionFormRow
         icon={UsersThree}
         fieldName="team"
@@ -92,6 +82,16 @@ const SplitPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
       >
         <TeamsSelect name="team" disabled={hasNoDecisionMethods} />
       </ActionFormRow>
+      <AmountRow
+        domainId={selectedTeam}
+        tooltips={{
+          label: {
+            tooltipContent: formatText({
+              id: 'actionSidebar.tooltip.simplePayment.amount',
+            }),
+          },
+        }}
+      />
       <DecisionMethodField />
       <Description />
       {currentToken && (

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentPercentField/SplitPaymentPercentField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentPercentField/SplitPaymentPercentField.tsx
@@ -26,6 +26,7 @@ const SplitPaymentPercentField: FC<SplitPaymentPercentFieldProps> = ({
         }
       }}
       wrapperClassName="flex-row flex text-md"
+      inputWrapperClassName="flex items-center gap-2"
       type="text"
       shouldAllowOnlyNumbers
       mode="secondary"

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/SplitPaymentRecipientsField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/SplitPaymentRecipientsField.tsx
@@ -1,9 +1,10 @@
-import { CopySimple, Plus, Trash } from '@phosphor-icons/react';
+import { Coins, CopySimple, Plus, Trash } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { useEffect, type FC } from 'react';
 import { useFieldArray, useWatch, useFormContext } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
+import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { SplitPaymentDistributionType } from '~gql';
 import { useTablet } from '~hooks/index.ts';
 import { formatText } from '~utils/intl.ts';
@@ -27,6 +28,9 @@ const SplitPaymentRecipientsField: FC<SplitPaymentRecipientsFieldProps> = ({
   token,
   disabled,
 }) => {
+  const {
+    colony: { nativeToken },
+  } = useColonyContext();
   const fieldArrayMethods = useFieldArray({
     name,
   });
@@ -51,6 +55,18 @@ const SplitPaymentRecipientsField: FC<SplitPaymentRecipientsFieldProps> = ({
   const getMenuProps = ({ index }) => ({
     cardClassName: 'min-w-[9.625rem] whitespace-nowrap',
     items: [
+      {
+        key: 'add-token',
+        onClick: () =>
+          fieldArrayMethods.insert(index + 1, {
+            recipient: '',
+            amount: '',
+            tokenAddress: nativeToken?.tokenAddress || '',
+            delay: '',
+          }),
+        label: formatText({ id: 'button.addRow' }),
+        icon: Coins,
+      },
       {
         key: 'duplicate',
         onClick: () => fieldArrayMethods.insert(index + 1, value[index]),

--- a/src/components/v5/common/CompletedAction/partials/SplitPayment/SplitPayment.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SplitPayment/SplitPayment.tsx
@@ -275,7 +275,6 @@ const SplitPayment = ({ action }: SplitPaymentProps) => {
             id: 'actionSidebar.tooltip.distributionTypes',
           })}
         />
-        <AmountRow amount={amount || '1'} token={splitToken} />
 
         {selectedTeam?.metadata && (
           <TeamFromRow
@@ -283,6 +282,7 @@ const SplitPayment = ({ action }: SplitPaymentProps) => {
             actionType={action.type}
           />
         )}
+        <AmountRow amount={amount || '1'} token={splitToken} />
 
         <DecisionMethodRow action={action} />
 

--- a/src/components/v5/common/CompletedAction/partials/SplitPayment/partials/SplitPaymentTable/hooks.tsx
+++ b/src/components/v5/common/CompletedAction/partials/SplitPayment/partials/SplitPaymentTable/hooks.tsx
@@ -103,9 +103,10 @@ export const useGetSplitPaymentColumns = (
               isLoading={isDataLoading}
               className="h-4 w-full rounded"
             >
-              <span className="text-md font-medium text-gray-900">
-                {parseFloat(percentCalculated.toFixed(4))}%
-              </span>
+              <div className="flex items-center gap-2 text-md font-medium text-gray-900">
+                {parseFloat(percentCalculated.toFixed(4))}
+                <span>%</span>
+              </div>
             </LoadingSkeleton>
           );
         },


### PR DESCRIPTION
## Description

- Move the team field above the amount field in both the creation and completed states.
- Add the 'Add row' feature (currently in the 'Advanced payments' payment table) to the split payments table.
- Ensure the padding between the percentage icon and the placeholder/inputted value matches the Figma design across all responsive states for both creation and completed states.

## Testing

* Create split payment action
* Check team field placement, add row option in meatball menu and padding between % and amount

<img width="227" alt="image" src="https://github.com/user-attachments/assets/d864b9a5-fec0-4a34-86dc-28747165b949" />

Resolves https://github.com/JoinColony/colonyCDapp/issues/3972
