### PR TITLE
feat: expand agreement desc by default

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/CreateDecision/CreateDecision.tsx
+++ b/src/components/v5/common/CompletedAction/partials/CreateDecision/CreateDecision.tsx
@@ -73,7 +73,10 @@ const CreateDecision = ({ action }: CreateDecisionProps) => {
         )}
       </ActionDataGrid>
       {action.decisionData?.description && (
-        <DescriptionRow description={action.decisionData.description} />
+        <DescriptionRow
+          description={action.decisionData.description}
+          isDefaultExpanded
+        />
       )}
     </>
   );

--- a/src/components/v5/common/CompletedAction/partials/rows/Description.tsx
+++ b/src/components/v5/common/CompletedAction/partials/rows/Description.tsx
@@ -13,6 +13,7 @@ const displayName = 'v5.common.CompletedAction.partials.DescriptionRow';
 
 interface DescriptionRowProps {
   description: string;
+  isDefaultExpanded?: boolean;
 }
 
 const SHORT_DESCRIPTION_CHAR_LIMIT = 180;
@@ -27,8 +28,11 @@ const MSG = defineMessages({
 
 // @NOTE this is pretty hacky with the arbitrary limit and DOMPurify sanitization
 // it's also outside the grid, since it changes from a row to a column
-const DescriptionRow = ({ description }: DescriptionRowProps) => {
-  const [isExpanded, setIsExpanded] = useState(false);
+const DescriptionRow = ({
+  description,
+  isDefaultExpanded = false,
+}: DescriptionRowProps) => {
+  const [isExpanded, setIsExpanded] = useState(isDefaultExpanded);
 
   const descriptionTextContent = DOMPurify.sanitize(description, {
     ALLOWED_TAGS: [],


### PR DESCRIPTION
## Description
- Description field for the “Create agreement” action type is expanded by default when in the completed state

<img width="1059" alt="image" src="https://github.com/user-attachments/assets/15ce6d5f-5315-4f20-b461-80b7f72c58b3" />

## Testing

* Install Reputation Weighted (Lazy Consensus method) extension
* Create a new agreement
* Check if description field is expanded by default

Resolves https://github.com/JoinColony/colonyCDapp/issues/3991
