### PR TITLE
Fix: No transaction action sidebar styling and behaviour

### DIFF
--- a/src/components/frame/Extensions/layouts/ColonyLayout.tsx
+++ b/src/components/frame/Extensions/layouts/ColonyLayout.tsx
@@ -23,7 +23,7 @@ import { useColonyCreatedModalContext } from '~context/ColonyCreateModalContext/
 import { useMemberModalContext } from '~context/MemberModalContext/MemberModalContext.ts';
 import { usePageLayoutContext } from '~context/PageLayoutContext/PageLayoutContext.ts';
 import { useTablet } from '~hooks';
-import useLocationChange from '~hooks/useLocationChange.ts';
+import useLocationPathnameChange from '~hooks/useLocationPathnameChange.ts';
 import usePrevious from '~hooks/usePrevious.ts';
 import { TX_SEARCH_PARAM } from '~routes/index.ts';
 import ActionSidebar from '~v5/common/ActionSidebar/index.ts';
@@ -82,7 +82,7 @@ const ColonyLayout: FC<PropsWithChildren> = ({ children }) => {
   const transactionId = searchParams?.get(TX_SEARCH_PARAM);
   const previousTransactionId = usePrevious(transactionId);
 
-  useLocationChange(() => {
+  useLocationPathnameChange(() => {
     if (!!previousTransactionId && !transactionId && isActionSidebarOpen) {
       toggleActionSidebarOff();
     }

--- a/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
@@ -14,7 +14,6 @@ import React, {
   useLayoutEffect,
   useRef,
 } from 'react';
-import { Link } from 'react-router-dom';
 
 import { isFullScreen } from '~constants/index.ts';
 import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
@@ -22,22 +21,18 @@ import { useMobile } from '~hooks/index.ts';
 import useCopyToClipboard from '~hooks/useCopyToClipboard.ts';
 import useDisableBodyScroll from '~hooks/useDisableBodyScroll/index.ts';
 import useToggle from '~hooks/useToggle/index.ts';
-import { COLONY_ACTIVITY_ROUTE, TX_SEARCH_PARAM } from '~routes';
 import Tooltip from '~shared/Extensions/Tooltip/Tooltip.tsx';
 import { formatText } from '~utils/intl.ts';
-import { removeQueryParamFromUrl } from '~utils/urls.ts';
-import Button from '~v5/shared/Button/Button.tsx';
-import ButtonLink from '~v5/shared/Button/ButtonLink.tsx';
 import Modal from '~v5/shared/Modal/index.ts';
 
 import CompletedAction from '../CompletedAction/index.ts';
-import FourOFourMessage from '../FourOFourMessage/index.ts';
 import PillsBase from '../Pills/PillsBase.tsx';
 
 import { actionSidebarAnimation } from './consts.ts';
 import useCloseSidebarClick from './hooks/useCloseSidebarClick.ts';
 import useGetActionData from './hooks/useGetActionData.ts';
 import useGetGroupedActionComponent from './hooks/useGetGroupedActionComponent.tsx';
+import { ActionNotFound } from './partials/ActionNotFound.tsx';
 import ActionSidebarContent from './partials/ActionSidebarContent/ActionSidebarContent.tsx';
 import ActionSidebarLoadingSkeleton from './partials/ActionSidebarLoadingSkeleton/ActionSidebarLoadingSkeleton.tsx';
 import ExpenditureActionStatusBadge from './partials/ExpenditureActionStatusBadge/ExpenditureActionStatusBadge.tsx';
@@ -118,65 +113,11 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
 
     if (actionNotFound) {
       return (
-        <div className="pt-14">
-          <FourOFourMessage
-            description={formatText({
-              id: isInvalidTransactionHash
-                ? 'actionSidebar.fourOfour.descriptionInvalidHash'
-                : 'actionSidebar.fourOfour.description',
-            })}
-            links={
-              <>
-                {!isInvalidTransactionHash && (
-                  <Link
-                    to={COLONY_ACTIVITY_ROUTE}
-                    className="mb-2 text-sm text-blue-400 underline"
-                    onClick={toggleActionSidebarOff}
-                  >
-                    {formatText({
-                      id: 'actionSidebar.fourOfour.activityPageLink',
-                    })}
-                  </Link>
-                )}
-                <Link
-                  to={removeQueryParamFromUrl(
-                    window.location.href,
-                    TX_SEARCH_PARAM,
-                  )}
-                  className="mb-2 text-sm text-blue-400 underline"
-                >
-                  {formatText({
-                    id: 'actionSidebar.fourOfour.createNewAction',
-                  })}
-                </Link>
-              </>
-            }
-            primaryLinkButton={
-              isInvalidTransactionHash ? (
-                <ButtonLink
-                  mode="primarySolid"
-                  to={COLONY_ACTIVITY_ROUTE}
-                  className="flex-1"
-                  onClick={toggleActionSidebarOff}
-                >
-                  {formatText({
-                    id: 'actionSidebar.fourOfour.activityPageLink',
-                  })}
-                </ButtonLink>
-              ) : (
-                <Button
-                  mode="primarySolid"
-                  className="flex-1"
-                  onClick={startPollingForAction}
-                >
-                  {formatText({
-                    id: 'button.retry',
-                  })}
-                </Button>
-              )
-            }
-          />
-        </div>
+        <ActionNotFound
+          isInvalidTransactionHash={isInvalidTransactionHash}
+          onCloseSidebar={toggleActionSidebarOff}
+          onRefetchAction={startPollingForAction}
+        />
       );
     }
 

--- a/src/components/v5/common/ActionSidebar/partials/ActionNotFound.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionNotFound.tsx
@@ -1,0 +1,90 @@
+import React, { type FC } from 'react';
+import { Link } from 'react-router-dom';
+
+import { COLONY_ACTIVITY_ROUTE, TX_SEARCH_PARAM } from '~routes';
+import { formatText } from '~utils/intl.ts';
+import { removeQueryParamFromUrl } from '~utils/urls.ts';
+import FourOFourMessage from '~v5/common/FourOFourMessage/FourOFourMessage.tsx';
+import Button from '~v5/shared/Button/Button.tsx';
+import ButtonLink from '~v5/shared/Button/ButtonLink.tsx';
+
+interface ActionNotFoundProps {
+  isInvalidTransactionHash?: boolean;
+  onCloseSidebar: VoidFunction;
+  onRefetchAction: VoidFunction;
+}
+
+export const ActionNotFound: FC<ActionNotFoundProps> = ({
+  isInvalidTransactionHash,
+  onCloseSidebar,
+  onRefetchAction,
+}) => {
+  const createNewActionLink = (
+    <Link
+      to={removeQueryParamFromUrl(window.location.href, TX_SEARCH_PARAM)}
+      className="mb-2 text-sm text-blue-400 underline"
+    >
+      {formatText({
+        id: 'actionSidebar.fourOfour.createNewAction',
+      })}
+    </Link>
+  );
+
+  if (isInvalidTransactionHash) {
+    return (
+      <FourOFourMessage
+        className="mt-14 w-full sm:max-w-md"
+        description={formatText({
+          id: 'actionSidebar.fourOfour.descriptionInvalidHash',
+        })}
+        links={createNewActionLink}
+        primaryLinkButton={
+          <ButtonLink
+            mode="primarySolid"
+            to={COLONY_ACTIVITY_ROUTE}
+            className="flex-1"
+            onClick={onCloseSidebar}
+          >
+            {formatText({
+              id: 'actionSidebar.fourOfour.activityPageLink',
+            })}
+          </ButtonLink>
+        }
+      />
+    );
+  }
+
+  return (
+    <FourOFourMessage
+      className="mt-14 w-full sm:max-w-md"
+      description={formatText({
+        id: 'actionSidebar.fourOfour.description',
+      })}
+      links={
+        <>
+          <Link
+            to={COLONY_ACTIVITY_ROUTE}
+            className="mb-2 text-sm text-blue-400 underline"
+            onClick={onCloseSidebar}
+          >
+            {formatText({
+              id: 'actionSidebar.fourOfour.activityPageLink',
+            })}
+          </Link>
+          {createNewActionLink}
+        </>
+      }
+      primaryLinkButton={
+        <Button
+          mode="primarySolid"
+          className="flex-1"
+          onClick={onRefetchAction}
+        >
+          {formatText({
+            id: 'button.retry',
+          })}
+        </Button>
+      }
+    />
+  );
+};

--- a/src/components/v5/common/FourOFourMessage/FourOFourMessage.tsx
+++ b/src/components/v5/common/FourOFourMessage/FourOFourMessage.tsx
@@ -1,4 +1,5 @@
 import { SmileySad } from '@phosphor-icons/react';
+import clsx from 'clsx';
 import React, { type FC } from 'react';
 import { defineMessages } from 'react-intl';
 
@@ -33,9 +34,15 @@ const FourOFourMessage: FC<FourOFourMessageProps> = ({
   description,
   links,
   primaryLinkButton,
+  className,
 }) => {
   return (
-    <div className="mx-auto flex w-full flex-col items-start sm:max-w-lg sm:p-0 md:w-auto">
+    <div
+      className={clsx(
+        className,
+        'mx-auto flex w-full flex-col items-start sm:max-w-lg sm:p-0 md:w-auto',
+      )}
+    >
       <SmileySad size={32} />
       <h3 className="my-2 heading-3">{formatText(MSG.title)}</h3>
       <p className="text-sm text-gray-600">{description}</p>

--- a/src/components/v5/common/FourOFourMessage/types.ts
+++ b/src/components/v5/common/FourOFourMessage/types.ts
@@ -4,4 +4,5 @@ export interface FourOFourMessageProps {
   description: string;
   links: ReactNode;
   primaryLinkButton: ReactNode;
+  className?: string;
 }

--- a/src/hooks/useLocationPathnameChange.ts
+++ b/src/hooks/useLocationPathnameChange.ts
@@ -1,13 +1,13 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
-const useLocationChange = (callback) => {
+const useLocationPathnameChange = (callback) => {
   const location = useLocation();
   useEffect(() => {
     callback();
-    // We want to react only to location changes
+    // We want to react only to location pathname changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location]);
+  }, [location.pathname]);
 };
 
-export default useLocationChange;
+export default useLocationPathnameChange;


### PR DESCRIPTION
## Description

- This PR aims fixing the broken styling for the not found action sidebar content, as well as the navigation to creating a new action from its `Create a new action` link
 
https://github.com/user-attachments/assets/1a403449-6d33-4754-bcdd-94b0dc763208


## Testing

TODO: Please check the navigation to creating a new action works properly, UI adjustments match [Figma](https://www.figma.com/design/5V8pr7iMwXsT9L3VAZsmUt/Actions-%26-Motions?node-id=23947-236415&t=bsEF0JbB2xNLxycb-4) and then we'll proceed to some regression testing 🙌 

* Step 1. Navigate to http://localhost:9091/planex?tx=0x
* Step 2. Check the action sidebar content matches the [Figma](https://www.figma.com/design/5V8pr7iMwXsT9L3VAZsmUt/Actions-%26-Motions?node-id=23947-236415&t=bsEF0JbB2xNLxycb-4) 

![Screenshot 2024-12-27 at 17 04 00](https://github.com/user-attachments/assets/c91cc122-797c-49ee-a9fe-c412c5842f64)


* Step 3. Click on `Create a new action` and make sure the action form is opened

https://github.com/user-attachments/assets/6ebdd2a8-0b73-45d6-a04a-d7a41354eabf

* Step 4. In `src/components/v5/common/ActionSidebar/ActionSidebar.tsx` at line `95` please update the timeout value to `1000`
<img width="740" alt="Screenshot 2024-12-27 at 17 00 20" src="https://github.com/user-attachments/assets/84f4b6d7-51cb-4b40-af07-41e035ccf17f" />

* Step 5. Navigate to http://localhost:9091/planex?tx=0x0ab68d8464728f01260ae8e37e8b1ea2263803fffebb1da300b7d7335abb4f34

Any `tx` value that doesn't already exist should be fine

* Step 6. Click on the `Create a new action` link and make sure it behaves correctly. Go back. Click on the `Go to activity page` link and make sure it behaves correctly. Go back. Click on `Retry` button.

https://github.com/user-attachments/assets/b48bdbf3-3cfb-4c01-a2a7-a27b60d83d5d

* Step 7. Now a bit of regression testing. Please create a mint tokens action.

![Screenshot 2024-12-27 at 17 05 08](https://github.com/user-attachments/assets/c199f2d9-60e0-437a-a7e8-44fafc55dc68)

* Step 8. Make sure you can see the completed action screen and the action sidebar doesn't get closed by default.

![Screenshot 2024-12-27 at 17 07 45](https://github.com/user-attachments/assets/328a8e04-bd5a-44e7-a2ae-60af7665a600)

* Step 9. Open the notifications and click on the `Incoming funds` one. Make sure you get to the `Incoming funds` page and the action sidebar gets closed.

https://github.com/user-attachments/assets/353d6095-8ff6-4f1d-9cf3-3833c317cd34


## Diffs

**New stuff** ✨ 

* `ActionNotFound` component

**Changes** 🏗

* Replaced `useLocationChange` with `useLocationPathnameChange` as this was causing the action sidebar to get closed upon removing the `txHash` even though the pathname remained the same
* Add `className` to `FourOFourMessage`

Resolves #3670 
