### PR TITLE
Fix: Total fund cards alignment on dashboard

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsItem.tsx
@@ -41,24 +41,23 @@ export const FundsCardsItem: FC<FundsCardsItemProps> = ({
     <WidgetCards.Item
       onClick={onTeamClick}
       title={
-        <LoadingSkeleton isLoading={loading} className="mb-1 h-5 w-14 rounded">
-          <span className="mb-1 mt-0.5 flex">{domainName}</span>
+        <LoadingSkeleton isLoading={loading} className="h-5 w-14 rounded">
+          <span className="flex">{domainName}</span>
         </LoadingSkeleton>
       }
       subTitle={
-        <div className="pt-0.5">
-          <FundsCardsSubTitle
-            currency={currency}
-            isLoading={loading}
-            value={
-              <NumeralCurrency
-                value={total.toString()}
-                prefix={currencySymbolMap[currency]}
-                decimals={18}
-              />
-            }
-          />
-        </div>
+        <FundsCardsSubTitle
+          className={loading ? 'mt-1' : 'mt-0.5'}
+          currency={currency}
+          isLoading={loading}
+          value={
+            <NumeralCurrency
+              value={total.toString()}
+              prefix={currencySymbolMap[currency]}
+              decimals={18}
+            />
+          }
+        />
       }
     />
   );

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsSubTitle.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsSubTitle.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import React, { type FC } from 'react';
 
 import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
@@ -6,14 +7,16 @@ interface FundsCardsSubTitleProps {
   value: React.ReactNode;
   currency: string;
   isLoading?: boolean;
+  className?: string;
 }
 export const FundsCardsSubTitle: FC<FundsCardsSubTitleProps> = ({
   value,
   currency,
   isLoading,
+  className,
 }) => {
   return (
-    <p className="flex items-center gap-2">
+    <p className={clsx(className, 'flex items-center gap-2')}>
       <LoadingSkeleton
         className="h-[27px] w-[90px] rounded"
         isLoading={isLoading}

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalDescription.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalDescription.tsx
@@ -20,6 +20,10 @@ const MSG = defineMessages({
     id: 'v5.frame.ColonyHome.FundsCards.FundsCardsTotalDescription.weeklyTrend',
     defaultMessage: '{percent} Week',
   },
+  native: {
+    id: 'v5.frame.ColonyHome.FundsCards.FundsCardsTotalDescription.native',
+    defaultMessage: 'Native',
+  },
 });
 
 export const FundsCardsTotalDescription: React.FC<
@@ -36,11 +40,11 @@ export const FundsCardsTotalDescription: React.FC<
   );
 
   return (
-    <div className="mt-1.5 flex w-full justify-between text-xs">
+    <div className="mt-1 flex w-full justify-between text-xs">
       <LoadingSkeleton isLoading={isLoading} className="h-4 w-[114px] rounded">
-        <span className="uppercase text-gray-400">
+        <span className="font-medium uppercase text-gray-400">
           <Numeral
-            prefix="Native"
+            prefix={formatText(MSG.native)}
             value={tokenBalance.toString()}
             decimals={nativeToken.decimals}
             suffix={` ${nativeToken.symbol}`}

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalItem.tsx
@@ -55,19 +55,18 @@ export const FundsCardsTotalItem: FC<FundsCardsTotalItemProps> = ({
         </LoadingSkeleton>
       }
       subTitle={
-        <div className="pb-1 pt-0.5">
-          <FundsCardsSubTitle
-            isLoading={loading}
-            value={
-              <NumeralCurrency
-                value={total ?? '-'}
-                prefix={currencySymbolMap[currency]}
-                decimals={18}
-              />
-            }
-            currency={currency}
-          />
-        </div>
+        <FundsCardsSubTitle
+          className={loading ? 'mt-1' : 'my-0.5'}
+          isLoading={loading}
+          value={
+            <NumeralCurrency
+              value={total ?? '-'}
+              prefix={currencySymbolMap[currency]}
+              decimals={18}
+            />
+          }
+          currency={currency}
+        />
       }
       onClick={onItemClick}
     >


### PR DESCRIPTION
## Description

- This PR aims to fix the total funds cards content alignment

https://github.com/user-attachments/assets/23b8e7de-2ee5-4480-b5ae-f33888e10a21

## Testing

TODO: Make sure the total funds cards on the dashboard match [Figma](https://www.figma.com/design/gac6xVgGNCAge5Bia933dp/Dashboard?node-id=4878-89693&t=qZsUrtUGdZQc0mXw-0) 

TODO: Please also test the loading state, by setting `loading` to `true` in `src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalItem.tsx` and `src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsItem.tsx`

> [!TIP]
> If you want to test this PR easier, you can use the [Pixel Perfect](https://chromewebstore.google.com/detail/perfectpixel-by-welldonec/dkaagdgjmgdmbnecmcefdhjekcoceebi) extension
> Then, you'll need to download [this design](https://www.figma.com/design/gac6xVgGNCAge5Bia933dp/Dashboard?node-id=4859-36367&t=qZsUrtUGdZQc0mXw-0)
> Make sure to select the `Dashboard` frame
> ![Screenshot 2024-12-30 at 11 14 44](https://github.com/user-attachments/assets/f71e8e8e-846c-4e9d-a05b-660b711e6c65)
> And make sure the `1` scale is set in the extension config
> ![Screenshot 2024-12-30 at 11 15 46](https://github.com/user-attachments/assets/561e4a78-bd2e-4d3e-a649-3f7a4b13e5c7)
> Set the browser width to `1574`


## Diffs

**New stuff** ✨

* Added `className` to `FundsCardsSubTitle` to remove wrapper elements

**Changes** 🏗

* Style updates for the fund cards components

Resolves #3653 
