### PR TITLE
Fix extension settings loading states

### DIFF
--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/InstallButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/InstallButton.tsx
@@ -2,6 +2,7 @@ import { Extension } from '@colony/colony-js';
 import React from 'react';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { useExtensionDetailsPageContext } from '~frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContext.ts';
 import { useMobile } from '~hooks/index.ts';
 import { ActionTypes } from '~redux/index.ts';
 import { type AnyExtensionData } from '~types/extensions.ts';
@@ -22,6 +23,7 @@ const InstallButton = ({ extensionData }: InstallButtonProps) => {
     colony: { colonyAddress, nativeToken },
     isSupportedColonyVersion,
   } = useColonyContext();
+  const { waitingForActionConfirmation } = useExtensionDetailsPageContext();
 
   const isMobile = useMobile();
 
@@ -53,7 +55,7 @@ const InstallButton = ({ extensionData }: InstallButtonProps) => {
       onSuccess={handleInstallSuccess}
       onError={handleInstallError}
       isFullSize={isMobile}
-      disabled={!isSupportedColonyVersion}
+      disabled={!isSupportedColonyVersion || waitingForActionConfirmation}
     >
       {formatText({ id: 'button.install' })}
     </ActionButton>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/ReenableButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/ReenableButton.tsx
@@ -1,6 +1,7 @@
 import { Question } from '@phosphor-icons/react';
 import React, { useState } from 'react';
 
+import { useExtensionDetailsPageContext } from '~frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContext.ts';
 import { useMobile } from '~hooks/index.ts';
 import { type AnyExtensionData } from '~types/extensions.ts';
 import { formatText } from '~utils/intl.ts';
@@ -22,6 +23,8 @@ const ReenableButton = ({
   });
   const isMobile = useMobile();
 
+  const { waitingForActionConfirmation } = useExtensionDetailsPageContext();
+
   return (
     <>
       <ButtonWithLoader
@@ -29,6 +32,7 @@ const ReenableButton = ({
         onClick={() => setIsReEnableModalOpen(true)}
         isFullSize={isMobile}
         loading={isLoading}
+        disabled={waitingForActionConfirmation}
       >
         {formatText({ id: 'button.enable' })}
       </ButtonWithLoader>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/SubmitButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/SubmitButton.tsx
@@ -74,6 +74,7 @@ const SubmitButton = ({ userHasRoot, extensionData }: SubmitButtonProps) => {
             setActiveTab(ExtensionDetailsPageTabId.Settings);
           }}
           isFullSize={isMobile}
+          disabled={waitingForActionConfirmation}
         >
           {formatText({ id: 'button.enable' })}
         </Button>
@@ -83,7 +84,7 @@ const SubmitButton = ({ userHasRoot, extensionData }: SubmitButtonProps) => {
     return (
       <ButtonWithLoader
         type="submit"
-        disabled={!isValid}
+        disabled={!isValid || waitingForActionConfirmation}
         isFullSize={isMobile}
         loading={isSubmitting || waitingForActionConfirmation}
       >
@@ -98,6 +99,7 @@ const SubmitButton = ({ userHasRoot, extensionData }: SubmitButtonProps) => {
         type="submit"
         isFullSize={isMobile}
         loading={isSubmitting || waitingForActionConfirmation}
+        disabled={waitingForActionConfirmation}
       >
         {formatText({ id: 'button.saveChanges' })}
       </ButtonWithLoader>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/UpgradeButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/UpgradeButton.tsx
@@ -8,6 +8,7 @@ import React, { useState } from 'react';
 import { toast } from 'react-toastify';
 
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { useExtensionDetailsPageContext } from '~frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContext.ts';
 import { waitForDbAfterExtensionAction } from '~frame/Extensions/pages/ExtensionDetailsPage/utils.tsx';
 import { useMobile } from '~hooks/index.ts';
 import useExtensionData, { ExtensionMethods } from '~hooks/useExtensionData.ts';
@@ -28,6 +29,8 @@ const UpgradeButton = ({ extensionData }: UpgradeButtonProps) => {
     isSupportedColonyVersion,
   } = useColonyContext();
   const isMobile = useMobile();
+  const { setWaitingForActionConfirmation, waitingForActionConfirmation } =
+    useExtensionDetailsPageContext();
   const { refetchExtensionData } = useExtensionData(extensionData.extensionId);
   const [isPolling, setIsPolling] = useState(false);
   const [isUpgradeDisabled, setIsUpgradeDisabled] = useState(false);
@@ -51,6 +54,7 @@ const UpgradeButton = ({ extensionData }: UpgradeButtonProps) => {
     setIsPolling(true);
     await waitForDbAfterExtensionAction({
       method: ExtensionMethods.UPGRADE,
+      setWaitingForActionConfirmation,
       refetchExtensionData,
       latestVersion: extensionData.availableVersion,
     });
@@ -85,7 +89,7 @@ const UpgradeButton = ({ extensionData }: UpgradeButtonProps) => {
       onError={handleUpgradeError}
       isLoading={isPolling}
       isFullSize={isMobile}
-      disabled={isUpgradeButtonDisabled}
+      disabled={isUpgradeButtonDisabled || waitingForActionConfirmation}
     >
       {formatText({ id: 'button.updateVersion' })}
     </ActionButton>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/hooks.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/hooks.tsx
@@ -21,6 +21,7 @@ export const useReenable = ({ extensionId }: { extensionId: Extension }) => {
     colony: { colonyAddress },
   } = useColonyContext();
   const { refetchExtensionData } = useExtensionData(extensionId);
+  const { setWaitingForActionConfirmation } = useExtensionDetailsPageContext();
 
   const enableExtensionValues = {
     colonyAddress,
@@ -40,6 +41,7 @@ export const useReenable = ({ extensionId }: { extensionId: Extension }) => {
       await enableAsyncFunction(enableExtensionValues);
       await waitForDbAfterExtensionAction({
         method: ExtensionMethods.REENABLE,
+        setWaitingForActionConfirmation,
         refetchExtensionData,
       });
       toast.success(

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/DeprecateButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/DeprecateButton.tsx
@@ -1,6 +1,7 @@
 import { Question } from '@phosphor-icons/react';
 import React, { useState } from 'react';
 
+import { useExtensionDetailsPageContext } from '~frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContext.ts';
 import { type AnyExtensionData } from '~types/extensions.ts';
 import { formatText } from '~utils/intl.ts';
 import Modal from '~v5/shared/Modal/Modal.tsx';
@@ -19,6 +20,7 @@ const DeprecateButton = ({
   extensionData: { extensionId },
 }: DeprecateButtonProps) => {
   const [isDeprecateModalOpen, setIsDeprecateModalOpen] = useState(false);
+  const { waitingForActionConfirmation } = useExtensionDetailsPageContext();
 
   const { handleDeprecate, isLoading } = useDeprecate({
     extensionId,
@@ -35,6 +37,7 @@ const DeprecateButton = ({
           loaderClassName="!px-4 !py-2 !text-sm"
           loaderIconSize={14}
           onClick={() => setIsDeprecateModalOpen(true)}
+          disabled={waitingForActionConfirmation}
         >
           {formatText({ id: 'button.deprecateExtension' })}
         </ButtonWithLoader>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
@@ -3,6 +3,7 @@ import { Trash } from '@phosphor-icons/react';
 import React, { useState } from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
 
+import { useExtensionDetailsPageContext } from '~frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContext.ts';
 import { type AnyExtensionData } from '~types/extensions.ts';
 import { formatText } from '~utils/intl.ts';
 import Checkbox from '~v5/common/Checkbox/Checkbox.tsx';
@@ -112,6 +113,7 @@ const UninstallButton = ({
   const [isUninstallModalOpen, setIsUninstallModalOpen] = useState(false);
   const [isCheckboxChecked, setIsCheckboxChecked] = useState(false);
   const { handleUninstall, isLoading } = useUninstall(extensionId);
+  const { waitingForActionConfirmation } = useExtensionDetailsPageContext();
 
   return (
     <>
@@ -122,6 +124,7 @@ const UninstallButton = ({
           isFullSize
           loading={isLoading}
           onClick={() => setIsUninstallModalOpen(true)}
+          disabled={waitingForActionConfirmation}
         >
           {formatText({ id: 'button.uninstallExtension' })}
         </Button>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/hooks.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/hooks.tsx
@@ -17,7 +17,8 @@ export const useUninstall = (extensionId: Extension) => {
   } = useColonyContext();
   const [isLoading, setIsLoading] = useState(false);
   const { refetchExtensionData } = useExtensionData(extensionId);
-  const { setActiveTab } = useExtensionDetailsPageContext();
+  const { setActiveTab, setWaitingForActionConfirmation } =
+    useExtensionDetailsPageContext();
 
   const uninstallAsyncFunction = useAsyncFunction({
     submit: ActionTypes.EXTENSION_UNINSTALL,
@@ -37,6 +38,7 @@ export const useUninstall = (extensionId: Extension) => {
       await waitForDbAfterExtensionAction({
         method: ExtensionMethods.UNINSTALL,
         refetchExtensionData,
+        setWaitingForActionConfirmation,
       });
       toast.success(
         <Toast
@@ -73,6 +75,7 @@ export const useDeprecate = ({ extensionId }: { extensionId: Extension }) => {
     colony: { colonyAddress },
   } = useColonyContext();
   const { refetchExtensionData } = useExtensionData(extensionId);
+  const { setWaitingForActionConfirmation } = useExtensionDetailsPageContext();
   const deprecateExtensionValues = {
     colonyAddress,
     extensionId,
@@ -93,6 +96,7 @@ export const useDeprecate = ({ extensionId }: { extensionId: Extension }) => {
       await deprecateAsyncFunction(deprecateExtensionValues);
       await waitForDbAfterExtensionAction({
         method: ExtensionMethods.DEPRECATE,
+        setWaitingForActionConfirmation,
         refetchExtensionData,
       });
       toast.success(

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionPermissionsBanner/PermissionsNeededBanner.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionPermissionsBanner/PermissionsNeededBanner.tsx
@@ -5,6 +5,7 @@ import { FormattedMessage, defineMessages } from 'react-intl';
 
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { useExtensionDetailsPageContext } from '~frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContext.ts';
 import { waitForDbAfterExtensionAction } from '~frame/Extensions/pages/ExtensionDetailsPage/utils.tsx';
 import useAsyncFunction from '~hooks/useAsyncFunction.ts';
 import useExtensionData, { ExtensionMethods } from '~hooks/useExtensionData.ts';
@@ -54,6 +55,7 @@ const PermissionsNeededBanner = ({
   });
 
   const { refetchExtensionData } = useExtensionData(extensionData.extensionId);
+  const { setWaitingForActionConfirmation } = useExtensionDetailsPageContext();
 
   const enableAndCheckStatus = async () => {
     await asyncFunction({
@@ -63,6 +65,7 @@ const PermissionsNeededBanner = ({
     refetchColony();
     await waitForDbAfterExtensionAction({
       method: ExtensionMethods.ENABLE,
+      setWaitingForActionConfirmation,
       refetchExtensionData,
     });
   };

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/utils.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/utils.tsx
@@ -149,6 +149,7 @@ export const handleWaitingForDbAfterFormCompletion = async ({
       await waitForDbAfterExtensionAction({
         method,
         refetchExtensionData,
+        setWaitingForActionConfirmation,
         initialiseTransactionFailed,
         setUserRolesTransactionFailed,
       });

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/utils.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/utils.tsx
@@ -5,6 +5,7 @@ import {
   ExtensionMethods,
   type RefetchExtensionDataFn,
 } from '~hooks/useExtensionData.ts';
+import { type SetStateFn } from '~types';
 import { type AnyExtensionData } from '~types/extensions.ts';
 import { isInstalledExtensionData } from '~utils/extensions.ts';
 import { camelCase } from '~utils/lodash.ts';
@@ -44,6 +45,7 @@ export const waitForDbAfterExtensionSettingsChange = async ({
 export const waitForDbAfterExtensionAction = async (
   args: {
     refetchExtensionData: RefetchExtensionDataFn;
+    setWaitingForActionConfirmation: SetStateFn;
     interval?: number;
     timeout?: number;
   } & (
@@ -68,10 +70,13 @@ export const waitForDbAfterExtensionAction = async (
 ) => {
   const {
     refetchExtensionData,
+    setWaitingForActionConfirmation,
     interval = 1000,
     timeout = 30000,
     method,
   } = args;
+
+  setWaitingForActionConfirmation(true);
 
   await waitForCondition(
     async () => {
@@ -165,6 +170,8 @@ export const waitForDbAfterExtensionAction = async (
       timeout,
     },
   );
+
+  setWaitingForActionConfirmation(false);
 };
 
 export const getTextChunks = () => {


### PR DESCRIPTION
## Description

- Ensure that while extensions are being managed (installed, settings changed, enabled, deprecated, and uninstalled) the other buttons to manage the extension are disabled. This prevents you from, for example, uninstalling an extension, and then while that loads, attempting to enable it as described here: https://github.com/JoinColony/colonyCDapp/issues/3577.

## Testing

* Go to any extension page
* Install the extension
* Change the extension settings (and save)
* Enable the extension
* Deprecate the extension
* Uninstall the extension
* At each stage, check that you cannot do another extension management action, and that any other buttons for extension management from the list above are disabled if they are shown. The video below may help:

https://github.com/user-attachments/assets/55749edc-0581-49a7-99ec-36973545c7fc

## Diffs

**Changes** 🏗

* Update the extension details page utils to make use of a loading state context, and have the buttons be disabled when it's active

Resolves #3577
