### PR TITLE
feat: add back button to action sidebar

### DIFF
--- a/src/components/common/ColonyActionsTable/hooks/useGetMenuProps.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useGetMenuProps.tsx
@@ -60,9 +60,6 @@ export const useGetMenuProps = ({
           onClick: () => {
             navigate(
               `${window.location.pathname}?${TX_SEARCH_PARAM}=${transactionHash}`,
-              {
-                replace: true,
-              },
             );
           },
         },

--- a/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
@@ -1,5 +1,4 @@
 import {
-  ArrowLeft,
   ArrowLineRight,
   ArrowsOutSimple,
   ShareNetwork,
@@ -32,15 +31,15 @@ import PillsBase from '../Pills/PillsBase.tsx';
 import { ACTION_TYPE_FIELD_NAME, actionSidebarAnimation } from './consts.ts';
 import useCloseSidebarClick from './hooks/useCloseSidebarClick.ts';
 import useGetActionData from './hooks/useGetActionData.ts';
-import { useGetActionGroup } from './hooks/useGetActionGroup.ts';
 import useGetGroupedActionComponent from './hooks/useGetGroupedActionComponent.tsx';
 import { ActionNotFound } from './partials/ActionNotFound.tsx';
 import ActionSidebarContent from './partials/ActionSidebarContent/ActionSidebarContent.tsx';
 import ActionSidebarLoadingSkeleton from './partials/ActionSidebarLoadingSkeleton/ActionSidebarLoadingSkeleton.tsx';
 import ExpenditureActionStatusBadge from './partials/ExpenditureActionStatusBadge/ExpenditureActionStatusBadge.tsx';
+import { GoBackButton } from './partials/GoBackButton/GoBackButton.tsx';
 import MotionOutcomeBadge from './partials/MotionOutcomeBadge/index.ts';
 import { type ActionSidebarProps } from './types.ts';
-import { mapActionTypeToAction } from './utils.ts';
+import { getActionGroup, mapActionTypeToAction } from './utils.ts';
 
 const displayName = 'v5.common.ActionSidebar';
 
@@ -65,17 +64,13 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
   const {
     actionSidebarToggle: [
       isActionSidebarOpen,
-      {
-        toggle: toggleActionSidebarOff,
-        toggleOn: toggleActionSidebarOn,
-        registerContainerRef,
-      },
+      { toggle: toggleActionSidebarOff, registerContainerRef },
     ],
     cancelModalToggle: [isCancelModalOpen, { toggleOff: toggleCancelModalOff }],
     actionSidebarInitialValues,
   } = useActionSidebarContext();
   const actionType = mapActionTypeToAction(action);
-  const actionGroupType = useGetActionGroup(
+  const actionGroupType = getActionGroup(
     actionSidebarInitialValues?.[ACTION_TYPE_FIELD_NAME] || actionType,
   );
   const GroupedActionComponent = useGetGroupedActionComponent();
@@ -220,29 +215,10 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
               <X size={18} />
             </button>
             {actionGroupType && (
-              <button
-                type="button"
-                className="flex items-center justify-center py-2.5 text-gray-400 transition sm:hover:text-blue-400"
-                onClick={() => {
-                  if (transactionId) {
-                    closeSidebarClick();
-
-                    setTimeout(() => {
-                      toggleActionSidebarOn({
-                        [ACTION_TYPE_FIELD_NAME]: actionGroupType,
-                      });
-                    }, 500);
-
-                    return;
-                  }
-
-                  toggleActionSidebarOn({
-                    [ACTION_TYPE_FIELD_NAME]: actionGroupType,
-                  });
-                }}
-              >
-                <ArrowLeft size={18} />
-              </button>
+              <GoBackButton
+                action={action}
+                onClick={transactionId ? closeSidebarClick : undefined}
+              />
             )}
             {!isMobile && (
               <div className="flex items-center gap-4">

--- a/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionSidebar.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowLeft,
   ArrowLineRight,
   ArrowsOutSimple,
   ShareNetwork,
@@ -28,9 +29,10 @@ import Modal from '~v5/shared/Modal/index.ts';
 import CompletedAction from '../CompletedAction/index.ts';
 import PillsBase from '../Pills/PillsBase.tsx';
 
-import { actionSidebarAnimation } from './consts.ts';
+import { ACTION_TYPE_FIELD_NAME, actionSidebarAnimation } from './consts.ts';
 import useCloseSidebarClick from './hooks/useCloseSidebarClick.ts';
 import useGetActionData from './hooks/useGetActionData.ts';
+import { useGetActionGroup } from './hooks/useGetActionGroup.ts';
 import useGetGroupedActionComponent from './hooks/useGetGroupedActionComponent.tsx';
 import { ActionNotFound } from './partials/ActionNotFound.tsx';
 import ActionSidebarContent from './partials/ActionSidebarContent/ActionSidebarContent.tsx';
@@ -38,6 +40,7 @@ import ActionSidebarLoadingSkeleton from './partials/ActionSidebarLoadingSkeleto
 import ExpenditureActionStatusBadge from './partials/ExpenditureActionStatusBadge/ExpenditureActionStatusBadge.tsx';
 import MotionOutcomeBadge from './partials/MotionOutcomeBadge/index.ts';
 import { type ActionSidebarProps } from './types.ts';
+import { mapActionTypeToAction } from './utils.ts';
 
 const displayName = 'v5.common.ActionSidebar';
 
@@ -62,12 +65,19 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
   const {
     actionSidebarToggle: [
       isActionSidebarOpen,
-      { toggle: toggleActionSidebarOff, registerContainerRef },
+      {
+        toggle: toggleActionSidebarOff,
+        toggleOn: toggleActionSidebarOn,
+        registerContainerRef,
+      },
     ],
     cancelModalToggle: [isCancelModalOpen, { toggleOff: toggleCancelModalOff }],
     actionSidebarInitialValues,
   } = useActionSidebarContext();
-
+  const actionType = mapActionTypeToAction(action);
+  const actionGroupType = useGetActionGroup(
+    actionSidebarInitialValues?.[ACTION_TYPE_FIELD_NAME] || actionType,
+  );
   const GroupedActionComponent = useGetGroupedActionComponent();
   const [isSidebarFullscreen, { toggle: toggleIsSidebarFullscreen, toggleOn }] =
     useToggle();
@@ -209,6 +219,31 @@ const ActionSidebar: FC<PropsWithChildren<ActionSidebarProps>> = ({
             >
               <X size={18} />
             </button>
+            {actionGroupType && (
+              <button
+                type="button"
+                className="flex items-center justify-center py-2.5 text-gray-400 transition sm:hover:text-blue-400"
+                onClick={() => {
+                  if (transactionId) {
+                    closeSidebarClick();
+
+                    setTimeout(() => {
+                      toggleActionSidebarOn({
+                        [ACTION_TYPE_FIELD_NAME]: actionGroupType,
+                      });
+                    }, 500);
+
+                    return;
+                  }
+
+                  toggleActionSidebarOn({
+                    [ACTION_TYPE_FIELD_NAME]: actionGroupType,
+                  });
+                }}
+              >
+                <ArrowLeft size={18} />
+              </button>
+            )}
             {!isMobile && (
               <div className="flex items-center gap-4">
                 <div className="flex items-center gap-2">

--- a/src/components/v5/common/ActionSidebar/ActionTypeSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/ActionTypeSelect.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import React, { type FC, useState } from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 
+import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { useAdditionalFormOptionsContext } from '~context/AdditionalFormOptionsContext/AdditionalFormOptionsContext.ts';
 import useRelativePortalElement from '~hooks/useRelativePortalElement.ts';
 import useToggle from '~hooks/useToggle/index.ts';
@@ -33,6 +34,7 @@ const ActionTypeSelect: FC<ActionTypeSelectProps> = ({ className }) => {
     { toggle: toggleSelect, toggleOff: toggleSelectOff, registerContainerRef },
   ] = useToggle();
   const actionType = useActiveActionType();
+  const { updateActionSidebarInitialValues } = useActionSidebarContext();
   const {
     field: { onChange },
   } = useController({ name: ACTION_TYPE_FIELD_NAME });
@@ -108,6 +110,9 @@ const ActionTypeSelect: FC<ActionTypeSelectProps> = ({ className }) => {
                 items={actionsList}
                 onSelect={(action) => {
                   toggleSelectOff();
+                  updateActionSidebarInitialValues({
+                    [ACTION_TYPE_FIELD_NAME]: action,
+                  });
 
                   if (action === actionType) {
                     return;

--- a/src/components/v5/common/ActionSidebar/hooks/useGetActionGroup.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useGetActionGroup.ts
@@ -1,0 +1,33 @@
+import { Action } from '~constants/actions.ts';
+
+export const useGetActionGroup = (actionType: Action) => {
+  if (!actionType) {
+    return null;
+  }
+
+  switch (actionType) {
+    case Action.SimplePayment:
+    case Action.StagedPayment:
+    case Action.SplitPayment:
+    case Action.BatchPayment:
+    case Action.PaymentBuilder:
+    case Action.StreamingPayment:
+      return Action.PaymentGroup;
+    case Action.CreateNewTeam:
+    case Action.EditColonyDetails:
+    case Action.EditExistingTeam:
+    case Action.EnterRecoveryMode:
+    case Action.ManagePermissions:
+    case Action.ManageReputation:
+    case Action.ManageTokens:
+    case Action.ManageVerifiedMembers:
+    case Action.MintTokens:
+    case Action.TransferFunds:
+    case Action.UnlockToken:
+    case Action.UpgradeColonyVersion:
+    case Action.UserPermissions:
+      return Action.ManageColony;
+    default:
+      return null;
+  }
+};

--- a/src/components/v5/common/ActionSidebar/partials/GoBackButton/GoBackButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/GoBackButton/GoBackButton.tsx
@@ -1,0 +1,55 @@
+import { ArrowLeft } from '@phosphor-icons/react';
+import React, { type FC } from 'react';
+
+import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
+import { type ColonyAction } from '~types/graphql.ts';
+import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
+import {
+  getActionGroup,
+  mapActionTypeToAction,
+} from '~v5/common/ActionSidebar/utils.ts';
+
+interface GoBackButtonProps {
+  action?: ColonyAction | null;
+  onClick?: () => void;
+}
+
+export const GoBackButton: FC<GoBackButtonProps> = ({ action, onClick }) => {
+  const { actionSidebarToggle, actionSidebarInitialValues } =
+    useActionSidebarContext();
+  const { toggleOn: toggleActionSidebarOn } = actionSidebarToggle[1];
+  const actionType = mapActionTypeToAction(action);
+  const actionGroupType = getActionGroup(
+    actionSidebarInitialValues?.[ACTION_TYPE_FIELD_NAME] || actionType,
+  );
+
+  const openGroupedAction = () => {
+    toggleActionSidebarOn({
+      [ACTION_TYPE_FIELD_NAME]: actionGroupType,
+    });
+  };
+
+  if (!actionGroupType) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      className="flex items-center justify-center py-2.5 text-gray-400 transition sm:hover:text-blue-400"
+      onClick={() => {
+        if (onClick) {
+          onClick();
+
+          setTimeout(openGroupedAction, 500);
+
+          return;
+        }
+
+        openGroupedAction();
+      }}
+    >
+      <ArrowLeft size={18} />
+    </button>
+  );
+};

--- a/src/components/v5/common/ActionSidebar/utils.ts
+++ b/src/components/v5/common/ActionSidebar/utils.ts
@@ -1,6 +1,7 @@
 import { apolloClient } from '~apollo';
-import { type Action } from '~constants/actions.ts';
+import { Action } from '~constants/actions.ts';
 import { SearchActionsDocument } from '~gql';
+import { ExtendedColonyActionType } from '~types/actions.ts';
 import { type ColonyAction, ColonyActionType } from '~types/graphql.ts';
 import { isQueryActive } from '~utils/isQueryActive.ts';
 import {
@@ -76,5 +77,87 @@ export const handleMotionCompleted = (action: ColonyAction) => {
     default: {
       break;
     }
+  }
+};
+
+export const mapActionTypeToAction = (
+  action: ColonyAction | undefined | null,
+) => {
+  if (!action) {
+    return null;
+  }
+
+  switch (action.type as ColonyActionType | ExtendedColonyActionType) {
+    case ColonyActionType.MintTokens:
+    case ColonyActionType.MintTokensMotion:
+    case ColonyActionType.MintTokensMultisig:
+      return Action.MintTokens;
+    case ColonyActionType.Payment:
+    case ColonyActionType.PaymentMotion:
+    case ColonyActionType.PaymentMultisig:
+    case ColonyActionType.MultiplePayment:
+    case ColonyActionType.MultiplePaymentMotion:
+    case ColonyActionType.MultiplePaymentMultisig:
+      return Action.SimplePayment;
+    case ColonyActionType.AddVerifiedMembers:
+    case ColonyActionType.AddVerifiedMembersMotion:
+    case ColonyActionType.AddVerifiedMembersMultisig:
+    case ColonyActionType.RemoveVerifiedMembers:
+    case ColonyActionType.RemoveVerifiedMembersMotion:
+    case ColonyActionType.RemoveVerifiedMembersMultisig:
+      return Action.ManageVerifiedMembers;
+    case ColonyActionType.ColonyEdit:
+    case ColonyActionType.ColonyEditMotion:
+    case ColonyActionType.ColonyEditMultisig:
+      return Action.EditColonyDetails;
+    case ColonyActionType.CreateDomain:
+    case ColonyActionType.CreateDomainMotion:
+    case ColonyActionType.CreateDomainMultisig:
+    case ExtendedColonyActionType.UpdateColonyObjectiveMotion:
+    case ExtendedColonyActionType.UpdateColonyObjectiveMultisig:
+      return Action.CreateNewTeam;
+    case ColonyActionType.EditDomain:
+    case ColonyActionType.EditDomainMotion:
+    case ColonyActionType.EditDomainMultisig:
+      return Action.EditExistingTeam;
+    case ColonyActionType.ManageTokens:
+    case ColonyActionType.ManageTokensMotion:
+    case ColonyActionType.ManageTokensMultisig:
+      return Action.ManageTokens;
+    case ColonyActionType.MoveFunds:
+    case ColonyActionType.MoveFundsMotion:
+    case ColonyActionType.MoveFundsMultisig:
+      return Action.TransferFunds;
+    case ColonyActionType.SetUserRoles:
+    case ColonyActionType.SetUserRolesMotion:
+    case ColonyActionType.SetUserRolesMultisig:
+      return Action.ManagePermissions;
+    case ColonyActionType.VersionUpgrade:
+    case ColonyActionType.VersionUpgradeMotion:
+    case ColonyActionType.VersionUpgradeMultisig:
+      return Action.UpgradeColonyVersion;
+    case ColonyActionType.UnlockToken:
+    case ColonyActionType.UnlockTokenMotion:
+    case ColonyActionType.UnlockTokenMultisig:
+      return Action.UnlockToken;
+    case ColonyActionType.EmitDomainReputationPenalty:
+    case ColonyActionType.EmitDomainReputationPenaltyMotion:
+    case ColonyActionType.EmitDomainReputationPenaltyMultisig:
+    case ColonyActionType.EmitDomainReputationReward:
+    case ColonyActionType.EmitDomainReputationRewardMotion:
+    case ColonyActionType.EmitDomainReputationRewardMultisig:
+      return Action.ManageReputation;
+    case ColonyActionType.MakeArbitraryTransaction:
+    case ColonyActionType.MakeArbitraryTransactionsMotion:
+    case ColonyActionType.MakeArbitraryTransactionsMultisig:
+      return Action.ArbitraryTxs;
+    case ColonyActionType.Recovery:
+      return Action.EnterRecoveryMode;
+    case ExtendedColonyActionType.StagedPayment:
+      return Action.StagedPayment;
+    case ExtendedColonyActionType.SplitPayment:
+      return Action.SplitPayment;
+    default:
+      return null;
   }
 };

--- a/src/components/v5/common/ActionSidebar/utils.ts
+++ b/src/components/v5/common/ActionSidebar/utils.ts
@@ -10,6 +10,16 @@ import {
 } from '~utils/members.ts';
 import { removeCacheEntry, CacheQueryKeys } from '~utils/queries.ts';
 
+import {
+  GROUP_FUNDS_LIST,
+  GROUP_TEAMS_LIST,
+  GROUP_ADMIN_LIST,
+} from './partials/ManageColonyGroup/GroupList.ts';
+import {
+  GROUP_LIST,
+  type GroupListItem,
+} from './partials/PaymentGroup/GroupList.ts';
+
 export const translateAction = (action?: Action) => {
   const actionName = action
     ?.split('-')
@@ -160,4 +170,28 @@ export const mapActionTypeToAction = (
     default:
       return null;
   }
+};
+
+const getAvailableActions = (list: GroupListItem[]) =>
+  list.filter((item) => !item.isHidden).map((item) => item.action);
+
+const ManageColonyActions = getAvailableActions([
+  ...GROUP_ADMIN_LIST,
+  ...GROUP_FUNDS_LIST,
+  ...GROUP_TEAMS_LIST,
+]);
+const PaymentActions = getAvailableActions(GROUP_LIST);
+
+export const getActionGroup = (actionType: Action) => {
+  if (!actionType) {
+    return null;
+  }
+
+  if (ManageColonyActions.includes(actionType)) return Action.ManageColony;
+
+  if (PaymentActions.includes(actionType)) {
+    return Action.PaymentGroup;
+  }
+
+  return null;
 };

--- a/src/context/ActionSidebarContext/ActionSidebarContext.ts
+++ b/src/context/ActionSidebarContext/ActionSidebarContext.ts
@@ -21,12 +21,14 @@ type ActionSidebarToggle = [
 export interface ActionSidebarContextValue {
   actionSidebarToggle: ActionSidebarToggle;
   cancelModalToggle: UseToggleReturnType;
+  updateActionSidebarInitialValues: (initialValues: FieldValues) => void;
   actionSidebarInitialValues?: FieldValues;
 }
 
 export const ActionSidebarContext = createContext<ActionSidebarContextValue>({
   actionSidebarToggle: DEFAULT_USE_TOGGLE_RETURN_VALUE,
   cancelModalToggle: DEFAULT_USE_TOGGLE_RETURN_VALUE,
+  updateActionSidebarInitialValues: () => {},
 });
 
 export const useActionSidebarContext = () => useContext(ActionSidebarContext);

--- a/src/context/ActionSidebarContext/ActionSidebarContextProvider.tsx
+++ b/src/context/ActionSidebarContext/ActionSidebarContextProvider.tsx
@@ -64,9 +64,7 @@ const ActionSidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const navigate = useNavigate();
 
   const removeTxParamOnClose = useCallback(() => {
-    navigate(removeQueryParamFromUrl(window.location.href, TX_SEARCH_PARAM), {
-      replace: true,
-    });
+    navigate(removeQueryParamFromUrl(window.location.href, TX_SEARCH_PARAM));
   }, [navigate]);
 
   actionSidebarUseRegisterOnBeforeCloseCallback((element) => {
@@ -93,14 +91,21 @@ const ActionSidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
     [selectedDomainNativeId],
   );
 
-  const toggleOn = useCallback(
+  const updateActionSidebarInitialValues = useCallback(
     (initialValues) => {
       setActionSidebarInitialValues(getSidebarInitialValues(initialValues));
+    },
+    [getSidebarInitialValues],
+  );
+
+  const toggleOn = useCallback(
+    (initialValues) => {
+      updateActionSidebarInitialValues(initialValues);
       // Track the event when the action panel is opened
       trackEvent(OPEN_ACTION_PANEL_EVENT);
       return toggleActionSidebarOn();
     },
-    [getSidebarInitialValues, toggleActionSidebarOn, trackEvent],
+    [updateActionSidebarInitialValues, toggleActionSidebarOn, trackEvent],
   );
 
   const toggleOff = useCallback((): void => {
@@ -111,11 +116,15 @@ const ActionSidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const toggle = useCallback(
     (initialValues): void => {
       if (!isActionSidebarOpen) {
-        setActionSidebarInitialValues(getSidebarInitialValues(initialValues));
+        updateActionSidebarInitialValues(initialValues);
       }
       toggleActionSidebar();
     },
-    [isActionSidebarOpen, getSidebarInitialValues, toggleActionSidebar],
+    [
+      isActionSidebarOpen,
+      updateActionSidebarInitialValues,
+      toggleActionSidebar,
+    ],
   );
 
   const value = useMemo<ActionSidebarContextValue>(
@@ -131,6 +140,7 @@ const ActionSidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
           registerContainerRef: actionSidebarRegisterContainerRef,
         },
       ],
+      updateActionSidebarInitialValues,
       cancelModalToggle,
       actionSidebarInitialValues,
     }),
@@ -138,6 +148,7 @@ const ActionSidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
       actionSidebarInitialValues,
       actionSidebarRegisterContainerRef,
       actionSidebarUseRegisterOnBeforeCloseCallback,
+      updateActionSidebarInitialValues,
       cancelModalToggle,
       isActionSidebarOpen,
       toggle,


### PR DESCRIPTION
## Description

- Added back button to action sidebar

<img width="742" alt="image" src="https://github.com/user-attachments/assets/f4422bff-7e1b-4062-9126-af99e6ec4d58" />

## Testing

1. Back Arrow:

- Appears only after an action is selected.
- Navigates to the relevant action list view category.
- Not visible on the main action list view.

2. Completed Actions:
- Navigates to the relevant list view category.

3. Browser Back Button:
- Returns to the previous action transaction if clicked after navigating away.

4. Hover State:
- On desktop, matches other action header icons and uses the blue-400 color.

Resolves https://github.com/JoinColony/colonyCDapp/issues/3973
