### PR TITLE
Fix: Update and rename z-index used for TeamsDropdown

### DIFF
--- a/src/components/v5/common/Filter/partials/SearchInput/SearchInput.tsx
+++ b/src/components/v5/common/Filter/partials/SearchInput/SearchInput.tsx
@@ -68,7 +68,7 @@ const SearchInput: FC<SearchInputProps> = ({
 
   return (
     <div className='group relative flex w-full justify-end bg-base-white text-md text-3 after:absolute after:-left-[0.1875rem] after:-top-[0.1875rem] after:block after:h-[calc(100%+0.1875rem+0.1875rem)] after:w-[calc(100%+0.1875rem+0.1875rem)] after:rounded-xl after:border-[0.1875rem] after:border-transparent after:transition-all after:duration-normal after:content-[""] focus-within:border-blue-100 hover:after:border-blue-100'>
-      <span className="pointer-events-none absolute left-3 top-[50%] z-mid flex translate-y-[-50%] text-gray-900 sm:left-[0.75rem] sm:text-gray-500">
+      <span className="pointer-events-none absolute left-3 top-[50%] z-aboveBase flex translate-y-[-50%] text-gray-900 sm:left-[0.75rem] sm:text-gray-500">
         <MagnifyingGlass size={14} />
       </span>
       <input

--- a/src/components/v5/shared/TeamFilter/partials/TeamsDropdown/TeamsDropdown.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamsDropdown/TeamsDropdown.tsx
@@ -49,7 +49,7 @@ const TeamsDropdown: FC<TeamsDropdownProps> = ({ domains }) => {
         <div
           ref={setTooltipRef}
           {...getTooltipProps()}
-          className="z-base flex flex-col gap-2 rounded-b-lg border-b border-l border-r border-gray-200 bg-base-white py-2"
+          className="z-aboveBase flex flex-col gap-2 rounded-b-lg border-b border-l border-r border-gray-200 bg-base-white py-2"
         >
           {domains.map((domain) => (
             <button

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -147,7 +147,7 @@ module.exports = {
       },
       zIndex: {
         base: '1',
-        mid: '2',
+        aboveBase: '2',
         sidebar: '10',
         dropdown: '20',
         header: '100',
@@ -157,7 +157,7 @@ module.exports = {
       },
       spacing: {
         4.5: '1.125rem',
-        8.5: '2.125rem'
+        8.5: '2.125rem',
       },
     },
   },


### PR DESCRIPTION
## Description

- This PR addresses the issue of having the loading skeletons overlapping the teams dropdown list
**Before**
<img width="531" alt="image" src="https://github.com/user-attachments/assets/5636afd7-ad08-4618-85f3-25b842bd6b79">
**Now**
![Screenshot 2024-12-30 at 13 31 33](https://github.com/user-attachments/assets/ffdf230b-7a04-41ab-aa95-9a5579962749)

## Testing

TODO: High level overview of what reviewers are testing with your pr. 

TODO: Followed by step-by-step instructions for testing your branch so reviewers can easily jump straight in and start testing. 

* Step 1. Make sure your dev env is running
* Step 2. Go to http://localhost:9091/planex
* Step 3. Please save these changes in a `.diff` file
```
diff --git a/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx b/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
index 37d904089..62fdbcc63 100644
--- a/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
@@ -37,7 +37,7 @@ export const useActionsTableProps = (
 
   const {
     data: colonyActions,
-    loading: colonyActionsLoading,
+    // loading: colonyActionsLoading,
     loadingMotionStates,
     goToNextPage,
     goToPreviousPage,
@@ -49,6 +49,8 @@ export const useActionsTableProps = (
     pageNumber,
   } = useActionsTableData(pageSize);
 
+  const colonyActionsLoading = true;
+
   const columns = useColonyActionsTableColumns({
     loading: colonyActionsLoading,
     loadingMotionStates,
diff --git a/src/components/v5/shared/TeamFilter/TeamFilter.tsx b/src/components/v5/shared/TeamFilter/TeamFilter.tsx
index c6d815758..0a44e266f 100644
--- a/src/components/v5/shared/TeamFilter/TeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/TeamFilter.tsx
@@ -32,24 +32,614 @@ const TeamFilter = () => {
   }, []);
 
   // this is in memo due to being a dependency for the other memos inside the components
-  const allDomains = useMemo(() => {
-    const filteredDomains = domains?.items.filter(notMaybe) || [];
-
-    return filteredDomains.sort((a, b) => {
-      const reputationA = parseFloat(a.reputationPercentage || '0');
-      const reputationB = parseFloat(b.reputationPercentage || '0');
-
-      // Sort by reputation percentage in descending order
-      if (reputationA !== reputationB) {
-        return reputationB - reputationA;
-      }
-
-      // If reputation percentages are equal or missing, sort alphabetically by name
-      const nameA = a.metadata?.name || '';
-      const nameB = b.metadata?.name || '';
-      return nameA.localeCompare(nameB);
-    });
-  }, [domains?.items]);
+  // const allDomains = useMemo(() => {
+  //   const filteredDomains = domains?.items.filter(notMaybe) || [];
+
+  //   return filteredDomains.sort((a, b) => {
+  //     const reputationA = parseFloat(a.reputationPercentage || '0');
+  //     const reputationB = parseFloat(b.reputationPercentage || '0');
+
+  //     // Sort by reputation percentage in descending order
+  //     if (reputationA !== reputationB) {
+  //       return reputationB - reputationA;
+  //     }
+
+  //     // If reputation percentages are equal or missing, sort alphabetically by name
+  //     const nameA = a.metadata?.name || '';
+  //     const nameB = b.metadata?.name || '';
+  //     return nameA.localeCompare(nameB);
+  //   });
+  // }, [domains?.items]);
+
+  const allDomains = [
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_1',
+      nativeId: 1,
+      isRoot: true,
+      nativeFundingPotId: 1,
+      nativeSkillId: '4',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'General',
+        color: 'ROOT',
+        description: '',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_1',
+        changelog: null,
+      },
+      reputation: '443205034443140594618',
+      reputationPercentage: '100',
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_5',
+      nativeId: 5,
+      isRoot: false,
+      nativeFundingPotId: 5,
+      nativeSkillId: '9',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'Ascendant',
+        color: 'YELLOW',
+        description: '',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_5',
+        changelog: null,
+      },
+      reputation: '56780925471572864301',
+      reputationPercentage: '12.811435127968378287',
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_4',
+      nativeId: 4,
+      isRoot: false,
+      nativeFundingPotId: 4,
+      nativeSkillId: '8',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'Rocinante',
+        color: 'LIGHT_PINK',
+        description: '',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_4',
+        changelog: null,
+      },
+      reputation: '56764305396404410509',
+      reputationPercentage: '12.807685153605082555',
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_3',
+      nativeId: 3,
+      isRoot: false,
+      nativeFundingPotId: 3,
+      nativeSkillId: '7',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'Serenity',
+        color: 'EMERALD_GREEN',
+        description: '',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_3',
+        changelog: null,
+      },
+      reputation: '55749936084964560587',
+      reputationPercentage: '12.578813811312154516',
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_8',
+      nativeId: 8,
+      isRoot: false,
+      nativeFundingPotId: 8,
+      nativeSkillId: '12',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'azizazizazizazizaziz',
+        color: 'YELLOW',
+        description: '',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_8',
+        changelog: null,
+      },
+      reputation: '54824107000960302025',
+      reputationPercentage: '12.369919730231260455',
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_7',
+      nativeId: 7,
+      isRoot: false,
+      nativeFundingPotId: 7,
+      nativeSkillId: '11',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'Agamemnon',
+        color: 'EMERALD_GREEN',
+        description: '',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_7',
+        changelog: null,
+      },
+      reputation: '54806836508853049974',
+      reputationPercentage: '12.366023002810519095',
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_6',
+      nativeId: 6,
+      isRoot: false,
+      nativeFundingPotId: 6,
+      nativeSkillId: '10',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'Daedalus',
+        color: 'EMERALD_GREEN',
+        description: '',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_6',
+        changelog: null,
+      },
+      reputation: '53793734587559664499',
+      reputationPercentage: '12.137437620749982559',
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_2',
+      nativeId: 2,
+      isRoot: false,
+      nativeFundingPotId: 2,
+      nativeSkillId: '6',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'Andromeda',
+        color: 'BLUE_GREY',
+        description: '',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_2',
+        changelog: null,
+      },
+      reputation: '53757942629902626501',
+      reputationPercentage: '12.129361909763980707',
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_17',
+      nativeId: 17,
+      isRoot: false,
+      nativeFundingPotId: 49,
+      nativeSkillId: '27',
+      metadata: null,
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_9',
+      nativeId: 9,
+      isRoot: false,
+      nativeFundingPotId: 41,
+      nativeSkillId: '19',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 1',
+        color: 'BLUE_GREY',
+        description: 'no purpose',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_9',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_18',
+      nativeId: 18,
+      isRoot: false,
+      nativeFundingPotId: 50,
+      nativeSkillId: '28',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 10',
+        color: 'PURPLE',
+        description: 'team 10',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_18',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_19',
+      nativeId: 19,
+      isRoot: false,
+      nativeFundingPotId: 51,
+      nativeSkillId: '29',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 11',
+        color: 'MAGENTA',
+        description: 'team 11',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_19',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_20',
+      nativeId: 20,
+      isRoot: false,
+      nativeFundingPotId: 52,
+      nativeSkillId: '30',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 12',
+        color: 'GREEN',
+        description: 'team 12',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_20',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_21',
+      nativeId: 21,
+      isRoot: false,
+      nativeFundingPotId: 53,
+      nativeSkillId: '31',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 13',
+        color: 'ORANGE',
+        description: 'team 13',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_21',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_22',
+      nativeId: 22,
+      isRoot: false,
+      nativeFundingPotId: 54,
+      nativeSkillId: '32',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 14',
+        color: 'ORANGE',
+        description: 'team 14',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_22',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_23',
+      nativeId: 23,
+      isRoot: false,
+      nativeFundingPotId: 55,
+      nativeSkillId: '33',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 15',
+        color: 'EMERALD_GREEN',
+        description: 'team 15',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_23',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_24',
+      nativeId: 24,
+      isRoot: false,
+      nativeFundingPotId: 56,
+      nativeSkillId: '34',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 16',
+        color: 'GREEN',
+        description: 'team 16',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_24',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_25',
+      nativeId: 25,
+      isRoot: false,
+      nativeFundingPotId: 57,
+      nativeSkillId: '35',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 17',
+        color: 'BLACK',
+        description: 'team 17',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_25',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_26',
+      nativeId: 26,
+      isRoot: false,
+      nativeFundingPotId: 58,
+      nativeSkillId: '36',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 18',
+        color: 'GREEN',
+        description: 'team 18',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_26',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_27',
+      nativeId: 27,
+      isRoot: false,
+      nativeFundingPotId: 59,
+      nativeSkillId: '37',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 19',
+        color: 'PINK',
+        description: 'team 19',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_27',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_10',
+      nativeId: 10,
+      isRoot: false,
+      nativeFundingPotId: 42,
+      nativeSkillId: '20',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 2',
+        color: 'AQUA',
+        description: 'team 2',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_10',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_28',
+      nativeId: 28,
+      isRoot: false,
+      nativeFundingPotId: 60,
+      nativeSkillId: '38',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 20',
+        color: 'RED',
+        description: 'team 20',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_28',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_29',
+      nativeId: 29,
+      isRoot: false,
+      nativeFundingPotId: 61,
+      nativeSkillId: '39',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 21',
+        color: 'BLUE_GREY',
+        description: 'team 21',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_29',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_30',
+      nativeId: 30,
+      isRoot: false,
+      nativeFundingPotId: 62,
+      nativeSkillId: '40',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 22',
+        color: 'ORANGE',
+        description: 'team 22',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_30',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_31',
+      nativeId: 31,
+      isRoot: false,
+      nativeFundingPotId: 63,
+      nativeSkillId: '41',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 23',
+        color: 'BLUE',
+        description: 'team 23',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_31',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_32',
+      nativeId: 32,
+      isRoot: false,
+      nativeFundingPotId: 64,
+      nativeSkillId: '42',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 24',
+        color: 'BLACK',
+        description: 'team 24',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_32',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_33',
+      nativeId: 33,
+      isRoot: false,
+      nativeFundingPotId: 65,
+      nativeSkillId: '43',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 25',
+        color: 'PURPLE_GREY',
+        description: 'team 25',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_33',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_11',
+      nativeId: 11,
+      isRoot: false,
+      nativeFundingPotId: 43,
+      nativeSkillId: '21',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 3',
+        color: 'AQUA',
+        description: 'team 3',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_11',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_12',
+      nativeId: 12,
+      isRoot: false,
+      nativeFundingPotId: 44,
+      nativeSkillId: '22',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 4',
+        color: 'AQUA',
+        description: 'team 4',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_12',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_13',
+      nativeId: 13,
+      isRoot: false,
+      nativeFundingPotId: 45,
+      nativeSkillId: '23',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 5',
+        color: 'GREEN',
+        description: 'team 5',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_13',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_14',
+      nativeId: 14,
+      isRoot: false,
+      nativeFundingPotId: 46,
+      nativeSkillId: '24',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 6',
+        color: 'MAGENTA',
+        description: 'team 6',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_14',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_15',
+      nativeId: 15,
+      isRoot: false,
+      nativeFundingPotId: 47,
+      nativeSkillId: '25',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 7',
+        color: 'GREEN',
+        description: 'team 7',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_15',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+    {
+      __typename: 'Domain',
+      id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_16',
+      nativeId: 16,
+      isRoot: false,
+      nativeFundingPotId: 48,
+      nativeSkillId: '26',
+      metadata: {
+        __typename: 'DomainMetadata',
+        name: 'team 8',
+        color: 'PURPLE',
+        description: 'team 8',
+        id: '0xEaAb7567321ffa6c0C892bba55560B3fEB44fc1e_16',
+        changelog: null,
+      },
+      reputation: null,
+      reputationPercentage: null,
+    },
+  ];
 
   if (isMobile) {
     return <MobileTeamFilter allDomains={allDomains} />;

```
* Step 4. Please apply these changes by running `git apply .diff`
* Step 5. You can set the browser width to `1280` only to make sure the teams dropdown list will overlap the Recent activity table
* Step 6. Make sure the loading skeletons don't overlap the teams dropdown list
![Screenshot 2024-12-30 at 13 31 33](https://github.com/user-attachments/assets/ffdf230b-7a04-41ab-aa95-9a5579962749)


## Diffs

**Changes** 🏗

* Use `z-aboveBase` instead of `z-base` for `TeamsDropdown`

Resolves #3651
