### PR TITLE
Fix: Make date filters single choice

### DIFF
--- a/src/components/common/ColonyActionsTable/FiltersContext/FiltersContextProvider.tsx
+++ b/src/components/common/ColonyActionsTable/FiltersContext/FiltersContextProvider.tsx
@@ -22,6 +22,15 @@ import { getDateFilter } from '../utils.ts';
 import { FiltersContext } from './FiltersContext.ts';
 import { FiltersValues } from './types.ts';
 
+const emptyDateFilters: DateOptions = {
+  pastHour: false,
+  pastDay: false,
+  pastWeek: false,
+  pastMonth: false,
+  pastYear: false,
+  custom: undefined,
+};
+
 const FiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const [searchFilter, setSearchFilter] = useState('');
   const [motionStates, setMotionStates] = useState<MotionState[]>([]);
@@ -29,14 +38,7 @@ const FiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
     ActivityDecisionMethod[]
   >([]);
   const [actionTypesFilters, setActionTypesFilters] = useState<Action[]>([]);
-  const [dateFilters, setDateFilters] = useState<DateOptions>({
-    pastHour: false,
-    pastDay: false,
-    pastWeek: false,
-    pastMonth: false,
-    pastYear: false,
-    custom: undefined,
-  });
+  const [dateFilters, setDateFilters] = useState<DateOptions>(emptyDateFilters);
   const { dateFromCurrentBlockTime } = useCurrentBlockTime();
 
   const handleActionTypesFilterChange = useCallback(
@@ -93,12 +95,12 @@ const FiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
       const name = event.target.name as keyof DateOptions;
 
       if (isChecked) {
-        setDateFilters({ ...dateFilters, [name]: true });
+        setDateFilters({ ...emptyDateFilters, [name]: true });
       } else {
-        setDateFilters({ ...dateFilters, [name]: false });
+        setDateFilters(emptyDateFilters);
       }
     },
-    [dateFilters],
+    [],
   );
 
   const handleCustomDateFilterChange = useCallback(
@@ -107,7 +109,7 @@ const FiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
 
       if (newStartDate && newEndDate) {
         setDateFilters({
-          ...dateFilters,
+          ...emptyDateFilters,
           custom:
             !newStartDate && !newEndDate
               ? undefined
@@ -115,7 +117,7 @@ const FiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
         });
       }
     },
-    [dateFilters],
+    [],
   );
 
   const activeFilters: ActivityFeedFilters = useMemo(() => {
@@ -168,14 +170,7 @@ const FiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
       }
       case FiltersValues.Date:
       case FiltersValues.Custom: {
-        return setDateFilters({
-          pastHour: false,
-          pastDay: false,
-          pastWeek: false,
-          pastMonth: false,
-          pastYear: false,
-          custom: undefined,
-        });
+        return setDateFilters(emptyDateFilters);
       }
       default: {
         return undefined;

--- a/src/components/frame/v5/pages/AgreementsPage/FiltersContext/FiltersContextProvider.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/FiltersContext/FiltersContextProvider.tsx
@@ -18,17 +18,19 @@ import { MOTION_FILTERS } from './consts.ts';
 import { FiltersContext } from './FiltersContext.ts';
 import { FiltersValues } from './types.ts';
 
+const emptyDateFilters: DateOptions = {
+  pastHour: false,
+  pastDay: false,
+  pastWeek: false,
+  pastMonth: false,
+  pastYear: false,
+  custom: undefined,
+};
+
 const FiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const [searchFilter, setSearchFilter] = useState('');
   const [motionStates, setMotionStates] = useState<MotionState[]>([]);
-  const [dateFilters, setDateFilters] = useState<DateOptions>({
-    pastHour: false,
-    pastDay: false,
-    pastWeek: false,
-    pastMonth: false,
-    pastYear: false,
-    custom: undefined,
-  });
+  const [dateFilters, setDateFilters] = useState<DateOptions>(emptyDateFilters);
 
   const handleMotionStatesFilterChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -54,12 +56,12 @@ const FiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
       const name = event.target.name as keyof DateOptions;
 
       if (isChecked) {
-        setDateFilters({ ...dateFilters, [name]: true });
+        setDateFilters({ ...emptyDateFilters, [name]: true });
       } else {
-        setDateFilters({ ...dateFilters, [name]: false });
+        setDateFilters(emptyDateFilters);
       }
     },
-    [dateFilters],
+    [],
   );
 
   const handleCustomDateFilterChange = useCallback(
@@ -68,7 +70,7 @@ const FiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
 
       if (newStartDate && newEndDate) {
         setDateFilters({
-          ...dateFilters,
+          ...emptyDateFilters,
           custom:
             !newStartDate && !newEndDate
               ? undefined
@@ -76,7 +78,7 @@ const FiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
         });
       }
     },
-    [dateFilters],
+    [],
   );
 
   const activeFilters: AgreementsPageFilters = useMemo(() => {
@@ -96,14 +98,7 @@ const FiltersContextProvider: FC<PropsWithChildren> = ({ children }) => {
       }
       case FiltersValues.Date:
       case FiltersValues.Custom: {
-        return setDateFilters({
-          pastHour: false,
-          pastDay: false,
-          pastWeek: false,
-          pastMonth: false,
-          pastYear: false,
-          custom: undefined,
-        });
+        return setDateFilters(emptyDateFilters);
       }
       default: {
         return undefined;


### PR DESCRIPTION
## Description

- Ensure that you cannot select more than one date option when filtering the actions / agreements table. The reasoning is that selecting `Past hour` and `Past week` for example at the same time is actually just equal to selecting only `Past week`. Custom date ranges are slightly different to this, but after some discussion with product, it is not worth the work of making them multi selectable alongside presets (currently, if you have a custom date range selected it ignores any preset you also select).

## Testing

* Go to the activity page and filter by the date. You should only be able to select one at a time.
* Go to the agreements page and filter by the date. You should only be able to select one at a time.

https://github.com/user-attachments/assets/ecb2c434-7e25-451a-a6f6-4868d621e79f

## Diffs

**Changes** 🏗

* Ensure that you cannot select more than one date option when filtering the actions / agreements table.

Resolves #3697
