### PR TITLE
Fix: go/colonyname redirects to 404 if no colony exists

### DIFF
--- a/src/components/frame/v5/pages/ColonyPreviewPage/ColonyPreviewPage.tsx
+++ b/src/components/frame/v5/pages/ColonyPreviewPage/ColonyPreviewPage.tsx
@@ -16,7 +16,7 @@ import {
   useGetPublicColonyByNameQuery,
 } from '~gql';
 import useIsContributor from '~hooks/useIsContributor.ts';
-import { CREATE_PROFILE_ROUTE } from '~routes/index.ts';
+import { CREATE_PROFILE_ROUTE, NOT_FOUND_ROUTE } from '~routes/index.ts';
 import PageLoader from '~v5/common/PageLoader/index.ts';
 import Button from '~v5/shared/Button/index.ts';
 import CardConnectWallet from '~v5/shared/CardConnectWallet/index.ts';
@@ -144,6 +144,10 @@ const ColonyPreviewPage = () => {
 
   if (isContributor) {
     return <Navigate to={`/${colonyName}`} />;
+  }
+
+  if (!colonyAddress) {
+    return <Navigate to={NOT_FOUND_ROUTE} />;
   }
 
   const inviteIsValid =


### PR DESCRIPTION
## Description

This PR fixes an issue where [http://localhost:9091/go/colonyname](http://localhost:9091/go/colonyname) would still load even if there is no colony with this name.

## Testing

Navigate to [http://localhost:9091/go/colonyname](http://localhost:9091/go/colonyname) you should be redirected to a 404 page.

As a logged in user with access to Planex, navigate to [http://localhost:9091/go/planex](http://localhost:9091/go/planex) you should be directed to the planex colony.

As a logged out user, navigate to [http://localhost:9091/go/planex](http://localhost:9091/go/planex) you should see the preview page.

## Diffs

**Changes** 🏗

* If no colonyAddress is found, redirect to 404 route

Resolves #3809
