### PR TITLE
build: remove usage of react-spring

### DIFF
--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/ChartCustomBarLabel.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/ChartCustomBarLabel.tsx
@@ -1,16 +1,31 @@
 import { type AxisTickProps } from '@nivo/axes';
-import { animated } from '@react-spring/web';
+import { motion } from 'framer-motion';
 import React, { type FC } from 'react';
 
 import { CHART_CONFIG_VALUES } from '../consts.ts';
 
 interface ChartCustomBarLabelProps
-  extends Pick<
-    AxisTickProps<string>,
-    'value' | 'textAnchor' | 'textBaseline' | 'animatedProps'
-  > {
+  extends Pick<AxisTickProps<string>, 'value' | 'textAnchor' | 'textBaseline'> {
   textColor: string;
   shouldTranslateX?: boolean;
+  motionProps: {
+    from: {
+      opacity: number;
+      transform: string;
+      textTransform: string;
+    };
+    to: {
+      opacity: number;
+      transform: string;
+      textTransform: string;
+    };
+    transition: {
+      type: string;
+      stiffness: number;
+      damping: number;
+      mass: number;
+    };
+  };
 }
 
 export const ChartCustomBarLabel: FC<ChartCustomBarLabelProps> = ({
@@ -18,14 +33,21 @@ export const ChartCustomBarLabel: FC<ChartCustomBarLabelProps> = ({
   textAnchor,
   textColor,
   textBaseline,
-  animatedProps,
   shouldTranslateX,
+  motionProps,
 }) => {
+  const { from, to, transition } = motionProps;
+
   return (
-    <animated.g style={{ transform: animatedProps.transform }}>
-      <animated.text
-        opacity={animatedProps.opacity}
-        transform={animatedProps.textTransform}
+    <motion.g
+      initial={{ opacity: from.opacity, transform: from.transform }}
+      animate={{ opacity: to.opacity, transform: to.transform }}
+      transition={transition}
+    >
+      <motion.text
+        initial={{ opacity: from.opacity, transform: from.textTransform }}
+        animate={{ opacity: to.opacity, transform: to.textTransform }}
+        transition={transition}
         textAnchor={textAnchor}
         dominantBaseline={textBaseline}
         style={{
@@ -38,7 +60,7 @@ export const ChartCustomBarLabel: FC<ChartCustomBarLabelProps> = ({
         }}
       >
         {value}
-      </animated.text>
-    </animated.g>
+      </motion.text>
+    </motion.g>
   );
 };

--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/ChartCustomXAxisStep.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/ChartCustomXAxisStep.tsx
@@ -1,4 +1,3 @@
-import { useSpring } from '@react-spring/web';
 import React, { type FC } from 'react';
 
 import { CHART_CONFIG_VALUES } from '../consts.ts';
@@ -16,27 +15,32 @@ export const ChartCustomXAxisStep: FC<ChartCustomXAxisStepProps> = ({
   value,
   textColor,
 }) => {
-  const animatedProps = useSpring({
-    to: {
-      opacity: 1,
-      transform: `translate(${x + CHART_CONFIG_VALUES.MARGIN_BOTTOM}px, 0)`,
-      textTransform: 'scale(1)',
-    },
+  const motionProps = {
     from: {
       opacity: 0,
-      transform: `translate(${x + CHART_CONFIG_VALUES.MARGIN_BOTTOM}px, 0)`,
+      transform: `translate(${x + CHART_CONFIG_VALUES.MARGIN_BOTTOM}px, 0) scale(0.8)`,
       textTransform: 'scale(0.8)',
     },
-    config: { tension: 170, friction: 26 },
-  });
+    to: {
+      opacity: 1,
+      transform: `translate(${x + CHART_CONFIG_VALUES.MARGIN_BOTTOM}px, 0) scale(1)`,
+      textTransform: 'scale(1)',
+    },
+    transition: {
+      type: 'spring',
+      stiffness: 170,
+      damping: 26,
+      mass: 1,
+    },
+  };
 
   return (
     <ChartCustomBarLabel
       value={value}
       textColor={textColor}
-      animatedProps={animatedProps}
       textAnchor="middle"
       textBaseline="hanging"
+      motionProps={motionProps}
     />
   );
 };

--- a/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/ChartCustomYAxisStep.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/TotalInOutBalance/partials/ChartCustomYAxisStep.tsx
@@ -1,4 +1,4 @@
-import { animated, useSpring } from '@react-spring/web';
+import { motion } from 'framer-motion';
 import React, { type FC } from 'react';
 
 import { CHART_CONFIG_VALUES } from '../consts.ts';
@@ -20,7 +20,7 @@ export const ChartCustomYAxisStep: FC<ChartCustomYAxisStepProps> = ({
   value,
   width,
 }) => {
-  const animatedProps = useSpring({
+  const motionProps = {
     to: {
       opacity: 1,
       transform: `translate(0, ${y}px)`,
@@ -31,20 +31,25 @@ export const ChartCustomYAxisStep: FC<ChartCustomYAxisStepProps> = ({
       transform: `translate(0, ${y}px)`,
       textTransform: 'scale(0.8)',
     },
-    config: { tension: 170, friction: 26 },
-  });
+    transition: {
+      type: 'spring',
+      stiffness: 170,
+      damping: 26,
+      mass: 1,
+    },
+  };
 
   return (
     <>
       <ChartCustomBarLabel
         value={value}
         textColor={textColor}
-        animatedProps={animatedProps}
         textAnchor="end"
         textBaseline="middle"
         shouldTranslateX
+        motionProps={motionProps}
       />
-      <animated.line
+      <motion.line
         x1={0}
         x2={width}
         y1={y}
@@ -53,7 +58,9 @@ export const ChartCustomYAxisStep: FC<ChartCustomYAxisStepProps> = ({
         strokeWidth={CHART_CONFIG_VALUES.GRID_LINE_WIDTH}
         strokeDasharray={CHART_CONFIG_VALUES.GRID_LINE_DASHED}
         strokeLinecap="round"
-        opacity={animatedProps.opacity}
+        initial={{ opacity: 0, transform: `translate(0, ${y}px) scale(0.8)` }}
+        animate={{ opacity: 1, transform: `translate(0, ${y}px) scale(1)` }}
+        transition={{ duration: 0.5 }}
       />
     </>
   );

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -24,7 +24,7 @@ export default defineConfig(({ mode }) => ({
     importMetaEnv.vite({
       example: '.env.example',
       env: '.env',
-    })
+    }),
   ],
   resolve: {
     alias: {
@@ -51,7 +51,11 @@ export default defineConfig(({ mode }) => ({
   },
   // NOTE: Do not define environment variables here. Instead, use .env files (__COMMIT_HASH__ is an exception)
   define: {
-    __COMMIT_HASH__: mode === 'production' ? JSON.stringify(__COMMIT_HASH__) : undefined,
+    __COMMIT_HASH__:
+      mode === 'production' ? JSON.stringify(__COMMIT_HASH__) : undefined,
+  },
+  optimizeDeps: {
+    exclude: ['react-spring'],
   },
   server: {
     port: 9091,


### PR DESCRIPTION
## Description

This PR removes automatically pulling in `react-spring` as a dependency.

## Testing

No other way about it than running 2 CDapp instances, `master` and this one and verifying that the bar chart labels work correctly :shrug: 

Run `npx vite-bundle-analyzer` Ctrl + F to try and find `react-spring` - it shouldn't exist anymore :sunglasses: 

Additionally

## Diffs

**Changes** 🏗

* `ChartCustomBarLabel` no longer uses spring for animating itself under the hood, but instead it receives very specific framer motion props


Resolves #3645 
