### PR TITLE
fix: date picker select future year and time dropdown style

### DIFF
--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
@@ -144,16 +144,6 @@ const UninstallButton = ({
   const shouldShowWarning =
     isStreamingPaymentsExtension && (hasActiveStream || hasUnclaimedFunds);
 
-  const isStreamingPaymentsExtension =
-    extensionId === Extension.StreamingPayments;
-
-  // @todo: add proper logic here to determine if there are active streams or unclaimed funds
-  const hasActiveStream = false;
-  const hasUnclaimedFunds = false;
-
-  const shouldShowWarning =
-    isStreamingPaymentsExtension && (hasActiveStream || hasUnclaimedFunds);
-
   return (
     <>
       <div className="flex w-full justify-center">

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
@@ -144,6 +144,16 @@ const UninstallButton = ({
   const shouldShowWarning =
     isStreamingPaymentsExtension && (hasActiveStream || hasUnclaimedFunds);
 
+  const isStreamingPaymentsExtension =
+    extensionId === Extension.StreamingPayments;
+
+  // @todo: add proper logic here to determine if there are active streams or unclaimed funds
+  const hasActiveStream = false;
+  const hasUnclaimedFunds = false;
+
+  const shouldShowWarning =
+    isStreamingPaymentsExtension && (hasActiveStream || hasUnclaimedFunds);
+
   return (
     <>
       <div className="flex w-full justify-center">

--- a/src/components/v5/common/ActionSidebar/partials/TimeRow/TimeRow.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TimeRow/TimeRow.tsx
@@ -13,8 +13,7 @@ import { StreamingPaymentEndCondition } from '~gql';
 import Tooltip from '~shared/Extensions/Tooltip/Tooltip.tsx';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/index.ts';
-
-import useHasNoDecisionMethods from '../../hooks/permissions/useHasNoDecisionMethods.ts';
+import useHasNoDecisionMethods from '~v5/common/ActionSidebar/hooks/permissions/useHasNoDecisionMethods.ts';
 
 import { END_OPTIONS, START_OPTIONS } from './consts.ts';
 import { CUSTOM_DATE_VALUE } from './partials/TimeRowField/consts.ts';

--- a/src/components/v5/common/ActionSidebar/partials/TimeRow/partials/TimeRowField/TimeRowField.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/TimeRow/partials/TimeRowField/TimeRowField.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { addYears, subYears } from 'date-fns';
 import format from 'date-fns/format';
 import isDate from 'date-fns/isDate';
 import React, { useState, type FC } from 'react';
@@ -35,6 +36,9 @@ const TimeRowField: FC<TimeRowFieldProps> = ({
   const [value, setValue] = useState(
     isDate(field.value) ? customDateValue : field.value,
   );
+
+  const year15YearsAgo = subYears(new Date(), 15).getFullYear();
+  const year15YearsAhead = addYears(new Date(), 15).getFullYear();
 
   return (
     <CardSelect<string>
@@ -97,6 +101,8 @@ const TimeRowField: FC<TimeRowFieldProps> = ({
                   inline
                   onClose={onClick}
                   minDate={minDate}
+                  minYear={year15YearsAgo}
+                  maxYear={year15YearsAhead}
                 />
               </div>
             )}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -75,6 +75,10 @@ body.ReactModal__Body--open:not(.show-header-in-modal) .modal-blur-navigation {
 }
 
 /* Styling for onboardJS */
+div.react-datepicker__day--selected {
+  @apply bg-base-white !important;
+}
+
 ul.react-datepicker__time-list {
   @apply bg-base-white;
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -75,6 +75,14 @@ body.ReactModal__Body--open:not(.show-header-in-modal) .modal-blur-navigation {
 }
 
 /* Styling for onboardJS */
+ul.react-datepicker__time-list {
+  @apply bg-base-white;
+}
+
+li.react-datepicker__time-list-item {
+  @apply hover:bg-gray-50 !important;
+}
+
 :root {
   --onboard-connect-sidebar-background: var(--color-gray-200);
   --onboard-main-scroll-container-background: var(--color-base-white);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -133,7 +133,7 @@ module.exports = {
         content: '0px 1px 2px rgba(16, 24, 40, 0.05)',
         overlay: 'blur(2px)',
         'light-blue': '0px 0px 3px 3px rgba(239, 248, 255, 1)',
-        'select': '0px 1px 2px 0px rgba(16, 24, 40, 0.05);'
+        select: '0px 1px 2px 0px rgba(16, 24, 40, 0.05);',
       },
       transitionDuration: {
         slow: '450ms',
@@ -309,6 +309,12 @@ module.exports = {
         },
         '.divider': {
           '@apply w-full border border-gray-200': {},
+        },
+        'ul.react-datepicker__time-list': {
+          '@apply bg-base-white': {},
+        },
+        'li.react-datepicker__time-list-item': {
+          '@apply hover:bg-gray-50 !important': {},
         },
       });
     },


### PR DESCRIPTION
## Description

Display future year in date picker and adjust dropdown background for dark mode

## Testing

Display future year:
- Create action for `Streaming payment`
- Select custom date and time
- open dropdown with year

Display dropdown for custom time:
- Create action for `Streaming payment`
- Select custom date and time
- click `Time`

## Diffs

Display future yaer:
![Screenshot 2025-01-07 at 15 21 11](https://github.com/user-attachments/assets/6c1366ed-2b33-4a75-9f9d-2769155418b2)

Display dropdown for dark mode:
![Screenshot 2025-01-07 at 14 37 29](https://github.com/user-attachments/assets/434bdc0a-522b-4a74-b910-f9581c258e69)

Resolves https://github.com/JoinColony/colonyCDapp/issues/4022 https://github.com/JoinColony/colonyCDapp/issues/4023
