### PR TITLE
Fix: Funds card hover state

### DIFF
--- a/src/components/v5/common/WidgetCards/WidgetCardsItem.tsx
+++ b/src/components/v5/common/WidgetCards/WidgetCardsItem.tsx
@@ -11,7 +11,7 @@ const wrapperClassName = tw`
   select-none flex-col justify-center rounded-lg border
   px-6 py-5 text-left outline-offset-[-1px]
 `;
-const hoverClassName = tw`transition-colors hover:border-gray-900 hover:text-gray-900`;
+const hoverClassName = tw`transition-colors hover:bg-gray-25`;
 
 type WidgetCardsItemVariant = 'default' | 'dashed';
 
@@ -21,6 +21,7 @@ interface WidgetCardsItemProps {
   title?: React.ReactNode;
   subTitle?: React.ReactNode;
   onClick?: () => void;
+  isLoading?: boolean;
   className?: string;
 }
 
@@ -36,6 +37,7 @@ export const WidgetCardsItem: FC<PropsWithChildren<WidgetCardsItemProps>> = ({
   title,
   subTitle,
   onClick,
+  isLoading,
   className,
 }) => {
   const wrapperVariantClassName = variantClassNames[variant];
@@ -51,7 +53,7 @@ export const WidgetCardsItem: FC<PropsWithChildren<WidgetCardsItemProps>> = ({
     </WidgetContent>
   );
 
-  if (onClick) {
+  if (onClick && !isLoading) {
     return (
       <button
         onClick={onClick}

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsItem.tsx
@@ -40,6 +40,7 @@ export const FundsCardsItem: FC<FundsCardsItemProps> = ({
   return (
     <WidgetCards.Item
       onClick={onTeamClick}
+      isLoading={loading}
       title={
         <LoadingSkeleton isLoading={loading} className="mb-1 h-5 w-14 rounded">
           <span className="mb-1 mt-0.5 flex">{domainName}</span>

--- a/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalItem.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/FundsCards/partials/FundsCardsTotalItem.tsx
@@ -46,6 +46,7 @@ export const FundsCardsTotalItem: FC<FundsCardsTotalItemProps> = ({
   return (
     <WidgetCards.Item
       className={className}
+      isLoading={loading}
       title={
         <LoadingSkeleton isLoading={loading} className="h-5 w-[34px] rounded">
           <span className="font-semibold">


### PR DESCRIPTION
## Description

This PR addresses an issue where the funds cards were clickable before the card content had loaded in. It also fixes the hover styling.

## Testing

Reload and hover over the funds whilst they are loading, make sure they are not clickable.

Once the are fully loaded, check the hover styling matches figma.

![Screenshot 2025-01-07 at 15 47 13](https://github.com/user-attachments/assets/2412f1f9-880f-46d9-b1b0-49b396567dc6)

Figma: [https://www.figma.com/design/gac6xVgGNCAge5Bia933dp/Dashboard?node-id=4878-84953&t=OpWCmWBoyrScYokI-4](https://www.figma.com/design/gac6xVgGNCAge5Bia933dp/Dashboard?node-id=4878-84953&t=OpWCmWBoyrScYokI-4)

## Diffs

**New stuff** ✨

* Added `isLoading` prop to WidgetCardsItem component and disabled button wrapper whilst loading

**Changes** 🏗

* Fixed hover styling

Resolves #3654
