### PR TITLE
Fix: Expandable rows not opening transaction

### DIFF
--- a/src/components/common/ColonyActionsTable/consts.ts
+++ b/src/components/common/ColonyActionsTable/consts.ts
@@ -1,0 +1,6 @@
+// Unique identifiers for colony action table column IDs
+
+export const MOTION_STATE_COLUMN_ID = 'motionState';
+export const TEAM_COLUMN_ID = 'team';
+export const DESCRIPTION_COLUMN_ID = 'description';
+export const CREATED_AT_COLUMN_ID = 'createdAt';

--- a/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
@@ -7,7 +7,10 @@ import { useMobile } from '~hooks/index.ts';
 import { type ColonyAction } from '~types/graphql.ts';
 import { merge } from '~utils/lodash.ts';
 import EmptyContent from '~v5/common/EmptyContent/index.ts';
-import { MEATBALL_MENU_COLUMN_ID } from '~v5/common/Table/consts.ts';
+import {
+  EXPANDER_COLUMN_ID,
+  MEATBALL_MENU_COLUMN_ID,
+} from '~v5/common/Table/consts.ts';
 import { type TableProps } from '~v5/common/Table/types.ts';
 
 import { useFiltersContext } from '../FiltersContext/FiltersContext.ts';
@@ -83,7 +86,7 @@ export const useActionsTableProps = (
   const tableProps = merge({
     className: clsx(
       className,
-      'sm:[&_td:first-child]:pl-[1.125rem] sm:[&_td]:pr-[1.125rem] sm:[&_th:first-child]:pl-[1.125rem] sm:[&_th:not(:first-child)]:pl-0 sm:[&_th]:pr-[1.125rem]',
+      '[&_td:first-child]:pl-4 sm:[&_td:first-child]:pl-4.5 [&_td]:pr-4 sm:[&_td]:pr-4.5 [&_th:first-child]:pl-4 sm:[&_th:first-child]:pl-4.5 [&_th:not(:first-child)]:pl-0 [&_th]:pr-4 sm:[&_th]:pr-4.5',
       {
         'sm:[&_td]:h-[66px]': isRecentActivityVariant,
         'sm:[&_td]:h-[70px]': !isRecentActivityVariant,
@@ -109,7 +112,7 @@ export const useActionsTableProps = (
                 motionState: true,
                 team: false,
                 createdAt: true,
-                expander: false,
+                [EXPANDER_COLUMN_ID]: false,
               },
           sorting,
           pagination: {
@@ -143,7 +146,7 @@ export const useActionsTableProps = (
       renderSubComponent,
     },
     columns,
-    renderCellWrapper: isMobile ? undefined : renderRowLink,
+    renderCellWrapper: renderRowLink,
     data: colonyActions,
     emptyContent: (
       <EmptyContent

--- a/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useActionsTableProps.tsx
@@ -13,6 +13,12 @@ import {
 } from '~v5/common/Table/consts.ts';
 import { type TableProps } from '~v5/common/Table/types.ts';
 
+import {
+  CREATED_AT_COLUMN_ID,
+  DESCRIPTION_COLUMN_ID,
+  MOTION_STATE_COLUMN_ID,
+  TEAM_COLUMN_ID,
+} from '../consts.ts';
 import { useFiltersContext } from '../FiltersContext/FiltersContext.ts';
 import { type ColonyActionsTableProps } from '../types.ts';
 
@@ -101,17 +107,17 @@ export const useActionsTableProps = (
         state: {
           columnVisibility: isMobile
             ? {
-                description: true,
-                motionState: true,
-                team: false,
-                createdAt: false,
+                [DESCRIPTION_COLUMN_ID]: true,
+                [MOTION_STATE_COLUMN_ID]: true,
+                [TEAM_COLUMN_ID]: false,
+                [CREATED_AT_COLUMN_ID]: false,
                 [MEATBALL_MENU_COLUMN_ID]: false,
               }
             : {
-                description: true,
-                motionState: true,
-                team: false,
-                createdAt: true,
+                [DESCRIPTION_COLUMN_ID]: true,
+                [MOTION_STATE_COLUMN_ID]: true,
+                [TEAM_COLUMN_ID]: false,
+                [CREATED_AT_COLUMN_ID]: true,
                 [EXPANDER_COLUMN_ID]: false,
               },
           sorting,

--- a/src/components/common/ColonyActionsTable/hooks/useColonyActionsTableColumns.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useColonyActionsTableColumns.tsx
@@ -12,6 +12,12 @@ import TeamBadge from '~v5/common/Pills/TeamBadge/index.ts';
 import { EXPANDER_COLUMN_ID } from '~v5/common/Table/consts.ts';
 import { makeMenuColumn } from '~v5/common/Table/utils.tsx';
 
+import {
+  MOTION_STATE_COLUMN_ID,
+  CREATED_AT_COLUMN_ID,
+  DESCRIPTION_COLUMN_ID,
+  TEAM_COLUMN_ID,
+} from '../consts.ts';
 import ActionBadge from '../partials/ActionBadge/ActionBadge.tsx';
 import ActionDescription from '../partials/ActionDescription/index.ts';
 
@@ -39,7 +45,7 @@ const useColonyActionsTableColumns = ({
 
     return [
       helper.display({
-        id: 'description',
+        id: DESCRIPTION_COLUMN_ID,
         staticSize: '100%',
         header: formatText(MSG.tableHeaderLatestActivity),
         enableSorting: false,
@@ -56,7 +62,7 @@ const useColonyActionsTableColumns = ({
         cellContentWrapperClassName: 'pr-0',
       }),
       helper.display({
-        id: 'team',
+        id: TEAM_COLUMN_ID,
         staticSize: '8.125rem',
         header: formatText({
           id: 'activityFeedTable.table.header.team',
@@ -82,7 +88,7 @@ const useColonyActionsTableColumns = ({
           ) : null;
         },
       }),
-      helper.accessor('createdAt', {
+      helper.accessor(CREATED_AT_COLUMN_ID, {
         staticSize: '10rem',
         header: formatText({
           id: 'activityFeedTable.table.header.date',
@@ -104,7 +110,7 @@ const useColonyActionsTableColumns = ({
           );
         },
       }),
-      helper.accessor('motionState', {
+      helper.accessor(MOTION_STATE_COLUMN_ID, {
         staticSize: isMobile ? '7.4375rem' : '6.25rem',
         header: formatText({
           id: 'activityFeedTable.table.header.status',
@@ -130,7 +136,7 @@ const useColonyActionsTableColumns = ({
           ? 'flex items-end'
           : '',
       }),
-      makeMenuColumn({
+      makeMenuColumn<ActivityFeedColonyAction>({
         helper,
         getMenuProps,
         cellProps: {

--- a/src/components/common/ColonyActionsTable/hooks/useColonyActionsTableColumns.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useColonyActionsTableColumns.tsx
@@ -9,6 +9,7 @@ import { type ActivityFeedColonyAction } from '~hooks/useActivityFeed/types.ts';
 import { getFormattedDateFrom } from '~utils/getFormattedDateFrom.ts';
 import { formatText } from '~utils/intl.ts';
 import TeamBadge from '~v5/common/Pills/TeamBadge/index.ts';
+import { EXPANDER_COLUMN_ID } from '~v5/common/Table/consts.ts';
 import { makeMenuColumn } from '~v5/common/Table/utils.tsx';
 
 import ActionBadge from '../partials/ActionBadge/ActionBadge.tsx';
@@ -137,7 +138,7 @@ const useColonyActionsTableColumns = ({
         },
       }),
       helper.display({
-        id: 'expander',
+        id: EXPANDER_COLUMN_ID,
         staticSize: '2.25rem',
         header: () => null,
         enableSorting: false,

--- a/src/components/common/ColonyActionsTable/hooks/useRenderRowLink.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useRenderRowLink.tsx
@@ -1,54 +1,98 @@
+import { type ColumnDef } from '@tanstack/react-table';
 import clsx from 'clsx';
 import React from 'react';
 
+import { useMobile } from '~hooks';
 import { type ActivityFeedColonyAction } from '~hooks/useActivityFeed/types.ts';
-import { TX_SEARCH_PARAM } from '~routes/index.ts';
 import { tw } from '~utils/css/index.ts';
-import { setQueryParamOnUrl } from '~utils/urls.ts';
 import {
   EXPANDER_COLUMN_ID,
   MEATBALL_MENU_COLUMN_ID,
 } from '~v5/common/Table/consts.ts';
 import { type RenderCellWrapper } from '~v5/common/Table/types.ts';
-import Link from '~v5/shared/Link/index.ts';
+
+import { MOTION_STATE_COLUMN_ID } from '../consts.ts';
+import { ColonyActionLinkWrapper } from '../partials/ColonyActionLinkWrapper.tsx';
+
+interface CellConfig {
+  isMeatballMenu: boolean;
+  isExpander: boolean;
+  isMotionState: boolean;
+}
+
+interface StyleConfig {
+  isRecentActivityVariant: boolean;
+}
+
+const baseCellClassName = tw(
+  'flex h-full flex-col justify-center py-4 text-md text-gray-500 sm:py-1',
+);
+
+const getCellClassName = (
+  cellConfig: CellConfig,
+  styleConfig: StyleConfig,
+  isLinkDisabled,
+) => {
+  const { isMeatballMenu, isMotionState } = cellConfig;
+  const { isRecentActivityVariant } = styleConfig;
+
+  if (!isLinkDisabled) {
+    return {
+      'items-end': isRecentActivityVariant,
+      'items-start': !isRecentActivityVariant,
+    };
+  }
+
+  return {
+    'items-end': isMeatballMenu || (isMotionState && isRecentActivityVariant),
+    'items-start': isMotionState && !isRecentActivityVariant,
+  };
+};
+
+const shouldDisableLink = (
+  { isMeatballMenu, isExpander, isMotionState }: CellConfig,
+  isMobile: boolean,
+  loading: boolean,
+): boolean => {
+  return isMeatballMenu || isExpander || (isMobile && isMotionState) || loading;
+};
+
+const isMotionStateColumn = (
+  column: ColumnDef<ActivityFeedColonyAction, unknown>,
+): boolean => {
+  return (
+    'accessorKey' in column && column.accessorKey === MOTION_STATE_COLUMN_ID
+  );
+};
 
 const useRenderRowLink = (
   loading: boolean,
   isRecentActivityVariant: boolean = false,
 ): RenderCellWrapper<ActivityFeedColonyAction> => {
-  const cellClassName = tw(
-    'flex h-full flex-col justify-center py-4 text-md text-gray-500 sm:py-1',
-  );
+  const isMobile = useMobile();
+  const styleConfig = { isRecentActivityVariant };
 
   return (_, content, { cell, row }) => {
-    const isMeatballMenuColumn =
-      cell.column.columnDef.id === MEATBALL_MENU_COLUMN_ID;
-    const isExpanderColumn = cell.column.columnDef.id === EXPANDER_COLUMN_ID;
+    const cellConfig = {
+      isMeatballMenu: cell.column.columnDef.id === MEATBALL_MENU_COLUMN_ID,
+      isExpander: cell.column.columnDef.id === EXPANDER_COLUMN_ID,
+      isMotionState: isMotionStateColumn(cell.column.columnDef),
+    };
 
-    if (isMeatballMenuColumn || isExpanderColumn || loading) {
-      return (
-        <div
-          className={clsx(cellClassName, {
-            'items-end': isMeatballMenuColumn,
-          })}
-        >
-          {content}
-        </div>
-      );
-    }
+    const isLinkDisabled = shouldDisableLink(cellConfig, isMobile, loading);
+    const cellClassName = getCellClassName(
+      cellConfig,
+      styleConfig,
+      isLinkDisabled,
+    );
 
     return (
-      <Link
-        className={clsx(cellClassName, {
-          'items-end': isRecentActivityVariant,
-          'items-start': !isRecentActivityVariant,
-        })}
-        to={setQueryParamOnUrl({
-          params: { [TX_SEARCH_PARAM]: row.original.transactionHash },
-        })}
+      <ColonyActionLinkWrapper
+        txHash={!isLinkDisabled ? row.original.transactionHash : undefined}
+        className={clsx(baseCellClassName, cellClassName)}
       >
         {content}
-      </Link>
+      </ColonyActionLinkWrapper>
     );
   };
 };

--- a/src/components/common/ColonyActionsTable/hooks/useRenderRowLink.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useRenderRowLink.tsx
@@ -5,7 +5,10 @@ import { type ActivityFeedColonyAction } from '~hooks/useActivityFeed/types.ts';
 import { TX_SEARCH_PARAM } from '~routes/index.ts';
 import { tw } from '~utils/css/index.ts';
 import { setQueryParamOnUrl } from '~utils/urls.ts';
-import { MEATBALL_MENU_COLUMN_ID } from '~v5/common/Table/consts.ts';
+import {
+  EXPANDER_COLUMN_ID,
+  MEATBALL_MENU_COLUMN_ID,
+} from '~v5/common/Table/consts.ts';
 import { type RenderCellWrapper } from '~v5/common/Table/types.ts';
 import Link from '~v5/shared/Link/index.ts';
 
@@ -14,19 +17,27 @@ const useRenderRowLink = (
   isRecentActivityVariant: boolean = false,
 ): RenderCellWrapper<ActivityFeedColonyAction> => {
   const cellClassName = tw(
-    'flex h-full flex-col justify-center py-1 text-md text-gray-500',
+    'flex h-full flex-col justify-center py-4 text-md text-gray-500 sm:py-1',
   );
 
-  return (_, content, { cell, row }) =>
-    cell.column.columnDef.id === MEATBALL_MENU_COLUMN_ID || loading ? (
-      <div
-        className={clsx(cellClassName, {
-          'items-end': cell.column.columnDef.id === MEATBALL_MENU_COLUMN_ID,
-        })}
-      >
-        {content}
-      </div>
-    ) : (
+  return (_, content, { cell, row }) => {
+    const isMeatballMenuColumn =
+      cell.column.columnDef.id === MEATBALL_MENU_COLUMN_ID;
+    const isExpanderColumn = cell.column.columnDef.id === EXPANDER_COLUMN_ID;
+
+    if (isMeatballMenuColumn || isExpanderColumn || loading) {
+      return (
+        <div
+          className={clsx(cellClassName, {
+            'items-end': isMeatballMenuColumn,
+          })}
+        >
+          {content}
+        </div>
+      );
+    }
+
+    return (
       <Link
         className={clsx(cellClassName, {
           'items-end': isRecentActivityVariant,
@@ -39,6 +50,7 @@ const useRenderRowLink = (
         {content}
       </Link>
     );
+  };
 };
 
 export default useRenderRowLink;

--- a/src/components/common/ColonyActionsTable/partials/ActionMobileDescription/ActionMobileDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionMobileDescription/ActionMobileDescription.tsx
@@ -73,7 +73,7 @@ const ActionMobileDescription: FC<ActionMobileDescriptionProps> = ({
   );
 
   return (
-    <div className="expandable flex items-start justify-between gap-1 pb-4 pl-[1.125rem] pr-[.9375rem]">
+    <div className="expandable flex items-start justify-between gap-1 pb-4">
       <div className="flex flex-col gap-2 text-gray-500">
         {shouldShowCounter && isMotion && motionData && motionState && (
           <MotionCountDownTimer

--- a/src/components/common/ColonyActionsTable/partials/ActionMobileDescription/ActionMobileDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionMobileDescription/ActionMobileDescription.tsx
@@ -13,6 +13,7 @@ import TeamBadge from '~v5/common/Pills/TeamBadge/index.ts';
 import MeatBallMenu from '~v5/shared/MeatBallMenu/index.ts';
 
 import ActionBadge from '../ActionBadge/ActionBadge.tsx';
+import { ColonyActionLinkWrapper } from '../ColonyActionLinkWrapper.tsx';
 
 import { type ActionMobileDescriptionProps } from './types.ts';
 
@@ -33,6 +34,7 @@ const ActionMobileDescription: FC<ActionMobileDescriptionProps> = ({
     fromDomain,
     createdAt,
     expenditureId,
+    transactionHash,
   } = action;
 
   const { expenditure, loadingExpenditure } =
@@ -73,74 +75,76 @@ const ActionMobileDescription: FC<ActionMobileDescriptionProps> = ({
   );
 
   return (
-    <div className="expandable flex items-start justify-between gap-1 pb-4">
-      <div className="flex flex-col gap-2 text-gray-500">
-        {shouldShowCounter && isMotion && motionData && motionState && (
-          <MotionCountDownTimer
-            className="flex-shrink-0 text-xs font-medium text-negative-400"
-            timerClassName="text-negative-400 font-medium text-xs"
-            prefix={formatText({
-              id: 'activityFeedTable.table.motionCountDown.prefix',
+    <div className="expandable flex items-start gap-1 pb-4">
+      <ColonyActionLinkWrapper className="flex-grow" txHash={transactionHash}>
+        <div className="flex flex-col gap-2 text-gray-500">
+          {shouldShowCounter && isMotion && motionData && motionState && (
+            <MotionCountDownTimer
+              className="flex-shrink-0 text-xs font-medium text-negative-400"
+              timerClassName="text-negative-400 font-medium text-xs"
+              prefix={formatText({
+                id: 'activityFeedTable.table.motionCountDown.prefix',
+              })}
+              motionId={motionData.motionId}
+              motionStakes={motionData.motionStakes}
+              motionState={motionState}
+              refetchMotionState={refetchMotionState}
+            />
+          )}
+          <p
+            className={clsx(textClassName, 'text-gray-600', {
+              'overflow-hidden rounded skeleton': isLoading,
             })}
-            motionId={motionData.motionId}
-            motionStakes={motionData.motionStakes}
-            motionState={motionState}
-            refetchMotionState={refetchMotionState}
-          />
-        )}
-        <p
-          className={clsx(textClassName, 'text-gray-600', {
-            'overflow-hidden rounded skeleton': isLoading,
-          })}
-        >
-          {actionMetadataDescription}
-        </p>
-        {team && (
+          >
+            {actionMetadataDescription}
+          </p>
+          {team && (
+            <div className="flex items-center gap-2">
+              {formatText(
+                { id: 'activityFeedTable.table.team' },
+                {
+                  teamBadge: (
+                    <TeamBadge
+                      textClassName="line-clamp-1 break-all"
+                      name={team?.name || ''.padEnd(6, '-')}
+                      color={team?.color}
+                    />
+                  ),
+                  p: renderLabel,
+                },
+              )}
+            </div>
+          )}
           <div className="flex items-center gap-2">
             {formatText(
-              { id: 'activityFeedTable.table.team' },
+              { id: 'activityFeedTable.table.date' },
               {
-                teamBadge: (
-                  <TeamBadge
-                    textClassName="line-clamp-1 break-all"
-                    name={team?.name || ''.padEnd(6, '-')}
-                    color={team?.color}
+                date: (
+                  <span className={clsx(textClassName, 'text-gray-600')}>
+                    {date}
+                  </span>
+                ),
+                p: renderLabel,
+              },
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            {formatText(
+              { id: 'activityFeedTable.table.status' },
+              {
+                statusBadge: (
+                  <ActionBadge
+                    motionState={motionState}
+                    loading={loadingMotionStates || isLoading}
+                    expenditureId={expenditureId ?? undefined}
                   />
                 ),
                 p: renderLabel,
               },
             )}
           </div>
-        )}
-        <div className="flex items-center gap-2">
-          {formatText(
-            { id: 'activityFeedTable.table.date' },
-            {
-              date: (
-                <span className={clsx(textClassName, 'text-gray-600')}>
-                  {date}
-                </span>
-              ),
-              p: renderLabel,
-            },
-          )}
         </div>
-        <div className="flex items-center gap-2">
-          {formatText(
-            { id: 'activityFeedTable.table.status' },
-            {
-              statusBadge: (
-                <ActionBadge
-                  motionState={motionState}
-                  loading={loadingMotionStates || isLoading}
-                  expenditureId={expenditureId ?? undefined}
-                />
-              ),
-              p: renderLabel,
-            },
-          )}
-        </div>
-      </div>
+      </ColonyActionLinkWrapper>
       {meatBallMenuProps && (
         <MeatBallMenu
           {...meatBallMenuProps}

--- a/src/components/common/ColonyActionsTable/partials/ColonyActionLinkWrapper.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ColonyActionLinkWrapper.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { type FC, type PropsWithChildren } from 'react';
+import { Link } from 'react-router-dom';
+
+import { TX_SEARCH_PARAM } from '~routes';
+import { setQueryParamOnUrl } from '~utils/urls.ts';
+
+interface ColonyActionLinkWrapperProps extends PropsWithChildren {
+  txHash?: string;
+  className?: string;
+}
+
+export const ColonyActionLinkWrapper: FC<ColonyActionLinkWrapperProps> = ({
+  txHash,
+  className,
+  children,
+}) => {
+  if (!txHash) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return (
+    <Link
+      className={className}
+      to={setQueryParamOnUrl({
+        params: { [TX_SEARCH_PARAM]: txHash },
+      })}
+    >
+      {children}
+    </Link>
+  );
+};

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransfersTable.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/FiatTransfersTable.tsx
@@ -10,6 +10,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import { useMobile } from '~hooks/index.ts';
 import { type BridgeDrain } from '~types/graphql.ts';
 import EmptyContent from '~v5/common/EmptyContent/index.ts';
+import { EXPANDER_COLUMN_ID } from '~v5/common/Table/consts.ts';
 import { Table } from '~v5/common/Table/Table.tsx';
 import TableHeader from '~v5/common/TableHeader/TableHeader.tsx';
 
@@ -66,7 +67,7 @@ const FiatTransfersTable = () => {
                   receipt: false,
                 }
               : {
-                  expander: false,
+                  [EXPANDER_COLUMN_ID]: false,
                 },
             sorting,
           },

--- a/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/hooks.tsx
+++ b/src/components/frame/v5/pages/UserCryptoToFiatPage/partials/FiatTransfersTable/hooks.tsx
@@ -15,6 +15,7 @@ import { getFormattedAmount } from '~utils/getFormattedAmount.ts';
 import { getFormattedDateFrom } from '~utils/getFormattedDateFrom.ts';
 import { formatText } from '~utils/intl.ts';
 import PillsBase from '~v5/common/Pills/PillsBase.tsx';
+import { EXPANDER_COLUMN_ID } from '~v5/common/Table/consts.ts';
 
 import { FiatTransferState, statusPillScheme, STATUS_MSGS } from './consts.ts';
 
@@ -156,7 +157,7 @@ export const useFiatTransfersTableColumns = (
         },
       }),
       columnHelper.display({
-        id: 'expander',
+        id: EXPANDER_COLUMN_ID,
         staticSize: '2.25rem',
         header: () => null,
         enableSorting: false,

--- a/src/components/v5/common/Table/consts.ts
+++ b/src/components/v5/common/Table/consts.ts
@@ -1,1 +1,2 @@
 export const MEATBALL_MENU_COLUMN_ID = 'menu';
+export const EXPANDER_COLUMN_ID = 'expander';

--- a/src/components/v5/common/Table/consts.ts
+++ b/src/components/v5/common/Table/consts.ts
@@ -1,2 +1,4 @@
+// Unique identifiers for generic table column IDs
+
 export const MEATBALL_MENU_COLUMN_ID = 'menu';
 export const EXPANDER_COLUMN_ID = 'expander';


### PR DESCRIPTION
## Description

- The purpose of this PR is to address the fact that the activity table rows do not open the action sidebar on mobile when clicked

**Before**

https://github.com/user-attachments/assets/9584878b-7cdc-403f-980e-e7ec6ad905e9


**After**

https://github.com/user-attachments/assets/47dcef74-21a3-47dc-b9b0-7e23637de627


## Testing

Please use a mobile simulator or just switch your browser to a width of `< 1024px`. 

* Step 1. Go to `planex` and scroll to the `Recent activity` table
![Screenshot 2025-01-07 at 19 28 11](https://github.com/user-attachments/assets/b1c8b796-8d50-46ba-b43d-83b5eaa830d5)

* Step 2. Click on any action and check that it opens the action sidebar
* Step 3. Try expanding the action and check it still works as expected
* Step 4. Check the column spacing is as expected
* Step 5. Go to http://localhost:9091/planex/activity
![Screenshot 2025-01-07 at 19 28 19](https://github.com/user-attachments/assets/287ad96d-ddf5-4da7-9d41-4b5e313a5ce9)

* Step 6. Repeat steps `2-4` and confirm everything still works as expected

## Diffs

**Changes** 🏗

* Use `renderRowLink` for the activity tables regardless of screen size

Resolves #3877
