### PR TITLE
fix: extensions order

### DIFF
--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/StakedExpenditureSettings.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/StakedExpenditureSettings.tsx
@@ -21,8 +21,7 @@ const MSG = defineMessages({
   },
   requiredStakeDescription: {
     id: `${displayName}.requiredStakeDescription`,
-    defaultMessage:
-      'What percentage of the team’s reputation, in token terms, is required to create a Payment builder, Split or Staged payment action?',
+    defaultMessage: `The percentage of a team's reputation, in token terms, that is required to stake in order to create Advanced payment, Split payment, and Staged payment actions.`,
   },
 });
 

--- a/src/components/frame/Extensions/pages/ExtensionsPage/ExtensionsPage.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionsPage/ExtensionsPage.tsx
@@ -1,3 +1,4 @@
+import { sortBy } from 'lodash';
 import React, { type FC, useMemo } from 'react';
 
 import ExtensionItem from '~common/Extensions/ExtensionItem/index.ts';
@@ -36,31 +37,35 @@ const ExtensionsPage: FC = () => {
       <h2 className="mb-6 heading-4">
         {formatText({ id: 'extensionsPage.availableExtensions' })}
       </h2>
-      {Object.entries(categorizedExtensions).map(([category, extensions]) => (
-        <div
-          key={category}
-          className="mb-6 border-b border-gray-100 last:mb-0 last:border-none"
-        >
-          <h3 className="mb-4 text-2">{category}</h3>
-          <ul className="flex flex-col gap-y-6 pb-6">
-            {extensions.map((extension) => (
-              <li key={extension.extensionId} className="pb-2">
-                <ExtensionItem
-                  title={extension.name}
-                  description={extension.descriptionShort}
-                  version={
-                    isInstalledExtensionData(extension)
-                      ? extension.currentVersion
-                      : extension.availableVersion
-                  }
-                  icon={extension.icon}
-                  extensionId={extension.extensionId}
-                />
-              </li>
-            ))}
-          </ul>
-        </div>
-      ))}
+      {Object.entries(categorizedExtensions)
+        .sort(([categoryA], [categoryB]) => categoryA.localeCompare(categoryB))
+        .map(([category, extensions]) => (
+          <div
+            key={category}
+            className="mb-6 border-b border-gray-100 last:mb-0 last:border-none"
+          >
+            <h3 className="mb-4 text-2">{category}</h3>
+            <ul className="flex flex-col gap-y-6 pb-6">
+              {sortBy(extensions, (item) => item.name.defaultMessage).map(
+                (extension) => (
+                  <li key={extension.extensionId} className="pb-2">
+                    <ExtensionItem
+                      title={extension.name}
+                      description={extension.descriptionShort}
+                      version={
+                        isInstalledExtensionData(extension)
+                          ? extension.currentVersion
+                          : extension.availableVersion
+                      }
+                      icon={extension.icon}
+                      extensionId={extension.extensionId}
+                    />
+                  </li>
+                ),
+              )}
+            </ul>
+          </div>
+        ))}
     </div>
   );
 };

--- a/src/constants/extensions.ts
+++ b/src/constants/extensions.ts
@@ -30,7 +30,6 @@ import { toFinite } from '~utils/lodash.ts';
 export enum ExtensionCategory {
   Payments = 'Payments',
   DecisionMethods = 'Decision Methods',
-  Expenditures = 'Expenditures',
 }
 
 const multiSigName = 'extensions.MultiSig';
@@ -342,7 +341,7 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
   {
     icon: ExtensionAdvancedPaymentsIcon,
     imageURLs: [stakedHero, stakedInterface],
-    category: ExtensionCategory.Expenditures,
+    category: ExtensionCategory.DecisionMethods,
     extensionId: Extension.StakedExpenditure,
     name: MSG.stakedExpenditureName,
     descriptionShort: MSG.stakedExpenditureDescriptionShort,
@@ -389,7 +388,7 @@ export const supportedExtensionsConfig: ExtensionConfig[] = [
   {
     icon: ExtensionStreamingPaymentsIcon,
     imageURLs: [streamingHero, streamingInterface],
-    category: ExtensionCategory.Expenditures,
+    category: ExtensionCategory.Payments,
     extensionId: Extension.StreamingPayments,
     name: MSG.streamingPaymentsName,
     descriptionShort: MSG.streamingPaymentsDescriptionShort,

--- a/src/constants/extensions.ts
+++ b/src/constants/extensions.ts
@@ -197,7 +197,8 @@ const streamingPaymentsMessage = {
   },
   streamingPaymentsDescriptionShort: {
     id: `${streamingPaymentsName}.description`,
-    defaultMessage: 'Streaming Payments extension.',
+    defaultMessage:
+      'Continuously stream tokens to a recipient, that are claimable at any time. Useful for things like salaries, subscriptions, and more.',
   },
   streamingPaymentsDescriptionLong: {
     id: `${streamingPaymentsName}.descriptionLong`,


### PR DESCRIPTION
## Description

Display extensions in alphabetical order and change copy for `Staking Advanced Payments`

## Testing

Order:
- Open `Extensions` page

Staking Advanced Payments copy:
- Open `Staking Advanced Payments` extension
- Go to `Extension settings` tab

Order before install extension:
![Screenshot 2025-01-10 at 16 02 04](https://github.com/user-attachments/assets/a35d5f22-6f0a-4557-86ed-894032ec687b)


Order after install extension:
![Screenshot 2025-01-10 at 16 02 35](https://github.com/user-attachments/assets/6c136dca-4ae0-4f38-b8dc-a500e775fec2)


Staking Advanced Payments copy:
![Screenshot 2025-01-08 at 16 50 50](https://github.com/user-attachments/assets/5b3ec3c4-e7dc-4dde-9c4e-04ba674bc79e)


Resolves https://github.com/JoinColony/colonyCDapp/issues/2928
