### PR TITLE
Fix: Prevent stale claimable state

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/FinalizeStep.tsx
@@ -40,7 +40,6 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
   actionData,
   startPollingAction,
   stopPollingAction,
-  refetchAction,
   motionState,
 }) => {
   const { onFinalizeSuccessCallback } = useFinalizeSuccessCallback();
@@ -60,7 +59,7 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
     handleClaimSuccess,
     claimPayload,
     canClaimStakes,
-  } = useClaimConfig(actionData, startPollingAction, refetchAction);
+  } = useClaimConfig(actionData, startPollingAction);
 
   const isMotionFinalized = actionData.motionData.isFinalized;
   const previousIsMotionFinalized = usePrevious(isMotionFinalized);
@@ -200,15 +199,14 @@ const FinalizeStep: FC<FinalizeStepProps> = ({
                         className={clsx({
                           'mb-6':
                             !isMotionFailedNotFinalizable &&
-                            (!isMotionFinalized ||
-                              (!isClaimed && canClaimStakes)),
+                            (!isMotionFinalized || !isClaimed),
                         })}
                       />
                     </>
                   )}
                   {canInteract && (
                     <>
-                      {(isPolling || isSubmitting) && (
+                      {(isPolling || isSubmitting) && !isClaimed && (
                         <IconButton
                           className="w-full"
                           rounded="s"

--- a/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/steps/FinalizeStep/hooks.tsx
@@ -19,7 +19,6 @@ import { isInstalledExtensionData } from '~utils/extensions.ts';
 import { formatText } from '~utils/intl.ts';
 import { getSafePollingInterval } from '~utils/queries.ts';
 import { getBalanceForTokenAndDomain } from '~utils/tokens.ts';
-import { type RefetchAction } from '~v5/common/ActionSidebar/hooks/useGetColonyAction.ts';
 
 import { type DescriptionListItem } from '../VotingStep/partials/DescriptionList/types.ts';
 
@@ -88,7 +87,6 @@ export const useFinalizeStep = (actionData: MotionAction) => {
 export const useClaimConfig = (
   actionData: MotionAction,
   startPollingAction: (pollingInterval: number) => void,
-  refetchAction: RefetchAction,
 ) => {
   const {
     motionData: {
@@ -96,14 +94,13 @@ export const useClaimConfig = (
       stakerRewards,
       usersStakes,
       voterRewards,
-      databaseMotionId,
       remainingStakes,
     },
     transactionHash,
   } = actionData;
   const { user } = useAppContext();
   const {
-    colony: { colonyAddress, nativeToken, motionsWithUnclaimedStakes },
+    colony: { colonyAddress, nativeToken },
   } = useColonyContext();
   const { extensionData } = useExtensionData(Extension.VotingReputation);
   const { pollLockedTokenBalance } = useUserTokenBalanceContext();
@@ -120,31 +117,6 @@ export const useClaimConfig = (
   const stakerReward = stakerRewards.find(
     ({ address }) => address === userAddress,
   );
-
-  // Keep isClaimed state in sync with changes to unclaimed motions on colony object
-  useEffect(() => {
-    if (motionsWithUnclaimedStakes) {
-      const motionIsUnclaimed = motionsWithUnclaimedStakes.some(
-        ({ motionId }) => motionId === databaseMotionId,
-      );
-
-      if (!motionIsUnclaimed) {
-        setIsClaimed(true);
-        refetchAction();
-      } else {
-        setIsClaimed(false);
-      }
-    }
-  }, [motionsWithUnclaimedStakes, databaseMotionId, refetchAction]);
-
-  // Keep isClaimed state in sync with user changes
-  useEffect(() => {
-    if (!user) {
-      setIsClaimed(false);
-    } else {
-      setIsClaimed(!!stakerReward?.isClaimed);
-    }
-  }, [user, stakerReward?.isClaimed]);
 
   useEffect(() => {
     if (stakerReward?.isClaimed && !isClaimed) {


### PR DESCRIPTION
## Description

After much investigation, I found that the effects I removed were redundant and were causing issues with how we control the claimed state. I have not been able to find an issue after removing them, hopefully this didn't break a flow that I'm not fully aware of 🤞

![claim-fix](https://github.com/user-attachments/assets/16c07756-63be-4772-adc9-6771ece34e3c)

## Testing

1. Enable the Reputation extension
2. Create a Mint Tokens motion
3. Oppose and fully stake it
4. Support and fully stake it
5. On the Voting phase, approve it
6. Finalise it
7. Claim back the tokens
8. Verify that
 - the Claim button doesn't linger
 - the Pending button doesn't linger

Resolves #3859 