### PR TITLE
Feat: Allow addition of proxy colonies with multisig

### DIFF
--- a/amplify/backend/api/colonycdapp/schema/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema/schema.graphql
@@ -903,6 +903,7 @@ enum ColonyActionType {
   """
   ADD_PROXY_COLONY
   ADD_PROXY_COLONY_MOTION
+  ADD_PROXY_COLONY_MULTISIG
   """
   An action related to disabling a proxy colony
   """

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=e423f7b371270d98a10d2a1fcc2bae636b150f16
+ENV BLOCK_INGESTOR_HASH=2766f21b7a98c62e76942d55ba7000f36155b979
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-proxy-block-ingestor
+++ b/docker/colony-cdapp-dev-env-proxy-block-ingestor
@@ -1,7 +1,7 @@
 FROM colony-cdapp-dev-env/base:latest
 
 # @TODO maybe add a PROXY_BLOCK_INGESTOR_HASH and fallback to BLOCK_INGESTOR_HASH
-ENV BLOCK_INGESTOR_HASH=e423f7b371270d98a10d2a1fcc2bae636b150f16
+ENV BLOCK_INGESTOR_HASH=2766f21b7a98c62e76942d55ba7000f36155b979
 # @TODO do we need here a contract to be in the format:
 # {
 #   name: 'ColonyNetwork',

--- a/src/components/v5/common/ActionSidebar/hooks/permissions/helpers.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/permissions/helpers.ts
@@ -106,6 +106,9 @@ export const getPermissionsNeededForAction = (
     case Action.StagedPayment: {
       return PERMISSIONS_NEEDED_FOR_ACTION.StagedPayment;
     }
+    case Action.ManageSupportedChains: {
+      return PERMISSIONS_NEEDED_FOR_ACTION.ManageSupportedChains;
+    }
 
     default:
       return undefined;

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageSupportedChainsForm/ManageSupportedChainsForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageSupportedChainsForm/ManageSupportedChainsForm.tsx
@@ -2,7 +2,6 @@ import { Link, PlusMinus } from '@phosphor-icons/react';
 import React, { type FC } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { DecisionMethod } from '~types/actions.ts';
 import { formatText } from '~utils/intl.ts';
 import ActionFormRow from '~v5/common/ActionFormRow/ActionFormRow.tsx';
 import {
@@ -17,7 +16,6 @@ import ChainSelect from '~v5/common/ActionSidebar/partials/ChainSelect/ChainSele
 import DecisionMethodField from '~v5/common/ActionSidebar/partials/DecisionMethodField/DecisionMethodField.tsx';
 import Description from '~v5/common/ActionSidebar/partials/Description/Description.tsx';
 import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
-import { createUnsupportedDecisionMethodFilter } from '~v5/common/ActionSidebar/utils.ts';
 import { FormCardSelect } from '~v5/common/Fields/CardSelect/index.ts';
 
 import { getManageSupportedChainsOptions } from './consts.ts';
@@ -34,9 +32,6 @@ const ManageSupportedChainsForm: FC<ActionFormBaseProps> = ({
   const { resetField } = useFormContext();
   const hasNoDecisionMethods = useHasNoDecisionMethods();
   const chainSelectFilterFn = useFilterChainSelectField();
-  const decisionMethodFilterFn = createUnsupportedDecisionMethodFilter([
-    DecisionMethod.MultiSig,
-  ]);
   const isRemoveOperation = useCheckOperationType(
     MANAGE_SUPPORTED_CHAINS_FIELD_NAME,
     ManageEntityOperation.Remove,
@@ -97,7 +92,7 @@ const ManageSupportedChainsForm: FC<ActionFormBaseProps> = ({
           filterOptionsFn={chainSelectFilterFn}
         />
       </ActionFormRow>
-      <DecisionMethodField filterOptionsFn={decisionMethodFilterFn} />
+      <DecisionMethodField />
       <Description />
     </>
   );

--- a/src/components/v5/common/ActionSidebar/partials/forms/ManageSupportedChainsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ManageSupportedChainsForm/hooks.ts
@@ -49,7 +49,10 @@ const useActionType = () => {
     return ActionTypes.PROXY_COLONY_ENABLE;
   }
 
-  if (decisionMethod === DecisionMethod.Reputation) {
+  if (
+    decisionMethod === DecisionMethod.Reputation ||
+    decisionMethod === DecisionMethod.MultiSig
+  ) {
     return ActionTypes.MOTION_PROXY_COLONY_CREATE;
   }
 

--- a/src/components/v5/common/CompletedAction/CompletedAction.tsx
+++ b/src/components/v5/common/CompletedAction/CompletedAction.tsx
@@ -87,6 +87,7 @@ const CompletedAction = ({ action }: CompletedActionProps) => {
       case ColonyActionType.AddProxyColony:
       case ColonyActionType.RemoveProxyColony:
       case ColonyActionType.AddProxyColonyMotion:
+      case ColonyActionType.AddProxyColonyMultisig:
         return <ManageSupportedChain action={action} />;
       case ColonyActionType.EmitDomainReputationReward:
       case ColonyActionType.EmitDomainReputationRewardMotion:

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -605,6 +605,7 @@ export enum ColonyActionType {
   /** An action related to creating a proxy colony */
   AddProxyColony = 'ADD_PROXY_COLONY',
   AddProxyColonyMotion = 'ADD_PROXY_COLONY_MOTION',
+  AddProxyColonyMultisig = 'ADD_PROXY_COLONY_MULTISIG',
   /** An action related to adding verified members */
   AddVerifiedMembers = 'ADD_VERIFIED_MEMBERS',
   AddVerifiedMembersMotion = 'ADD_VERIFIED_MEMBERS_MOTION',

--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -59,6 +59,7 @@ const actionsMessageDescriptors = {
       ${ColonyActionType.FundExpenditureMotion} {Payment to {recipientsNumber} {recipientsNumber, plural, one {recipient} other {recipients}} with {tokensNumber} {tokensNumber, plural, one {token} other {tokens}} by {initiator}}
       ${ColonyActionType.AddProxyColony} {Add support for {chain} chain by {initiator}}
       ${ColonyActionType.AddProxyColonyMotion} {Add support for {chain} chain by {initiator}}
+      ${ColonyActionType.AddProxyColonyMultisig} {Add support for {chain} chain by {initiator}}
       ${ColonyActionType.RemoveProxyColony} {Remove support for {chain} chain by {initiator}}
       ${ExtendedColonyActionType.AddSafe} {Add Safe from {chainName}}
       ${ExtendedColonyActionType.RemoveSafe} {Remove Safe}
@@ -126,6 +127,7 @@ const actionsMessageDescriptors = {
       ${ColonyActionType.ManageTokensMultisig} {Manage tokens}
       ${ColonyActionType.AddProxyColony} {Manage supported chains}
       ${ColonyActionType.AddProxyColonyMotion} {Manage supported chains}
+      ${ColonyActionType.AddProxyColonyMultisig} {Manage supported chains}
       ${ColonyActionType.RemoveProxyColony} {Manage supported chains}
       ${ExtendedColonyActionType.StagedPayment} {Staged payment}
       ${ExtendedColonyActionType.AddSafe} {Add Safe}

--- a/src/redux/types/actions/motion.ts
+++ b/src/redux/types/actions/motion.ts
@@ -486,6 +486,7 @@ export type MotionActionTypes =
         colonyDomains: Domain[];
         foreignChainId: number;
         creationSalt: string;
+        isMultiSig: boolean;
       },
       MetaWithSetter<object>
     >

--- a/src/utils/multiSig/index.ts
+++ b/src/utils/multiSig/index.ts
@@ -69,6 +69,9 @@ export const getRolesNeededForMultiSigAction = ({
     case ColonyActionType.ManageTokensMultisig:
       permissions = PERMISSIONS_NEEDED_FOR_ACTION.ManageTokens;
       break;
+    case ColonyActionType.AddProxyColonyMultisig:
+      permissions = PERMISSIONS_NEEDED_FOR_ACTION.ManageSupportedChains;
+      break;
     default:
       permissions = undefined;
       break;


### PR DESCRIPTION
## Description

- This PR adds functionality to create a proxy colony via voting reputation.

Block ingestor changes [here](https://github.com/JoinColony/block-ingestor/pull/312)

## Testing

* On a fresh dev env, install the multisig extension, and give multisig owner permissions to Leela
<img width="1387" alt="Screenshot 2025-01-09 at 16 34 16" src="https://github.com/user-attachments/assets/fff4000e-d308-4106-b0fd-c988e05fea74" />
<img width="1065" alt="Screenshot 2025-01-09 at 16 34 55" src="https://github.com/user-attachments/assets/1b64d4b8-3f58-4a58-9a7b-dd395e9c790c" />

* Run the following query to ensure that no proxy colonies currently exist
```graphql
query MyQuery {
  listProxyColonies {
    items {
      chainId
      colonyAddress
      createdAt
      id
      isActive
      updatedAt
    }
  }
}

```
<img width="1314" alt="Screenshot 2025-01-09 at 16 27 45" src="https://github.com/user-attachments/assets/f766a128-ec8e-42da-bbe0-db80a89c7da1" />

* Create a `Manage supported chains` action and choose multisig as the decision method
<img width="1062" alt="Screenshot 2025-01-09 at 16 36 10" src="https://github.com/user-attachments/assets/9e9f4cd1-05a9-4a4e-9b05-b96c6f2d4c6e" />

* Finalize the multisig motion
* Run the query again to ensure that a proxy colony was made
```graphql
query MyQuery {
  listProxyColonies {
    items {
      chainId
      colonyAddress
      createdAt
      id
      isActive
      updatedAt
    }
  }
}
```
<img width="1609" alt="Screenshot 2025-01-09 at 16 36 48" src="https://github.com/user-attachments/assets/4d6c5125-b971-43f2-b369-f968bdd9cae8" />


## Diffs

**New stuff** ✨

* New block ingestor hash

**Changes** 🏗

* Allow add proxy colony actions to be made with multisig

Resolves #3451
