### PR TITLE
Fix: Search activity feed by formatted action type

### DIFF
--- a/src/hooks/useActivityFeed/helpers.ts
+++ b/src/hooks/useActivityFeed/helpers.ts
@@ -6,7 +6,10 @@ import { type AnyActionType } from '~types/actions.ts';
 import { type InstalledExtensionData } from '~types/extensions.ts';
 import { type ColonyAction } from '~types/graphql.ts';
 import { notMaybe } from '~utils/arrays/index.ts';
-import { getExtendedActionType } from '~utils/colonyActions.ts';
+import {
+  formatActionType,
+  getExtendedActionType,
+} from '~utils/colonyActions.ts';
 import { getMotionState, MotionState } from '~utils/colonyMotions.ts';
 import { getMultiSigState } from '~utils/multiSig/index.ts';
 
@@ -80,13 +83,15 @@ export const filterBySearch = (
     isMotion ? pendingColonyMetadata : colony.metadata,
   );
 
+  const formattedActionType = formatActionType(extendedActionType);
+
   const searchValue = search.toLowerCase();
   const searchIsAddress = isHexString(searchValue);
   const terms = searchIsAddress
     ? [transactionHash, initiatorAddress, recipientAddress, token?.tokenAddress]
     : [
         metadata?.customTitle,
-        extendedActionType,
+        formattedActionType,
         amount,
         token?.name,
         token?.symbol,


### PR DESCRIPTION
## Description

Searching the action feed was matching against the ColonyActionType (i.e. `UNLOCK_TOKEN`) rather than how the action type appears in the UI. (`Unlock token`) This PR adjusts the search to use the correctly formatted action type.

## Testing

You can test this with any action type, but for the sake of testing lets use the `Unlock token` action.

Create an `Unlock token` action, do not use the words "Unlock token" in the custom title.

Navigate to the action feed and type into the search "unlock token", the action should appear.

![Screenshot 2025-01-09 at 17 17 04](https://github.com/user-attachments/assets/a71420ce-72a7-4e51-aed0-3c51f27f7d5b)

Compared to master:

![Screenshot 2025-01-09 at 17 17 12](https://github.com/user-attachments/assets/6aca070c-3d7b-47f4-b34b-451be612a360)

## Diffs

**Changes** 🏗

* Activity feed search now uses the formatted action type

Resolves #3701
