### PR TITLE
fix: display streaming payment metadata for action and activity feed

### DIFF
--- a/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
+++ b/src/components/common/ColonyActionsTable/partials/ActionDescription/ActionDescription.tsx
@@ -45,7 +45,7 @@ const ActionDescription: FC<ActionDescriptionProps> = ({
     useGetExpenditureData(expenditureId);
 
   const { streamingPaymentData, loadingStreamingPayment } =
-    useGetStreamingPaymentData(expenditureId);
+    useGetStreamingPaymentData(action?.streamingPaymentId);
 
   const isLoading =
     loading || loadingExpenditure || loadingStreamingPayment || loadingUser;

--- a/src/components/v5/common/CompletedAction/partials/StreamingPayment/StreamingPayment.tsx
+++ b/src/components/v5/common/CompletedAction/partials/StreamingPayment/StreamingPayment.tsx
@@ -23,7 +23,11 @@ import { ONE_DAY_IN_SECONDS, ONE_HOUR_IN_SECONDS } from '~constants/time.ts';
 import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
-import { ColonyActionType, StreamingPaymentEndCondition } from '~gql';
+import {
+  ColonyActionType,
+  StreamingPaymentEndCondition,
+  useGetUserByAddressQuery,
+} from '~gql';
 import { useMobile } from '~hooks';
 import {
   COLONY_ACTIVITY_ROUTE,
@@ -101,6 +105,14 @@ const StreamingPayment: FC<StreamingPaymentProps> = ({
   const decisionMethod = useDecisionMethod(action);
 
   const { loadingStreamingPayment, streamingPaymentData } = streamingPayment;
+
+  const { data: recipentData } = useGetUserByAddressQuery({
+    variables: { address: streamingPaymentData?.recipientAddress || '' },
+    skip: !streamingPaymentData?.recipientAddress,
+  });
+
+  const recipientName =
+    recipentData?.getUserByAddress?.items[0]?.profile?.displayName ?? '';
 
   if (loadingStreamingPayment) {
     return (
@@ -275,7 +287,9 @@ const StreamingPayment: FC<StreamingPaymentProps> = ({
                 walletAddress={recipientAddress}
                 withVerifiedBadge={false}
                 withUserName
-              />
+              >
+                {recipientName}
+              </UserInfoPopover>
             ) : null,
             initiator: initiatorUser ? (
               <UserInfoPopover


### PR DESCRIPTION
## Description

Display streaming payment metadata for action and activity feed

## Testing

- Create streaming payment action
- Display streaming payment in action sidebar
- Display streaming payment in activity feed

## Diffs

**New stuff** ✨

![Screenshot 2025-01-10 at 10 09 26](https://github.com/user-attachments/assets/91be6f4d-fb3d-42bd-a076-4f3776d09e16)

![Screenshot 2025-01-10 at 10 09 05](https://github.com/user-attachments/assets/ddada50d-8db2-4584-abef-b74abb27cb4d)

Resolves https://github.com/JoinColony/colonyCDapp/issues/4044
