### PR TITLE
Fix/16227916 streaming display extension error

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/hooks.ts
@@ -1,4 +1,3 @@
-import { Extension } from '@colony/colony-js';
 import { useMemo } from 'react';
 
 import { Action } from '~constants/actions.ts';
@@ -17,6 +16,8 @@ import {
   type ClaimMintTokensActionParams,
   type FinalizeSuccessCallback,
 } from '../types.ts';
+
+import { getNeededExtension } from './utils.ts';
 
 const SUBMIT_BUTTON_TEXT_MAP: Partial<Record<Action, string>> = {
   [Action.PaymentBuilder]: 'button.createPayment',
@@ -74,17 +75,6 @@ export const useSubmitButtonDisabled = () => {
 };
 
 export const useIsFieldDisabled = () => {
-  const getNeededExtension = (action: Action) => {
-    switch (action) {
-      case Action.CreateDecision:
-        return Extension.VotingReputation;
-      case Action.StreamingPayment:
-        return Extension.StreamingPayments;
-      default:
-        return '';
-    }
-  };
-
   const selectedAction = useActiveActionType();
   const extensionId = selectedAction ? getNeededExtension(selectedAction) : '';
   const { extensionData, loading } = useExtensionData(extensionId);

--- a/src/components/v5/common/ActionSidebar/partials/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/hooks.ts
@@ -95,7 +95,8 @@ export const useIsFieldDisabled = () => {
 
   if (
     extensionId &&
-    selectedAction === Action.CreateDecision &&
+    (selectedAction === Action.CreateDecision ||
+      selectedAction === Action.StreamingPayment) &&
     !isExtensionEnabled &&
     !loading
   ) {

--- a/src/components/v5/common/ActionSidebar/partials/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/utils.ts
@@ -1,0 +1,14 @@
+import { Extension } from '@colony/colony-js';
+
+import { Action } from '~constants/actions.ts';
+
+export const getNeededExtension = (action: Action) => {
+  switch (action) {
+    case Action.CreateDecision:
+      return Extension.VotingReputation;
+    case Action.StreamingPayment:
+      return Extension.StreamingPayments;
+    default:
+      return '';
+  }
+};

--- a/src/components/v5/shared/ActionTypeNotification/ActionTypeNotification.tsx
+++ b/src/components/v5/shared/ActionTypeNotification/ActionTypeNotification.tsx
@@ -29,10 +29,10 @@ const MSG = defineMessages({
     defaultMessage:
       'This will disable the Colony and prevent any further activity until resolved.',
   },
-  createDecisionError: {
-    id: `${displayName}.createDecisionError`,
+  noExtensionError: {
+    id: `${displayName}.noExtensionError`,
     defaultMessage:
-      'Agreements requires the Reputation weighted extension to be enabled.',
+      '{actionName} requires the {extensionName} extension to be enabled.',
   },
   learnMore: {
     id: `${displayName}.learnMore`,
@@ -48,6 +48,11 @@ const MSG = defineMessages({
       'You need to install the {extensionName} extension to create this action.',
   },
 });
+
+const extensions = {
+  [Action.CreateDecision]: Extension.VotingReputation,
+  [Action.StreamingPayment]: Extension.StreamingPayments,
+};
 
 export const ActionTypeNotification: FC<ActionTypeNotificationProps> = ({
   selectedAction,
@@ -76,7 +81,10 @@ export const ActionTypeNotification: FC<ActionTypeNotificationProps> = ({
         return formatText(MSG.enterRecoveryModeError);
       case Action.CreateDecision:
         return isFieldDisabled
-          ? formatText(MSG.createDecisionError)
+          ? formatText(MSG.noExtensionError, {
+              actionName: 'Agreements',
+              extensionName: 'Reputation weighted',
+            })
           : undefined;
       case Action.StreamingPayment: {
         const extensionName = supportedExtensionsConfig.find(
@@ -84,8 +92,9 @@ export const ActionTypeNotification: FC<ActionTypeNotificationProps> = ({
         )?.name;
 
         return isFieldDisabled && extensionName
-          ? formatText(MSG.extensionNotInstalled, {
-              extensionName: formatText(extensionName),
+          ? formatText(MSG.noExtensionError, {
+              actionName: 'Streaming',
+              extensionName: 'Streaming Payments',
             })
           : undefined;
       }
@@ -113,17 +122,15 @@ export const ActionTypeNotification: FC<ActionTypeNotificationProps> = ({
                   {formatText(MSG.learnMore)}
                 </a>
               ) : (
-                selectedAction === Action.CreateDecision && (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      navigate(`extensions/${Extension.VotingReputation}`);
-                      toggleActionSidebarOff();
-                    }}
-                  >
-                    {formatText(MSG.viewExtension)}
-                  </button>
-                )
+                <button
+                  type="button"
+                  onClick={() => {
+                    navigate(`extensions/${extensions[selectedAction]}`);
+                    toggleActionSidebarOff();
+                  }}
+                >
+                  {formatText(MSG.viewExtension)}
+                </button>
               )
             }
           >

--- a/src/components/v5/shared/ActionTypeNotification/ActionTypeNotification.tsx
+++ b/src/components/v5/shared/ActionTypeNotification/ActionTypeNotification.tsx
@@ -8,7 +8,9 @@ import { supportedExtensionsConfig } from '~constants';
 import { Action } from '~constants/actions.ts';
 import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
+import { COLONY_EXTENSIONS_ROUTE } from '~routes';
 import { formatText } from '~utils/intl.ts';
+import { getNeededExtension } from '~v5/common/ActionSidebar/partials/utils.ts';
 import NotificationBanner from '~v5/shared/NotificationBanner/index.ts';
 
 import { type ActionTypeNotificationProps } from './types.ts';
@@ -48,11 +50,6 @@ const MSG = defineMessages({
       'You need to install the {extensionName} extension to create this action.',
   },
 });
-
-const extensions = {
-  [Action.CreateDecision]: Extension.VotingReputation,
-  [Action.StreamingPayment]: Extension.StreamingPayments,
-};
 
 export const ActionTypeNotification: FC<ActionTypeNotificationProps> = ({
   selectedAction,
@@ -105,6 +102,9 @@ export const ActionTypeNotification: FC<ActionTypeNotificationProps> = ({
 
   const notificationTitle = getNotificationTitle();
 
+  const extensionId = getNeededExtension(selectedAction);
+  const extensionLink = `${COLONY_EXTENSIONS_ROUTE}/${extensionId}`;
+
   return (
     <>
       {notificationTitle && (
@@ -125,7 +125,7 @@ export const ActionTypeNotification: FC<ActionTypeNotificationProps> = ({
                 <button
                   type="button"
                   onClick={() => {
-                    navigate(`extensions/${extensions[selectedAction]}`);
+                    navigate(extensionLink);
                     toggleActionSidebarOff();
                   }}
                 >


### PR DESCRIPTION
## Description

Display and handle streaming payments extension error when the extension is not installed

## Testing

Create `Streaming payment` action without extension installed.

## Diffs

![Screenshot 2025-01-10 at 15 31 28](https://github.com/user-attachments/assets/03ee55ee-2d23-4b53-a8bd-8564ca689e62)

Resolves https://github.com/JoinColony/colonyCDapp/issues/4052
