### PR TITLE
Fix/3928+3905 member card permissions and reputation

### DIFF
--- a/src/components/frame/v5/pages/MembersPage/partials/MembersTabContent/MembersTabContent.tsx
+++ b/src/components/frame/v5/pages/MembersPage/partials/MembersTabContent/MembersTabContent.tsx
@@ -91,12 +91,11 @@ const MembersTabContent: FC<PropsWithChildren<MembersTabContentProps>> = ({
                 key={item.member.walletAddress}
                 userAddress={item.member.walletAddress}
                 user={item.member.user ?? undefined}
+                domains={item.member.domains}
                 meatBallMenuProps={item.meatBallMenuProps}
                 reputation={item.member.reputation}
-                role={item.member.role}
                 isVerified={item.member.isVerified}
                 contributorType={item.member.contributorType}
-                isRoleInherited={item.member.isRoleInherited}
               />
             );
           })}

--- a/src/components/frame/v5/pages/MembersPage/types.ts
+++ b/src/components/frame/v5/pages/MembersPage/types.ts
@@ -1,10 +1,12 @@
 import { type UserRoleMeta } from '~constants/permissions.ts';
 import { type ContributorType } from '~gql';
+import { type DomainWithPermissionsAndReputation } from '~hooks/members/types.ts';
 import { type User } from '~types/graphql.ts';
 import { type MeatBallMenuProps } from '~v5/shared/MeatBallMenu/types.ts';
 
 export interface MemberItem {
   user?: User | null;
+  domains: DomainWithPermissionsAndReputation[];
   walletAddress: string;
   role?: UserRoleMeta;
   isRoleInherited?: boolean;

--- a/src/components/frame/v5/pages/MembersPage/utils.ts
+++ b/src/components/frame/v5/pages/MembersPage/utils.ts
@@ -6,10 +6,12 @@ import {
   type UserRoleMeta,
 } from '~constants/permissions.ts';
 import { type ColonyContributorFragment, type ColonyFragment } from '~gql';
+import { getContributorBreakdown } from '~hooks/members/useContributorBreakdown.ts';
 import {
   getHighestTierRoleForUser,
   getUserRolesForDomain,
 } from '~transformers/index.ts';
+import { notNull } from '~utils/arrays/index.ts';
 import { extractColonyRoles } from '~utils/colonyRoles.ts';
 
 import { type MemberItem } from './types.ts';
@@ -106,6 +108,13 @@ export const getMembersList = (
       type,
     } = contributor;
 
+    const { domains: colonyDomains } = colony;
+
+    const domains = getContributorBreakdown(
+      colonyDomains?.items.filter(notNull) || [],
+      contributor,
+    );
+
     const { role: domainRolesMeta, isInherited: isRoleInherited } = getRoleInfo(
       {
         colonyRoles,
@@ -144,6 +153,7 @@ export const getMembersList = (
 
     return {
       user,
+      domains,
       walletAddress: contributorAddress,
       isVerified,
       reputation: isAllTeamsSelected

--- a/src/components/v5/common/MemberCard/MemberCard.tsx
+++ b/src/components/v5/common/MemberCard/MemberCard.tsx
@@ -34,12 +34,13 @@ const MemberCard: FC<MemberCardProps> = ({
   const contributorRootDomain = domains.find(
     ({ nativeId }) => nativeId === Id.RootDomain,
   );
-  const contributorDomain = domains.find(
-    ({ nativeId }) => nativeId === selectedDomain?.nativeId,
-  );
 
   const isRootDomain =
-    selectedDomain?.nativeId === contributorRootDomain?.nativeId;
+    !selectedDomain || selectedDomain.nativeId === Id.RootDomain;
+
+  const contributorDomain = isRootDomain
+    ? contributorRootDomain
+    : domains.find(({ nativeId }) => nativeId === selectedDomain?.nativeId);
 
   return (
     <div className="flex h-full w-full flex-col rounded-lg border border-gray-200 bg-gray-25 p-5">

--- a/src/components/v5/common/MemberCard/MemberCard.tsx
+++ b/src/components/v5/common/MemberCard/MemberCard.tsx
@@ -62,12 +62,10 @@ const MemberCard: FC<MemberCardProps> = ({
       </div>
       {(reputation !== undefined || role) && (
         <div className="mt-[.6875rem] flex w-full items-center justify-between gap-4 border-t border-t-gray-200 pt-[.6875rem]">
-          {reputation !== undefined && (
-            <ReputationBadge
-              className="min-h-[1.625rem]"
-              reputation={reputation}
-            />
-          )}
+          <ReputationBadge
+            className="min-h-[1.625rem]"
+            reputation={reputation || 0}
+          />
           {role && (
             <div className="ml-auto">
               <RolesTooltip role={role} isRoleInherited={isRoleInherited} />

--- a/src/components/v5/common/MemberCard/types.ts
+++ b/src/components/v5/common/MemberCard/types.ts
@@ -1,14 +1,13 @@
-import { type UserRoleMeta } from '~constants/permissions.ts';
 import { type ContributorType } from '~gql';
+import { type DomainWithPermissionsAndReputation } from '~hooks/members/types.ts';
 import { type User } from '~types/graphql.ts';
 import { type MeatBallMenuProps } from '~v5/shared/MeatBallMenu/types.ts';
 
 export interface MemberCardProps {
   userAddress: string;
   user?: User;
+  domains: DomainWithPermissionsAndReputation[];
   meatBallMenuProps: MeatBallMenuProps;
-  role?: UserRoleMeta;
-  isRoleInherited?: boolean;
   reputation?: number;
   isVerified?: boolean;
   contributorType?: ContributorType;

--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/utils.ts
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/utils.ts
@@ -5,6 +5,7 @@ import { TEAM_SEARCH_PARAM } from '~routes';
 import { type Domain } from '~types/graphql.ts';
 import { formatText } from '~utils/intl.ts';
 import { adjustPercentagesTo100 } from '~utils/numbers.ts';
+import { splitWalletAddress } from '~utils/splitWalletAddress.ts';
 import { getTeamHexColor } from '~utils/teams.ts';
 
 import { CONTRIBUTORS_COLORS_LIST } from './consts.ts';
@@ -122,7 +123,7 @@ export const getContributorReputationChartData = (
     .map(({ walletAddress, user, reputation }, index) => {
       return {
         id: walletAddress,
-        label: user?.profile?.displayName || '',
+        label: user?.profile?.displayName || splitWalletAddress(walletAddress),
         value: reputation || 0,
         color: getTeamHexColor(CONTRIBUTORS_COLORS_LIST[index]),
       };

--- a/src/components/v5/shared/UserInfoPopover/partials/PermissionTooltip/PermissionTooltip.tsx
+++ b/src/components/v5/shared/UserInfoPopover/partials/PermissionTooltip/PermissionTooltip.tsx
@@ -66,31 +66,36 @@ const PermissionTooltip: FC<PermissionTooltipProps> = ({
   const role = getRole(mergedPermissions);
 
   return (
-    <Tooltip
-      placement="top"
-      // Add singleBadge container when there is only one badge
-      className="justify-end only:w-full only:@container/singleBadge"
-      tooltipContent={
-        <PermissionTooltipContent
-          userPermissions={userPermissionsInDomain}
-          userInheritedPermissions={userInheritedPermissions}
-          rolePrepend={isMultiSig ? formatText(MSG.multiSigPrepend) : undefined}
-        />
-      }
-    >
-      <PermissionsBadge
-        icon={isMultiSig ? UsersThree : User}
-        pillSize={showRoleLabel ? 'medium' : 'small'}
-        // If only one badge, show at a smaller container width
-        textClassName="hidden @[6rem]/singleBadge:block @[11rem]/cardDetails:block"
-        text={
-          showRoleLabel
-            ? USER_ROLES.find(({ role: roleField }) => roleField === role.role)
-                ?.name || formatText({ id: 'role.custom' })
-            : undefined
+    // Add singleBadge container when there is only one badge
+    <div className="only:flex only:w-full only:justify-end only:@container/singleBadge">
+      <Tooltip
+        placement="top"
+        className="w-fit"
+        tooltipContent={
+          <PermissionTooltipContent
+            userPermissions={userPermissionsInDomain}
+            userInheritedPermissions={userInheritedPermissions}
+            rolePrepend={
+              isMultiSig ? formatText(MSG.multiSigPrepend) : undefined
+            }
+          />
         }
-      />
-    </Tooltip>
+      >
+        <PermissionsBadge
+          icon={isMultiSig ? UsersThree : User}
+          pillSize={showRoleLabel ? 'medium' : 'small'}
+          // If only one badge, show at a smaller container width
+          textClassName="hidden @[6rem]/singleBadge:block @[11rem]/cardDetails:block"
+          text={
+            showRoleLabel
+              ? USER_ROLES.find(
+                  ({ role: roleField }) => roleField === role.role,
+                )?.name || formatText({ id: 'role.custom' })
+              : undefined
+          }
+        />
+      </Tooltip>
+    </div>
   );
 };
 

--- a/src/components/v5/shared/UserInfoPopover/partials/PermissionTooltip/PermissionTooltip.tsx
+++ b/src/components/v5/shared/UserInfoPopover/partials/PermissionTooltip/PermissionTooltip.tsx
@@ -1,8 +1,13 @@
+import { ColonyRole } from '@colony/colony-js';
 import { User, UsersThree } from '@phosphor-icons/react';
 import React, { type FC } from 'react';
 import { defineMessages } from 'react-intl';
 
-import { getInheritedPermissions } from '~constants/permissions.ts';
+import {
+  getInheritedPermissions,
+  getRole,
+  USER_ROLES,
+} from '~constants/permissions.ts';
 import { type AvailablePermission } from '~hooks/members/types.ts';
 import Tooltip from '~shared/Extensions/Tooltip/Tooltip.tsx';
 import { formatText } from '~utils/intl.ts';
@@ -24,6 +29,7 @@ interface PermissionTooltipProps {
   isRootDomain?: boolean;
   userPermissionsInDomain: AvailablePermission[];
   userPermissionsInParentDomain: AvailablePermission[];
+  showRoleLabel?: boolean;
 }
 
 const PermissionTooltip: FC<PermissionTooltipProps> = ({
@@ -31,6 +37,7 @@ const PermissionTooltip: FC<PermissionTooltipProps> = ({
   isRootDomain = false,
   userPermissionsInDomain,
   userPermissionsInParentDomain,
+  showRoleLabel = false,
 }) => {
   const userInheritedPermissions = getInheritedPermissions({
     parentPermissions: userPermissionsInParentDomain,
@@ -45,9 +52,24 @@ const PermissionTooltip: FC<PermissionTooltipProps> = ({
     return null;
   }
 
+  let mergedPermissions = [
+    ...new Set([...userPermissionsInDomain, ...userPermissionsInParentDomain]),
+  ];
+
+  if (!isRootDomain) {
+    mergedPermissions = mergedPermissions.filter(
+      (permission) =>
+        permission !== ColonyRole.Root && permission !== ColonyRole.Recovery,
+    );
+  }
+
+  const role = getRole(mergedPermissions);
+
   return (
     <Tooltip
       placement="top"
+      // Add singleBadge container when there is only one badge
+      className="justify-end only:w-full only:@container/singleBadge"
       tooltipContent={
         <PermissionTooltipContent
           userPermissions={userPermissionsInDomain}
@@ -58,7 +80,15 @@ const PermissionTooltip: FC<PermissionTooltipProps> = ({
     >
       <PermissionsBadge
         icon={isMultiSig ? UsersThree : User}
-        pillSize="small"
+        pillSize={showRoleLabel ? 'medium' : 'small'}
+        // If only one badge, show at a smaller container width
+        textClassName="hidden @[6rem]/singleBadge:block @[11rem]/cardDetails:block"
+        text={
+          showRoleLabel
+            ? USER_ROLES.find(({ role: roleField }) => roleField === role.role)
+                ?.name || formatText({ id: 'role.custom' })
+            : undefined
+        }
       />
     </Tooltip>
   );

--- a/src/components/v5/shared/UserInfoPopover/partials/PermissionTooltip/PermissionTooltip.tsx
+++ b/src/components/v5/shared/UserInfoPopover/partials/PermissionTooltip/PermissionTooltip.tsx
@@ -71,6 +71,9 @@ const PermissionTooltip: FC<PermissionTooltipProps> = ({
       <Tooltip
         placement="top"
         className="w-fit"
+        popperOptions={{
+          strategy: 'fixed',
+        }}
         tooltipContent={
           <PermissionTooltipContent
             userPermissions={userPermissionsInDomain}

--- a/src/stories/common/MemberCard.stories.tsx
+++ b/src/stories/common/MemberCard.stories.tsx
@@ -1,4 +1,3 @@
-import { UserRole } from '~constants/permissions.ts';
 import { ContributorType } from '~gql';
 import MemberCard from '~v5/common/MemberCard/index.ts';
 
@@ -43,11 +42,7 @@ export const WithBadge: StoryObj<typeof MemberCard> = {
     },
     contributorType: ContributorType.Active,
     userAddress: '',
-    role: {
-      name: 'admin',
-      role: UserRole.Admin,
-      permissions: [],
-    },
+    domains: [],
   },
 };
 
@@ -60,10 +55,6 @@ export const WithReputation: StoryObj<typeof MemberCard> = {
 export const WithReputationAndBadge: StoryObj<typeof MemberCard> = {
   args: {
     reputation: 59,
-    role: {
-      name: 'admin',
-      role: UserRole.Admin,
-      permissions: [],
-    },
+    domains: [],
   },
 };

--- a/src/stories/common/MemberCardList.stories.tsx
+++ b/src/stories/common/MemberCardList.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { UserRole } from '~constants/permissions.ts';
 import MemberCard from '~v5/common/MemberCard/index.ts';
 import MemberCardList from '~v5/common/MemberCardList/index.ts';
 
@@ -32,11 +31,7 @@ const memberCardListMeta: Meta<typeof MemberCardList> = {
             ],
           }}
           reputation={42}
-          role={{
-            name: 'admin',
-            role: UserRole.Admin,
-            permissions: [],
-          }}
+          domains={[]}
           isVerified
           contributorType={undefined}
         />
@@ -61,11 +56,7 @@ const memberCardListMeta: Meta<typeof MemberCardList> = {
             ],
           }}
           reputation={37}
-          role={{
-            name: 'admin',
-            role: UserRole.Admin,
-            permissions: [],
-          }}
+          domains={[]}
           isVerified
           contributorType={undefined}
         />
@@ -90,11 +81,7 @@ const memberCardListMeta: Meta<typeof MemberCardList> = {
             ],
           }}
           reputation={22}
-          role={{
-            name: 'admin',
-            role: UserRole.Admin,
-            permissions: [],
-          }}
+          domains={[]}
           isVerified={false}
           contributorType={undefined}
         />
@@ -119,11 +106,7 @@ const memberCardListMeta: Meta<typeof MemberCardList> = {
             ],
           }}
           reputation={13}
-          role={{
-            name: 'payer',
-            role: UserRole.Payer,
-            permissions: [],
-          }}
+          domains={[]}
           isVerified
           contributorType={undefined}
         />
@@ -148,11 +131,7 @@ const memberCardListMeta: Meta<typeof MemberCardList> = {
             ],
           }}
           reputation={9}
-          role={{
-            name: 'payer',
-            role: UserRole.Payer,
-            permissions: [],
-          }}
+          domains={[]}
           isVerified
           contributorType={undefined}
         />
@@ -177,11 +156,7 @@ const memberCardListMeta: Meta<typeof MemberCardList> = {
             ],
           }}
           reputation={6}
-          role={{
-            name: 'payer',
-            role: UserRole.Payer,
-            permissions: [],
-          }}
+          domains={[]}
           isVerified
           contributorType={undefined}
         />
@@ -206,11 +181,7 @@ const memberCardListMeta: Meta<typeof MemberCardList> = {
             ],
           }}
           reputation={5}
-          role={{
-            name: 'payer',
-            role: UserRole.Payer,
-            permissions: [],
-          }}
+          domains={[]}
           isVerified
           contributorType={undefined}
         />


### PR DESCRIPTION
WIP

## Description

This PR resolves a few permissions / reputation related UI issues:

* The top users chart on the dashboard now shows the wallet address if a user does not have a profile / display name.
* The domains list on the user popover will now show all domains if a user has permissions in the root domain to show their inherited permissions.
* The permissions badges on the member cards now more closely align with the permissions badges on the user popover.

## Testing

First lets check the top users chart shows the wallet address when a user does not have a profile / display name.

* Step 1: Navigate to [http://localhost:9091/planex/members](http://localhost:9091/planex/members)
* Step 2: Copy the wallet address of a member with reputation in a sub-domain:

![Screenshot 2025-01-14 at 12 54 12](https://github.com/user-attachments/assets/e9dab37c-30a3-41bf-b9cb-552ed0579c77)

* Step 3: Use GraphiQL to delete their profile:

```
mutation MyMutation {
  deleteProfile(input: {id: "USERS_WALLET_ADDRESS"}) {
    id
  }
}
```

![Screenshot 2025-01-14 at 12 54 40](https://github.com/user-attachments/assets/32c875dd-48db-42e3-95d1-3b1bf3f27d07)

* Step 4: Refresh, then navigate to the colony dashboard, select a sub-domain where the user has reputation and check the "Top users" chart. The wallet address should be visible. (Compared to master where an empty string is rendered).

![Screenshot 2025-01-14 at 12 56 53](https://github.com/user-attachments/assets/a7a54f03-712a-4632-a093-80f384eba8da)

Next lets check the full list of domains shows on the user popover when the user has permissions in the root domain.

* Step 5: We need to copy the wallet address of a user who has no reputation. The easiest way to do this is disconnect your dev wallet, then connect with dev wallet 4. Copy the wallet address.

![Screenshot 2025-01-14 at 12 59 04](https://github.com/user-attachments/assets/e0eb4ee6-8307-4166-9efe-66922b7f302d)

* Step 6: Then reconnect with dev wallet 1 so we can assign some permissions.
* Step 7: Create a manage permissions action and give the user some permissions in the general.

![Screenshot 2025-01-14 at 13 01 10](https://github.com/user-attachments/assets/c34ca85f-e054-4606-8d71-63693ac2c672)

* Step 8: Navigate to [http://localhost:9091/planex/members](http://localhost:9091/planex/members) and click on the user to open the user popover. Check the full list of domains appears as they will have inherited permissions in each domain. (Compared to master where only "General", or teams in which they had reputation / other permissions would show). You can also check here that the reputation badge is shown for users who have permissions even if they have 0 reputation.

![Screenshot 2025-01-14 at 13 03 21](https://github.com/user-attachments/assets/7050810e-f347-4251-9578-5ba6767751c9)

And lastly we want to check the members cards properly shown inherited permissions and align them more closely with the permissions badges that show in the user popover.

* Step 9: Assign Fry custom funding permissions in Serenity.

![Screenshot 2025-01-14 at 13 06 06](https://github.com/user-attachments/assets/271f169e-1142-4698-bcc4-0e02fd6ea1e4)

* Step 10: Select the Serenity team filter and check the permissions badge shown for Fry is as expected.

![Screenshot 2025-01-14 at 13 06 39](https://github.com/user-attachments/assets/adb1506a-a03c-4e9f-88f6-25c21d223638)

* Step 11: Assign Fry custom admin and arbitration in General.

![Screenshot 2025-01-14 at 13 08 03](https://github.com/user-attachments/assets/b6c44c76-7079-4a1f-9f9e-d82c9e43d115)

* Step 12: With the Serenity team filter selected, check the badge shows Payer to ensure it accounts for the inherited permissions.

![Screenshot 2025-01-14 at 13 08 29](https://github.com/user-attachments/assets/224f8154-5f0b-4fe1-a4ed-7dfa95380f23)

* Step 13: Switch to General and check it shows Custom.

![Screenshot 2025-01-14 at 13 09 31](https://github.com/user-attachments/assets/0402947a-ff0c-422f-9aa5-9c0fce0f8661)

* Step 14: Install the multisig extension.
* Step 15: Assign Amy custom multisig funding permissions in Serenity.

![Screenshot 2025-01-14 at 13 11 04](https://github.com/user-attachments/assets/f39a1180-1c76-4206-ac6a-2db49e0c29fb)

* Step 16: With the Serenity team filter selected, check the expected permissions badge is shown (note the different icon for multisig)

![Screenshot 2025-01-14 at 13 11 36](https://github.com/user-attachments/assets/8659e3a2-6fc6-43ff-9445-c43b3bc63a18)

* Step 17: Assign Amy custom multisig admin and arbitration in General.

![Screenshot 2025-01-14 at 13 12 42](https://github.com/user-attachments/assets/e4549bd9-c2c1-4c32-b443-b13c6bf51fe3)

* Step 18: With the Serenity team filter selected, check the badge shows Payer to ensure it accounts for the inherited permissions. Then check General shows custom.

![Screenshot 2025-01-14 at 13 13 12](https://github.com/user-attachments/assets/d089f8ed-3129-44fe-bf48-65166ce26c58)

* Step 19 - Assign multi-sig permissions to Leela in General.

![Screenshot 2025-01-14 at 13 14 15](https://github.com/user-attachments/assets/141c796a-8ca1-4e29-82de-e8ade93db6f1)

* Step 20 - Check both permissions badges are shown.

![Screenshot 2025-01-14 at 13 14 31](https://github.com/user-attachments/assets/7a2ad54f-8479-4b40-a980-c0da5afd91b9)

* Step 21 - Resize the window to confirm the text on the badge is hidden when there is not sufficient space.

![Screenshot 2025-01-14 at 13 15 43](https://github.com/user-attachments/assets/657a88a7-eb4f-482c-83bb-0293d5decb0a)

## Diffs

**Changes** 🏗

* Top users chart now falls back to wallet address if no profile is found
* Member card now uses PermissionsTooltip rather than RolesTooltip
* PermissionsTooltip has been adjusted to conditionally show the role name

Resolves #3928 
Resolves #3905
