### PR TITLE
test: staged payment e2e tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     /* Collect trace for failed tests. See https://playwright.dev/docs/trace-viewer */
     trace: 'retain-on-failure',
   },
-  timeout: !process.env.CI ? 60000 : undefined,
+  timeout: !process.env.CI ? 90000 : undefined,
   /* Configure projects for major browsers */
   projects: [
     {

--- a/playwright/e2e/simple-payment.spec.ts
+++ b/playwright/e2e/simple-payment.spec.ts
@@ -2,10 +2,9 @@ import { type BrowserContext, expect, type Page, test } from '@playwright/test';
 
 import { convertToDecimal } from '~utils/convertToDecimal.ts';
 
+import { Extensions } from '../models/extensions.ts';
 import { SimplePayment } from '../models/simple-payment.ts';
 import {
-  uninstallReputationWeightedExtension,
-  enableReputationWeightedExtension,
   setCookieConsent,
   signInAndNavigateToColony,
   forwardTime,
@@ -17,265 +16,231 @@ import { getFirstDomainAndTotalFunds } from '../utils/graphqlHelpers.ts';
 test.describe.configure({ mode: 'serial' });
 
 test.describe('Simple payment', () => {
-  test.describe('User has required permissions', () => {
-    let page: Page;
-    let context: BrowserContext;
-    let simplePayment: SimplePayment;
+  let page: Page;
+  let context: BrowserContext;
+  let simplePayment: SimplePayment;
+  let extensions: Extensions;
 
-    test.beforeAll(async ({ browser, baseURL }) => {
-      context = await browser.newContext();
-      page = await context.newPage();
-      simplePayment = new SimplePayment(page);
-
-      await setCookieConsent(context, baseURL);
-      await signInAndNavigateToColony(page, {
-        colonyUrl: '/planex',
-        wallet: /dev wallet 1$/i,
-      });
-      await enableReputationWeightedExtension(page, {
-        colonyPath: '/planex',
-      });
+  test.beforeAll(async ({ browser, baseURL }) => {
+    context = await browser.newContext();
+    page = await context.newPage();
+    simplePayment = new SimplePayment(page);
+    extensions = new Extensions(page);
+    await setCookieConsent(context, baseURL);
+    await signInAndNavigateToColony(page, {
+      colonyUrl: '/planex',
+      wallet: /dev wallet 1$/i,
     });
-
-    test.afterAll(async () => {
-      await uninstallReputationWeightedExtension(page, {
-        colonyPath: '/planex',
-      });
-      await context?.close();
-    });
-
-    test.beforeEach(async () => {
-      await simplePayment.open();
-    });
-
-    test.afterEach(async () => {
-      await simplePayment.close();
-    });
-
-    test('Should successfully create a simple payment (Permissions decision method)', async () => {
-      const recipientAddress = '0x27fF0C145E191C22C75cD123C679C3e1F58a4469';
-
-      await simplePayment.fillForm({
-        title: 'Test Simple Payment',
-        team: 'General',
-        recipient: recipientAddress,
-        amount: '1',
-        decisionMethod: 'Permissions',
-      });
-
-      await simplePayment.submit();
-
-      await simplePayment.waitForTransaction();
-
-      await expect(simplePayment.completedAction).toBeVisible();
-      await expect(
-        simplePayment.completedAction.getByText(
-          /Member used permissions to create this action/i,
-        ),
-      ).toBeVisible();
-    });
-
-    test('Should support a payment with reputation', async () => {
-      const recipientAddress = '0x27fF0C145E191C22C75cD123C679C3e1F58a4469';
-
-      await simplePayment.fillForm({
-        title: 'Test Simple Payment',
-        team: 'General',
-        recipient: recipientAddress,
-        amount: '1',
-        decisionMethod: 'Reputation',
-      });
-
-      await expect(simplePayment.form.getByText('Created In')).toBeVisible();
-
-      await expect(
-        simplePayment.form.getByRole('button', { name: 'General' }),
-      ).toHaveCount(2);
-
-      await simplePayment.submit();
-
-      await simplePayment.waitForTransaction();
-
-      await expect(simplePayment.stepper).toBeVisible();
-      await simplePayment.verifyStepperUI();
-      await simplePayment.voteOnMotion('Support');
-
-      await forwardTime(0.1);
-      await simplePayment.reloadPage();
-
-      await expect(
-        simplePayment.completedAction.getByText(
-          'Finalize to execute the agreed transactions and return stakes',
-        ),
-      ).toBeVisible();
-
-      await simplePayment.finalize();
-
-      await simplePayment.claim();
-    });
-
-    test('Should oppose a payment with reputation', async () => {
-      const recipientAddress = '0x27fF0C145E191C22C75cD123C679C3e1F58a4469';
-
-      await simplePayment.fillForm({
-        title: 'Test Simple Payment to Oppose',
-        team: 'General',
-        recipient: recipientAddress,
-        amount: '1',
-        decisionMethod: 'Reputation',
-      });
-
-      await expect(simplePayment.form.getByText('Created In')).toBeVisible();
-      await expect(
-        simplePayment.form.getByRole('button', { name: 'General' }),
-      ).toHaveCount(2);
-
-      await simplePayment.submit();
-
-      await simplePayment.waitForTransaction();
-
-      await expect(simplePayment.stepper).toBeVisible();
-      await simplePayment.verifyStepperUI();
-      await simplePayment.voteOnMotion('Oppose');
-
-      await forwardTime(0.1);
-      await simplePayment.reloadPage();
-
-      await expect(
-        simplePayment.completedAction.getByText(
-          'Action failed and cannot be executed',
-        ),
-      ).toBeVisible();
-
-      await expect(
-        simplePayment.completedAction.getByRole('button', { name: 'Failed' }),
-      ).toBeVisible();
-    });
-
-    test('Should validate simple payment form fields', async () => {
-      await simplePayment.submit();
-
-      // Verify validation messages
-      for (const message of SimplePayment.validationMessages
-        .allRequiredFields) {
-        await expect(simplePayment.getValidationMessage(message)).toBeVisible();
-      }
-
-      await simplePayment.setTitle(
-        'This is a test title that exceeds the maximum character limit of sixty.',
-      );
-      await expect(
-        simplePayment.getValidationMessage(
-          SimplePayment.validationMessages.title.maxLengthExceeded,
-        ),
-      ).toBeVisible();
-    });
-
-    test('Should display tooltips and user info', async () => {
-      for (const [field, message] of Object.entries(
-        SimplePayment.tooltipMessages,
-      )) {
-        await simplePayment.form.getByText(field, { exact: true }).hover();
-        await expect(simplePayment.getTooltip(message)).toBeVisible();
-      }
-
-      await simplePayment.openUserInfo();
-
-      await expect(simplePayment.drawer.getByTestId('user-info')).toBeVisible();
-    });
-
-    test('Should display the confirmation modal when the user tries to close the form', async () => {
-      await simplePayment.setTitle('Test');
-
-      await simplePayment.closeButton.click();
-
-      await simplePayment.getConfirmationDialog().waitFor({ state: 'visible' });
-
-      await expect(
-        simplePayment.getConfirmationDialog().getByRole('button', {
-          name: 'Yes, cancel the action',
-        }),
-      ).toBeVisible();
-
-      await expect(
-        simplePayment.getConfirmationDialog().getByRole('button', {
-          name: 'No, go back to editing',
-        }),
-      ).toBeVisible();
-
-      await simplePayment
-        .getConfirmationDialog()
-        .getByRole('button', { name: 'No, go back to editing' })
-        .click();
-
-      await simplePayment.getConfirmationDialog().waitFor({ state: 'hidden' });
-
-      await expect(simplePayment.form).toBeVisible();
-    });
-
-    test("Shouldn't be able to make a payment with a locked token outside of it's native colony", async () => {
-      // Select a token that is not native to the colony
-      await simplePayment.selectToken('ƓƓƓ');
-
-      await expect(
-        simplePayment.getValidationMessage(
-          SimplePayment.validationMessages.token.locked,
-        ),
-      ).toBeVisible();
-    });
-
-    test('Should prevent payment amount equal to total domain balance to reserve funds for network fees', async () => {
-      const { balance, domainName, tokenDecimals, tokenSymbol } =
-        await getFirstDomainAndTotalFunds({
-          colonyName: 'planex',
-        });
-
-      expect(Number(balance)).toBeGreaterThan(0);
-
-      await simplePayment.fillForm({
-        title: 'Test Simple Payment',
-        team: domainName,
-        amount: convertToDecimal(balance, tokenDecimals)?.toString() || '',
-        token: tokenSymbol,
-        decisionMethod: 'Permissions',
-      });
-
-      await expect(
-        simplePayment.getValidationMessage(
-          SimplePayment.validationMessages.amount.maxExceeded,
-        ),
-      ).toBeVisible();
+    await extensions.enableReputationWeightedExtension({
+      colonyPath: '/planex',
     });
   });
 
-  test.describe('User has no permissions', () => {
-    let simplePayment: SimplePayment;
+  test.afterAll(async () => {
+    await context?.close();
+  });
 
-    test.beforeEach(async ({ page, context, baseURL }) => {
-      simplePayment = new SimplePayment(page);
+  test.beforeEach(async () => {
+    await simplePayment.open();
+  });
 
-      await setCookieConsent(context, baseURL);
+  test.afterEach(async () => {
+    await simplePayment.close();
+  });
 
-      await signInAndNavigateToColony(page, {
-        colonyUrl: '/planex',
-        // NOTE: Assuming this test user does not have permissions for Simple Payment in Planex Colony
-        wallet: /dev wallet 3$/i,
+  test('Permissions decision method', async () => {
+    const recipientAddress = '0x27fF0C145E191C22C75cD123C679C3e1F58a4469';
+
+    await simplePayment.fillForm({
+      title: 'Test Simple Payment',
+      team: 'General',
+      recipient: recipientAddress,
+      amount: '1',
+      decisionMethod: 'Permissions',
+    });
+
+    await simplePayment.submit();
+
+    await simplePayment.waitForTransaction();
+
+    await expect(simplePayment.completedAction).toBeVisible();
+    await expect(
+      simplePayment.completedAction.getByText(
+        /Member used permissions to create this action/i,
+      ),
+    ).toBeVisible();
+  });
+
+  test('Reputation decision method | Vote Support', async () => {
+    const recipientAddress = '0x27fF0C145E191C22C75cD123C679C3e1F58a4469';
+
+    await simplePayment.fillForm({
+      title: 'Test Simple Payment',
+      team: 'General',
+      recipient: recipientAddress,
+      amount: '1',
+      decisionMethod: 'Reputation',
+    });
+
+    await expect(simplePayment.form.getByText('Created In')).toBeVisible();
+
+    await expect(
+      simplePayment.form.getByRole('button', { name: 'General' }),
+    ).toHaveCount(2);
+
+    await simplePayment.submit();
+
+    await simplePayment.waitForTransaction();
+
+    await expect(simplePayment.stepper).toBeVisible();
+    await simplePayment.verifyStepperUI();
+    await simplePayment.voteOnMotion('Support');
+
+    await forwardTime(0.1);
+    await simplePayment.reloadPage();
+
+    await expect(
+      simplePayment.completedAction.getByText(
+        'Finalize to execute the agreed transactions and return stakes',
+      ),
+    ).toBeVisible();
+
+    await simplePayment.finalize();
+
+    await simplePayment.claim();
+  });
+
+  test('Reputation decision method | VoteOppose', async () => {
+    const recipientAddress = '0x27fF0C145E191C22C75cD123C679C3e1F58a4469';
+
+    await simplePayment.fillForm({
+      title: 'Test Simple Payment to Oppose',
+      team: 'General',
+      recipient: recipientAddress,
+      amount: '1',
+      decisionMethod: 'Reputation',
+    });
+
+    await expect(simplePayment.form.getByText('Created In')).toBeVisible();
+    await expect(
+      simplePayment.form.getByRole('button', { name: 'General' }),
+    ).toHaveCount(2);
+
+    await simplePayment.submit();
+
+    await simplePayment.waitForTransaction();
+
+    await expect(simplePayment.stepper).toBeVisible();
+    await simplePayment.verifyStepperUI();
+    await simplePayment.voteOnMotion('Oppose');
+
+    await forwardTime(0.1);
+    await simplePayment.reloadPage();
+
+    await expect(
+      simplePayment.completedAction.getByText(
+        'Action failed and cannot be executed',
+      ),
+    ).toBeVisible();
+
+    await expect(
+      simplePayment.completedAction.getByRole('button', { name: 'Failed' }),
+    ).toBeVisible();
+  });
+
+  test('Form validation', async () => {
+    await simplePayment.submit();
+
+    // Verify validation messages
+    for (const message of SimplePayment.validationMessages.allRequiredFields) {
+      await expect(simplePayment.getValidationMessage(message)).toBeVisible();
+    }
+
+    await simplePayment.setTitle(
+      'This is a test title that exceeds the maximum character limit of sixty.',
+    );
+    await expect(
+      simplePayment.getValidationMessage(
+        SimplePayment.validationMessages.title.maxLengthExceeded,
+      ),
+    ).toBeVisible();
+  });
+
+  test('Form tooltips and user info dropdown', async () => {
+    for (const [field, message] of Object.entries(
+      SimplePayment.tooltipMessages,
+    )) {
+      await simplePayment.form.getByText(field, { exact: true }).hover();
+      await expect(simplePayment.getTooltip(message)).toBeVisible();
+    }
+
+    await simplePayment.openUserInfo();
+
+    await expect(simplePayment.drawer.getByTestId('user-info')).toBeVisible();
+  });
+
+  test('Confirmation modal on close', async () => {
+    await simplePayment.setTitle('Test');
+
+    await simplePayment.closeButton.click();
+
+    await simplePayment.getConfirmationDialog().waitFor({ state: 'visible' });
+
+    await expect(
+      simplePayment.getConfirmationDialog().getByRole('button', {
+        name: 'Yes, cancel the action',
+      }),
+    ).toBeVisible();
+
+    await expect(
+      simplePayment.getConfirmationDialog().getByRole('button', {
+        name: 'No, go back to editing',
+      }),
+    ).toBeVisible();
+
+    await simplePayment
+      .getConfirmationDialog()
+      .getByRole('button', { name: 'No, go back to editing' })
+      .click();
+
+    await simplePayment.getConfirmationDialog().waitFor({ state: 'hidden' });
+
+    await expect(simplePayment.form).toBeVisible();
+  });
+
+  test('Attempt to use an external locked token', async () => {
+    // Select a token that is not native to the colony
+    await simplePayment.selectToken('ƓƓƓ');
+    await simplePayment.selectToken('ƓƓƓ');
+
+    //  User shouldn't be able to make a payment with a locked token outside of it's native colony
+    await expect(
+      simplePayment.getValidationMessage(
+        SimplePayment.validationMessages.token.locked,
+      ),
+    ).toBeVisible();
+  });
+
+  test('Token amount validation', async () => {
+    const { balance, domainName, tokenDecimals, tokenSymbol } =
+      await getFirstDomainAndTotalFunds({
+        colonyName: 'planex',
       });
 
-      await simplePayment.open();
-    });
+    expect(Number(balance)).toBeGreaterThan(0);
 
-    test('Should not allow to create a simple payment with Permission Decision method', async () => {
-      await expect(
-        simplePayment.getValidationMessage(
-          SimplePayment.validationMessages.permissions,
-        ),
-      ).toBeVisible();
-
-      await expect(simplePayment.submitButton).toBeDisabled();
-      // User should still be able to change the action type
-      await simplePayment.changeActionType('Advanced payment');
-      await expect(simplePayment.submitButton).toBeEnabled();
+    await simplePayment.fillForm({
+      title: 'Test Simple Payment',
+      team: domainName,
+      amount: convertToDecimal(balance, tokenDecimals)?.toString() || '',
+      token: tokenSymbol,
+      decisionMethod: 'Permissions',
     });
+    // Should prevent payment amount equal to total domain balance to reserve funds for network fees
+    await expect(
+      simplePayment.getValidationMessage(
+        SimplePayment.validationMessages.amount.maxExceeded,
+      ),
+    ).toBeVisible();
   });
 });

--- a/playwright/e2e/staged-payment.spec.ts
+++ b/playwright/e2e/staged-payment.spec.ts
@@ -208,16 +208,15 @@ test.describe('Staged Payment', () => {
       }),
     ).toBeVisible();
 
-    await stagedPayment.support();
+    await stagedPayment.voteOnMotion('Support');
+    await stagedPayment.stepper.getByText('100% Supported').waitFor();
 
     await stagedPayment.stepper
       .getByText('The action has been fully supported and will pass.')
       .waitFor();
 
-    await stagedPayment.oppose();
-
-    await expect(stagedPayment.stepper).toHaveText(/100% Opposed/);
-    await expect(stagedPayment.stepper).toHaveText(/100% Supported/);
+    await stagedPayment.voteOnMotion('Oppose');
+    await stagedPayment.stepper.getByText('100% Opposed').waitFor();
 
     await stagedPayment.supportButton.click();
 

--- a/playwright/e2e/staged-payment.spec.ts
+++ b/playwright/e2e/staged-payment.spec.ts
@@ -1,0 +1,390 @@
+import { type BrowserContext, expect, type Page, test } from '@playwright/test';
+
+import { Extensions } from '../models/extensions.ts';
+import { StagedPayment } from '../models/staged-payment.ts';
+import {
+  setCookieConsent,
+  signInAndNavigateToColony,
+} from '../utils/common.ts';
+
+// eslint-disable-next-line no-warning-comments
+// TODO: When running in parallel locally, amplify mock service fails to handle multiple parallel requests from test cases
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Staged Payment', () => {
+  let page: Page;
+  let context: BrowserContext;
+  let stagedPayment: StagedPayment;
+  let extensions: Extensions;
+  const recipientAddress = '0x27fF0C145E191C22C75cD123C679C3e1F58a4469';
+
+  test.beforeAll(async ({ browser, baseURL }) => {
+    context = await browser.newContext();
+    page = await context.newPage();
+    stagedPayment = new StagedPayment(page);
+    extensions = new Extensions(page);
+
+    await setCookieConsent(context, baseURL);
+    await signInAndNavigateToColony(page, {
+      colonyUrl: '/planex',
+      wallet: /dev wallet 1$/i,
+    });
+    await extensions.enableStagedExpenditureExtension({
+      colonyPath: '/planex',
+    });
+
+    await extensions.enableReputationWeightedExtension({
+      colonyPath: '/planex',
+    });
+  });
+
+  test.afterAll(async () => {
+    await context?.close();
+  });
+
+  test.beforeEach(async () => {
+    await stagedPayment.open();
+  });
+
+  test.afterEach(async () => {
+    await stagedPayment.close();
+  });
+
+  test('Permission decision method', async () => {
+    await stagedPayment.fillForm({
+      title: 'Test Staged Payment with Permission Decision Method',
+      team: 'General',
+      recipient: recipientAddress,
+      decisionMethod: 'Permissions',
+      stages: [
+        {
+          title: 'Stage 1',
+          amount: '1',
+        },
+        {
+          title: 'Stage 2',
+          amount: '1',
+        },
+      ],
+    });
+
+    await stagedPayment.submitButton.click();
+
+    await stagedPayment.waitForTransaction();
+
+    await expect(stagedPayment.completedAction).toBeVisible();
+    await expect(stagedPayment.stepper).toBeVisible();
+    await expect(stagedPayment.expenditureActionStatusBadge).toHaveText(
+      'Review',
+    );
+
+    await stagedPayment.confirmPayment();
+    await stagedPayment.fundPayment('Permissions');
+
+    await stagedPayment.releasePayment();
+
+    await expect(stagedPayment.expenditureActionStatusBadge).toHaveText(
+      'Payable',
+    );
+
+    await stagedPayment.makePayment('Permissions');
+
+    await expect(
+      stagedPayment.stagesTable
+        .locator('tbody tr')
+        .nth(0)
+        .getByText('Released'),
+    ).toBeVisible();
+
+    await expect(
+      stagedPayment.stepper.getByRole('button', { name: 'Stage 1 Passed' }),
+    ).toBeVisible();
+
+    await stagedPayment.makePayment('Permissions');
+
+    await expect(
+      stagedPayment.stepper.getByRole('button', { name: 'Stage 2 Passed' }),
+    ).toBeVisible();
+
+    await expect(
+      stagedPayment.completedAction.getByText('Permissions', { exact: true }),
+    ).toBeVisible();
+
+    await verifyCompletedStagedPayment(stagedPayment);
+  });
+
+  test('Staking decision method', async () => {
+    await stagedPayment.fillForm({
+      title: 'Test Staged Payment',
+      team: 'General',
+      recipient: recipientAddress,
+      decisionMethod: 'Staking',
+      stages: [
+        {
+          title: 'Stage 1',
+          amount: '1',
+        },
+        {
+          title: 'Stage 2',
+          amount: '1',
+        },
+      ],
+    });
+
+    await stagedPayment.submitButton.click();
+
+    await stagedPayment.confirmRequiredStakeDialog();
+
+    await stagedPayment.waitForTransaction();
+
+    await expect(stagedPayment.completedAction).toBeVisible();
+
+    await stagedPayment.confirmPayment();
+    await stagedPayment.fundPayment();
+    await stagedPayment.releasePayment();
+
+    await expect(stagedPayment.expenditureActionStatusBadge).toHaveText(
+      'Payable',
+    );
+
+    await stagedPayment.makePayment('Permissions');
+
+    await expect(
+      stagedPayment.stagesTable
+        .locator('tbody tr')
+        .nth(0)
+        .getByText('Released'),
+    ).toBeVisible();
+
+    await expect(
+      stagedPayment.stepper.getByRole('button', { name: 'Stage 1 Passed' }),
+    ).toBeVisible();
+
+    await stagedPayment.makePayment('Payment creator');
+
+    await expect(
+      stagedPayment.stepper.getByRole('button', { name: 'Stage 2 Passed' }),
+    ).toBeVisible();
+
+    await expect(
+      stagedPayment.completedAction.getByText('Staking', { exact: true }),
+    ).toBeVisible();
+
+    await verifyCompletedStagedPayment(stagedPayment);
+  });
+
+  test('Reputation decision method', async () => {
+    await stagedPayment.fillForm({
+      title: 'Test Staged Payment with Reputation Decision Method',
+      team: 'General',
+      recipient: recipientAddress,
+      decisionMethod: 'Permissions',
+      stages: [
+        {
+          title: 'Stage 1',
+          amount: '1',
+        },
+      ],
+    });
+
+    await stagedPayment.submitButton.click();
+
+    await stagedPayment.waitForTransaction();
+
+    await expect(stagedPayment.completedAction).toBeVisible();
+
+    await stagedPayment.confirmPayment();
+
+    // Fund the payment using Reputation decision method
+    await stagedPayment.fundPayment('Reputation');
+
+    await expect(stagedPayment.expenditureActionStatusBadge).toHaveText(
+      'Funding',
+    );
+
+    await expect(
+      stagedPayment.stepper.getByRole('heading', {
+        name: 'Total stake required',
+      }),
+    ).toBeVisible();
+
+    await stagedPayment.support();
+
+    await stagedPayment.stepper
+      .getByText('The action has been fully supported and will pass.')
+      .waitFor();
+
+    await stagedPayment.oppose();
+
+    await expect(stagedPayment.stepper).toHaveText(/100% Opposed/);
+    await expect(stagedPayment.stepper).toHaveText(/100% Supported/);
+
+    await stagedPayment.supportButton.click();
+
+    await stagedPayment.submitVoteButton.click();
+
+    await stagedPayment.revealVoteButton.click();
+
+    await stagedPayment.finalizeButton.click();
+
+    await stagedPayment.releasePayment();
+
+    await stagedPayment.makePayment('Permissions');
+
+    await expect(
+      stagedPayment.stepper.getByRole('button', { name: 'Stage 1 Passed' }),
+    ).toBeVisible();
+
+    await expect(
+      stagedPayment.drawer.getByTestId('expenditure-action-status-badge'),
+    ).toHaveText('Paid');
+  });
+
+  test('Form validation', async () => {
+    await stagedPayment.submit();
+
+    for (const message of StagedPayment.validationMessages.allRequiredFields) {
+      await expect(stagedPayment.drawer.getByText(message)).toBeVisible();
+    }
+
+    await stagedPayment.setTitle(
+      'This is a test title that exceeds the maximum character limit of sixty.',
+    );
+
+    await stagedPayment.submit();
+
+    await expect(
+      stagedPayment.drawer.getByText(
+        StagedPayment.validationMessages.title.maxLengthExceeded,
+      ),
+    ).toBeVisible();
+
+    // Attempt to use a locked token
+    await stagedPayment.fillForm({
+      stages: [
+        {
+          title: 'Stage 1',
+          amount: '1',
+          token: 'ƓƓƓ',
+        },
+      ],
+    });
+
+    await expect(
+      stagedPayment.drawer.getByText(
+        StagedPayment.validationMessages.token.locked,
+      ),
+    ).toBeVisible();
+
+    // Amount exceeds the balance
+    await stagedPayment.fillForm({
+      title: 'Test Staged Payment',
+      team: 'General',
+      recipient: recipientAddress,
+      decisionMethod: 'Permissions',
+      stages: [
+        {
+          title:
+            'This is a very long test title that definitely exceeds the maximum character limit of eighty characters',
+          amount: '999_999_999_999_999_999_999',
+          token: 'CREDS',
+        },
+      ],
+    });
+
+    await expect(
+      stagedPayment.drawer.getByText(
+        StagedPayment.validationMessages.amount.maxExceeded,
+      ),
+    ).toBeVisible();
+
+    await expect(
+      stagedPayment.drawer.getByText(
+        StagedPayment.validationMessages.milestone.maxLengthExceeded,
+      ),
+    ).toBeVisible();
+    // eslint-disable-next-line no-warning-comments
+    // TODO: uncomment once #4185 is fixed
+    // Amount field handles very small numbers
+    // await stagedPayment.fillForm({
+    //   stages: [
+    //     {
+    //       title: 'Stage 1',
+    //       amount: '0.000000000000000000000001', // 24 decimal places
+    //     },
+    //   ],
+    // });
+
+    // await expect(stagedPayment.drawer.getByText('×10-24')).toBeVisible();
+  });
+
+  test('Milestones table actions', async () => {
+    await stagedPayment.fillForm({
+      title: 'Test Staged Payment',
+      team: 'General',
+      recipient: recipientAddress,
+      decisionMethod: 'Permissions',
+      stages: [
+        {
+          title: 'Stage 1',
+          amount: '1',
+        },
+      ],
+    });
+
+    await expect(
+      stagedPayment.form.getByRole('table').locator('tbody tr'),
+    ).toHaveCount(1);
+
+    await stagedPayment.duplicateMilestone(0);
+
+    await expect(
+      stagedPayment.form.getByRole('table').locator('tbody tr'),
+    ).toHaveCount(2);
+
+    await expect(
+      stagedPayment.form.getByRole('table').getByText('Stage 1'),
+    ).toHaveCount(2);
+
+    await stagedPayment.deleteMilestone(1);
+
+    await expect(
+      stagedPayment.form.getByRole('table').locator('tbody tr'),
+    ).toHaveCount(1);
+  });
+});
+
+async function verifyCompletedStagedPayment(stagedPayment: StagedPayment) {
+  await expect(stagedPayment.expenditureActionStatusBadge).toHaveText('Paid');
+  await expect(
+    stagedPayment.completedAction.getByRole('heading', {
+      name: 'Test Staged Payment',
+    }),
+  ).toBeVisible();
+
+  await expect(
+    stagedPayment.completedAction.getByText('Staged payment of 2 CREDS to'),
+  ).toBeVisible();
+
+  await expect(
+    stagedPayment.completedAction.getByText('Staged payment', {
+      exact: true,
+    }),
+  ).toBeVisible();
+
+  await expect(
+    stagedPayment.completedAction.getByText('General'),
+  ).toBeVisible();
+
+  await expect(
+    stagedPayment.completedAction.getByRole('button', {
+      name: 'Avatar of user fry fry',
+    }),
+  ).toBeVisible();
+
+  await expect(
+    stagedPayment.stagesTable.getByText('TOTAL 2 MILESTONES'),
+  ).toBeVisible();
+
+  await expect(stagedPayment.stagesTable.getByText('2CREDS')).toBeVisible();
+}

--- a/playwright/models/extensions.ts
+++ b/playwright/models/extensions.ts
@@ -1,0 +1,168 @@
+import type { Page, Locator } from '@playwright/test';
+
+export class Extensions {
+  installExtensionButton: Locator;
+
+  enableExtensionButton: Locator;
+
+  deprecateExtensionButton: Locator;
+
+  uninstallExtensionButton: Locator;
+
+  constructor(private page: Page) {
+    this.installExtensionButton = this.page.getByRole('button', {
+      name: 'Install',
+      exact: true,
+    });
+
+    this.enableExtensionButton = this.page.getByRole('button', {
+      name: 'Enable',
+      exact: true,
+    });
+
+    this.deprecateExtensionButton = this.page.getByRole('button', {
+      name: 'Deprecate',
+    });
+
+    this.uninstallExtensionButton = this.page.getByRole('button', {
+      name: 'Uninstall',
+    });
+  }
+
+  async goToExtensionsPage({
+    colonyPath,
+    extension,
+  }: {
+    colonyPath: string;
+    extension: string;
+  }) {
+    await this.page.goto(`${colonyPath}/extensions/${extension}`);
+  }
+
+  async enableReputationWeightedExtension({
+    colonyPath,
+  }: {
+    colonyPath: string;
+  }) {
+    await this.goToExtensionsPage({
+      colonyPath,
+      extension: 'VotingReputation',
+    });
+    await this.page.getByText('Loading colony').waitFor({ state: 'hidden' });
+    await this.page
+      .getByRole('heading', { name: 'Extension details' })
+      .waitFor();
+    if (await this.deprecateExtensionButton.isVisible()) {
+      return;
+    }
+    await this.installExtensionButton.click();
+
+    await this.page.getByRole('button', { name: 'Pending' }).waitFor({
+      state: 'hidden',
+    });
+
+    await this.page
+      .getByRole('listitem')
+      .filter({ hasText: 'Testing governance' })
+      .click();
+
+    await this.enableExtensionButton.click();
+
+    await this.deprecateExtensionButton.waitFor();
+  }
+
+  async uninstallReputationWeightedExtension({
+    colonyPath,
+  }: {
+    colonyPath: string;
+  }) {
+    await this.goToExtensionsPage({
+      colonyPath,
+      extension: 'VotingReputation',
+    });
+
+    await this.page.getByText('Loading colony').waitFor({ state: 'hidden' });
+    await this.page
+      .getByRole('heading', { name: 'Extension details' })
+      .waitFor();
+    if (await this.installExtensionButton.isVisible()) {
+      return;
+    }
+
+    await this.deprecateExtensionButton.click();
+
+    await this.page
+      .getByRole('dialog')
+      .getByRole('button', { name: /Deprecate/ })
+      .click();
+
+    await this.uninstallExtensionButton.click();
+    const dialog = this.page.getByRole('dialog');
+
+    await dialog.getByText('I understand that there is a risk').click();
+
+    await dialog
+      .getByRole('button', { name: 'Continue with uninstalling' })
+      .click();
+
+    await this.installExtensionButton.waitFor();
+  }
+
+  async enableStagedExpenditureExtension({
+    colonyPath,
+  }: {
+    colonyPath: string;
+  }) {
+    await this.goToExtensionsPage({
+      colonyPath,
+      extension: 'StagedExpenditure',
+    });
+    await this.page.getByText('Loading colony').waitFor({ state: 'hidden' });
+    await this.page
+      .getByRole('heading', { name: 'Extension details' })
+      .waitFor();
+    if (await this.deprecateExtensionButton.isVisible()) {
+      return;
+    }
+    await this.installExtensionButton.click();
+
+    await this.deprecateExtensionButton.waitFor();
+  }
+
+  async uninstallStagedExpenditureExtension({
+    colonyPath,
+  }: {
+    colonyPath: string;
+  }) {
+    await this.goToExtensionsPage({
+      colonyPath,
+      extension: 'StagedExpenditure',
+    });
+    await this.page.getByText('Loading colony').waitFor({ state: 'hidden' });
+
+    if (await this.installExtensionButton.isVisible()) {
+      return;
+    }
+
+    await this.deprecateExtensionButton.click();
+
+    await this.page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Deprecate' })
+      .click();
+
+    await this.uninstallExtensionButton.click();
+
+    await this.page
+      .getByRole('dialog')
+      .getByText('I understand that unreleased funds cannot be released')
+      .click();
+
+    await this.page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Continue with uninstalling' })
+      .click();
+
+    await this.installExtensionButton.waitFor();
+  }
+}

--- a/playwright/models/staged-payment.ts
+++ b/playwright/models/staged-payment.ts
@@ -1,0 +1,390 @@
+import type { Locator, Page } from '@playwright/test';
+
+export class StagedPayment {
+  static readonly validationMessages = {
+    title: {
+      maxLengthExceeded: 'Title must not exceed 60 characters',
+      isRequired: 'Title is required',
+    },
+    allRequiredFields: [
+      'from must be a `number` type, but the final value was: `NaN` (cast from the value `""`)',
+      'decisionMethod must be defined',
+      'Recipient is required',
+      'Title is required',
+      'Name is required in 1st milestone',
+      'Amount must be greater than zero',
+    ],
+    amount: {
+      isRequired: 'Amount is required',
+      mustBeGreaterThanZero: 'Amount must be greater than zero',
+      maxExceeded: /Not enough \w+ tokens/,
+    },
+    token: {
+      locked:
+        'This token is locked and is not able to be used for payments. Check with the token creator for details.',
+    },
+    milestone: {
+      maxLengthExceeded: /\w+ milestone exceeds limit of 80 characters./,
+    },
+  };
+
+  drawer: Locator;
+
+  form: Locator;
+
+  selectDropdown: Locator;
+
+  decisionMethodDropdown: Locator;
+
+  sidebar: Locator;
+
+  stepper: Locator;
+
+  closeButton: Locator;
+
+  submitButton: Locator;
+
+  completedAction: Locator;
+
+  expenditureActionStatusBadge: Locator;
+
+  makePaymentButton: Locator;
+
+  stagesTable: Locator;
+
+  addMilestoneButton: Locator;
+
+  supportButton: Locator;
+
+  opposeButton: Locator;
+
+  submitVoteButton: Locator;
+
+  revealVoteButton: Locator;
+
+  finalizeButton: Locator;
+
+  constructor(private page: Page) {
+    this.drawer = page.getByTestId('action-drawer');
+    this.form = page.getByTestId('action-form');
+    this.selectDropdown = page.getByTestId('search-select-menu');
+    this.decisionMethodDropdown = page
+      .getByRole('list')
+      .filter({ hasText: /Available decision methods/i });
+    this.sidebar = page.getByTestId('colony-page-sidebar');
+    this.stepper = page.getByTestId('stepper');
+    this.closeButton = page.getByRole('button', { name: /close the modal/i });
+    this.submitButton = page.getByRole('button', { name: 'Create payment' });
+    this.completedAction = page.getByTestId('completed-action');
+    this.expenditureActionStatusBadge = this.drawer.getByTestId(
+      'expenditure-action-status-badge',
+    );
+    this.makePaymentButton = this.completedAction.getByRole('button', {
+      name: 'Make next payment',
+    });
+    this.stagesTable = this.completedAction.getByRole('table');
+    this.addMilestoneButton = this.form.getByRole('button', {
+      name: 'Add milestone',
+    });
+    this.supportButton = this.stepper.getByText('Support', { exact: true });
+    this.opposeButton = this.stepper.getByText('Oppose', { exact: true });
+    this.submitVoteButton = this.stepper.getByRole('button', {
+      name: 'Submit vote',
+    });
+    this.revealVoteButton = this.stepper.getByRole('button', {
+      name: 'Reveal vote',
+    });
+    this.finalizeButton = this.stepper.getByRole('button', {
+      name: 'Finalize',
+    });
+  }
+
+  async open() {
+    await this.sidebar.getByLabel('Start the payment group action').click();
+    await this.drawer.waitFor({ state: 'visible' });
+    await this.drawer
+      .getByRole('button', {
+        name: 'New Staged payments Pre-funded milestone based payments',
+      })
+      .click();
+    await this.form.waitFor({ state: 'visible' });
+    await this.drawer
+      .getByTestId('action-sidebar-description')
+      .waitFor({ state: 'visible' });
+  }
+
+  async close() {
+    await this.closeButton.click();
+
+    const dialog = this.getConfirmationDialog();
+    if (await dialog.isVisible()) {
+      await dialog
+        .getByRole('button', { name: 'Yes, cancel the action' })
+        .click();
+    }
+  }
+
+  async setTitle(title: string) {
+    await this.form.getByPlaceholder('Enter title').fill(title);
+  }
+
+  async selectTeam(teamName: string) {
+    await this.form.getByRole('button', { name: 'Select team' }).click();
+    await this.selectDropdown.getByRole('button', { name: teamName }).click();
+  }
+
+  async setRecipient(address: string) {
+    await this.form.getByLabel('Select user').click();
+    await this.page.getByPlaceholder('Search or add wallet address').click();
+    await this.page
+      .getByPlaceholder('Search or add wallet address')
+      .fill(address);
+    await this.page
+      .getByRole('button', {
+        name: address,
+      })
+      .click();
+  }
+
+  async setAmount(amount: string) {
+    await this.form.getByPlaceholder('Enter amount').fill(amount);
+  }
+
+  async selectToken(tokenName: string) {
+    await this.form.getByRole('button', { name: 'Select token' }).click();
+    await this.page
+      .getByTestId('token-list-item')
+      .getByText(tokenName)
+      .first()
+      .click();
+  }
+
+  async selectDecisionMethod(method: string) {
+    await this.form.getByRole('button', { name: 'Select method' }).click();
+
+    await this.decisionMethodDropdown
+      .getByRole('button', { name: method })
+      .click();
+  }
+
+  async submit() {
+    await this.submitButton.click();
+  }
+
+  async waitForTransaction() {
+    await this.page.waitForURL(/\?tx=/);
+    await this.page
+      .getByTestId('loading-skeleton')
+      .last()
+      .waitFor({ state: 'hidden' });
+  }
+
+  getConfirmationDialog() {
+    return this.page
+      .getByRole('dialog')
+      .filter({ hasText: 'Do you wish to cancel the action creation?' });
+  }
+
+  async setStages(stages: Stage[]) {
+    for (const [index, stage] of stages.entries()) {
+      if (index !== 0) {
+        await this.form.getByRole('button', { name: 'Add milestone' }).click();
+      }
+      await this.form
+        .getByPlaceholder('Enter milestone')
+        .nth(index)
+        .fill(stage.title);
+      await this.form
+        .getByPlaceholder('Enter amount')
+        .nth(index)
+        .fill(stage.amount);
+      if (stage.token) {
+        await this.form
+
+          .getByRole('button', { name: 'Select token' })
+          .nth(index)
+          .click();
+        await this.page
+          .getByTestId('token-list-item')
+          .getByText(stage.token)
+          .first()
+          .click();
+      }
+    }
+  }
+
+  async confirmRequiredStakeDialog() {
+    const modal = this.page.getByRole('dialog').filter({
+      hasText: 'Create the payment',
+    });
+    await modal.waitFor({ state: 'visible' });
+    await modal
+      .getByText('Required stake amount')
+      .waitFor({ state: 'visible' });
+    await modal.getByRole('button', { name: 'Create payment' }).click();
+    await modal.waitFor({ state: 'hidden' });
+  }
+
+  async confirmPayment() {
+    await this.completedAction
+      .getByRole('button', { name: 'Confirm details' })
+      .click();
+
+    await this.completedAction
+      .getByRole('button', { name: 'Pending' })
+      .waitFor({ state: 'hidden' });
+
+    await this.expenditureActionStatusBadge
+      .filter({
+        hasText: 'Funding',
+      })
+      .waitFor();
+  }
+
+  async fundPayment(method: 'Permissions' | 'Reputation' = 'Permissions') {
+    await this.completedAction
+      .getByRole('button', { name: 'Fund', exact: true })
+      .click();
+
+    const fundDialog = this.page
+      .getByRole('dialog')
+      .filter({ hasText: 'Payment funding' });
+    await fundDialog.waitFor({ state: 'visible' });
+    await fundDialog.getByText('Select Method').click();
+    await this.page.getByRole('option', { name: method }).click();
+    await fundDialog.getByRole('button', { name: 'Fund Payment' }).click();
+    await fundDialog.waitFor({ state: 'hidden' });
+    await this.completedAction
+      .getByRole('button', { name: 'Pending' })
+      .waitFor({ state: 'hidden' });
+  }
+
+  async releasePayment(method: 'Permissions' | 'Reputation' = 'Permissions') {
+    await this.completedAction
+      .getByRole('button', { name: 'Release' })
+      .nth(1)
+      .click();
+    const releaseDialog = this.page
+      .getByRole('dialog')
+      .filter({ hasText: 'Release payment' });
+
+    await releaseDialog.waitFor({ state: 'visible' });
+    await releaseDialog.getByText('Select Method').click();
+    await this.page.getByRole('option', { name: method }).click();
+    await releaseDialog
+      .getByRole('button', { name: 'Release Payment' })
+      .click();
+    await releaseDialog.waitFor({ state: 'hidden' });
+    await this.completedAction
+      .getByRole('button', { name: 'Pending' })
+      .waitFor({ state: 'hidden' });
+  }
+
+  async makePayment(method: 'Permissions' | 'Payment creator' | 'Reputation') {
+    await this.makePaymentButton.click();
+
+    await this.page.getByRole('button', { name: 'Pending' }).last().waitFor({
+      state: 'hidden',
+    });
+
+    const modal = this.page.getByRole('dialog').filter({
+      hasText: 'Make milestone payments',
+    });
+    await modal.waitFor({ state: 'visible' });
+    await modal.getByText('Select method').click();
+    await this.page.getByRole('option', { name: method, exact: true }).click();
+
+    await modal.getByRole('button', { name: 'Make payment' }).click();
+
+    await modal.waitFor({ state: 'hidden' });
+    if (
+      await this.completedAction
+        .getByRole('button', { name: 'Pending' })
+        .isVisible()
+    ) {
+      await this.completedAction
+        .getByRole('button', { name: 'Pending' })
+        .waitFor({ state: 'hidden' });
+    }
+  }
+
+  async fillForm({
+    title,
+    team,
+    recipient,
+    decisionMethod,
+    stages,
+  }: {
+    title?: string;
+    team?: string;
+    recipient?: string;
+    decisionMethod?: string;
+    stages?: Stage[];
+  }) {
+    if (title) {
+      await this.setTitle(title);
+    }
+    if (team) {
+      await this.selectTeam(team);
+    }
+    if (recipient) {
+      await this.setRecipient(recipient);
+    }
+    if (decisionMethod) {
+      await this.selectDecisionMethod(decisionMethod);
+    }
+
+    if (stages) {
+      await this.setStages(stages);
+    }
+  }
+
+  async duplicateMilestone(row: number) {
+    await this.form
+      .getByRole('table')
+      .locator('tbody tr')
+      .nth(row)
+      .getByRole('cell', { name: 'Open menu' })
+      .click();
+    await this.form.getByRole('button', { name: 'Duplicate row' }).click();
+  }
+
+  async deleteMilestone(row: number) {
+    await this.form
+      .getByRole('table')
+      .locator('tbody tr')
+      .nth(row)
+      .getByRole('cell', { name: 'Open menu' })
+      .click();
+    await this.form.getByRole('button', { name: 'Remove row' }).click();
+  }
+
+  async support(stakeAmount?: string) {
+    await this.supportButton.click();
+    await this.stepper.getByRole('textbox').waitFor({ state: 'visible' });
+    if (stakeAmount) {
+      await this.stepper.getByRole('textbox').fill(stakeAmount);
+    } else {
+      await this.stepper.getByRole('button', { name: 'Max' }).click();
+    }
+    await this.stepper.getByRole('button', { name: 'Stake' }).waitFor();
+    await this.stepper.getByRole('button', { name: 'Stake' }).click();
+  }
+
+  async oppose(stakeAmount?: string) {
+    await this.opposeButton.click();
+    if (stakeAmount) {
+      await this.stepper.getByRole('textbox').fill(stakeAmount);
+    } else {
+      await this.stepper.getByRole('button', { name: 'Max' }).click();
+    }
+    await this.stepper.getByRole('button', { name: 'Stake' }).waitFor();
+    await this.stepper.getByRole('button', { name: 'Stake' }).click();
+  }
+}
+
+type Stage = {
+  title: string;
+  amount: string;
+  token?: string;
+};

--- a/playwright/models/staged-payment.ts
+++ b/playwright/models/staged-payment.ts
@@ -277,6 +277,7 @@ export class StagedPayment {
     await releaseDialog.waitFor({ state: 'hidden' });
     await this.completedAction
       .getByRole('button', { name: 'Pending' })
+      .last()
       .waitFor({ state: 'hidden' });
   }
 
@@ -359,27 +360,23 @@ export class StagedPayment {
     await this.form.getByRole('button', { name: 'Remove row' }).click();
   }
 
-  async support(stakeAmount?: string) {
-    await this.supportButton.click();
-    await this.stepper.getByRole('textbox').waitFor({ state: 'visible' });
-    if (stakeAmount) {
-      await this.stepper.getByRole('textbox').fill(stakeAmount);
-    } else {
-      await this.stepper.getByRole('button', { name: 'Max' }).click();
-    }
-    await this.stepper.getByRole('button', { name: 'Stake' }).waitFor();
-    await this.stepper.getByRole('button', { name: 'Stake' }).click();
-  }
+  async voteOnMotion(voteType: 'Support' | 'Oppose') {
+    await this.completedAction
+      .getByRole('heading', {
+        name: 'Total stake required',
+      })
+      .waitFor({ state: 'visible' });
+    await this.completedAction.getByTestId('countDownTimer').waitFor({
+      state: 'visible',
+    });
+    await this.completedAction.getByText(voteType, { exact: true }).click();
+    await this.completedAction.getByRole('button', { name: 'Max' }).click();
 
-  async oppose(stakeAmount?: string) {
-    await this.opposeButton.click();
-    if (stakeAmount) {
-      await this.stepper.getByRole('textbox').fill(stakeAmount);
-    } else {
-      await this.stepper.getByRole('button', { name: 'Max' }).click();
-    }
-    await this.stepper.getByRole('button', { name: 'Stake' }).waitFor();
-    await this.stepper.getByRole('button', { name: 'Stake' }).click();
+    await this.completedAction.getByRole('button', { name: 'Stake' }).click();
+
+    await this.completedAction.getByRole('button', { name: 'Stake' }).waitFor({
+      state: 'hidden',
+    });
   }
 }
 

--- a/playwright/setup/index.ts
+++ b/playwright/setup/index.ts
@@ -2,22 +2,27 @@ import { test as baseTest } from '@playwright/test';
 
 import { AdvancedPayment } from '../models/advanced-payment.ts';
 import { SimplePayment } from '../models/simple-payment.ts';
+import { StagedPayment } from '../models/staged-payment.ts';
 
 // Extend the test context to include page objects
 type ModelFixtures = {
   simplePayment: SimplePayment;
   advancedPayment: AdvancedPayment;
+  stagedPayment: StagedPayment;
 };
 
 const test = baseTest.extend<ModelFixtures>({
   simplePayment: async ({ page }, use) => {
     const simplePayment = new SimplePayment(page);
-
     await use(simplePayment);
   },
   advancedPayment: async ({ page }, use) => {
     const advancedPayment = new AdvancedPayment(page);
     await use(advancedPayment);
+  },
+  stagedPayment: async ({ page }, use) => {
+    const stagedPayment = new StagedPayment(page);
+    await use(stagedPayment);
   },
 });
 

--- a/playwright/utils/common.ts
+++ b/playwright/utils/common.ts
@@ -1,5 +1,6 @@
-import { type BrowserContext, type Page } from '@playwright/test';
 import fetch from 'node-fetch';
+
+import type { BrowserContext, Page } from '@playwright/test';
 
 export const acceptCookieConsentBanner = async (page: Page) => {
   // Check if the cookie banner is present on the page
@@ -106,74 +107,6 @@ export const signInAndNavigateToColony = async (
     .getByTestId('loading-skeleton')
     .last()
     .waitFor({ state: 'hidden' });
-};
-
-export const enableReputationWeightedExtension = async (
-  page: Page,
-  {
-    colonyPath,
-  }: {
-    colonyPath: string;
-  },
-) => {
-  await page.goto(`${colonyPath}/extensions/VotingReputation`);
-  await page.getByText('Loading colony').waitFor({ state: 'hidden' });
-
-  const installExtensionButton = page.getByRole('button', {
-    name: 'Install',
-  });
-
-  const enableExtensionButton = page.getByRole('button', {
-    name: 'Enable',
-  });
-
-  await installExtensionButton.click();
-
-  await page.getByRole('button', { name: 'Pending' }).waitFor({
-    state: 'hidden',
-  });
-
-  await page
-    .getByRole('listitem')
-    .filter({ hasText: 'Testing governance' })
-    .click();
-
-  await enableExtensionButton.click();
-
-  await page.getByRole('button', { name: 'Deprecate extension' }).waitFor();
-};
-
-export const uninstallReputationWeightedExtension = async (
-  page: Page,
-  {
-    colonyPath,
-  }: {
-    colonyPath: string;
-  },
-) => {
-  await page.goto(`${colonyPath}/extensions/VotingReputation`);
-  await page.getByText('Loading colony').waitFor({ state: 'hidden' });
-
-  await page.getByRole('button', { name: 'Deprecate extension' }).click();
-
-  await page
-    .getByRole('dialog')
-    .getByRole('button', { name: 'Deprecate' })
-    .click();
-
-  await page.getByRole('button', { name: 'Uninstall extension' }).click();
-
-  await page
-    .getByRole('dialog')
-    .getByText('I understand that there is a risk')
-    .click();
-
-  await page
-    .getByRole('dialog')
-    .getByRole('button', { name: 'Continue with uninstalling' })
-    .click();
-
-  await page.getByRole('button', { name: 'Install' }).waitFor();
 };
 
 /**


### PR DESCRIPTION
## Description

This MR adds some initial e2e test suit for the Staged Payment motion. 

Test cases included in the PR:

1. Staged payment with
   - Permission decision method
   - Staking decision method
   - Reputation decision method
2. Form validation 
3. Milestones table interactions (duplicate/delete entries)




## Testing

**Step 1**. Spin up the dev env and seed the test data 

`npm run dev`  followed by `node scripts/create-data.js --yes`

**Step 2**. Build and start the frontend in preview mode

`npm run preview` 

**Step 3.** Run the tests in a separate terminal 

`npm run e2e staged-payment`

**Step 4**. The tests should pass ( if any failures - please send me .zip files from `/playwright-report/data` directory)

