### PR TITLE
Fix: Set the Created In field for Fund Transfers to the Parent domain

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/TransferFundsForm/hooks.ts
@@ -95,9 +95,8 @@ export const useTransferFunds = (
   getFormOptions: ActionFormBaseProps['getFormOptions'],
 ) => {
   const { colony } = useColonyContext();
-  const { [DECISION_METHOD_FIELD_NAME]: decisionMethod, from } = useWatch<{
+  const { [DECISION_METHOD_FIELD_NAME]: decisionMethod } = useWatch<{
     decisionMethod: DecisionMethod;
-    from: TransferFundsFormValues['from'];
   }>();
 
   const validationSchema = useValidationSchema();
@@ -106,10 +105,10 @@ export const useTransferFunds = (
     validationSchema,
     defaultValues: useMemo<DeepPartial<TransferFundsFormValues>>(
       () => ({
-        createdIn: from || Id.RootDomain,
+        createdIn: Id.RootDomain,
         tokenAddress: colony.nativeToken.tokenAddress,
       }),
-      [from, colony.nativeToken.tokenAddress],
+      [colony.nativeToken.tokenAddress],
     ),
     actionType:
       decisionMethod === DecisionMethod.Permissions


### PR DESCRIPTION
## Description

From what I understand, at least for the time being anyway since we don't have nested teams yet, the Permission Domain ID (created in field value) should be set to the Parent Domain of the From and To domains. This is currently reflected by how we're filtering the domains list for the Created in field to only contain the Root domain. Either that or the Permission Domain ID should be equal to both of them, but this isn't an option since we can't do fund transfers from and to the same domain. So the Created In field should really be the Root domain. We'll cross the bridge of dealing with nested domains when we get there 🌉 

![transfer-funds](https://github.com/user-attachments/assets/9273df10-8cd7-4a85-806c-125846704bb9)

## Testing

1. Install and enable the Reputation extension
2. Go to the Dashboard page
3. Using the teams filter, click a subdomain i.e. Daedalus
4. Bring up the Transfer funds form
5. Set the decision method to Reputation
6. Verify that the Created in field is set to General
7. Fill in all other required fields
8. Submit the form
9. Verify that you are able to submit the form
10. Verify that you can finalise the motion

Resolves #3919 