### PR TITLE
Fix: Apply Domain filter to the Agreements Page

### DIFF
--- a/src/components/frame/v5/pages/AgreementsPage/hooks.ts
+++ b/src/components/frame/v5/pages/AgreementsPage/hooks.ts
@@ -13,6 +13,7 @@ import {
   makeWithMotionStateMapper,
 } from '~hooks/useActivityFeed/helpers.ts';
 import useEnabledExtensions from '~hooks/useEnabledExtensions.ts';
+import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
 import useNetworkMotionStates from '~hooks/useNetworkMotionStates.ts';
 import { notNull } from '~utils/arrays/index.ts';
 import { isTransactionFormat } from '~utils/web3/index.ts';
@@ -100,6 +101,8 @@ export const useGetAgreements = () => {
 
   const { agreementsData, refetchAgreements, loading } = useGetAllAgreements();
 
+  const selectedDomain = useGetSelectedDomainFilter();
+
   const motionIds = useMemo(
     () =>
       agreementsData
@@ -144,7 +147,15 @@ export const useGetAgreements = () => {
     (motionStatesLoading || loadingExtensions) &&
     !!activeFilters?.motionStates?.length;
 
-  const filteredAgreements = agreements
+  const filteredAgreements = (
+    selectedDomain
+      ? agreements.filter(
+          (agreement) =>
+            Number(agreement.motionData?.nativeMotionDomainId) ===
+            selectedDomain?.nativeId,
+        )
+      : agreements
+  )
     .filter((agreement) =>
       filterActionByMotionState(agreement, activeFilters?.motionStates),
     )


### PR DESCRIPTION
## Description

This just simply filters out the Agreements to show based on the domain filter.

![agreements-domain-filter](https://github.com/user-attachments/assets/509d8983-ceb5-4a9a-a34d-3ef9798a10b0)

## Testing

1. Install and enable the Reputation extension
2. Create an agreement for the Daedalus team
3. Visit the Agreements page
4. Set the Teams filter to All teams
5. Verify that you can see the Agreement you just made
6. Set the Teams filter to Andromeda
7. Verify that you cannot see the Agreement you just made
8. Set the Teams filter to Daedalus
7. Verify that you can see the Agreement you just made

Resolves #3992 