### PR TITLE
Fix: Prevent app crash during colony creation

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransaction.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransaction.tsx
@@ -58,9 +58,7 @@ const GroupedTransaction: FC<GroupedTransactionProps> = ({
   const isMobile = useMobile();
   const navigate = useNavigate();
   const { joinedColonies, joinedColoniesLoading } = useAppContext();
-  const {
-    colony: { name: currentColonyName },
-  } = useColonyContext();
+  const colonyContext = useColonyContext({ nullableContext: true });
 
   const groupKey = getGroupKey(transactionGroup);
   const groupId = getGroupId(transactionGroup);
@@ -146,7 +144,7 @@ const GroupedTransaction: FC<GroupedTransactionProps> = ({
 
     // Otherwise, this is transaction is related to an action.
     const path =
-      colonyName === currentColonyName
+      colonyContext && colonyName === colonyContext.colony.name
         ? window.location.pathname
         : `/${colonyName}`;
     navigate(


### PR DESCRIPTION
## Description

The app was crashing because the GroupedTransaction component is attempting to access the Colony Context before the app even navigates to a Colony. I slightly tweaked the logic to make sure this doesn't happen.

![create-colony](https://github.com/user-attachments/assets/1d5edfb7-84d3-4b24-a3d7-6cd04e826603)

## Testing

1. Generate a create Colony URL using the following command:

```console
node scripts/create-colony-url.js
```

2. Proceed to create a Colony
3. Verify that the app doesn't crash during Colony creation 

Resolves #4083 