### PR TITLE
test: Manage Colony - Mint token motion

### DIFF
--- a/playwright/e2e/manage-colony-funds.spec.ts
+++ b/playwright/e2e/manage-colony-funds.spec.ts
@@ -1,0 +1,175 @@
+import { type BrowserContext, expect, type Page, test } from '@playwright/test';
+
+import { Extensions } from '../models/extensions.ts';
+import { ManageColonyFunds } from '../models/manage-colony-funds.ts';
+import {
+  setCookieConsent,
+  signInAndNavigateToColony,
+} from '../utils/common.ts';
+
+// eslint-disable-next-line no-warning-comments
+test.describe.configure({ mode: 'serial' });
+test.describe('Manage Colony Funds', () => {
+  let page: Page;
+  let context: BrowserContext;
+  let manageColonyFunds: ManageColonyFunds;
+  let extensions: Extensions;
+  test.beforeAll(async ({ browser, baseURL }) => {
+    context = await browser.newContext();
+    page = await context.newPage();
+    manageColonyFunds = new ManageColonyFunds(page);
+    extensions = new Extensions(page);
+    await setCookieConsent(context, baseURL);
+    await signInAndNavigateToColony(page, {
+      colonyUrl: '/planex',
+      wallet: /dev wallet 1$/i,
+    });
+    await extensions.enableReputationWeightedExtension({
+      colonyPath: '/planex',
+    });
+  });
+
+  test.afterAll(async () => {
+    await context?.close();
+  });
+  test.describe('Mint tokens', () => {
+    test('Permissions decision method', async () => {
+      const currentBalance = (await manageColonyFunds.getBalance({
+        token: 'CREDS',
+      })) as string;
+      await manageColonyFunds.open('Mint tokens');
+
+      await manageColonyFunds.fillMintTokensForm({
+        amount: '1_000_000',
+        decisionMethod: 'Permissions',
+        title: 'Mint tokens',
+      });
+      await manageColonyFunds.mintTokensButton.click();
+      await manageColonyFunds.waitForTransaction();
+
+      await expect(
+        manageColonyFunds.completedAction.getByRole('heading', {
+          name: 'Mint tokens',
+        }),
+      ).toBeVisible();
+
+      await expect(
+        manageColonyFunds.completedAction.getByText(/Mint \w+ CREDS by \w+/),
+      ).toBeVisible();
+
+      await expect(
+        manageColonyFunds.completedAction.getByText('Mint Tokens', {
+          exact: true,
+        }),
+      ).toBeVisible();
+
+      await expect(
+        manageColonyFunds.completedAction.getByText('1MCREDS', {
+          exact: true,
+        }),
+      ).toBeVisible();
+
+      await expect(
+        manageColonyFunds.completedAction.getByText('Permissions', {
+          exact: true,
+        }),
+      ).toBeVisible();
+
+      await expect(
+        manageColonyFunds.completedAction.getByText(
+          'Member used permissions to',
+        ),
+      ).toBeVisible();
+
+      await expect(
+        manageColonyFunds.completedAction.getByRole('heading', {
+          name: 'Overview',
+        }),
+      ).toBeVisible();
+
+      const newBalance = (await manageColonyFunds.getBalance({
+        token: 'CREDS',
+      })) as string;
+
+      const initial = parseFloat(currentBalance);
+      const after = parseFloat(newBalance);
+
+      await expect(after).toBeGreaterThan(initial);
+    });
+
+    test('Reputation decision method', async () => {
+      await manageColonyFunds.open('Mint tokens');
+
+      await manageColonyFunds.fillMintTokensForm({
+        amount: '1',
+        decisionMethod: 'Reputation',
+        title: 'Mint tokens',
+      });
+
+      await manageColonyFunds.mintTokensButton.click();
+      await manageColonyFunds.waitForTransaction();
+
+      await expect(manageColonyFunds.stepper).toBeVisible();
+      await expect(manageColonyFunds.completedAction).toBeVisible();
+      await expect(
+        manageColonyFunds.stepper.getByText(/Total stake required: \d+/),
+      ).toBeVisible();
+
+      await manageColonyFunds.support();
+
+      await expect(manageColonyFunds.stepper).toHaveText(/100% Supported/);
+
+      await manageColonyFunds.oppose();
+
+      await expect(manageColonyFunds.stepper).toHaveText(/100% Opposed/);
+
+      await manageColonyFunds.stepper
+        .getByText(/Vote to support or oppose?/)
+        .waitFor();
+      await manageColonyFunds.supportButton.click();
+      await manageColonyFunds.submitVoteButton.click();
+      await manageColonyFunds.revealVoteButton.click();
+      await manageColonyFunds.stepper.getByText('vote revealed').waitFor();
+      await expect(
+        manageColonyFunds.stepper.getByText(
+          'Finalize to execute the agreed transaction',
+        ),
+      ).toBeVisible();
+      await manageColonyFunds.finalizeButton.click();
+
+      await manageColonyFunds.waitForPending();
+      await manageColonyFunds.claimButton.click();
+      await manageColonyFunds.waitForPending();
+      await manageColonyFunds.completedAction
+        .getByRole('heading', { name: 'Your overview Claimed' })
+        .waitFor();
+
+      await manageColonyFunds.claimButton.waitFor({
+        state: 'hidden',
+      });
+    });
+
+    test('Form validation', async () => {
+      await manageColonyFunds.open('Mint tokens');
+      await manageColonyFunds.mintTokensButton.click();
+
+      for (const message of ManageColonyFunds.validationMessages
+        .allRequiredFields) {
+        await expect(manageColonyFunds.drawer.getByText(message)).toBeVisible();
+      }
+
+      await manageColonyFunds.fillMintTokensForm({
+        title:
+          'This is a test title that exceeds the maximum character limit of sixty.',
+      });
+
+      await manageColonyFunds.mintTokensButton.click();
+
+      await expect(
+        manageColonyFunds.drawer.getByText(
+          ManageColonyFunds.validationMessages.title.maxLengthExceeded,
+        ),
+      ).toBeVisible();
+    });
+  });
+});

--- a/playwright/models/manage-colony-funds.ts
+++ b/playwright/models/manage-colony-funds.ts
@@ -1,0 +1,201 @@
+import type { Page, Locator } from '@playwright/test';
+
+export class ManageColonyFunds {
+  static readonly validationMessages = {
+    title: {
+      maxLengthExceeded: 'Title must not exceed 60 characters',
+      isRequired: 'Title is required',
+    },
+    allRequiredFields: [
+      'required field',
+      'decisionMethod must be defined',
+      'Title is required',
+    ],
+    amount: {
+      isRequired: 'required field',
+      mustBeGreaterThanZero: 'Amount must be greater than zero',
+    },
+  };
+
+  drawer: Locator;
+
+  form: Locator;
+
+  sidebar: Locator;
+
+  selectDropdown: Locator;
+
+  decisionMethodDropdown: Locator;
+
+  stepper: Locator;
+
+  closeButton: Locator;
+
+  mintTokensButton: Locator;
+
+  completedAction: Locator;
+
+  confirmationDialog: Locator;
+
+  supportButton: Locator;
+
+  opposeButton: Locator;
+
+  submitVoteButton: Locator;
+
+  revealVoteButton: Locator;
+
+  finalizeButton: Locator;
+
+  claimButton: Locator;
+
+  constructor(private page: Page) {
+    this.drawer = page.getByTestId('action-drawer');
+    this.form = page.getByTestId('action-form');
+    this.selectDropdown = page.getByTestId('search-select-menu');
+    this.decisionMethodDropdown = page
+      .getByRole('list')
+      .filter({ hasText: /Available decision methods/i });
+    this.sidebar = page.getByTestId('colony-page-sidebar');
+    this.stepper = page.getByTestId('stepper');
+    this.closeButton = page.getByRole('button', { name: /close the modal/i });
+    this.mintTokensButton = page
+      .getByRole('button', {
+        name: 'Mint tokens',
+      })
+      .nth(1);
+    this.completedAction = page.getByTestId('completed-action');
+    this.confirmationDialog = this.page
+      .getByRole('dialog')
+      .filter({ hasText: 'Do you wish to cancel the action creation?' });
+    this.supportButton = this.stepper.getByText('Support', { exact: true });
+    this.opposeButton = this.stepper.getByText('Oppose', { exact: true });
+    this.submitVoteButton = this.stepper.getByRole('button', {
+      name: 'Submit vote',
+    });
+    this.revealVoteButton = this.stepper.getByRole('button', {
+      name: 'Reveal vote',
+    });
+    this.finalizeButton = this.completedAction
+      .getByRole('button', {
+        name: 'Finalize',
+      })
+      .last();
+    this.claimButton = this.stepper
+      .getByRole('button', {
+        name: 'Claim',
+      })
+      .last();
+  }
+
+  async open(motionTitle: 'Mint tokens') {
+    await this.sidebar.getByLabel('Start the manage colony action').click();
+    await this.drawer.waitFor({ state: 'visible' });
+    await this.drawer
+      .getByRole('button', {
+        name: motionTitle,
+      })
+      .click();
+    await this.form.waitFor({ state: 'visible' });
+    await this.drawer
+      .getByTestId('action-sidebar-description')
+      .waitFor({ state: 'visible' });
+  }
+
+  async close() {
+    await this.closeButton.click();
+
+    const dialog = this.confirmationDialog;
+    if (await dialog.isVisible()) {
+      await dialog
+        .getByRole('button', { name: 'Yes, cancel the action' })
+        .click();
+    }
+  }
+
+  async getBalance({ token }: { token: string }) {
+    await this.sidebar
+      .getByLabel('Go to the Colony balances page')
+      .first()
+      .click();
+    await this.sidebar.getByText('Balances').click();
+
+    await this.page.waitForURL('**/balances');
+    const balanceCell = this.page
+      .getByRole('table')
+      .locator('tr td')
+      .filter({ hasText: token })
+      .last();
+    const balance = await balanceCell.textContent();
+    return balance?.split(' ')[0];
+  }
+
+  async waitForTransaction() {
+    await this.waitForPending();
+    await this.page.waitForURL(/\?tx=/);
+    await this.page
+      .getByTestId('loading-skeleton')
+      .last()
+      .waitFor({ state: 'hidden' });
+  }
+
+  async waitForPending() {
+    await this.page
+      .getByRole('button', { name: 'Pending' })
+      .last()
+      .waitFor({ state: 'visible' });
+
+    await this.page
+      .getByRole('button', { name: 'Pending' })
+      .last()
+      .waitFor({ state: 'hidden' });
+  }
+
+  async fillMintTokensForm({
+    amount,
+    decisionMethod,
+    title,
+  }: {
+    amount?: string;
+    decisionMethod?: 'Permissions' | 'Reputation';
+    title?: string;
+  }) {
+    if (title) {
+      await this.form.getByPlaceholder('Enter title').fill(title);
+    }
+    if (amount) {
+      await this.form.getByPlaceholder('Enter amount').fill(amount);
+    }
+
+    if (decisionMethod) {
+      await this.form.getByRole('button', { name: 'Select method' }).click();
+
+      await this.decisionMethodDropdown
+        .getByRole('button', { name: decisionMethod })
+        .click();
+    }
+  }
+
+  async support(stakeAmount?: string) {
+    await this.supportButton.click();
+    await this.stepper.getByRole('textbox').waitFor({ state: 'visible' });
+    if (stakeAmount) {
+      await this.stepper.getByRole('textbox').fill(stakeAmount);
+    } else {
+      await this.stepper.getByRole('button', { name: 'Max' }).click();
+    }
+    await this.stepper.getByRole('button', { name: 'Stake' }).waitFor();
+    await this.stepper.getByRole('button', { name: 'Stake' }).click();
+  }
+
+  async oppose(stakeAmount?: string) {
+    await this.opposeButton.click();
+    if (stakeAmount) {
+      await this.stepper.getByRole('textbox').fill(stakeAmount);
+    } else {
+      await this.stepper.getByRole('button', { name: 'Max' }).click();
+    }
+    await this.stepper.getByRole('button', { name: 'Stake' }).waitFor();
+    await this.stepper.getByRole('button', { name: 'Stake' }).click();
+  }
+}


### PR DESCRIPTION
## Description

E2e tests for Mint Tokens flow. 
Test cases included in the PR:
- Happy path of Mint Token  payment (Permissions and Staking method)
- Form fields validation


The playwright package version has been upgraded in this PR. 
Please run `npm run e2e:install` and `npm install`. 

## Testing

**Step 1**. Spin up the dev env and seed the test data 

`npm run dev`  followed by `node scripts/create-data.js`

**Step 2**. Build and start the frontend in preview mode

`npm run preview` 

**Step 3.** Run the tests in a separate terminal 

`npm run e2e manage-colony-funds`

**Step 5**. The tests should pass ( if any failures - please send me .zip files from `/playwright-report/data` directory)



(Resolves | Contributes to) #31415
