### PR TITLE
Fix: Correctly sort timeframe bar chart items

### DIFF
--- a/src/context/TotalInOutBalanceChartContext/TotalInOutBalanceChartContext.ts
+++ b/src/context/TotalInOutBalanceChartContext/TotalInOutBalanceChartContext.ts
@@ -7,9 +7,9 @@ export const TotalInOutBalanceChartContext = createContext<
     loading: boolean;
     timeframe:
       | {
-          label: string | undefined;
-          in: string | undefined | null;
-          out: string | undefined | null;
+          label: string;
+          in: string;
+          out: string;
         }[]
       | undefined
       | null;

--- a/src/context/TotalInOutBalanceChartContext/TotalInOutBalanceChartContextProvider.tsx
+++ b/src/context/TotalInOutBalanceChartContext/TotalInOutBalanceChartContextProvider.tsx
@@ -14,8 +14,9 @@ import {
 } from '~gql';
 import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
 import {
-  sortByLabel,
+  mapToFormattedLabel,
   parseTimeframeKey,
+  sortByLabel,
 } from '~v5/frame/ColonyHome/partials/TotalInOutBalance/utils.ts';
 
 import { useColonyContext } from '../ColonyContext/ColonyContext.ts';
@@ -82,11 +83,12 @@ const TotalInOutBalanceChartContextProvider: FC<PropsWithChildren> = ({
   const value = useMemo(() => {
     const timeframeBalanceArray = domainBalanceData?.timeframe
       ?.map((timeframeBalance) => ({
-        label: parseTimeframeKey(timeframeBalance?.key),
+        label: parseTimeframeKey(timeframeBalance?.key ?? ''),
         in: convertAmount(timeframeBalance?.value?.totalIn ?? '0'),
         out: convertAmount(timeframeBalance?.value?.totalOut ?? '0'),
       }))
-      .sort(sortByLabel);
+      .sort(sortByLabel)
+      .map(mapToFormattedLabel);
 
     let stepValue = 10000;
     const ySteps: number[] = [];


### PR DESCRIPTION
## Description

- This PR aims to fix the `Total in and out` chart bars sorting.
The issue was caused by the fact that once the `GetDomainBalance` would retrieve the data, we would subtract from the `timeframe.key` the `Month` and then perform a sort based on this value. This would behave properly if the keys are within the same year, however, it would cause an incorrect sorting once a new year starts - issue that can be observed on `master`. To fix this, once the `GetDomainBalance` retrieves data we would map the items to the `BarChartDataItem` type, followed by a sort on the label (the `timeframe.key`) and only after mapping the label to the full date format `dd-MM-yyyy`. Then the `getMonthShortName` will be responsible to retrieve the short month label format (`Jan`, `Feb` etc.)


**On this branch**
![Screenshot 2025-01-20 at 12 53 30](https://github.com/user-attachments/assets/948328b8-0ad9-4ae9-8638-6f9baa5233ba)

**Master**
![Screenshot 2025-01-20 at 12 57 18](https://github.com/user-attachments/assets/1db63f6b-16ba-4ea5-a852-10f2ca7fa043)

## Testing

TODO: Let's test our changes behave as expected. 

* Step 1. Go to http://localhost:9091/planex
* Step 2. Check the chart on the `Total in and out` card has `Jan` as the last item on the x-axis
![Screenshot 2025-01-20 at 12 53 30](https://github.com/user-attachments/assets/948328b8-0ad9-4ae9-8638-6f9baa5233ba)
* Step 3. Let's test this behaves as expected also with some other values
* Step 4. Please replace  `domainBalanceData?.timeframe` from line `84` in `src/context/TotalInOutBalanceChartContext/TotalInOutBalanceChartContextProvider.tsx` with
```json
[{ "key": "10-12-2024", "value": undefined, }, { "key": "10-09-2024", "value": undefined, }, { "key": "01-10-2024", "value": undefined, }, { "key": "10-11-2024", "value": undefined, }]
```
* Step 5. Check the chart on the `Total in and out` card has `Sep`, `Oct`, `Nov` and `Dec` correctly sorted
![Screenshot 2025-01-20 at 14 29 15](https://github.com/user-attachments/assets/f9210c30-22e7-477f-b409-7cafa0ca2b74)

* Step 5. Now replace  `domainBalanceData?.timeframe` from line `84` in `src/context/TotalInOutBalanceChartContext/TotalInOutBalanceChartContextProvider.tsx` with
```json
[{ "key": "10-12-2024", "value": undefined, }, { "key": "10-09-2024", "value": undefined, }, { "key": "01-10-2024", "value": undefined, }, { "key": "10-12-2025", "value": undefined, }]
```
* Step 6. Check the chart on the `Total in and out` card has two entries for `Dec`, one for `2024` and one for `2025`
![Screenshot 2025-01-20 at 14 36 35](https://github.com/user-attachments/assets/205e50c8-89d9-4692-9826-671d51f07f2b)

> [!NOTE]
> This is more of an extreme case, that should never happen and will require label updates to include also the year for better UX. However, it is treated for the moment in a way to ensure data doesn't get overridden in case there are matching months from different years.



## Diffs

**New stuff** ✨

* `IntermediateBarChartDataItem` type for storing the `label` as `Date` until the sorting by date is performed

**Changes** 🏗

* Updated to mapping, sorting and label formatting for the bar chart items

Resolves #4087
