### PR TITLE
Fix: Long recipient names should not be cut off

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
@@ -96,13 +96,17 @@ const UserSelect: FC<UserSelectProps> = ({
       <button
         type="button"
         ref={relativeElementRef}
-        className={clsx('flex items-center text-md transition-colors', {
-          'text-gray-400': !isError && !isUserSelectVisible && !disabled,
-          'text-gray-300': disabled,
-          'text-negative-400': isError,
-          'text-blue-400': isUserSelectVisible,
-          'md:hover:text-blue-400': !disabled,
-        })}
+        className={clsx(
+          'flex max-w-full items-center text-md transition-colors',
+          {
+            'max-w-[calc(100%-1.125rem)]': !selectedUser?.isVerified,
+            'text-gray-400': !isError && !isUserSelectVisible && !disabled,
+            'text-gray-300': disabled,
+            'text-negative-400': isError,
+            'text-blue-400': isUserSelectVisible,
+            'md:hover:text-blue-400': !disabled,
+          },
+        )}
         onClick={toggleUserSelect}
         aria-label={formatText({ id: 'ariaLabel.selectUser' })}
         disabled={disabled}


### PR DESCRIPTION
## Description

This PR fixes an issue where long recipient names would overflow the action form on mobile.

## Testing

* Step 1 - Connect to Dev Wallet 4 and create a profile making full use of the 30 character limit.

![Screenshot 2025-01-14 at 15 39 00](https://github.com/user-attachments/assets/16e95262-5d21-4c1d-a28f-85f217f12776)

* Step 2 - Copy the user's wallet address.

![Screenshot 2025-01-14 at 15 39 26](https://github.com/user-attachments/assets/b7acea88-5c1b-4d57-ab2a-9ba0009213bd)

* Step 3 - Switch back to dev wallet 1
* Step 4 - Create a simple payment and paste the wallet address into the recipient field. Switch to mobile and check the name does not overflow the edge of the screen.

![Screenshot 2025-01-14 at 15 47 55](https://github.com/user-attachments/assets/aaf3dda7-7f4b-46b0-b0c8-31d9bd1faeb5)

Feel free to also check when the user is verified too if you wish:

![Screenshot 2025-01-14 at 15 35 00](https://github.com/user-attachments/assets/c6d68396-a2aa-46c4-9838-c60a73bc09ec)

## Diffs

**Changes** 🏗

* UserSelect toggle now has a max width

Resolves #3348
