### PR TITLE
Fix extension management enable / save loading states

### DIFF
--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContext.ts
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContext.ts
@@ -13,8 +13,6 @@ import { ExtensionDetailsPageTabId } from '../types.ts';
 interface ExtensionDetailsPageContextValues {
   activeTab: ExtensionDetailsPageTabId;
   setActiveTab: Dispatch<SetStateAction<ExtensionDetailsPageTabId>>;
-  waitingForActionConfirmation: boolean;
-  setWaitingForActionConfirmation: Dispatch<SetStateAction<boolean>>;
   extensionData: AnyExtensionData;
   userHasRoot: boolean;
   isPendingManagement: boolean;
@@ -27,8 +25,6 @@ export const ExtensionDetailsPageContext =
   createContext<ExtensionDetailsPageContextValues>({
     activeTab: ExtensionDetailsPageTabId.Overview,
     setActiveTab: noop,
-    waitingForActionConfirmation: false,
-    setWaitingForActionConfirmation: noop,
     extensionData: {} as AnyExtensionData,
     userHasRoot: false,
     isPendingManagement: false,

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContext.ts
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContext.ts
@@ -17,6 +17,10 @@ interface ExtensionDetailsPageContextValues {
   setWaitingForActionConfirmation: Dispatch<SetStateAction<boolean>>;
   extensionData: AnyExtensionData;
   userHasRoot: boolean;
+  isPendingManagement: boolean;
+  setIsPendingManagement: Dispatch<SetStateAction<boolean>>;
+  isSavingChanges: boolean;
+  setIsSavingChanges: Dispatch<SetStateAction<boolean>>;
 }
 
 export const ExtensionDetailsPageContext =
@@ -27,6 +31,10 @@ export const ExtensionDetailsPageContext =
     setWaitingForActionConfirmation: noop,
     extensionData: {} as AnyExtensionData,
     userHasRoot: false,
+    isPendingManagement: false,
+    setIsPendingManagement: noop,
+    isSavingChanges: false,
+    setIsSavingChanges: noop,
   });
 
 export const useExtensionDetailsPageContext = () => {

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContextProvider.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContextProvider.tsx
@@ -28,8 +28,6 @@ export const ExtensionDetailsPageContextProvider: FC<
   const [activeTab, setActiveTab] = useState(
     ExtensionDetailsPageTabId.Overview,
   );
-  const [waitingForActionConfirmation, setWaitingForActionConfirmation] =
-    useState(false);
   const [isPendingManagement, setIsPendingManagement] = useState(false);
   const [isSavingChanges, setIsSavingChanges] = useState(false);
 
@@ -46,8 +44,6 @@ export const ExtensionDetailsPageContextProvider: FC<
     () => ({
       activeTab,
       setActiveTab,
-      waitingForActionConfirmation,
-      setWaitingForActionConfirmation,
       extensionData,
       userHasRoot,
       isPendingManagement,
@@ -61,7 +57,6 @@ export const ExtensionDetailsPageContextProvider: FC<
       isPendingManagement,
       isSavingChanges,
       userHasRoot,
-      waitingForActionConfirmation,
     ],
   );
 

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContextProvider.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContextProvider.tsx
@@ -30,6 +30,8 @@ export const ExtensionDetailsPageContextProvider: FC<
   );
   const [waitingForActionConfirmation, setWaitingForActionConfirmation] =
     useState(false);
+  const [isPendingManagement, setIsPendingManagement] = useState(false);
+  const [isSavingChanges, setIsSavingChanges] = useState(false);
 
   const userHasRoot =
     !!user &&
@@ -48,8 +50,19 @@ export const ExtensionDetailsPageContextProvider: FC<
       setWaitingForActionConfirmation,
       extensionData,
       userHasRoot,
+      isPendingManagement,
+      setIsPendingManagement,
+      isSavingChanges,
+      setIsSavingChanges,
     }),
-    [activeTab, extensionData, userHasRoot, waitingForActionConfirmation],
+    [
+      activeTab,
+      extensionData,
+      isPendingManagement,
+      isSavingChanges,
+      userHasRoot,
+      waitingForActionConfirmation,
+    ],
   );
 
   return (

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/ExtensionDetailsHeader.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/ExtensionDetailsHeader.tsx
@@ -21,7 +21,7 @@ const displayName = 'pages.ExtensionDetailsPage.ExtensionDetailsHeader';
 
 const ExtensionDetailsHeader: FC = () => {
   const { user } = useAppContext();
-  const { extensionData, userHasRoot, waitingForActionConfirmation } =
+  const { extensionData, userHasRoot, isPendingManagement } =
     useExtensionDetailsPageContext();
 
   const activeInstalls = useActiveInstalls(extensionData.extensionId);
@@ -49,7 +49,7 @@ const ExtensionDetailsHeader: FC = () => {
     isInstalledExtensionData(extensionData) &&
     extensionData.isEnabled &&
     extensionData.missingColonyPermissions.length > 0 &&
-    !waitingForActionConfirmation;
+    !isPendingManagement;
 
   return (
     <>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/InstallButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/InstallButton.tsx
@@ -23,8 +23,7 @@ const InstallButton = ({ extensionData }: InstallButtonProps) => {
     colony: { colonyAddress, nativeToken },
     isSupportedColonyVersion,
   } = useColonyContext();
-  const { waitingForActionConfirmation, isPendingManagement } =
-    useExtensionDetailsPageContext();
+  const { isPendingManagement } = useExtensionDetailsPageContext();
 
   const isMobile = useMobile();
 
@@ -56,11 +55,7 @@ const InstallButton = ({ extensionData }: InstallButtonProps) => {
       onSuccess={handleInstallSuccess}
       onError={handleInstallError}
       isFullSize={isMobile}
-      disabled={
-        isPendingManagement ||
-        !isSupportedColonyVersion ||
-        waitingForActionConfirmation
-      }
+      disabled={isPendingManagement || !isSupportedColonyVersion}
     >
       {formatText({ id: 'button.install' })}
     </ActionButton>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/InstallButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/InstallButton.tsx
@@ -23,11 +23,12 @@ const InstallButton = ({ extensionData }: InstallButtonProps) => {
     colony: { colonyAddress, nativeToken },
     isSupportedColonyVersion,
   } = useColonyContext();
-  const { waitingForActionConfirmation } = useExtensionDetailsPageContext();
+  const { waitingForActionConfirmation, isPendingManagement } =
+    useExtensionDetailsPageContext();
 
   const isMobile = useMobile();
 
-  const { isLoading, handleInstallSuccess, handleInstallError } =
+  const { handleInstallSuccess, handleInstallError, isLoading } =
     useInstall(extensionData);
 
   const getDefaultExtensionParams = (extensionId: Extension) => {
@@ -55,7 +56,11 @@ const InstallButton = ({ extensionData }: InstallButtonProps) => {
       onSuccess={handleInstallSuccess}
       onError={handleInstallError}
       isFullSize={isMobile}
-      disabled={!isSupportedColonyVersion || waitingForActionConfirmation}
+      disabled={
+        isPendingManagement ||
+        !isSupportedColonyVersion ||
+        waitingForActionConfirmation
+      }
     >
       {formatText({ id: 'button.install' })}
     </ActionButton>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/ReenableButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/ReenableButton.tsx
@@ -28,8 +28,7 @@ const ReenableButton = ({
     formState: { isSubmitting },
   } = useFormContext();
 
-  const { waitingForActionConfirmation, isPendingManagement } =
-    useExtensionDetailsPageContext();
+  const { isPendingManagement } = useExtensionDetailsPageContext();
 
   return (
     <>
@@ -38,9 +37,7 @@ const ReenableButton = ({
         onClick={() => setIsReEnableModalOpen(true)}
         isFullSize={isMobile}
         loading={isLoading}
-        disabled={
-          isPendingManagement || isSubmitting || waitingForActionConfirmation
-        }
+        disabled={isPendingManagement || isSubmitting}
       >
         {formatText({ id: 'button.enable' })}
       </ButtonWithLoader>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/ReenableButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/ReenableButton.tsx
@@ -1,5 +1,6 @@
 import { Question } from '@phosphor-icons/react';
 import React, { useState } from 'react';
+import { useFormContext } from 'react-hook-form';
 
 import { useExtensionDetailsPageContext } from '~frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContext.ts';
 import { useMobile } from '~hooks/index.ts';
@@ -23,7 +24,12 @@ const ReenableButton = ({
   });
   const isMobile = useMobile();
 
-  const { waitingForActionConfirmation } = useExtensionDetailsPageContext();
+  const {
+    formState: { isSubmitting },
+  } = useFormContext();
+
+  const { waitingForActionConfirmation, isPendingManagement } =
+    useExtensionDetailsPageContext();
 
   return (
     <>
@@ -32,7 +38,9 @@ const ReenableButton = ({
         onClick={() => setIsReEnableModalOpen(true)}
         isFullSize={isMobile}
         loading={isLoading}
-        disabled={waitingForActionConfirmation}
+        disabled={
+          isPendingManagement || isSubmitting || waitingForActionConfirmation
+        }
       >
         {formatText({ id: 'button.enable' })}
       </ButtonWithLoader>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/SubmitButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/SubmitButton.tsx
@@ -30,8 +30,13 @@ const SubmitButton = ({ userHasRoot, extensionData }: SubmitButtonProps) => {
   const { colony } = useColonyContext();
   const isMobile = useMobile();
 
-  const { waitingForActionConfirmation, activeTab, setActiveTab } =
-    useExtensionDetailsPageContext();
+  const {
+    waitingForActionConfirmation,
+    activeTab,
+    setActiveTab,
+    isPendingManagement,
+    isSavingChanges,
+  } = useExtensionDetailsPageContext();
 
   const {
     formState: { isValid, isSubmitting, isDirty },
@@ -74,7 +79,9 @@ const SubmitButton = ({ userHasRoot, extensionData }: SubmitButtonProps) => {
             setActiveTab(ExtensionDetailsPageTabId.Settings);
           }}
           isFullSize={isMobile}
-          disabled={waitingForActionConfirmation}
+          disabled={
+            isPendingManagement || isSubmitting || waitingForActionConfirmation
+          }
         >
           {formatText({ id: 'button.enable' })}
         </Button>
@@ -84,9 +91,13 @@ const SubmitButton = ({ userHasRoot, extensionData }: SubmitButtonProps) => {
     return (
       <ButtonWithLoader
         type="submit"
-        disabled={!isValid || waitingForActionConfirmation}
+        disabled={
+          isPendingManagement || !isValid || waitingForActionConfirmation
+        }
         isFullSize={isMobile}
-        loading={isSubmitting || waitingForActionConfirmation}
+        loading={
+          isSubmitting || (waitingForActionConfirmation && isSavingChanges)
+        }
       >
         {formatText({ id: 'button.enable' })}
       </ButtonWithLoader>
@@ -98,8 +109,12 @@ const SubmitButton = ({ userHasRoot, extensionData }: SubmitButtonProps) => {
       <ButtonWithLoader
         type="submit"
         isFullSize={isMobile}
-        loading={isSubmitting || waitingForActionConfirmation}
-        disabled={waitingForActionConfirmation}
+        loading={
+          isSubmitting || (waitingForActionConfirmation && isSavingChanges)
+        }
+        disabled={
+          isPendingManagement || isSubmitting || waitingForActionConfirmation
+        }
       >
         {formatText({ id: 'button.saveChanges' })}
       </ButtonWithLoader>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/SubmitButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/SubmitButton.tsx
@@ -30,13 +30,8 @@ const SubmitButton = ({ userHasRoot, extensionData }: SubmitButtonProps) => {
   const { colony } = useColonyContext();
   const isMobile = useMobile();
 
-  const {
-    waitingForActionConfirmation,
-    activeTab,
-    setActiveTab,
-    isPendingManagement,
-    isSavingChanges,
-  } = useExtensionDetailsPageContext();
+  const { activeTab, setActiveTab, isPendingManagement, isSavingChanges } =
+    useExtensionDetailsPageContext();
 
   const {
     formState: { isValid, isSubmitting, isDirty },
@@ -79,9 +74,7 @@ const SubmitButton = ({ userHasRoot, extensionData }: SubmitButtonProps) => {
             setActiveTab(ExtensionDetailsPageTabId.Settings);
           }}
           isFullSize={isMobile}
-          disabled={
-            isPendingManagement || isSubmitting || waitingForActionConfirmation
-          }
+          disabled={isPendingManagement || isSubmitting}
         >
           {formatText({ id: 'button.enable' })}
         </Button>
@@ -91,13 +84,9 @@ const SubmitButton = ({ userHasRoot, extensionData }: SubmitButtonProps) => {
     return (
       <ButtonWithLoader
         type="submit"
-        disabled={
-          isPendingManagement || !isValid || waitingForActionConfirmation
-        }
+        disabled={isPendingManagement || !isValid}
         isFullSize={isMobile}
-        loading={
-          isSubmitting || (waitingForActionConfirmation && isSavingChanges)
-        }
+        loading={isSubmitting || (isPendingManagement && isSavingChanges)}
       >
         {formatText({ id: 'button.enable' })}
       </ButtonWithLoader>
@@ -109,12 +98,8 @@ const SubmitButton = ({ userHasRoot, extensionData }: SubmitButtonProps) => {
       <ButtonWithLoader
         type="submit"
         isFullSize={isMobile}
-        loading={
-          isSubmitting || (waitingForActionConfirmation && isSavingChanges)
-        }
-        disabled={
-          isPendingManagement || isSubmitting || waitingForActionConfirmation
-        }
+        loading={isSubmitting || (isPendingManagement && isSavingChanges)}
+        disabled={isPendingManagement || isSubmitting}
       >
         {formatText({ id: 'button.saveChanges' })}
       </ButtonWithLoader>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/UpgradeButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/UpgradeButton.tsx
@@ -29,7 +29,7 @@ const UpgradeButton = ({ extensionData }: UpgradeButtonProps) => {
     isSupportedColonyVersion,
   } = useColonyContext();
   const isMobile = useMobile();
-  const { setWaitingForActionConfirmation, waitingForActionConfirmation } =
+  const { setIsPendingManagement, isPendingManagement } =
     useExtensionDetailsPageContext();
   const { refetchExtensionData } = useExtensionData(extensionData.extensionId);
   const [isPolling, setIsPolling] = useState(false);
@@ -52,12 +52,13 @@ const UpgradeButton = ({ extensionData }: UpgradeButtonProps) => {
   const handleUpgradeSuccess = async () => {
     setIsUpgradeDisabled(true);
     setIsPolling(true);
+    setIsPendingManagement(true);
     await waitForDbAfterExtensionAction({
       method: ExtensionMethods.UPGRADE,
-      setWaitingForActionConfirmation,
       refetchExtensionData,
       latestVersion: extensionData.availableVersion,
     });
+    setIsPendingManagement(false);
     setIsPolling(false);
     toast.success(
       <Toast
@@ -89,7 +90,7 @@ const UpgradeButton = ({ extensionData }: UpgradeButtonProps) => {
       onError={handleUpgradeError}
       isLoading={isPolling}
       isFullSize={isMobile}
-      disabled={isUpgradeButtonDisabled || waitingForActionConfirmation}
+      disabled={isUpgradeButtonDisabled || isPendingManagement}
     >
       {formatText({ id: 'button.updateVersion' })}
     </ActionButton>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/hooks.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/hooks.tsx
@@ -21,7 +21,8 @@ export const useReenable = ({ extensionId }: { extensionId: Extension }) => {
     colony: { colonyAddress },
   } = useColonyContext();
   const { refetchExtensionData } = useExtensionData(extensionId);
-  const { setWaitingForActionConfirmation } = useExtensionDetailsPageContext();
+  const { setWaitingForActionConfirmation, setIsPendingManagement } =
+    useExtensionDetailsPageContext();
 
   const enableExtensionValues = {
     colonyAddress,
@@ -37,6 +38,7 @@ export const useReenable = ({ extensionId }: { extensionId: Extension }) => {
 
   const handleReenable = async () => {
     try {
+      setIsPendingManagement(true);
       setIsLoading(true);
       await enableAsyncFunction(enableExtensionValues);
       await waitForDbAfterExtensionAction({
@@ -62,6 +64,7 @@ export const useReenable = ({ extensionId }: { extensionId: Extension }) => {
         />,
       );
     } finally {
+      setIsPendingManagement(false);
       setIsLoading(false);
     }
   };
@@ -71,22 +74,29 @@ export const useReenable = ({ extensionId }: { extensionId: Extension }) => {
 
 export const useInstall = (extensionData: AnyExtensionData) => {
   const { refetchExtensionData } = useExtensionData(extensionData.extensionId);
-  const { setActiveTab, setWaitingForActionConfirmation } =
-    useExtensionDetailsPageContext();
+  const {
+    setActiveTab,
+    setWaitingForActionConfirmation,
+    setIsPendingManagement,
+    setIsSavingChanges,
+  } = useExtensionDetailsPageContext();
   const { reset } = useFormContext();
 
   const [isLoading, setIsLoading] = useState(false);
 
   const handleInstallSuccess = async () => {
+    setIsPendingManagement(true);
     setIsLoading(true);
     await handleWaitingForDbAfterFormCompletion({
       setWaitingForActionConfirmation,
+      setIsSavingChanges,
       extensionData,
       refetchExtensionData,
       setActiveTab,
       reset,
       method: ExtensionMethods.INSTALL,
     });
+    setIsPendingManagement(false);
     setIsLoading(false);
   };
 
@@ -105,9 +115,11 @@ export const useInstall = (extensionData: AnyExtensionData) => {
       return;
     }
 
+    setIsPendingManagement(true);
     setIsLoading(true);
     await handleWaitingForDbAfterFormCompletion({
       setWaitingForActionConfirmation,
+      setIsSavingChanges,
       extensionData,
       refetchExtensionData,
       setActiveTab,
@@ -116,6 +128,7 @@ export const useInstall = (extensionData: AnyExtensionData) => {
       initialiseTransactionFailed,
       setUserRolesTransactionFailed,
     });
+    setIsPendingManagement(false);
     setIsLoading(false);
   };
 

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/hooks.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsHeader/hooks.tsx
@@ -21,8 +21,7 @@ export const useReenable = ({ extensionId }: { extensionId: Extension }) => {
     colony: { colonyAddress },
   } = useColonyContext();
   const { refetchExtensionData } = useExtensionData(extensionId);
-  const { setWaitingForActionConfirmation, setIsPendingManagement } =
-    useExtensionDetailsPageContext();
+  const { setIsPendingManagement } = useExtensionDetailsPageContext();
 
   const enableExtensionValues = {
     colonyAddress,
@@ -43,7 +42,6 @@ export const useReenable = ({ extensionId }: { extensionId: Extension }) => {
       await enableAsyncFunction(enableExtensionValues);
       await waitForDbAfterExtensionAction({
         method: ExtensionMethods.REENABLE,
-        setWaitingForActionConfirmation,
         refetchExtensionData,
       });
       toast.success(
@@ -74,12 +72,8 @@ export const useReenable = ({ extensionId }: { extensionId: Extension }) => {
 
 export const useInstall = (extensionData: AnyExtensionData) => {
   const { refetchExtensionData } = useExtensionData(extensionData.extensionId);
-  const {
-    setActiveTab,
-    setWaitingForActionConfirmation,
-    setIsPendingManagement,
-    setIsSavingChanges,
-  } = useExtensionDetailsPageContext();
+  const { setActiveTab, setIsPendingManagement, setIsSavingChanges } =
+    useExtensionDetailsPageContext();
   const { reset } = useFormContext();
 
   const [isLoading, setIsLoading] = useState(false);
@@ -88,7 +82,6 @@ export const useInstall = (extensionData: AnyExtensionData) => {
     setIsPendingManagement(true);
     setIsLoading(true);
     await handleWaitingForDbAfterFormCompletion({
-      setWaitingForActionConfirmation,
       setIsSavingChanges,
       extensionData,
       refetchExtensionData,
@@ -118,7 +111,6 @@ export const useInstall = (extensionData: AnyExtensionData) => {
     setIsPendingManagement(true);
     setIsLoading(true);
     await handleWaitingForDbAfterFormCompletion({
-      setWaitingForActionConfirmation,
       setIsSavingChanges,
       extensionData,
       refetchExtensionData,

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/DeprecateButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/DeprecateButton.tsx
@@ -1,5 +1,6 @@
 import { Question } from '@phosphor-icons/react';
 import React, { useState } from 'react';
+import { useFormContext } from 'react-hook-form';
 
 import { useExtensionDetailsPageContext } from '~frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContext.ts';
 import { type AnyExtensionData } from '~types/extensions.ts';
@@ -20,11 +21,16 @@ const DeprecateButton = ({
   extensionData: { extensionId },
 }: DeprecateButtonProps) => {
   const [isDeprecateModalOpen, setIsDeprecateModalOpen] = useState(false);
-  const { waitingForActionConfirmation } = useExtensionDetailsPageContext();
+  const { waitingForActionConfirmation, isPendingManagement } =
+    useExtensionDetailsPageContext();
 
   const { handleDeprecate, isLoading } = useDeprecate({
     extensionId,
   });
+
+  const {
+    formState: { isSubmitting },
+  } = useFormContext();
 
   return (
     <>
@@ -37,7 +43,9 @@ const DeprecateButton = ({
           loaderClassName="!px-4 !py-2 !text-sm"
           loaderIconSize={14}
           onClick={() => setIsDeprecateModalOpen(true)}
-          disabled={waitingForActionConfirmation}
+          disabled={
+            isPendingManagement || isSubmitting || waitingForActionConfirmation
+          }
         >
           {formatText({ id: 'button.deprecateExtension' })}
         </ButtonWithLoader>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/DeprecateButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/DeprecateButton.tsx
@@ -21,8 +21,7 @@ const DeprecateButton = ({
   extensionData: { extensionId },
 }: DeprecateButtonProps) => {
   const [isDeprecateModalOpen, setIsDeprecateModalOpen] = useState(false);
-  const { waitingForActionConfirmation, isPendingManagement } =
-    useExtensionDetailsPageContext();
+  const { isPendingManagement } = useExtensionDetailsPageContext();
 
   const { handleDeprecate, isLoading } = useDeprecate({
     extensionId,
@@ -43,9 +42,7 @@ const DeprecateButton = ({
           loaderClassName="!px-4 !py-2 !text-sm"
           loaderIconSize={14}
           onClick={() => setIsDeprecateModalOpen(true)}
-          disabled={
-            isPendingManagement || isSubmitting || waitingForActionConfirmation
-          }
+          disabled={isPendingManagement || isSubmitting}
         >
           {formatText({ id: 'button.deprecateExtension' })}
         </ButtonWithLoader>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
@@ -1,6 +1,7 @@
 import { Extension } from '@colony/colony-js';
 import { Trash } from '@phosphor-icons/react';
 import React, { useState } from 'react';
+import { useFormContext } from 'react-hook-form';
 import { FormattedMessage, defineMessages } from 'react-intl';
 
 import { useExtensionDetailsPageContext } from '~frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContext.ts';
@@ -113,7 +114,12 @@ const UninstallButton = ({
   const [isUninstallModalOpen, setIsUninstallModalOpen] = useState(false);
   const [isCheckboxChecked, setIsCheckboxChecked] = useState(false);
   const { handleUninstall, isLoading } = useUninstall(extensionId);
-  const { waitingForActionConfirmation } = useExtensionDetailsPageContext();
+  const { waitingForActionConfirmation, isPendingManagement } =
+    useExtensionDetailsPageContext();
+
+  const {
+    formState: { isSubmitting },
+  } = useFormContext();
 
   return (
     <>
@@ -124,7 +130,9 @@ const UninstallButton = ({
           isFullSize
           loading={isLoading}
           onClick={() => setIsUninstallModalOpen(true)}
-          disabled={waitingForActionConfirmation}
+          disabled={
+            isPendingManagement || isSubmitting || waitingForActionConfirmation
+          }
         >
           {formatText({ id: 'button.uninstallExtension' })}
         </Button>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
@@ -114,8 +114,7 @@ const UninstallButton = ({
   const [isUninstallModalOpen, setIsUninstallModalOpen] = useState(false);
   const [isCheckboxChecked, setIsCheckboxChecked] = useState(false);
   const { handleUninstall, isLoading } = useUninstall(extensionId);
-  const { waitingForActionConfirmation, isPendingManagement } =
-    useExtensionDetailsPageContext();
+  const { isPendingManagement } = useExtensionDetailsPageContext();
 
   const {
     formState: { isSubmitting },
@@ -130,9 +129,7 @@ const UninstallButton = ({
           isFullSize
           loading={isLoading}
           onClick={() => setIsUninstallModalOpen(true)}
-          disabled={
-            isPendingManagement || isSubmitting || waitingForActionConfirmation
-          }
+          disabled={isPendingManagement || isSubmitting}
         >
           {formatText({ id: 'button.uninstallExtension' })}
         </Button>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/hooks.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/hooks.tsx
@@ -17,11 +17,8 @@ export const useUninstall = (extensionId: Extension) => {
   } = useColonyContext();
   const [isLoading, setIsLoading] = useState(false);
   const { refetchExtensionData } = useExtensionData(extensionId);
-  const {
-    setActiveTab,
-    setWaitingForActionConfirmation,
-    setIsPendingManagement,
-  } = useExtensionDetailsPageContext();
+  const { setActiveTab, setIsPendingManagement } =
+    useExtensionDetailsPageContext();
 
   const uninstallAsyncFunction = useAsyncFunction({
     submit: ActionTypes.EXTENSION_UNINSTALL,
@@ -42,7 +39,6 @@ export const useUninstall = (extensionId: Extension) => {
       await waitForDbAfterExtensionAction({
         method: ExtensionMethods.UNINSTALL,
         refetchExtensionData,
-        setWaitingForActionConfirmation,
       });
       toast.success(
         <Toast
@@ -80,8 +76,7 @@ export const useDeprecate = ({ extensionId }: { extensionId: Extension }) => {
     colony: { colonyAddress },
   } = useColonyContext();
   const { refetchExtensionData } = useExtensionData(extensionId);
-  const { setWaitingForActionConfirmation, setIsPendingManagement } =
-    useExtensionDetailsPageContext();
+  const { setIsPendingManagement } = useExtensionDetailsPageContext();
   const deprecateExtensionValues = {
     colonyAddress,
     extensionId,
@@ -103,7 +98,6 @@ export const useDeprecate = ({ extensionId }: { extensionId: Extension }) => {
       await deprecateAsyncFunction(deprecateExtensionValues);
       await waitForDbAfterExtensionAction({
         method: ExtensionMethods.DEPRECATE,
-        setWaitingForActionConfirmation,
         refetchExtensionData,
       });
       toast.success(

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/hooks.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/hooks.tsx
@@ -17,8 +17,11 @@ export const useUninstall = (extensionId: Extension) => {
   } = useColonyContext();
   const [isLoading, setIsLoading] = useState(false);
   const { refetchExtensionData } = useExtensionData(extensionId);
-  const { setActiveTab, setWaitingForActionConfirmation } =
-    useExtensionDetailsPageContext();
+  const {
+    setActiveTab,
+    setWaitingForActionConfirmation,
+    setIsPendingManagement,
+  } = useExtensionDetailsPageContext();
 
   const uninstallAsyncFunction = useAsyncFunction({
     submit: ActionTypes.EXTENSION_UNINSTALL,
@@ -33,6 +36,7 @@ export const useUninstall = (extensionId: Extension) => {
 
   const handleUninstall = async () => {
     try {
+      setIsPendingManagement(true);
       setIsLoading(true);
       await uninstallAsyncFunction(uninstallExtensionPayload);
       await waitForDbAfterExtensionAction({
@@ -63,6 +67,7 @@ export const useUninstall = (extensionId: Extension) => {
         />,
       );
     } finally {
+      setIsPendingManagement(false);
       setIsLoading(false);
     }
   };
@@ -75,7 +80,8 @@ export const useDeprecate = ({ extensionId }: { extensionId: Extension }) => {
     colony: { colonyAddress },
   } = useColonyContext();
   const { refetchExtensionData } = useExtensionData(extensionId);
-  const { setWaitingForActionConfirmation } = useExtensionDetailsPageContext();
+  const { setWaitingForActionConfirmation, setIsPendingManagement } =
+    useExtensionDetailsPageContext();
   const deprecateExtensionValues = {
     colonyAddress,
     extensionId,
@@ -92,6 +98,7 @@ export const useDeprecate = ({ extensionId }: { extensionId: Extension }) => {
 
   const handleDeprecate = async () => {
     try {
+      setIsPendingManagement(true);
       setIsLoading(true);
       await deprecateAsyncFunction(deprecateExtensionValues);
       await waitForDbAfterExtensionAction({
@@ -116,6 +123,7 @@ export const useDeprecate = ({ extensionId }: { extensionId: Extension }) => {
         />,
       );
     } finally {
+      setIsPendingManagement(false);
       setIsLoading(false);
     }
   };

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionPermissionsBanner/PermissionsNeededBanner.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionPermissionsBanner/PermissionsNeededBanner.tsx
@@ -55,9 +55,10 @@ const PermissionsNeededBanner = ({
   });
 
   const { refetchExtensionData } = useExtensionData(extensionData.extensionId);
-  const { setWaitingForActionConfirmation } = useExtensionDetailsPageContext();
+  const { setIsPendingManagement } = useExtensionDetailsPageContext();
 
   const enableAndCheckStatus = async () => {
+    setIsPendingManagement(true);
     await asyncFunction({
       colonyAddress: colony.colonyAddress,
       extensionData,
@@ -65,9 +66,9 @@ const PermissionsNeededBanner = ({
     refetchColony();
     await waitForDbAfterExtensionAction({
       method: ExtensionMethods.ENABLE,
-      setWaitingForActionConfirmation,
       refetchExtensionData,
     });
+    setIsPendingManagement(false);
   };
 
   const handleEnableClick = async () => {

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/ExtensionSettingsForm.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/ExtensionSettingsForm.tsx
@@ -20,8 +20,12 @@ const ExtensionSettingsForm: FC<PropsWithChildren> = ({ children }) => {
   const {
     colony: { colonyAddress },
   } = useColonyContext();
-  const { extensionData, setActiveTab, setWaitingForActionConfirmation } =
-    useExtensionDetailsPageContext();
+  const {
+    extensionData,
+    setActiveTab,
+    setWaitingForActionConfirmation,
+    setIsSavingChanges,
+  } = useExtensionDetailsPageContext();
   const { refetchExtensionData } = useExtensionData(extensionData?.extensionId);
 
   const defaultValues = useMemo(
@@ -44,6 +48,7 @@ const ExtensionSettingsForm: FC<PropsWithChildren> = ({ children }) => {
     extensionData,
     refetchExtensionData,
     setWaitingForActionConfirmation,
+    setIsSavingChanges,
     setActiveTab,
   });
 
@@ -51,6 +56,7 @@ const ExtensionSettingsForm: FC<PropsWithChildren> = ({ children }) => {
     extensionData,
     refetchExtensionData,
     setWaitingForActionConfirmation,
+    setIsSavingChanges,
     setActiveTab,
   });
 

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/ExtensionSettingsForm.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/ExtensionSettingsForm.tsx
@@ -23,7 +23,7 @@ const ExtensionSettingsForm: FC<PropsWithChildren> = ({ children }) => {
   const {
     extensionData,
     setActiveTab,
-    setWaitingForActionConfirmation,
+    setIsPendingManagement,
     setIsSavingChanges,
   } = useExtensionDetailsPageContext();
   const { refetchExtensionData } = useExtensionData(extensionData?.extensionId);
@@ -47,7 +47,7 @@ const ExtensionSettingsForm: FC<PropsWithChildren> = ({ children }) => {
   const handleFormSuccess = getFormSuccessFn<typeof defaultValues>({
     extensionData,
     refetchExtensionData,
-    setWaitingForActionConfirmation,
+    setIsPendingManagement,
     setIsSavingChanges,
     setActiveTab,
   });
@@ -55,7 +55,7 @@ const ExtensionSettingsForm: FC<PropsWithChildren> = ({ children }) => {
   const handleFormError = getFormErrorFn<typeof defaultValues>({
     extensionData,
     refetchExtensionData,
-    setWaitingForActionConfirmation,
+    setIsPendingManagement,
     setIsSavingChanges,
     setActiveTab,
   });

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/MultiSigSettings/MultiSigSettings.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/MultiSigSettings/MultiSigSettings.tsx
@@ -1,5 +1,6 @@
 import { CaretDown } from '@phosphor-icons/react';
 import React, { useEffect, type FC } from 'react';
+import { useFormContext } from 'react-hook-form';
 import { defineMessages } from 'react-intl';
 
 import { InputGroup } from '~common/Extensions/Fields/InputGroup/InputGroup.tsx';
@@ -94,7 +95,7 @@ const inputGroupSharedConfig = {
 };
 
 const MultiSigSettings: FC = () => {
-  const { extensionData, userHasRoot, waitingForActionConfirmation } =
+  const { extensionData, userHasRoot, isPendingManagement } =
     useExtensionDetailsPageContext();
   const {
     register,
@@ -105,6 +106,10 @@ const MultiSigSettings: FC = () => {
     handleDomainThresholdTypeChange,
     handleGlobalThresholdTypeChange,
   } = useThresholdData(extensionData);
+
+  const {
+    formState: { isSubmitting },
+  } = useFormContext();
 
   const [isCustomSettingsVisible, { toggle: toggleCustomSettings, toggleOn }] =
     useToggle();
@@ -144,7 +149,7 @@ const MultiSigSettings: FC = () => {
     );
   }
 
-  const isFormDisabled = !userHasRoot || waitingForActionConfirmation;
+  const isFormDisabled = !userHasRoot || isPendingManagement || isSubmitting;
 
   return (
     <div className="w-full">

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/StakedExpenditureSettings.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/StakedExpenditureSettings.tsx
@@ -1,4 +1,5 @@
 import React, { type FC } from 'react';
+import { useFormContext } from 'react-hook-form';
 import { FormattedMessage, defineMessages } from 'react-intl';
 
 import { useExtensionDetailsPageContext } from '~frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContext.ts';
@@ -30,7 +31,11 @@ const StakedExpenditureSettings: FC = () => {
   const { userHasRoot, isPendingManagement } = useExtensionDetailsPageContext();
   const { h4, p, b, ul, li } = getTextChunks();
 
-  const isFormDisabled = !userHasRoot || isPendingManagement;
+  const {
+    formState: { isSubmitting },
+  } = useFormContext();
+
+  const isFormDisabled = !userHasRoot || isPendingManagement || isSubmitting;
 
   return (
     <div>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/StakedExpenditureSettings.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/StakedExpenditureSettings.tsx
@@ -27,11 +27,10 @@ const MSG = defineMessages({
 });
 
 const StakedExpenditureSettings: FC = () => {
-  const { userHasRoot, waitingForActionConfirmation } =
-    useExtensionDetailsPageContext();
+  const { userHasRoot, isPendingManagement } = useExtensionDetailsPageContext();
   const { h4, p, b, ul, li } = getTextChunks();
 
-  const isFormDisabled = !userHasRoot || waitingForActionConfirmation;
+  const isFormDisabled = !userHasRoot || isPendingManagement;
 
   return (
     <div>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/VotingReputationSettings/VotingReputationSettings.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/VotingReputationSettings/VotingReputationSettings.tsx
@@ -79,11 +79,15 @@ interface VotingReputationSettingsProps {
 const VotingReputationSettings: FC<VotingReputationSettingsProps> = ({
   userHasRoot,
 }) => {
-  const { extensionData } = useExtensionDetailsPageContext();
+  const { extensionData, isPendingManagement } =
+    useExtensionDetailsPageContext();
   const { openIndex, onOpenIndexChange, isAccordionOpen } = useAccordion();
   const [isCustomChecked, setIsCustomChecked] = useState(false);
 
-  const { setValue } = useFormContext();
+  const {
+    setValue,
+    formState: { isSubmitting },
+  } = useFormContext();
 
   const onChangeGovernance = (selectedDefaultOption: GovernanceOptions) => {
     if (selectedDefaultOption === GovernanceOptions.CUSTOM) {
@@ -113,6 +117,8 @@ const VotingReputationSettings: FC<VotingReputationSettingsProps> = ({
     return <VotingReputationParams extensionData={extensionData} />;
   }
 
+  const isFormDisabled = isPendingManagement || isSubmitting;
+
   return (
     <div className="w-full">
       <p className="text-md text-gray-600">
@@ -126,7 +132,14 @@ const VotingReputationSettings: FC<VotingReputationSettingsProps> = ({
       <div className="mt-6">
         <RadioList
           title={formatText({ id: 'choose.governanceStyle' })}
-          items={governanceRadioList}
+          items={
+            isFormDisabled
+              ? governanceRadioList.map((item) => ({
+                  ...item,
+                  disabled: true,
+                }))
+              : governanceRadioList
+          }
           onChange={onChangeGovernance}
           name="governance"
           checkedRadios={{ [GovernanceOptions.CUSTOM]: isCustomChecked }}

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/utils.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionSettings/utils.tsx
@@ -123,6 +123,7 @@ const showEnableErrorToast = (isSaveChanges?: boolean) => {
 
 export const handleWaitingForDbAfterFormCompletion = async ({
   setWaitingForActionConfirmation,
+  setIsSavingChanges,
   extensionData,
   refetchExtensionData,
   setActiveTab,
@@ -132,6 +133,7 @@ export const handleWaitingForDbAfterFormCompletion = async ({
   method,
 }: {
   setWaitingForActionConfirmation: SetStateFn;
+  setIsSavingChanges: SetStateFn;
   setActiveTab: (tabId: ExtensionDetailsPageTabId) => void;
   extensionData: AnyExtensionData;
   refetchExtensionData: RefetchExtensionDataFn;
@@ -143,6 +145,10 @@ export const handleWaitingForDbAfterFormCompletion = async ({
   setWaitingForActionConfirmation(true);
 
   const isSaveChanges = getIsSaveChanges(extensionData, method);
+
+  if (isSaveChanges) {
+    setIsSavingChanges(true);
+  }
 
   try {
     if (!isSaveChanges) {
@@ -250,17 +256,20 @@ export const handleWaitingForDbAfterFormCompletion = async ({
     }
   } finally {
     setWaitingForActionConfirmation(false);
+    setIsSavingChanges(false);
   }
 };
 
 export const getFormSuccessFn =
   <T extends FieldValues>({
     setWaitingForActionConfirmation,
+    setIsSavingChanges,
     extensionData,
     refetchExtensionData,
     setActiveTab,
   }: {
     setWaitingForActionConfirmation: SetStateFn;
+    setIsSavingChanges: SetStateFn;
     setActiveTab: (tabId: ExtensionDetailsPageTabId) => void;
     extensionData: AnyExtensionData;
     refetchExtensionData: RefetchExtensionDataFn;
@@ -268,6 +277,7 @@ export const getFormSuccessFn =
   async (_, { reset }) => {
     await handleWaitingForDbAfterFormCompletion({
       setWaitingForActionConfirmation,
+      setIsSavingChanges,
       extensionData,
       refetchExtensionData,
       setActiveTab,
@@ -279,11 +289,13 @@ export const getFormSuccessFn =
 export const getFormErrorFn =
   <T extends FieldValues>({
     setWaitingForActionConfirmation,
+    setIsSavingChanges,
     extensionData,
     refetchExtensionData,
     setActiveTab,
   }: {
     setWaitingForActionConfirmation: SetStateFn;
+    setIsSavingChanges: SetStateFn;
     setActiveTab: (tabId: ExtensionDetailsPageTabId) => void;
     extensionData: AnyExtensionData;
     refetchExtensionData: RefetchExtensionDataFn;
@@ -295,6 +307,7 @@ export const getFormErrorFn =
     if (initialiseTransactionFailed || setUserRolesTransactionFailed) {
       await handleWaitingForDbAfterFormCompletion({
         setWaitingForActionConfirmation,
+        setIsSavingChanges,
         extensionData,
         refetchExtensionData,
         setActiveTab,

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/utils.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/utils.tsx
@@ -5,7 +5,6 @@ import {
   ExtensionMethods,
   type RefetchExtensionDataFn,
 } from '~hooks/useExtensionData.ts';
-import { type SetStateFn } from '~types';
 import { type AnyExtensionData } from '~types/extensions.ts';
 import { isInstalledExtensionData } from '~utils/extensions.ts';
 import { camelCase } from '~utils/lodash.ts';
@@ -45,7 +44,6 @@ export const waitForDbAfterExtensionSettingsChange = async ({
 export const waitForDbAfterExtensionAction = async (
   args: {
     refetchExtensionData: RefetchExtensionDataFn;
-    setWaitingForActionConfirmation: SetStateFn;
     interval?: number;
     timeout?: number;
   } & (
@@ -70,13 +68,10 @@ export const waitForDbAfterExtensionAction = async (
 ) => {
   const {
     refetchExtensionData,
-    setWaitingForActionConfirmation,
     interval = 1000,
     timeout = 30000,
     method,
   } = args;
-
-  setWaitingForActionConfirmation(true);
 
   await waitForCondition(
     async () => {
@@ -170,8 +165,6 @@ export const waitForDbAfterExtensionAction = async (
       timeout,
     },
   );
-
-  setWaitingForActionConfirmation(false);
 };
 
 export const getTextChunks = () => {

--- a/src/components/shared/Extensions/Accordion/partials/AccordionContent.tsx
+++ b/src/components/shared/Extensions/Accordion/partials/AccordionContent.tsx
@@ -1,6 +1,7 @@
 import React, { type SyntheticEvent, type FC } from 'react';
 import { useFormContext } from 'react-hook-form';
 
+import { useExtensionDetailsPageContext } from '~frame/Extensions/pages/ExtensionDetailsPage/context/ExtensionDetailsPageContext.ts';
 import { GovernanceOptions } from '~frame/Extensions/pages/ExtensionsPage/types.ts';
 import SpecialHourInput from '~shared/Extensions/ConnectForm/partials/SpecialHourInput.tsx';
 import SpecialPercentageInput from '~shared/Extensions/ConnectForm/partials/SpecialPercentageInput.tsx';
@@ -15,12 +16,19 @@ const AccordionContent: FC<AccordionItemProps> = ({
   content,
   onInputChange,
 }) => {
-  const { setValue } = useFormContext();
+  const {
+    setValue,
+    formState: { isSubmitting },
+  } = useFormContext();
+
+  const { isPendingManagement } = useExtensionDetailsPageContext();
 
   const handleInputChange = (e: SyntheticEvent<HTMLInputElement>) => {
     onInputChange?.(e);
     setValue('option', GovernanceOptions.CUSTOM);
   };
+
+  const isFormDisabled = isPendingManagement || isSubmitting;
 
   return (
     <div className="mt-6">
@@ -45,12 +53,14 @@ const AccordionContent: FC<AccordionItemProps> = ({
                         name={name}
                         step={step}
                         onInputChange={handleInputChange}
+                        disabled={isFormDisabled}
                       />
                     ) : (
                       <SpecialHourInput
                         name={name}
                         step={step}
                         onInputChange={onInputChange}
+                        disabled={isFormDisabled}
                       />
                     )}
                   </div>

--- a/src/components/shared/Extensions/ConnectForm/partials/SpecialHourInput.tsx
+++ b/src/components/shared/Extensions/ConnectForm/partials/SpecialHourInput.tsx
@@ -16,6 +16,7 @@ const SpecialHourInput: FC<SpecialInputProps> = ({
   step,
   name = '',
   onInputChange,
+  disabled,
 }) => {
   const {
     formState: { errors },
@@ -39,6 +40,7 @@ const SpecialHourInput: FC<SpecialInputProps> = ({
           type="hours"
           placeholder="1"
           onChange={handleInputChange}
+          disabled={disabled}
         />
         {error && <FormError>{formatText(error)}</FormError>}
       </div>

--- a/src/redux/sagas/expenditures/setStakeFraction.ts
+++ b/src/redux/sagas/expenditures/setStakeFraction.ts
@@ -40,10 +40,6 @@ function* setStakeFractionAction({
     yield takeFrom(setStakeFraction.channel, ActionTypes.TRANSACTION_CREATED);
 
     yield initiateTransaction(setStakeFraction.id);
-    yield takeFrom(
-      setStakeFraction.channel,
-      ActionTypes.TRANSACTION_HASH_RECEIVED,
-    );
 
     yield waitForTxResult(setStakeFraction.channel);
 


### PR DESCRIPTION
## Description

- Attempt number two at fixing the super awkward and spaghetti like extension management loading states! 🎉 

Our talented QA engineer spotted some bugs with my previous fix - mostly to do with the `Save Changes` button when saving the settings for an extension. Also when testing with Metamask, which highlighted some other issues.

## Testing

⚠️  You'll need to login as Leela using Metamask. If you need help with that, let me know. Alternatively, log in as a random dev user with Metamask, but ensure they have permissions to manage extensions in a colony.

* Install the multisig extension.
* Change the threshold, and while that form is submitting, and the changes are pending, check that the `deprecate extension` button is disabled.
* Click on a different threshold, but **don't** click save changes (just ensure that the save changes button shows). Instead, click on `deprecate extension`. The `save changes` button should be disabled while this is loading.
* Change the threshold, and while that form is submitting, and the changes are pending, check that both the `uninstall extension` button and the `enable` button are disabled.
* Click on a different threshold, but **don't** click save changes. Instead, click on `enable`. The `save changes` button and the `uninstall extension` buttons should be disabled while this is loading.
* Deprecate the extension, then again choose a different threshold without saving (so that the save changes button appears). This time, uninstall the extension. The other buttons should be disabled while this happens.

Here's a video of me going through this flow, hope it helps!

https://github.com/user-attachments/assets/b7b638ac-718e-4136-a57f-332643bf530d

## Diffs

**Changes** 🏗

* Changes to the extension management button loading states

Resolves #4089
