### PR TITLE
Fix: App crashing if preferredCurrency not in localStorage

### DIFF
--- a/src/context/CurrencyContext/CurrencyContextProvider.tsx
+++ b/src/context/CurrencyContext/CurrencyContextProvider.tsx
@@ -23,7 +23,7 @@ const CurrencyContextProvider = ({ children }: { children: ReactNode }) => {
    * @Note This needs to be removed once we re-enable SupportedCurrencies.Clny
    */
   const isCLNYTokenStored =
-    JSON.parse(localStorage.getItem(STORED_CURRENCY_KEY) || '') ===
+    JSON.parse(localStorage.getItem(STORED_CURRENCY_KEY) || '{}') ===
     SupportedCurrencies.Clny;
 
   const updatePreferredCurrency = useCallback(


### PR DESCRIPTION
## Description

Fixes an issue where the app would crash if `preferredCurrency` wasn't in local storage, as JSON.parse was receiving an empty string instead of valid JSON.

## Testing

Delete `preferredCurrency` entry from your local storage and refresh the app. Confirm it no longer crashes.