### PR TITLE
fix: string for create agreement motion action type

### DIFF
--- a/src/components/v5/common/CompletedAction/consts.ts
+++ b/src/components/v5/common/CompletedAction/consts.ts
@@ -1,17 +1,2 @@
-import { ColonyActionType } from '~gql';
-
 export const ICON_SIZE = 14;
 export const DEFAULT_TOOLTIP_POSITION = 'top';
-
-export const actionTypeTranslations = {
-  [ColonyActionType.CreateDecisionMotion]: 'actions.createDecision',
-  [ColonyActionType.CreateDomain]: 'actions.createNewTeam',
-  [ColonyActionType.ColonyEdit]: 'actions.editColonyDetails',
-  [ColonyActionType.MintTokens]: 'actions.mintTokens',
-  [ColonyActionType.Payment]: 'actions.simplePayment',
-  [ColonyActionType.MoveFunds]: 'actions.transferFunds',
-  [ColonyActionType.UnlockToken]: 'actions.unlockToken',
-  [ColonyActionType.VersionUpgrade]: 'actions.upgradeColonyVersion',
-  [ColonyActionType.VersionUpgradeMotion]: 'actions.upgradeColonyVersion',
-  default: 'Action',
-};

--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -111,7 +111,7 @@ const actionsMessageDescriptors = {
       ${ColonyActionType.EmitDomainReputationReward} {Manage reputation}
       ${ColonyActionType.EmitDomainReputationRewardMotion} {Manage reputation}
       ${ColonyActionType.EmitDomainReputationRewardMultisig} {Manage reputation}
-      ${ColonyActionType.CreateDecisionMotion} {Decision}
+      ${ColonyActionType.CreateDecisionMotion} {Create agreement}
       ${ColonyActionType.AddVerifiedMembers} {Manage verified members}
       ${ColonyActionType.AddVerifiedMembersMotion} {Manage verified members}
       ${ColonyActionType.AddVerifiedMembersMultisig} {Manage verified members}


### PR DESCRIPTION
## Description

Classic `en-actions.ts` mismatch :D 

## Testing

1. Install the voting reputation extension
2. Create an agreement motion, observe that in the form the action type is `Create agreement`
![image](https://github.com/user-attachments/assets/709f61d0-6523-4405-ae35-03f337ee5f80)
3. Verify that when it's created it still says `Create agreement` for the action type
![image](https://github.com/user-attachments/assets/24ebf2d7-7291-4b87-8efa-e218f484ff7d)


## Diffs


**Changes** 🏗

* Fixed the string for `ColonyActionType.CreateDecisionMotion` in `en-actions.ts`

**Deletions** ⚰️

* unused translations objects in completed action

Resolves #3986
