### PR TITLE
Fix: Buttons on the extensions page should show a loader whilst extension data is being fetched

### DIFF
--- a/src/components/common/Extensions/ExtensionItem/ExtensionItem.tsx
+++ b/src/components/common/Extensions/ExtensionItem/ExtensionItem.tsx
@@ -1,6 +1,7 @@
 import React, { type FC } from 'react';
 import { useIntl } from 'react-intl';
 
+import LoadingSkeleton from '~common/LoadingSkeleton/LoadingSkeleton.tsx';
 import ExtensionStatusBadge from '~v5/common/Pills/ExtensionStatusBadge/index.ts';
 import Link from '~v5/shared/Link/index.ts';
 
@@ -21,6 +22,7 @@ const ExtensionItem: FC<ExtensionItemProps> = ({
   const {
     extensionUrl,
     isExtensionInstalled,
+    isExtensionDataLoading,
     status,
     handleNavigateToExtensionDetails,
   } = useExtensionItem(extensionId);
@@ -51,10 +53,15 @@ const ExtensionItem: FC<ExtensionItemProps> = ({
                   v{version}
                 </span>
               </h5>
-              <ExtensionStatusBadge
-                mode={status}
-                text={formatMessage({ id: `extension.status.${status}` })}
-              />
+              <LoadingSkeleton
+                isLoading={isExtensionDataLoading}
+                className="h-6.5 w-20 min-w-20 rounded-full"
+              >
+                <ExtensionStatusBadge
+                  mode={status}
+                  text={formatMessage({ id: `extension.status.${status}` })}
+                />
+              </LoadingSkeleton>
             </div>
             <p className="mt-1.5 text-md text-gray-600">
               {formatMessage(description)}
@@ -62,7 +69,12 @@ const ExtensionItem: FC<ExtensionItemProps> = ({
           </div>
         </Link>
         <div className="ml-[3.125rem] self-stretch sm:ml-0 sm:self-auto">
-          {button}
+          <LoadingSkeleton
+            isLoading={isExtensionDataLoading}
+            className="h-10 w-full rounded-lg sm:w-20"
+          >
+            {button}
+          </LoadingSkeleton>
         </div>
       </div>
     </div>

--- a/src/components/common/Extensions/ExtensionItem/hooks.ts
+++ b/src/components/common/Extensions/ExtensionItem/hooks.ts
@@ -11,7 +11,7 @@ export const useExtensionItem = (extensionId: string) => {
   const {
     colony: { name: colonyName },
   } = useColonyContext();
-  const { extensionData } = useExtensionData(extensionId);
+  const { extensionData, loading } = useExtensionData(extensionId);
   const navigate = useNavigate();
 
   const isExtensionInstalled =
@@ -28,6 +28,7 @@ export const useExtensionItem = (extensionId: string) => {
   return {
     extensionUrl,
     isExtensionInstalled,
+    isExtensionDataLoading: loading,
     status,
     handleNavigateToExtensionDetails,
   };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -157,6 +157,7 @@ module.exports = {
       },
       spacing: {
         4.5: '1.125rem',
+        6.5: '1.625rem',
         8.5: '2.125rem',
       },
     },


### PR DESCRIPTION
## Description

- This PR aims to solve the issue on the `Extensions` page of having both the extension button and status pill change state after the extension data has been fetched by adding a loading skeleton before actually showing the button and status pill

**Before**

https://github.com/user-attachments/assets/53777465-9159-4e19-9d07-320cc8e87bde

**After**

https://github.com/user-attachments/assets/b5b301fd-5cb6-4ab2-85c2-f6f57b846962



## Testing

TODO: Please test the loading skeleton is shown instead of the button while the extension data is fetched on the `Extensions` page

> [!NOTE]
> If you want to skip the page refresh, just change line `14` in `src/components/common/Extensions/ExtensionItem/hooks.ts` with
> ```
>  const { extensionData /* loading */ } = useExtensionData(extensionId);
>  const loading = true;
> ```

* Step 1. Go to http://localhost:9091/planex/extensions
* Step 2. Refresh the page
* Step 3. Check the loading skeleton is shown before actually displaying the extension action button and status pill

https://github.com/user-attachments/assets/b5b301fd-5cb6-4ab2-85c2-f6f57b846962

* Step 4. Please change to a mobile view
* Step 5. Refresh the page and check again the loading state for the button and status pill

https://github.com/user-attachments/assets/785a7479-bba0-40d2-bbc4-8a9ada52df75

## Diffs

**New stuff** ✨
* `6.5` tailwind spacing utility

**Changes** 🏗

* `useExtensionItem` returns also `isExtensionDataLoading` flag

Resolves [#3837](https://github.com/JoinColony/colonyCDapp/issues/3837)
