### PR TITLE
Chore: Turn off notifications in dev by default

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=358ad9a2ea10a8e3037fc23f1e2aae5cf005dcff
+ENV BLOCK_INGESTOR_HASH=87073303a0369e97cf439baf572809f238f923ed
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/scripts/generate-local-notifications-key.js
+++ b/scripts/generate-local-notifications-key.js
@@ -6,7 +6,9 @@
 
 var fs = require('fs');
 
-const LOCAL_KEY = Math.floor(100000000 + Math.random() * 900000000);
+const LOCAL_KEY = process.env.npm_config_notifications
+  ? Math.floor(100000000 + Math.random() * 900000000)
+  : 'OFF';
 
 fs.readFile('.env', 'utf8', function (err, data) {
   if (err) {

--- a/src/context/Notifications/NotificationsDataContext/NotificationsDataContextProvider.tsx
+++ b/src/context/Notifications/NotificationsDataContext/NotificationsDataContextProvider.tsx
@@ -76,7 +76,7 @@ const NotificationsDataContextProvider = ({
               {
                 id: 'dev-store',
                 defaultQueryParams: {
-                  category: import.meta.env.MAGICBELL_DEV_KEY,
+                  topic: import.meta.env.MAGICBELL_DEV_KEY,
                   // eslint-disable-next-line camelcase
                   per_page: 10,
                 },

--- a/src/context/Notifications/NotificationsDataContext/NotificationsDataContextProvider.tsx
+++ b/src/context/Notifications/NotificationsDataContext/NotificationsDataContextProvider.tsx
@@ -71,7 +71,7 @@ const NotificationsDataContextProvider = ({
       userExternalId={user.notificationsData.magicbellUserId}
       userKey={data?.getUserNotificationsHMAC || ''}
       stores={
-        isDev
+        isDev && !!import.meta.env.MAGICBELL_DEV_KEY
           ? [
               {
                 id: 'dev-store',


### PR DESCRIPTION
## Description

Currently we have notifications turned on in dev, QA and production (of course). We use two separate projects on Magicbell - one for production, and one shared between QA and our development environments. 

The PR aims to reduce the amount of unnecessary notifications being fired, especially since we are now paying for Magicbell, and lots of notifications has the potential to push us up a pay bracket.

This PR will turn off notifications being sent in our development environments, whilst keeping it super easy to turn them back on in case you're developing something that needs them. 

The idea here is that you will run `npm run dev --notifications` if you want to have notifications enabled locally. This will ensure that the MAGICBELL_DEV_KEY is generated for you (if you don't pass the notifications flag, it will be set to 'OFF').

I've tried to leave helpful comments in the right places to help future us.

A side note: I've also changed the use of `category` to distinguish our local notifications from each other, to instead use `topic` as that felt more fitting in the Magicbell eco system, and also doesn't clog up the Magicbell interface (I've just spent a while cleaning up all the 800 old categories we had stored in Magicbell - topics are _not_ stored).

Block ingestor changes are here: https://github.com/JoinColony/block-ingestor/pull/316

## Testing

* Restart you environment, but ensure you run `npm run dev --notifications` instead of just `npm run dev` at the beginning.
* Make any action (such as a simple payment) and check that you received a notification for it.

<img width="1052" alt="Screenshot 2025-01-15 at 17 35 09" src="https://github.com/user-attachments/assets/b107d240-461d-40f9-8bde-d5b965408bdb" />
<img width="808" alt="Screenshot 2025-01-15 at 17 35 28" src="https://github.com/user-attachments/assets/9cd9b60f-6c90-48d3-b3ef-7da112b0f676" />

* Restart your environment again, only this time run `npm run dev` without the notifications flag.
* Make another action, and check that there's no notification.
<img width="1064" alt="Screenshot 2025-01-15 at 17 52 31" src="https://github.com/user-attachments/assets/60f0e1ef-82cc-4078-b729-486b9f2fd3ed" />
<img width="816" alt="Screenshot 2025-01-15 at 17 52 38" src="https://github.com/user-attachments/assets/05fa8af5-b788-4885-a81b-8f4c3b5dd0d8" />

* Also check your block ingestor logs, you should see a helpful comment:
<img width="1270" alt="Screenshot 2025-01-15 at 17 52 25" src="https://github.com/user-attachments/assets/1d0af905-1da0-47a2-9d67-0b41105d75f1" />

## Diffs

**Changes** 🏗

* Changed the way MAGICBELL_DEV_KEY is generated, to make sure notifications are off by default in development.
* Changed the dev notifications store to look at topic instead of category.
* Block ingestor changes https://github.com/JoinColony/block-ingestor/pull/316
