### PR TITLE
Fix: Advanced payments not processing all slots

### DIFF
--- a/src/redux/sagas/utils/expenditures.ts
+++ b/src/redux/sagas/utils/expenditures.ts
@@ -112,7 +112,7 @@ export const getPayoutsWithSlotIds = (
 ) => {
   return payouts.map((payout, index) => ({
     ...payout,
-    slotId: index + 1,
+    slotId: payout.slotId ?? index + 1,
   }));
 };
 


### PR DESCRIPTION
## Description

This issue was a bit of a pain to pin down, but luckily has a very simple solution!

This issue only occurred when more than 164 payment rows are added. This is because we chunk the payouts into multiple transactions as otherwise they become too big to process. There was a bug where the slotId was being overwritten for each chunk, so every chunk would start back at slotId 1. Effectively meaning the later chunks were editing the values for the previous chunks.

This PR resolves the issue by using the existing slotId value if it already exists.

## Testing

Create an advanced payment with more than 164 rows.

[Feel free to use this CSV](https://drive.google.com/file/d/1kNvrcIYzkfUDda7lbpV8GB11NYusjMvw/view?usp=sharing)

Check the completed action screen loads all the payments in the expected order (may take a short while to process them all).

![Screenshot 2025-01-15 at 17 59 52](https://github.com/user-attachments/assets/4555900f-d91f-4600-9dec-3d6dbf1ecf2d)

## Diffs

**Changes** 🏗

* `getPayoutsWithSlotIds` uses existing slotId if not undefined

Resolves #3744
