### PR TITLE
[Arbitrary Txs] Fix array encoding issue

### DIFF
--- a/src/redux/sagas/actions/arbitraryTx.ts
+++ b/src/redux/sagas/actions/arbitraryTx.ts
@@ -1,6 +1,5 @@
 import { ClientType } from '@colony/colony-js';
 import { utils } from 'ethers';
-import { Interface } from 'ethers/lib/utils';
 import { call, put, takeEvery } from 'redux-saga/effects';
 
 import { type Action, ActionTypes, type AllActions } from '~redux/index.ts';
@@ -12,6 +11,7 @@ import {
   getTxChannel,
   waitForTxResult,
 } from '../transactions/index.ts';
+import { encodeArbitraryTransactions } from '../utils/arbitraryTxs.ts';
 import {
   initiateTransaction,
   putError,
@@ -34,17 +34,8 @@ function* arbitraryTxSaga({
   try {
     txChannel = yield call(getTxChannel, metaId);
 
-    const contractAddresses: string[] = [];
-    const methodsBytes: string[] = [];
-
-    transactions.forEach(({ contractAddress, ...item }) => {
-      const encodedFunction = new Interface(item.jsonAbi).encodeFunctionData(
-        item.method,
-        item.args?.map((arg) => arg.value),
-      );
-      contractAddresses.push(contractAddress);
-      methodsBytes.push(encodedFunction);
-    });
+    const { contractAddresses, methodsBytes } =
+      encodeArbitraryTransactions(transactions);
 
     // setup batch ids and channels
     const batchKey = TRANSACTION_METHODS.ArbitraryTxs;

--- a/src/redux/sagas/motions/arbitraryTx.ts
+++ b/src/redux/sagas/motions/arbitraryTx.ts
@@ -1,7 +1,6 @@
 import { ClientType, Id } from '@colony/colony-js';
 import { AddressZero } from '@ethersproject/constants';
 import { BigNumber, utils } from 'ethers';
-import { Interface } from 'ethers/lib/utils';
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
 import { PERMISSIONS_NEEDED_FOR_ACTION } from '~constants/actions.ts';
@@ -16,6 +15,7 @@ import {
   getTxChannel,
   waitForTxResult,
 } from '../transactions/index.ts';
+import { encodeArbitraryTransactions } from '../utils/arbitraryTxs.ts';
 import {
   putError,
   takeFrom,
@@ -44,17 +44,9 @@ function* arbitraryTxMotion({
   try {
     const colonyManager: ColonyManager = yield getColonyManager();
 
-    const contractAddresses: string[] = [];
-    const methodsBytes: string[] = [];
+    const { contractAddresses, methodsBytes } =
+      encodeArbitraryTransactions(transactions);
 
-    transactions.forEach(({ contractAddress, ...item }) => {
-      const encodedFunction = new Interface(item.jsonAbi).encodeFunctionData(
-        item.method,
-        item.args?.map((arg) => arg.value),
-      );
-      contractAddresses.push(contractAddress);
-      methodsBytes.push(encodedFunction);
-    });
     const colonyClient = yield colonyManager.getClient(
       ClientType.ColonyClient,
       colonyAddress,

--- a/src/redux/sagas/utils/arbitraryTxs.ts
+++ b/src/redux/sagas/utils/arbitraryTxs.ts
@@ -1,0 +1,30 @@
+import { Interface } from 'ethers/lib/utils';
+
+import { type AddTransactionTableModel } from '~v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/types.ts';
+
+export const encodeArbitraryTransactions = (
+  transactions: AddTransactionTableModel[],
+) => {
+  const contractAddresses: string[] = [];
+  const methodsBytes: string[] = [];
+
+  transactions.forEach(({ contractAddress, ...item }) => {
+    const encodedFunction = new Interface(item.jsonAbi).encodeFunctionData(
+      item.method,
+      item.args?.map((arg) => {
+        if (arg.type.endsWith('[]')) {
+          return JSON.parse(arg.value);
+        }
+        return arg.value;
+      }),
+    );
+
+    contractAddresses.push(contractAddress);
+    methodsBytes.push(encodedFunction);
+  });
+
+  return {
+    contractAddresses,
+    methodsBytes,
+  };
+};

--- a/src/redux/sagas/utils/arbitraryTxs.ts
+++ b/src/redux/sagas/utils/arbitraryTxs.ts
@@ -2,6 +2,56 @@ import { Interface } from 'ethers/lib/utils';
 
 import { type AddTransactionTableModel } from '~v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/types.ts';
 
+/**
+ * Parses a string representation of an array into an array of values.
+ * It supports nested arrays and handles strings within arrays.
+ */
+const getArrayFromString = (value: string, type: string) => {
+  if (value === '[]') {
+    return [];
+  }
+
+  if (!value.startsWith('[') || !value.endsWith(']')) {
+    throw new Error('Invalid array format');
+  }
+
+  const contents = value.slice(1, -1);
+  const parsedElements: string[] = [];
+
+  let bracketLevel = 0;
+  let isInString = false;
+  let startIndex = 0;
+
+  for (let i = 0; i < contents.length; i += 1) {
+    const char = contents[i];
+    if (char === '"') {
+      isInString = !isInString;
+    }
+
+    if (char === '[') {
+      bracketLevel += 1;
+    } else if (char === ']') {
+      bracketLevel -= 1;
+    }
+
+    const isLastChar = i === contents.length - 1;
+    if ((char === ',' || isLastChar) && !isInString && bracketLevel === 0) {
+      const endIndex = isLastChar ? contents.length : i;
+      parsedElements.push(contents.slice(startIndex, endIndex).trim());
+      startIndex = i + 1;
+    }
+  }
+
+  return parsedElements.map((element) => {
+    const elementType = type.slice(0, -2);
+
+    if (elementType.endsWith('[]')) {
+      return getArrayFromString(element, elementType);
+    }
+    return element;
+  });
+};
+
 export const encodeArbitraryTransactions = (
   transactions: AddTransactionTableModel[],
 ) => {
@@ -13,7 +63,7 @@ export const encodeArbitraryTransactions = (
       item.method,
       item.args?.map((arg) => {
         if (arg.type.endsWith('[]')) {
-          return JSON.parse(arg.value);
+          return getArrayFromString(arg.value, arg.type);
         }
         return arg.value;
       }),

--- a/src/utils/arbitraryTxs.ts
+++ b/src/utils/arbitraryTxs.ts
@@ -11,6 +11,14 @@ const getFunctionSignature = (encodedFunction: string) => {
     : `0x${encodedFunction.slice(0, 8)}`;
 };
 
+const parseValue = (value: any) => {
+  if (Array.isArray(value)) {
+    return `[${value.map((element) => parseValue(element)).join(', ')}]`;
+  }
+
+  return value.toString();
+};
+
 export const decodeArbitraryTransaction = (
   jsonAbi: string,
   encodedFunction: string,
@@ -31,7 +39,7 @@ export const decodeArbitraryTransaction = (
       method: functionFragment.name,
       args: decodedArgs.map((arg, index) => ({
         name: functionArgs[index].name,
-        value: arg.toString(),
+        value: parseValue(arg),
         type: functionArgs[index].type,
       })),
     };


### PR DESCRIPTION
## Description

This PR fixes an issue with array encoding when creating arbitrary transactions. The cause of the issue was passing a string representation of an array (e.g. `"[]"`) instead of a "first-class" JS array.

It also improves the decoding of array arguments when showing a completed action.

## Testing

To ensure thorough coverage, we'll deploy a test contract that has a function with nearly all possible argument types.

### Deploying test contract

1. Ensure your dev env is fully running.
2. Create a new file called `TestContract.sol` in your CDapp root directory with the following contents:
```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.0;

contract TestContract {
    function testFunction(
        uint256 uint256Arg,
        uint256[] memory uint256ArrayArg,
        uint256[][] memory uint256NestedArrayArg,
        bool boolArg,
        bool[] memory boolArrayArg,
        address addressArg,
        address[] memory addressArrayArg,
        bytes memory bytesArg,
        bytes[] memory bytesArrayArg,
        string memory stringArg,
        string[] memory stringArrayArg
    ) public {}
}
```
3. Run the following in your terminal to copy the contract over to the network container and compile it:
```bash
docker cp TestContract.sol network:/colonyCDappBackend/colonyNetwork/contracts && docker exec -it -w /colonyCDappBackend/colonyNetwork network npx hardhat compile
```
4. Start the hardhat console with `npm run hardhat`, then run the following code line-by-line:
```js
cf = await ethers.getContractFactory('TestContract')
c = await cf.deploy()
c.address
```
The last expression will print the address of the newly deployed contract. Copy it for later use.

### Testing arbitrary transactions

1. Create new arbitrary transaction action.
2. In the modal, paste the deployed contract address and the following JSON ABI:
```json
[
  {
    "inputs": [
      {
        "internalType": "uint256",
        "name": "uint256Arg",
        "type": "uint256"
      },
      {
        "internalType": "uint256[]",
        "name": "uint256ArrayArg",
        "type": "uint256[]"
      },
      {
        "internalType": "uint256[][]",
        "name": "uint256NestedArrayArg",
        "type": "uint256[][]"
      },
      {
        "internalType": "bool",
        "name": "boolArg",
        "type": "bool"
      },
      {
        "internalType": "bool[]",
        "name": "boolArrayArg",
        "type": "bool[]"
      },
      {
        "internalType": "address",
        "name": "addressArg",
        "type": "address"
      },
      {
        "internalType": "address[]",
        "name": "addressArrayArg",
        "type": "address[]"
      },
      {
        "internalType": "bytes",
        "name": "bytesArg",
        "type": "bytes"
      },
      {
        "internalType": "bytes[]",
        "name": "bytesArrayArg",
        "type": "bytes[]"
      },
      {
        "internalType": "string",
        "name": "stringArg",
        "type": "string"
      },
      {
        "internalType": "string[]",
        "name": "stringArrayArg",
        "type": "string[]"
      }
    ],
    "name": "testFunction",
    "outputs": [],
    "stateMutability": "nonpayable",
    "type": "function"
  }
]
```

3. Select `testFunction` from the dropdown, and fill the fields with correct values according to their type. For example:
- uint256Arg: `123456789`
- uint256ArrayArg: `[123, 456, 789]`
- uint256NestedArrayArg: `[[1, 2], [3, 4, 5]]`
- boolArg: `true`
- boolArrayArg: `[true, false, true]`
- addressArg: `0x742d35Cc6634C0532925a3b844Bc454e4438f44e`
- addressArrayArg: `[0x742d35Cc6634C0532925a3b844Bc454e4438f44e, 0x5B38Da6a701c568545dCfcB03FcB875f56beddC4]`
- bytesArg: `0xFF`
- bytesArrayArg: `[0xFF, 0xAA]`
- stringArg: `Hello World`
- stringArrayArg: `["Hello", "World", "Blockchain"]`

4. Submit the form. The transaction should go through and you should see the decoded arguments in the temporary completed action view.

5. Repeat the steps using reputation or multi-sig decision method (both use the same code).


<img width="1080" alt="image" src="https://github.com/user-attachments/assets/4ecfe3e7-e9eb-4cc2-85d8-77ef4a0abc5d" />


Resolves #4124 
