### PR TITLE
Fix: Manage verified members member selection dropdown issues

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/NonVerifiedMembersSelect/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/NonVerifiedMembersSelect/hooks.ts
@@ -1,47 +1,12 @@
 import { useMemberContext } from '~context/MemberContext/MemberContext.ts';
-import { splitAddress } from '~utils/strings.ts';
-import { type SearchSelectOption } from '~v5/shared/SearchSelect/types.ts';
+import { formatMembersSelectOptions } from '~v5/common/ActionSidebar/utils.ts';
 
 export const useNonVerifiedMembersSelect = () => {
   const { totalMembers } = useMemberContext();
 
-  const options = totalMembers.reduce<SearchSelectOption[]>(
-    (result, member) => {
-      if (member.isVerified) {
-        return result;
-      }
-
-      const { walletAddress, profile } = member.user || {};
-
-      const splittedWalletAddress =
-        walletAddress && splitAddress(walletAddress);
-      const maskedWalletAddress =
-        splittedWalletAddress &&
-        `${splittedWalletAddress.header}${splittedWalletAddress.start}...${splittedWalletAddress.end}`;
-
-      const splittedContributorAddress = splitAddress(
-        member.contributorAddress,
-      );
-      const maskedContributorAddress = `${splittedContributorAddress.header}${splittedContributorAddress.start}...${splittedContributorAddress.end}`;
-
-      return [
-        ...result,
-        {
-          value: walletAddress || '',
-          isVerified: false,
-          label:
-            profile?.displayName ||
-            (walletAddress && maskedWalletAddress) ||
-            maskedContributorAddress,
-          avatar: profile?.thumbnail || profile?.avatar || undefined,
-          id: result.length,
-          showAvatar: true,
-          walletAddress,
-          profile,
-        },
-      ];
-    },
-    [],
+  const options = formatMembersSelectOptions(
+    totalMembers.filter((member) => !member.isVerified),
+    false,
   );
 
   return {

--- a/src/components/v5/common/ActionSidebar/partials/VerifiedMembersSelect/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/VerifiedMembersSelect/hooks.ts
@@ -1,44 +1,10 @@
 import { useMemberContext } from '~context/MemberContext/MemberContext.ts';
-import { splitAddress } from '~utils/strings.ts';
-import { type SearchSelectOption } from '~v5/shared/SearchSelect/types.ts';
+import { formatMembersSelectOptions } from '~v5/common/ActionSidebar/utils.ts';
 
 export const useVerifiedMembersSelect = () => {
   const { verifiedMembers } = useMemberContext();
 
-  const options = verifiedMembers.reduce<SearchSelectOption[]>(
-    (result, member) => {
-      const { walletAddress, profile } = member.user || {};
-
-      const splittedWalletAddress =
-        walletAddress && splitAddress(walletAddress);
-      const maskedWalletAddress =
-        splittedWalletAddress &&
-        `${splittedWalletAddress.header}${splittedWalletAddress.start}...${splittedWalletAddress.end}`;
-
-      const splittedContributorAddress = splitAddress(
-        member.contributorAddress,
-      );
-      const maskedContributorAddress = `${splittedContributorAddress.header}${splittedContributorAddress.start}...${splittedContributorAddress.end}`;
-
-      return [
-        ...result,
-        {
-          value: walletAddress || '',
-          isVerified: true,
-          label:
-            profile?.displayName ||
-            (walletAddress && maskedWalletAddress) ||
-            maskedContributorAddress,
-          avatar: profile?.thumbnail || profile?.avatar || undefined,
-          id: result.length,
-          profile,
-          showAvatar: true,
-          walletAddress,
-        },
-      ];
-    },
-    [],
-  );
+  const options = formatMembersSelectOptions(verifiedMembers);
 
   return {
     usersOptions: {


### PR DESCRIPTION
## Description

This PR aims to solve multiple issues encountered with the member select dropdown:
- Same blockies shown for different user addresses
- Searching wrongly matches other addresses as well

These two issues were caused by the fact that on `prod` there were contributors in the list having the user set to `null`, thus the `walletAddress` and `value` for a member option were not set/set to an empty string. Given there was no avatar to be shown and the wallet address was not existing, the same blockie was displayed. Also, given the option `value` was empty, upon searching, given the React list `key` was set to an empty value, these items were not reliably unmounted.

The solution was to fallback to the `contributorAddress`

Regarding the other issues mentioned in #3164
- The members table pagination issues were solved in a different PR
- Could not reproduce "User avatars were not shown in the members select dropdown" ❌ 

## Testing

TODO: Let's try to test these changes solve the above mentioned issues.

* Step 1. Make sure your dev env is running and has fresh data 🥗
* Step 2. Now copy these changes into a `.diff` file
```
diff --git a/src/context/MemberContext/MemberContextProvider.tsx b/src/context/MemberContext/MemberContextProvider.tsx
index bac39ad89..3d8818880 100644
--- a/src/context/MemberContext/MemberContextProvider.tsx
+++ b/src/context/MemberContext/MemberContextProvider.tsx
@@ -194,8 +194,43 @@ const MemberContextProvider: FC<PropsWithChildren> = ({ children }) => {
   }, [newColonyContributorUpdate, newColonyUpdate, refetchColonyContributors]);
 
   const allMembers = useMemo(
-    () =>
-      memberSearchData?.searchColonyContributors?.items.filter(notNull) || [],
+    () => [
+      ...(memberSearchData?.searchColonyContributors?.items.filter(notNull) ||
+        []),
+      ...[
+        {
+          contributorAddress: '0x700000fE834D15647F7292cC15bb515D0136A923',
+          isVerified: true,
+          user: null,
+        },
+        {
+          contributorAddress: '0x7bc87Bf1230015647F7292cC85aA515D0136A911',
+          isVerified: true,
+          user: null,
+        },
+        {
+          contributorAddress: '0x7bc11BfE834D15647F7292cC15bb515D0136A923',
+          user: null,
+        },
+        {
+          contributorAddress: '0x7bc87BfE830015647F7292cC85aA515D0136A911',
+          user: null,
+        },
+        {
+          contributorAddress: '0x1bc87BfE834D15647F7292cC85aA515D0136A914',
+          user: null,
+        },
+        {
+          contributorAddress: '0x1bc87BfE834D15647F72111C85aA515D0136A914',
+          user: {
+            profile: {
+              avatar:
+                'http://xsgames.co/randomusers/assets/avatars/female/20.jpg',
+            },
+          },
+        },
+      ],
+    ],
     [memberSearchData],
   );
 

```
* Step 3. Run `git apply .diff`
* Step 4. Now create a `Manage verified members` action
* Step 5. Select `Add members` 
* Step 6. Click on the `Add member` in the table and make sure the member select shows 4 more entries, 3 of which should have different blockies and one with an avatar
![Screenshot 2025-01-16 at 16 46 57](https://github.com/user-attachments/assets/c70906b6-2499-4983-a736-8ee9dc98ba47)
* Step 7. Try searching for  `0x1bc87BfE834D15647F7292cC85aA515D0136A914`. You should get a single result in the list
![Screenshot 2025-01-16 at 16 49 24](https://github.com/user-attachments/assets/e1abe70d-645c-42a9-b4ef-c5474b8c72ae)
* Step 8. Try searching for a term like `ra`
![Screenshot 2025-01-16 at 16 50 38](https://github.com/user-attachments/assets/9d438236-fba3-4912-880b-cbc440613666)
> [!NOTE]
> Keep in mind the search will be performed both against the visible label and the actual wallet address/contributor address
* Step 9. This step is more to confirm the pagination is no longer displayed, so please select `> 10 members` 
The pagination should not show up
![Screenshot 2025-01-16 at 16 53 13](https://github.com/user-attachments/assets/da086f17-222f-4419-9ddb-e8e2b522d5da)

### Further testing
You can further test this, by selecting the `Remove members` operation. There should be 2 additional entries. Perform the same checks as before regarding the blockies and searching.
![Screenshot 2025-01-16 at 16 55 35](https://github.com/user-attachments/assets/cfd57529-ef9b-435b-a855-bce29a452086)


## Diffs

**New stuff** ✨

* `formatMembersSelectOptions` util

**Changes** 🏗

* Fallback to `member.contributorAddress` for the member dropdown option `value` and `walletAddress`

Resolves #3164
