### PR TITLE
Fix: Userhub transactions and notifications should not clear team

### DIFF
--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/ActionNotification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Action/ActionNotification.tsx
@@ -12,6 +12,7 @@ import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
 import { TX_SEARCH_PARAM } from '~routes';
 import { type Notification as NotificationInterface } from '~types/notifications.ts';
 import { formatText } from '~utils/intl.ts';
+import { setQueryParamOnUrl } from '~utils/urls.ts';
 
 import NotificationWrapper from '../NotificationWrapper.tsx';
 
@@ -64,9 +65,17 @@ const ActionNotification: FC<NotificationProps> = ({
       ? window.location.pathname
       : `/${colony?.name}`;
 
-    navigate(`${path}?${TX_SEARCH_PARAM}=${transactionHash}`, {
-      replace: true,
-    });
+    navigate(
+      setQueryParamOnUrl({
+        path,
+        params: {
+          [TX_SEARCH_PARAM]: transactionHash,
+        },
+      }),
+      {
+        replace: true,
+      },
+    );
   };
 
   const titleValues = useGetActionTitleValues({

--- a/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureNotification.tsx
+++ b/src/components/common/Extensions/UserHub/partials/NotificationsTab/partials/Notification/Expenditure/ExpenditureNotification.tsx
@@ -14,6 +14,7 @@ import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
 import { TX_SEARCH_PARAM } from '~routes';
 import { type Notification as NotificationInterface } from '~types/notifications.ts';
 import { formatText } from '~utils/intl.ts';
+import { setQueryParamOnUrl } from '~utils/urls.ts';
 
 import { MentionNotificationMessage } from '../Action/MentionNotificationMessage.tsx';
 import NotificationWrapper from '../NotificationWrapper.tsx';
@@ -147,9 +148,17 @@ const ExpenditureNotification: FC<NotificationProps> = ({
       ? window.location.pathname
       : `/${colony?.name}`;
 
-    navigate(`${path}?${TX_SEARCH_PARAM}=${transactionHash}`, {
-      replace: true,
-    });
+    navigate(
+      setQueryParamOnUrl({
+        path,
+        params: {
+          [TX_SEARCH_PARAM]: transactionHash,
+        },
+      }),
+      {
+        replace: true,
+      },
+    );
   };
 
   const actionTitle = action?.metadata?.customTitle || '';

--- a/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransaction.tsx
+++ b/src/components/common/Extensions/UserHub/partials/TransactionsTab/partials/GroupedTransaction.tsx
@@ -28,6 +28,7 @@ import { TRANSACTION_METHODS } from '~types/transactions.ts';
 import { arrayToObject } from '~utils/arrays/index.ts';
 import { getFormattedDateFrom } from '~utils/getFormattedDateFrom.ts';
 import { formatText } from '~utils/intl.ts';
+import { setQueryParamOnUrl } from '~utils/urls.ts';
 
 import { type GroupedTransactionProps } from '../types.ts';
 
@@ -148,7 +149,12 @@ const GroupedTransaction: FC<GroupedTransactionProps> = ({
         ? window.location.pathname
         : `/${colonyName}`;
     navigate(
-      `${path}?${TX_SEARCH_PARAM}=${values.associatedActionId || values.hash}`,
+      setQueryParamOnUrl({
+        path,
+        params: {
+          [TX_SEARCH_PARAM]: values.associatedActionId || values.hash,
+        },
+      }),
       {
         replace: true,
       },


### PR DESCRIPTION
## Description

This PR fixes an issue where the selected team is cleared when opening a notification or transaction from the userhub.

## Testing

* Step 1 - Create an action which will create both a notification and a transaction.
* Step 2 - On the dashboard, ensure you can selected a team.
* Step 3 - Select the action notification from the userhub, it should open and keep the selected team.
* Step 4 - Close the action sidebar and confirm the team is still selected. Now select the action transaction from the userhub. It should open and keep the selected team.

https://github.com/user-attachments/assets/f58fe6c2-a77d-41b9-9c9f-f6f25f1e5b5f

## Diffs

**Changes** 🏗

* Notification items now use `setQueryParamOnUrl` to use the transaction hash
* Grouped transactions now use `setQueryParamOnUrl` to use the transaction hash

Resolves #3879
Resolves #3880