### PR TITLE
Fix: Motion to release a staked payment gets stuck on pending

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizePaymentModal/FinalizePaymentModal.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/FinalizePaymentModal/FinalizePaymentModal.tsx
@@ -110,7 +110,9 @@ const FinalizePaymentModal: FC<FinalizePaymentModalProps> = ({
           nativeExpenditureId: expenditure.nativeId,
         };
 
-        await reclaimExpenditureStake(payload);
+        if (decisionMethod.value === DecisionMethod.Permissions) {
+          await reclaimExpenditureStake(payload);
+        }
       }
 
       onSuccess(decisionMethod);


### PR DESCRIPTION
## Description

This PR fixes an issue spotted by @rumzledz where users creating a motion to release a staked advanced payment would see the submit button stuck on Pending infinitely. This was because the UI would try to reclaim expenditure stake no matter the decision method used to release. In case of motions, this can only happen once the motion has been finalized, not at its creation.

## Testing

1. Install and enable Voting Reputation extension.
2. Create an advanced payment using Staking decision method.
3. Advance the payment to the release step.
4. In the release payment modal, select Reputation decision method and submit.

The modal should close as soon as the motion to release gets created.

