### PR TITLE
Fix: Display persisted draft agreement

### DIFF
--- a/src/components/frame/v5/pages/AgreementsPage/AgreementsPage.tsx
+++ b/src/components/frame/v5/pages/AgreementsPage/AgreementsPage.tsx
@@ -1,13 +1,14 @@
 import { Binoculars, FilePlus } from '@phosphor-icons/react';
 import { motion } from 'framer-motion';
 import React, { type FC } from 'react';
+import { useSelector } from 'react-redux';
 
 import { Action } from '~constants/actions.ts';
 import { useActionSidebarContext } from '~context/ActionSidebarContext/ActionSidebarContext.ts';
 import { useAppContext } from '~context/AppContext/AppContext.ts';
 import { useColonyContext } from '~context/ColonyContext/ColonyContext.ts';
 import { useSetPageHeadingTitle } from '~context/PageHeadingContext/PageHeadingContext.ts';
-import { getDraftDecisionFromLocalStorage } from '~utils/decisions.ts';
+import { getDraftDecisionFromStore } from '~utils/decisions.ts';
 import { formatText } from '~utils/intl.ts';
 import { ACTION_TYPE_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 import EmptyContent from '~v5/common/EmptyContent/EmptyContent.tsx';
@@ -42,9 +43,8 @@ const AgreementsPage: FC = () => {
     !!activeFilters.motionStates ||
     !!activeFilters.search;
 
-  const draftAgreement = getDraftDecisionFromLocalStorage(
-    user?.walletAddress || '',
-    colonyAddress,
+  const draftAgreement = useSelector(
+    getDraftDecisionFromStore(user?.walletAddress || '', colonyAddress),
   );
 
   const passedAgreements = searchedAgreements.filter(

--- a/src/components/v5/common/ActionSidebar/consts.ts
+++ b/src/components/v5/common/ActionSidebar/consts.ts
@@ -9,6 +9,8 @@ import { formatText } from '~utils/intl.ts';
 
 import { reputationValidationSchema } from './hooks/useReputationValidation.ts';
 
+export { REPUTATION_VALIDATION_FIELD_NAME } from './hooks/useReputationValidation.ts';
+
 export const ACTION_TYPE_FIELD_NAME = 'actionType';
 export const DECISION_METHOD_FIELD_NAME = 'decisionMethod';
 export const TITLE_FIELD_NAME = 'title';

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarContent/hooks.ts
@@ -2,7 +2,7 @@ import { useFormContext } from 'react-hook-form';
 
 import useFlatFormErrors from '~hooks/useFlatFormErrors.ts';
 import { uniqBy } from '~utils/lodash.ts';
-import { REPUTATION_VALIDATION_FIELD_NAME } from '~v5/common/ActionSidebar/hooks/useReputationValidation.ts';
+import { REPUTATION_VALIDATION_FIELD_NAME } from '~v5/common/ActionSidebar/consts.ts';
 
 export const useGetFormActionErrors = () => {
   const {


### PR DESCRIPTION
## Description

- This PR addresses the fact that the draft agreement is not always showing up upon saving due to being fetched on the `Agreements` page directly from local storage. However, given the component might not re-render, the draft agreement wouldn't always be rendered. The solution was to make use of `Redux` store which already saves this value and re-populates the store with the values persisted in the local storage on page refresh.
- Also there was a validation error regarding the missing reputation when creating a new colony. Given the `Save draft` is of `type=button` and not `type=submit`, the error message was not showing up, but neither was the draft saved. In this case, the solution was to check if among the form errors there is only the `isMissingReputation`, in which case the draft can still be saved.

> [!NOTE]
> In the initial issue it was thought it has to do with the `Reputation` **extension version**, but the draft was saved in the local storage and only a few attempts it did appear on the `Agreements` page.
> [Check recording here](https://github.com/user-attachments/assets/3b5515bd-68cd-44c2-9506-ae89eddc867a)

> [!IMPORTANT]
> If you do however want to test this with a lower version of the `Reputation` extension (eg. `v11`), give me a sign and I'll provide more guidance until I'll update the `Notion` page - bit shoutout to @area on this 🙏 and to @iamsamgibbs for guiding me to the `Redux` store

## Testing

TODO: Let's test we can actually save a draft agreement and it will appear in the `Agreements` page without issues. 

* Step 1. Make sure to start a clean env
* Step 2. Install the `Reputation` extension
* Step 3. Now go to http://localhost:9091/planex/agreements
* Step 4. Create a few agreements
![Screenshot 2025-01-20 at 21 45 59](https://github.com/user-attachments/assets/2fde6ffd-c858-422b-85cb-0f537e8fbcc2)
* Step 5. Now let us create another agreement, but instead of `Create agreement`, click `Save draft`.

https://github.com/user-attachments/assets/bd005893-a50e-413b-97d8-026f26ddfa38

It should be rendered and you can see the entry in the local storage. Try to edit it, close it, delete it, create another one etc.

* Step 6. Now for the other issue I have discovered, please generate a new colony url
`node scripts/create-colony-url.js`
* Step 7. Go through the entire colony creation flow.
* Step 8. Install the `Reputation` extension
* Step 9. Now please click on the `Create a new agreement` from the side navigation (alternatively you can go to the `Agrements` page as before, it doesn't really matter)
* Step 10. Fill in all the missing fields and click `Create agreement`.
* Step 11. The `No reputation` warning should be shown
* Step 12. Now click on the `Save draft`. The draft should be saved without errors.
* Step 13. If you remove the `Title` or `Description`, clicking on the `Save draft` should show an error and the draft should not be updated

https://github.com/user-attachments/assets/597cab52-6bcd-4917-a9d0-87b2275aca18



**If you have more testing ideas in mind, do not hesitate to try them out**

## Diffs

**Changes** 🏗

* Replace `getDraftDecisionFromLocalStorage` with `useSelector(getDraftDecisionFromStore(...))` for the `draftAgreement` 
* In `SaveDraftButton` the `onClick` handler checks if the form is valid or there is only the missing reputation error before saving the draft agreement

Resolves #3826
