### PR TITLE
Account for Metamask not supporting the `eth_maxPriorityFeePerGas` call

### DIFF
--- a/src/redux/sagas/transactions/estimateGasCost.ts
+++ b/src/redux/sagas/transactions/estimateGasCost.ts
@@ -88,10 +88,10 @@ export default function* estimateGasCost({
           },
         }),
       );
-    }
 
-    // wait for transactions options to be updated
-    yield take(ActionTypes.TRANSACTION_UPDATED_IN_DB);
+      // wait for transactions options to be updated
+      yield take(ActionTypes.TRANSACTION_UPDATED_IN_DB);
+    }
 
     yield put(transactionSend(id));
   } catch (error) {


### PR DESCRIPTION
This issue came about after the introduction of #4123 which, while technically correct, runs into the a problem with Metamask, and more specifically Metamask's provider.

Even while running a manually set RPC endpoint which can be confirmed as supporting [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)

![Screenshot from 2025-01-21 14-47-48](https://github.com/user-attachments/assets/32c12888-6ced-4844-80c3-750c480c418e)

Metamask will **block the `eth_maxPriorityFeePerGas` call**

![Screenshot from 2025-01-20 17-16-48](https://github.com/user-attachments/assets/74ad7f01-9bbe-47ea-ac96-a11a6075e6c4)

While waiting to see if this ever gets resolved _(see this PR MetaMask/metamask-extension#29818 by our very own @area)_ we are accounting for it by setting it to zero (`0`).

This means that the transaction sender will not pay anything extra, besides the required gas fee, for their transaction to be mined.

This works great on Arbitrum, Arbitrum Sepolia since they make user of a Sequencer, however, on something like Mainnet this won't work, and we'll need to find another way around it

More reading: https://docs.arbitrum.io/learn-more/faq#do-i-need-to-pay-a-tip-or-priority-fee-for-my-arbitrum-transactions

![Screenshot from 2025-01-21 14-56-38](https://github.com/user-attachments/assets/72882ff6-5430-4125-b31e-bf6f8454011d)

![Screenshot from 2025-01-21 14-58-31](https://github.com/user-attachments/assets/ebb41d1c-92cb-49ce-9643-140b3be2f08c)

## Additional Fix

This issue actually highlighted a bug inside the `estimateGasCost` saga, where, if `maxFeePerGas` and `maxPriorityFeePerGas` were not available, we would skip updating the transaction's `options` object, however we would wait for said object to _finish_ updating which could never actually succeed.

I have fixed that as well, by moving the `take` call, which waits for the next `TRANSACTION_UPDATED_IN_DB` action, inside the logic check block.

## Testing

1. Run the dev environment: `npm run dev`
2. Create demo data: `node scripts/create-data.js`
3. Run the frontend: `npm run frontend`
4. Ensure you connect your Metamask wallet, and not your Dev wallet, and ensure you use one of the first 3 Dev wallets addresses with Metamask _(If you don't have them added, you can get them here:  http://localhost:3006/ganache-accounts.json)_
5. Go to the `planex` colony
6. Ensure you see the Metamask / gas estimator warnings _(which mean it couldn't make the `eth_maxPriorityFeePerGas` call)_ ![Screenshot from 2025-01-21 15-08-14](https://github.com/user-attachments/assets/a005841a-43c2-4746-b625-46aedd10275f)
7. Ensure you see the Gas Debug Log with the `maxPriorityFeePerGas` set to `0` ![Screenshot from 2025-01-21 14-56-38](https://github.com/user-attachments/assets/72882ff6-5430-4125-b31e-bf6f8454011d)
8. Send a transaction _(can be anything, payment, mint, extensions, etc)_
9. Ensure your TX Debug Log has the `overrides` correctly set, and inside the `overrides` you have your `maxPriorityFeePerGas` value set to `0`

_Note: that this can also be tested live on QA_

## Thanks

Special thanks to @area for actually looking into Metamask's codebase and providing a stop gas solution, as well as raising a PR with Metamask

Resolves #4147 