### PR TITLE
Use debug logging for CoinGecko token price requests

### DIFF
--- a/src/utils/currency/tokenPriceByAddress.ts
+++ b/src/utils/currency/tokenPriceByAddress.ts
@@ -1,5 +1,6 @@
 import { SupportedCurrencies } from '~gql';
 import { Network } from '~types/network.ts';
+import debugLogging from '~utils/debug/debugLogging.ts';
 
 import { currencyApiConfig, coinGeckoMappings } from './config.ts';
 import {
@@ -41,8 +42,8 @@ const extractAddressPriceFromResponse = (
       mapToAPIFormat(currencies, conversionDenomination)
     ];
   } catch (e) {
-    console.error(
-      'Could not get contract price from CoinGecko response. Response shape might have changed.',
+    debugLogging(
+      'CoinGecko: Could not get contract price from response. Response shape might have changed.',
       e,
     );
     return 0;
@@ -89,8 +90,8 @@ export const fetchTokenPriceByAddress = async ({
         );
       }
 
-      console.error(
-        `Unable to get price for ${contractAddress}. It probably doesn't have a listed exchange value.`,
+      debugLogging(
+        `CoinGecko: Unable to get price for ${contractAddress}. It probably doesn't have a listed exchange value.`,
       );
       return 0;
     });

--- a/src/utils/currency/tokenPriceByName.ts
+++ b/src/utils/currency/tokenPriceByName.ts
@@ -1,4 +1,5 @@
 import { SupportedCurrencies } from '~gql';
+import debugLogging from '~utils/debug/debugLogging.ts';
 
 import { currencyApiConfig, coinGeckoMappings } from './config.ts';
 import {
@@ -36,8 +37,8 @@ const extractTokenPriceFromResponse = (
       mapToAPIFormat(currencies, conversionDenomination)
     ];
   } catch (e) {
-    console.error(
-      'Could not get token price from CoinGecko response. Response shape might have changed.',
+    debugLogging(
+      'CoinGecko: Could not get token price from response. Response shape might have changed.',
       e,
     );
     return 0;
@@ -80,14 +81,14 @@ export const fetchTokenPriceByName = async ({
         );
       }
 
-      console.error(
-        `Unable to get price for ${tokenName}. It probably doesn't have a listed exchange value.`,
+      debugLogging(
+        `CoinGecko: Unable to get price for ${tokenName}. It probably doesn't have a listed exchange value.`,
       );
       return 0;
     });
   } catch (e) {
     if (import.meta.env.DEV) {
-      console.error(e);
+      debugLogging(e);
     }
     return 0;
   }

--- a/src/utils/currency/tokenPriceDataByName.ts
+++ b/src/utils/currency/tokenPriceDataByName.ts
@@ -1,6 +1,7 @@
 import fromUnixTime from 'date-fns/fromUnixTime';
 
 import { SupportedCurrencies } from '~gql';
+import debugLogging from '~utils/debug/debugLogging.ts';
 
 import { currencyApiConfig, coinGeckoMappings } from './config.ts';
 import {
@@ -51,8 +52,8 @@ const extractTokenPriceDataFromResponse = (
       lastUpdatedAt: fromUnixTime(tokenData.last_updated_at),
     };
   } catch (e) {
-    console.error(
-      'Could not get token price from CoinGecko response. Response shape might have changed.',
+    debugLogging(
+      'CoinGecko: Could not get token price from response. Response shape might have changed.',
       e,
     );
     return fallbackResponseData;
@@ -95,14 +96,14 @@ export const fetchTokenPriceDataByName = async ({
         );
       }
 
-      console.error(
-        `Unable to get price for ${tokenName}. It probably doesn't have a listed exchange value.`,
+      debugLogging(
+        `CoinGecko: Unable to get price for ${tokenName}. It probably doesn't have a listed exchange value.`,
       );
       return fallbackResponseData;
     });
   } catch (e) {
     if (!import.meta.env.DEV) {
-      console.error(e);
+      debugLogging(e);
     }
     return fallbackResponseData;
   }


### PR DESCRIPTION
This PR is here because of my recent quest to make the console output of the CDapp cleaner, by "hiding" all the relevant messages that we show behind `debugLogging` call.

This has the benefit of being hidden by default in production, while still allowing us to investigate any errors that might show up, once we manually enable it

This time it is the output from all the CoinGecko calls make to fetch the various exchange rates.

For the most part, most tokens colonies will interact with, especially native ones, will not in fact have an exchange rate, so the console output will be needlessly spammed with these fetch errors

All I've done here is to clean that up a bit by logging the errors out via the debug logging util.

Here's how it used to look:
![Screenshot from 2025-01-21 17-51-28](https://github.com/user-attachments/assets/9032a0ed-e5f7-4d4f-8aba-a0bed1e5bc2c)

And here is how it looks now, if you turn on debug logging:
![Screenshot from 2025-01-21 17-50-55](https://github.com/user-attachments/assets/f62caf2d-51a0-410b-b888-463b48183af8)

If you disagree with this change, and this it is better served as an error instead, I am open to feedback.

### Testing on QA

This is easier to test on QA than locally, so I'll list these instructions first _(you can test either, don't have to bother with both)_

1. Go to QA
2. Go to a colony _(try `rc` if you don't have one handy)_
3. Open your dev tools
4. Go to the balances page
5. Notice there should be no output regarding CoinGecko
6. Enable debug logging _(if you don't know how, ask me)_
7. Refresh the page, and go back to the balances page
8. Notice that you'll now have a output similar to this: ![Screenshot from 2025-01-21 17-50-55](https://github.com/user-attachments/assets/f62caf2d-51a0-410b-b888-463b48183af8)

### Testing Locally

As I've said above, testing locally is a tad more involved, as you have to overcome both Coingecko being available, as well as the code that prevents CoinGecko calls locally

1. Run the dev environment: `npm run dev`
2. Create demo data: `node scripts/create-data.js`
3. Ensure you have values for `COINGECKO_API_URL` and `COINGECKO_API_KEY` in your `.env.local.secrets` file _(and that you have ran `npm run prepare` after)_
4. Run the frontend: `npm run frontend`
5. Go to the `planex` colony
6. Go to the balances page http://localhost:9091/planex/balances
7. Notice there's no output relate to CoinGecko _(however, this is a bit of a trick)_
8. In your code editor, open the `src/utils/currency/currency.ts` file and comment out line `79` ![Screenshot from 2025-01-21 18-00-53](https://github.com/user-attachments/assets/06e7db3d-2cf0-4c0c-8ad0-e611da9ba576)
9. Refresh your browser page
11. Go back to `planex` and the balances page
12. Notice that you have similar output to this in your console ![Screenshot from 2025-01-21 17-50-55](https://github.com/user-attachments/assets/f62caf2d-51a0-410b-b888-463b48183af8)

**Optional:**

Optionally, you can check out the comparison on how this looked before:
13. Keep the code changes you have
14. Roll back one commit back `git checkout HEAD~1`
15. Go back to `planex` and the balances page
16. Check out the output in your console log that should be similar to this ![Screenshot from 2025-01-21 17-51-28](https://github.com/user-attachments/assets/9032a0ed-e5f7-4d4f-8aba-a0bed1e5bc2c)