### PR TITLE
Fix: Open empty action sidebar on back navigation

### DIFF
--- a/src/components/common/ColonyActionsTable/hooks/useGetMenuProps.tsx
+++ b/src/components/common/ColonyActionsTable/hooks/useGetMenuProps.tsx
@@ -18,6 +18,7 @@ import {
 } from '~routes';
 import TransactionLink from '~shared/TransactionLink/index.ts';
 import { formatText } from '~utils/intl.ts';
+import { setQueryParamOnUrl } from '~utils/urls.ts';
 import { type MeatBallMenuProps } from '~v5/shared/MeatBallMenu/types.ts';
 
 import MeatballMenuCopyItem from '../partials/MeatballMenuCopyItem/index.ts';
@@ -59,7 +60,9 @@ export const useGetMenuProps = ({
           icon: FilePlus,
           onClick: () => {
             navigate(
-              `${window.location.pathname}?${TX_SEARCH_PARAM}=${transactionHash}`,
+              setQueryParamOnUrl({
+                params: { [TX_SEARCH_PARAM]: transactionHash },
+              }),
             );
           },
         },

--- a/src/context/ActionSidebarContext/ActionSidebarContextProvider.tsx
+++ b/src/context/ActionSidebarContext/ActionSidebarContextProvider.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { type FieldValues } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useTablet } from '~hooks';
 import useGetSelectedDomainFilter from '~hooks/useGetSelectedDomainFilter.tsx';
@@ -62,10 +62,15 @@ const ActionSidebarContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const selectedDomain = useGetSelectedDomainFilter();
   const selectedDomainNativeId = selectedDomain?.nativeId ?? '';
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const transactionId = searchParams?.get(TX_SEARCH_PARAM);
 
   const removeTxParamOnClose = useCallback(() => {
-    navigate(removeQueryParamFromUrl(window.location.href, TX_SEARCH_PARAM));
-  }, [navigate]);
+    // Remove the TX_SEARCH_PARAM search param only if it is present
+    if (transactionId) {
+      navigate(removeQueryParamFromUrl(window.location.href, TX_SEARCH_PARAM));
+    }
+  }, [navigate, transactionId]);
 
   actionSidebarUseRegisterOnBeforeCloseCallback((element) => {
     const isClickedInside = isElementInsideModalOrPortal(element);

--- a/src/hooks/useLocationKeyChange.ts
+++ b/src/hooks/useLocationKeyChange.ts
@@ -1,13 +1,13 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
-const useLocationPathnameChange = (callback: VoidFunction) => {
+const useLocationKeyChange = (callback: VoidFunction) => {
   const location = useLocation();
   useEffect(() => {
     callback();
-    // We want to react only to location pathname changes
+    // We want to react only to location key changes, as in when the location history changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location.pathname]);
+  }, [location.key]);
 };
 
-export default useLocationPathnameChange;
+export default useLocationKeyChange;


### PR DESCRIPTION
Fix: Open empty action sidebar on back navigation

## Description

- The original issue stated the `Redo action` opens an empty action sidebar, even though this is no longer reproducible.

https://github.com/user-attachments/assets/10c051d0-35dd-4a05-9811-217f5f345ec2

- However there was an issue when opening a completed action, followed by the action sidebar back button and then using the browser back button a couple of time that would trigger the empty action sidebar being shown.

https://github.com/user-attachments/assets/42a3dac9-2982-47fd-a3e3-37950deecb5b

This was mainly caused by the fact that on back navigation, if the action sidebar was opened, we didn't react to the absence of a `txHash` and `actionType`. So my solution involved listening to location key changes (the `key` should update once the navigation history updates) and if there is no `txHash` and `actionType` present, to close the action sidebar. 
Additionally, we were mutating the history state needlessly by always performing a navigation without the `txHash` upon closing the action sidebar, even if there was no `txHash` set, so I have fixed that.

> [!IMPORTANT]
> If you do find a better solution or approach, please do reach out

**On this branch**

https://github.com/user-attachments/assets/71a1d0a5-53cc-4562-aaf4-2a1de46a42d6


## Testing

TODO: Let's test the browser back navigation no longer opens an empty action sidebar.

* Step 1. Go to http://localhost:9091/planex
* Step 2. Open a completed action. Click on the action sidebar back button
![Screenshot 2025-01-23 at 14 06 48](https://github.com/user-attachments/assets/0432b020-6216-4ebe-bd79-19299bf7993a)
* Step 3. Now click a couple of times on the browser back button
* Step 4. Check the empty action sidebar is not present
* Step 5. Try redoing an action
* Step 6. Click again on the browser back button
* Step 7. Create a new action and complete it (eg. Mint tokens)
* Step 8. Click again on the browser back button
* Step 9. Now let's create a new colony by running the `create-colony-url` script. Complete the colony creation form.
* Step 10. On the dashboard, go to the `Recent Activity` table
![Screenshot 2025-01-23 at 14 10 50](https://github.com/user-attachments/assets/b0ee496a-06fd-4676-bc10-effa3b9f9716)
* Step 11. Click on the `Create new action` button. Check it still opens the empty action sidebar.
* Step 12. Click on the back navigation. It should redirect to the colony creation form

**Please try also whatever other scenario comes to mind.**

## Diffs

**New stuff** ✨

* `useLocationKeyChange` hook

**Changes** 🏗

* Use the `actionSidebarInitialValues?.[ACTION_TYPE_FIELD_NAME]` in the `ColonyLayout`
* Get the current `txHash` and perform the navigation on action sidebar close only if it exists in `ActionSidebarContextProvider`

Resolves #3890 
