### PR TITLE
Fix: Truncate Search Item label text

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/VerifiedMembersSelect/VerifiedMembersSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/VerifiedMembersSelect/VerifiedMembersSelect.tsx
@@ -160,7 +160,6 @@ const VerifiedMembersSelect: FC<VerifiedMembersSelectProps> = ({
                 'left-6 right-[1.9rem] w-auto': isMobile,
               })}
               showEmptyContent
-              shouldReturnAddresses
               additionalButtons={
                 isMobile && (
                   <div className="flex items-center justify-between gap-2 pt-2">

--- a/src/components/v5/shared/SearchSelect/partials/CheckboxSearchItem/CheckboxSearchItem.tsx
+++ b/src/components/v5/shared/SearchSelect/partials/CheckboxSearchItem/CheckboxSearchItem.tsx
@@ -4,6 +4,7 @@ import React, { type FC } from 'react';
 
 import { DomainColor } from '~gql';
 import { useMobile } from '~hooks/index.ts';
+import MaskedAddress from '~shared/MaskedAddress/MaskedAddress.tsx';
 import { getEnumValueFromKey } from '~utils/getEnumValueFromKey.ts';
 import { formatText } from '~utils/intl.ts';
 import { getTeamColor } from '~utils/teams.ts';
@@ -12,6 +13,8 @@ import ExtensionsStatusBadge from '~v5/common/Pills/ExtensionStatusBadge/index.t
 import { sortDisabled } from '~v5/shared/SearchSelect/utils.ts';
 import { TokenAvatar } from '~v5/shared/TokenAvatar/TokenAvatar.tsx';
 import UserAvatar from '~v5/shared/UserAvatar/index.ts';
+
+import { SearchItemLabelText } from '../SearchItemLabelText/index.tsx';
 
 import { type CheckboxSearchItemProps } from './types.ts';
 
@@ -123,13 +126,23 @@ const CheckboxSearchItem: FC<CheckboxSearchItemProps> = ({
                       size={20}
                     />
                   )}
-                  {isLabelVisible && labelText}
+
+                  {isLabelVisible && (
+                    <span className="truncate">
+                      <SearchItemLabelText labelText={labelText} />
+                    </span>
+                  )}
                   {isVerified && (
                     <span className="ml-1 flex text-blue-400">
                       <SealCheck size={14} />
                     </span>
                   )}
-                  {!label && <span className="truncate">{walletAddress}</span>}
+                  {!label && (
+                    <span className="truncate">
+                      <MaskedAddress address={walletAddress} />
+                    </span>
+                  )}
+
                   {firstDisabledOption?.value === value && (
                     <div className="absolute right-0 top-1/2 -translate-y-1/2 transform">
                       <ExtensionsStatusBadge

--- a/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
+++ b/src/components/v5/shared/SearchSelect/partials/SearchItem/SearchItem.tsx
@@ -4,6 +4,7 @@ import React, { type FC } from 'react';
 
 import { DomainColor } from '~gql';
 import { useMobile } from '~hooks/index.ts';
+import MaskedAddress from '~shared/MaskedAddress/MaskedAddress.tsx';
 import { getEnumValueFromKey } from '~utils/getEnumValueFromKey.ts';
 import { formatText } from '~utils/intl.ts';
 import { getTeamColor } from '~utils/teams.ts';
@@ -11,6 +12,8 @@ import ExtensionsStatusBadge from '~v5/common/Pills/ExtensionStatusBadge/index.t
 import { sortDisabled } from '~v5/shared/SearchSelect/utils.ts';
 import { TokenAvatar } from '~v5/shared/TokenAvatar/TokenAvatar.tsx';
 import { UserAvatar } from '~v5/shared/UserAvatar/UserAvatar.tsx';
+
+import { SearchItemLabelText } from '../SearchItemLabelText/index.tsx';
 
 import { type SearchItemProps } from './types.ts';
 
@@ -112,8 +115,12 @@ const SearchItem: FC<SearchItemProps> = ({
                       size={20}
                     />
                   )}
-                  {isLabelVisible && labelText}
-                  {!label && <span className="truncate">{walletAddress}</span>}
+                  <span className="truncate">
+                    {isLabelVisible && (
+                      <SearchItemLabelText labelText={labelText} />
+                    )}
+                    {!label && <MaskedAddress address={walletAddress} />}
+                  </span>
                   {isVerified && (
                     <CircleWavyCheck
                       size={14}

--- a/src/components/v5/shared/SearchSelect/partials/SearchItemLabelText/index.tsx
+++ b/src/components/v5/shared/SearchSelect/partials/SearchItemLabelText/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import MaskedAddress from '~shared/MaskedAddress/index.ts';
+import { isAddress } from '~utils/web3/index.ts';
+
+export const SearchItemLabelText = ({ labelText }: { labelText: string }) => {
+  const lowerCasedLabelText = labelText.toLowerCase();
+
+  return isAddress(lowerCasedLabelText) ? (
+    <MaskedAddress address={lowerCasedLabelText} />
+  ) : (
+    <>{labelText}</>
+  );
+};


### PR DESCRIPTION
## Description

Just a good ol' combination of text and address truncation.

![truncate-address](https://github.com/user-attachments/assets/1131b8af-ebd6-4379-82ae-0153d6f2e81a)

## Testing

> [!IMPORTANT]
> ### 1. Update amy's username
> 1. Open the `UserAccountPage/hooks.tsx` file and update line 31 to:
> ```js
> return { canChangeUsername: true, daysTillUsernameChange };
> ```
> 2. Connect amy's wallet
> 3. Visit your profile page: http://localhost:9091/account/profile
> 4. Update your username to: 
> ```js
> QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ
> ```
> ### 2. Add a wallet address to the list of recippients
> 1. Visit the Wayne colony: http://localhost:9091/wayne
> 2. Copy its address
> 3. Visit the Planex colony: http://localhost:9091/planex
> 4. Bring up the Manage verified members form
> 5. Add Wayne's address and submit the form

### Verifying the truncation

1. Bring up the Simple payment form
2. Bring up the recipients list popover
3. Verify that:
 - the popover doesn't have a horizontal scrollbar
 - your new username is truncated
 - Wayne's contract address conforms to our address truncation
4. Change the action type to Manage Verified Members form
5. Set the Add/remove field to Remove members
6. Click the Select members field
7. Verify that:
 - the popover doesn't have a horizontal scrollbar
 - your new username is truncated
 - Wayne's contract address conforms to our address truncation

Resolves #3679 