### PR TITLE
[Proxy colonies M1] Feat: Fetch available chains from DB and update SUPPORTED_CHAINS config

### DIFF
--- a/amplify/backend/api/colonycdapp/schema/proxyColonies.graphql
+++ b/amplify/backend/api/colonycdapp/schema/proxyColonies.graphql
@@ -22,3 +22,14 @@ type ProxyColony @model {
   """
   isActive: Boolean!
 }
+
+type SupportedChain @model {
+  """
+  The chainId of the supported chain
+  """
+  id: ID!
+  """
+  A flag that tells us if the supported chain is active or not
+  """
+  isActive: Boolean
+}

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=983e0b68472b8f7f7406352679e29b2d2d4d49c0
+ENV BLOCK_INGESTOR_HASH=4ac06d5744f8ada7b80047afd586da4d82898436
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-proxy-block-ingestor
+++ b/docker/colony-cdapp-dev-env-proxy-block-ingestor
@@ -1,7 +1,7 @@
 FROM colony-cdapp-dev-env/base:latest
 
 # @TODO maybe add a PROXY_BLOCK_INGESTOR_HASH and fallback to BLOCK_INGESTOR_HASH
-ENV BLOCK_INGESTOR_HASH=983e0b68472b8f7f7406352679e29b2d2d4d49c0
+ENV BLOCK_INGESTOR_HASH=4ac06d5744f8ada7b80047afd586da4d82898436
 
 ENV CHAIN_RPC_ENDPOINTS='["http://network-contracts-remote:8545", "http://network-contracts-remote-2:8545"]'
 ENV STATS_PORTS='["10002", "10003"]'

--- a/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
+++ b/src/components/common/ColonyActions/helpers/mapItemToMessageFormat.tsx
@@ -211,7 +211,7 @@ const getExpenditureStagesData = (
 const getProxyColonyDeployedChain = (actionData: ColonyAction) => {
   const chainInfo = findSupportedChain(actionData?.targetChainId);
 
-  return chainInfo?.name;
+  return chainInfo?.shortName;
 };
 
 export const useMapColonyActionToExpectedFormat = ({

--- a/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/ManageSupportedChainsDescription.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ActionSidebarDescription/partials/ManageSupportedChainsDescription.tsx
@@ -40,7 +40,7 @@ export const ManageSupportedChainsDescription = () => {
     <FormattedMessage
       id="action.title"
       values={{
-        chain: chainInfo.name,
+        chain: chainInfo.shortName,
         actionType:
           manageSupportedChains === ManageEntityOperation.Add
             ? ColonyActionType.AddProxyColony

--- a/src/components/v5/common/ActionSidebar/partials/ChainSelect/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/ChainSelect/hooks.ts
@@ -1,18 +1,33 @@
 import { useMemo } from 'react';
 
 import { SUPPORTED_CHAINS } from '~constants/proxyColonies.ts';
+import { useGetSupportedChainsQuery } from '~gql';
+import GanacheIcon from '~icons/GanacheIcon.tsx';
+import { notNull } from '~utils/arrays/index.ts';
 
 export const useChainOptions = (filterOptionsFn) => {
-  const chainOptions = useMemo(
-    () =>
-      SUPPORTED_CHAINS.map(({ icon, chainId, name, isDisabled }) => ({
-        icon,
-        isDisabled,
-        value: chainId,
-        label: name,
-      })).filter((option) => filterOptionsFn && filterOptionsFn(option)),
-    [filterOptionsFn],
-  );
+  const { data } = useGetSupportedChainsQuery();
+
+  const chainOptions = useMemo(() => {
+    return (data?.listSupportedChains?.items ?? [])
+      .map((chain) => {
+        const chainConfig = SUPPORTED_CHAINS.find(
+          (supportedChain) => supportedChain.chainId === chain?.id,
+        );
+        if (!chainConfig) {
+          return null;
+        }
+
+        return {
+          icon: chainConfig.icon ?? GanacheIcon,
+          isDisabled: !chain?.isActive,
+          value: chainConfig.chainId,
+          label: chainConfig.shortName,
+        };
+      })
+      .filter(notNull)
+      .filter((option) => filterOptionsFn && filterOptionsFn(option));
+  }, [data, filterOptionsFn]);
 
   return chainOptions;
 };

--- a/src/components/v5/common/CompletedAction/partials/ManageSupportedChain/ManageSupportedChain.tsx
+++ b/src/components/v5/common/CompletedAction/partials/ManageSupportedChain/ManageSupportedChain.tsx
@@ -75,7 +75,7 @@ const ManageSupportedChain: FC<ManageSupportedChainProps> = ({ action }) => {
     },
     {
       actionType: action.type,
-      chain: chainInfo?.name,
+      chain: chainInfo?.shortName,
       initiator:
         initiatorUser || initiatorAddress ? (
           <UserInfoPopover

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -156,6 +156,36 @@ export const GANACHE_NETWORK: NetworkInfo = {
   blockTime: 5,
 };
 
+export const GANACHE_NETWORK_1: NetworkInfo = {
+  name: 'Local Proxy Chain 1',
+  chainId: '265669101',
+  shortName: 'Local Proxy Chain 1',
+  blockExplorerName: 'Noexplorer',
+  blockExplorerUrl: 'http://localhost',
+  displayENSDomain: 'joincolony.eth',
+  tokenExplorerLink: 'http://localhost',
+  contractAddressLink: 'http://localhost',
+  apiUri: 'https://api-sepolia.arbiscan.io/api',
+  icon: GanacheIcon,
+  nativeToken: ETHER_TOKEN,
+  blockTime: 5,
+};
+
+export const GANACHE_NETWORK_2: NetworkInfo = {
+  name: 'Local Proxy Chain 2',
+  chainId: '265669102',
+  shortName: 'Local Proxy Chain 2',
+  blockExplorerName: 'Noexplorer',
+  blockExplorerUrl: 'http://localhost',
+  displayENSDomain: 'joincolony.eth',
+  tokenExplorerLink: 'http://localhost',
+  contractAddressLink: 'http://localhost',
+  apiUri: 'https://api-sepolia.arbiscan.io/api',
+  icon: GanacheIcon,
+  nativeToken: ETHER_TOKEN,
+  blockTime: 5,
+};
+
 export const BINANCE_NETWORK: NetworkInfo = {
   name: 'Binance Smart Chain',
   chainId: '56',

--- a/src/constants/proxyColonies.ts
+++ b/src/constants/proxyColonies.ts
@@ -1,55 +1,12 @@
-import AvalancheIcon from '~icons/AvalancheIcon.tsx';
-import BaseIcon from '~icons/BaseIcon.tsx';
-import BinanceIcon from '~icons/BinanceIcon.tsx';
-import EthereumIcon from '~icons/EthereumIcon.tsx';
-import OptimismIcon from '~icons/OptimismIcon.tsx';
-import PolygonIcon from '~icons/PolygonIcon.tsx';
-import { type SupportedChain } from '~types/proxyColonies.ts';
+import {
+  POLYGON_NETWORK,
+  GANACHE_NETWORK_1,
+  GANACHE_NETWORK_2,
+  type NetworkInfo,
+} from '~constants';
 
-// @TODO this probably needs to be setup more dynamically, but let's hardcode it for now
-const POLYGON_NETWORK = {
-  name: 'Polygon',
-  chainId: 265669101,
-  icon: PolygonIcon,
-};
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const ETHEREUM_NETWORK = {
-  name: 'Ethereum',
-  chainId: 265669102,
-  icon: EthereumIcon,
-};
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const BASE_NETWORK = {
-  name: 'Base',
-  chainId: 265669103,
-  icon: BaseIcon,
-  isDisabled: true,
-};
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const OPTIMISM_NETWORK = {
-  name: 'Optimism',
-  chainId: 265669104,
-  icon: OptimismIcon,
-  isDisabled: true,
-};
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const AVALANCHE_NETWORK = {
-  name: 'Avalanche',
-  chainId: 265669105,
-  icon: AvalancheIcon,
-  isDisabled: true,
-};
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const BINANCE_NETWORK = {
-  name: 'Binance',
-  chainId: 265669106,
-  icon: BinanceIcon,
-  isDisabled: true,
-};
-
-export const SUPPORTED_CHAINS: SupportedChain[] = [POLYGON_NETWORK];
+export const SUPPORTED_CHAINS: NetworkInfo[] = [
+  POLYGON_NETWORK,
+  GANACHE_NETWORK_1,
+  GANACHE_NETWORK_2,
+];

--- a/src/constants/proxyColonies.ts
+++ b/src/constants/proxyColonies.ts
@@ -1,5 +1,6 @@
 import {
   POLYGON_NETWORK,
+  AMOY_NETWORK,
   GANACHE_NETWORK_1,
   GANACHE_NETWORK_2,
   type NetworkInfo,
@@ -7,6 +8,7 @@ import {
 
 export const SUPPORTED_CHAINS: NetworkInfo[] = [
   POLYGON_NETWORK,
+  AMOY_NETWORK,
   GANACHE_NETWORK_1,
   GANACHE_NETWORK_2,
 ];

--- a/src/graphql/fragments/proxyColonies.graphql
+++ b/src/graphql/fragments/proxyColonies.graphql
@@ -4,3 +4,8 @@ fragment ProxyColony on ProxyColony {
   chainId
   isActive
 }
+
+fragment SupportedChain on SupportedChain {
+  id
+  isActive
+}

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -1947,6 +1947,11 @@ export type CreateStreamingPaymentMetadataInput = {
   limitAmount?: InputMaybe<Scalars['String']>;
 };
 
+export type CreateSupportedChainInput = {
+  id?: InputMaybe<Scalars['ID']>;
+  isActive?: InputMaybe<Scalars['Boolean']>;
+};
+
 export type CreateTokenExchangeRateInput = {
   date: Scalars['AWSDateTime'];
   id?: InputMaybe<Scalars['ID']>;
@@ -2221,6 +2226,10 @@ export type DeleteStreamingPaymentInput = {
 };
 
 export type DeleteStreamingPaymentMetadataInput = {
+  id: Scalars['ID'];
+};
+
+export type DeleteSupportedChainInput = {
   id: Scalars['ID'];
 };
 
@@ -4849,6 +4858,13 @@ export type ModelSubscriptionStringInput = {
   notIn?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
+export type ModelSubscriptionSupportedChainFilterInput = {
+  and?: InputMaybe<Array<InputMaybe<ModelSubscriptionSupportedChainFilterInput>>>;
+  id?: InputMaybe<ModelSubscriptionIdInput>;
+  isActive?: InputMaybe<ModelSubscriptionBooleanInput>;
+  or?: InputMaybe<Array<InputMaybe<ModelSubscriptionSupportedChainFilterInput>>>;
+};
+
 export type ModelSubscriptionTokenExchangeRateFilterInput = {
   and?: InputMaybe<Array<InputMaybe<ModelSubscriptionTokenExchangeRateFilterInput>>>;
   date?: InputMaybe<ModelSubscriptionStringInput>;
@@ -4939,6 +4955,27 @@ export type ModelSubscriptionVoterRewardsHistoryFilterInput = {
   motionId?: InputMaybe<ModelSubscriptionIdInput>;
   or?: InputMaybe<Array<InputMaybe<ModelSubscriptionVoterRewardsHistoryFilterInput>>>;
   userAddress?: InputMaybe<ModelSubscriptionIdInput>;
+};
+
+export type ModelSupportedChainConditionInput = {
+  and?: InputMaybe<Array<InputMaybe<ModelSupportedChainConditionInput>>>;
+  isActive?: InputMaybe<ModelBooleanInput>;
+  not?: InputMaybe<ModelSupportedChainConditionInput>;
+  or?: InputMaybe<Array<InputMaybe<ModelSupportedChainConditionInput>>>;
+};
+
+export type ModelSupportedChainConnection = {
+  __typename?: 'ModelSupportedChainConnection';
+  items: Array<Maybe<SupportedChain>>;
+  nextToken?: Maybe<Scalars['String']>;
+};
+
+export type ModelSupportedChainFilterInput = {
+  and?: InputMaybe<Array<InputMaybe<ModelSupportedChainFilterInput>>>;
+  id?: InputMaybe<ModelIdInput>;
+  isActive?: InputMaybe<ModelBooleanInput>;
+  not?: InputMaybe<ModelSupportedChainFilterInput>;
+  or?: InputMaybe<Array<InputMaybe<ModelSupportedChainFilterInput>>>;
 };
 
 export type ModelSupportedCurrenciesInput = {
@@ -5433,6 +5470,7 @@ export type Mutation = {
   createSafeTransactionData?: Maybe<SafeTransactionData>;
   createStreamingPayment?: Maybe<StreamingPayment>;
   createStreamingPaymentMetadata?: Maybe<StreamingPaymentMetadata>;
+  createSupportedChain?: Maybe<SupportedChain>;
   createToken?: Maybe<Token>;
   createTokenExchangeRate?: Maybe<TokenExchangeRate>;
   createTransaction?: Maybe<Transaction>;
@@ -5482,6 +5520,7 @@ export type Mutation = {
   deleteSafeTransactionData?: Maybe<SafeTransactionData>;
   deleteStreamingPayment?: Maybe<StreamingPayment>;
   deleteStreamingPaymentMetadata?: Maybe<StreamingPaymentMetadata>;
+  deleteSupportedChain?: Maybe<SupportedChain>;
   deleteToken?: Maybe<Token>;
   deleteTokenExchangeRate?: Maybe<TokenExchangeRate>;
   deleteTransaction?: Maybe<Transaction>;
@@ -5531,6 +5570,7 @@ export type Mutation = {
   updateSafeTransactionData?: Maybe<SafeTransactionData>;
   updateStreamingPayment?: Maybe<StreamingPayment>;
   updateStreamingPaymentMetadata?: Maybe<StreamingPaymentMetadata>;
+  updateSupportedChain?: Maybe<SupportedChain>;
   updateToken?: Maybe<Token>;
   updateTokenExchangeRate?: Maybe<TokenExchangeRate>;
   updateTransaction?: Maybe<Transaction>;
@@ -5830,6 +5870,13 @@ export type MutationCreateStreamingPaymentArgs = {
 export type MutationCreateStreamingPaymentMetadataArgs = {
   condition?: InputMaybe<ModelStreamingPaymentMetadataConditionInput>;
   input: CreateStreamingPaymentMetadataInput;
+};
+
+
+/** Root mutation type */
+export type MutationCreateSupportedChainArgs = {
+  condition?: InputMaybe<ModelSupportedChainConditionInput>;
+  input: CreateSupportedChainInput;
 };
 
 
@@ -6161,6 +6208,13 @@ export type MutationDeleteStreamingPaymentMetadataArgs = {
 
 
 /** Root mutation type */
+export type MutationDeleteSupportedChainArgs = {
+  condition?: InputMaybe<ModelSupportedChainConditionInput>;
+  input: DeleteSupportedChainInput;
+};
+
+
+/** Root mutation type */
 export type MutationDeleteTokenArgs = {
   condition?: InputMaybe<ModelTokenConditionInput>;
   input: DeleteTokenInput;
@@ -6484,6 +6538,13 @@ export type MutationUpdateStreamingPaymentArgs = {
 export type MutationUpdateStreamingPaymentMetadataArgs = {
   condition?: InputMaybe<ModelStreamingPaymentMetadataConditionInput>;
   input: UpdateStreamingPaymentMetadataInput;
+};
+
+
+/** Root mutation type */
+export type MutationUpdateSupportedChainArgs = {
+  condition?: InputMaybe<ModelSupportedChainConditionInput>;
+  input: UpdateSupportedChainInput;
 };
 
 
@@ -6904,6 +6965,7 @@ export type Query = {
   getSafeTransactionStatus?: Maybe<Array<Scalars['String']>>;
   getStreamingPayment?: Maybe<StreamingPayment>;
   getStreamingPaymentMetadata?: Maybe<StreamingPaymentMetadata>;
+  getSupportedChain?: Maybe<SupportedChain>;
   getToken?: Maybe<Token>;
   getTokenByAddress?: Maybe<ModelTokenConnection>;
   getTokenExchangeRate?: Maybe<TokenExchangeRate>;
@@ -6969,6 +7031,7 @@ export type Query = {
   listSafeTransactions?: Maybe<ModelSafeTransactionConnection>;
   listStreamingPaymentMetadata?: Maybe<ModelStreamingPaymentMetadataConnection>;
   listStreamingPayments?: Maybe<ModelStreamingPaymentConnection>;
+  listSupportedChains?: Maybe<ModelSupportedChainConnection>;
   listTokenExchangeRates?: Maybe<ModelTokenExchangeRateConnection>;
   listTokens?: Maybe<ModelTokenConnection>;
   listTransactions?: Maybe<ModelTransactionConnection>;
@@ -7658,6 +7721,12 @@ export type QueryGetStreamingPaymentMetadataArgs = {
 
 
 /** Root query type */
+export type QueryGetSupportedChainArgs = {
+  id: Scalars['ID'];
+};
+
+
+/** Root query type */
 export type QueryGetTokenArgs = {
   id: Scalars['ID'];
 };
@@ -8129,6 +8198,14 @@ export type QueryListStreamingPaymentMetadataArgs = {
 /** Root query type */
 export type QueryListStreamingPaymentsArgs = {
   filter?: InputMaybe<ModelStreamingPaymentFilterInput>;
+  limit?: InputMaybe<Scalars['Int']>;
+  nextToken?: InputMaybe<Scalars['String']>;
+};
+
+
+/** Root query type */
+export type QueryListSupportedChainsArgs = {
+  filter?: InputMaybe<ModelSupportedChainFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
   nextToken?: InputMaybe<Scalars['String']>;
 };
@@ -8734,6 +8811,7 @@ export type Subscription = {
   onCreateSafeTransactionData?: Maybe<SafeTransactionData>;
   onCreateStreamingPayment?: Maybe<StreamingPayment>;
   onCreateStreamingPaymentMetadata?: Maybe<StreamingPaymentMetadata>;
+  onCreateSupportedChain?: Maybe<SupportedChain>;
   onCreateToken?: Maybe<Token>;
   onCreateTokenExchangeRate?: Maybe<TokenExchangeRate>;
   onCreateTransaction?: Maybe<Transaction>;
@@ -8779,6 +8857,7 @@ export type Subscription = {
   onDeleteSafeTransactionData?: Maybe<SafeTransactionData>;
   onDeleteStreamingPayment?: Maybe<StreamingPayment>;
   onDeleteStreamingPaymentMetadata?: Maybe<StreamingPaymentMetadata>;
+  onDeleteSupportedChain?: Maybe<SupportedChain>;
   onDeleteToken?: Maybe<Token>;
   onDeleteTokenExchangeRate?: Maybe<TokenExchangeRate>;
   onDeleteTransaction?: Maybe<Transaction>;
@@ -8824,6 +8903,7 @@ export type Subscription = {
   onUpdateSafeTransactionData?: Maybe<SafeTransactionData>;
   onUpdateStreamingPayment?: Maybe<StreamingPayment>;
   onUpdateStreamingPaymentMetadata?: Maybe<StreamingPaymentMetadata>;
+  onUpdateSupportedChain?: Maybe<SupportedChain>;
   onUpdateToken?: Maybe<Token>;
   onUpdateTokenExchangeRate?: Maybe<TokenExchangeRate>;
   onUpdateTransaction?: Maybe<Transaction>;
@@ -9021,6 +9101,11 @@ export type SubscriptionOnCreateStreamingPaymentArgs = {
 
 export type SubscriptionOnCreateStreamingPaymentMetadataArgs = {
   filter?: InputMaybe<ModelSubscriptionStreamingPaymentMetadataFilterInput>;
+};
+
+
+export type SubscriptionOnCreateSupportedChainArgs = {
+  filter?: InputMaybe<ModelSubscriptionSupportedChainFilterInput>;
 };
 
 
@@ -9249,6 +9334,11 @@ export type SubscriptionOnDeleteStreamingPaymentMetadataArgs = {
 };
 
 
+export type SubscriptionOnDeleteSupportedChainArgs = {
+  filter?: InputMaybe<ModelSubscriptionSupportedChainFilterInput>;
+};
+
+
 export type SubscriptionOnDeleteTokenArgs = {
   filter?: InputMaybe<ModelSubscriptionTokenFilterInput>;
 };
@@ -9474,6 +9564,11 @@ export type SubscriptionOnUpdateStreamingPaymentMetadataArgs = {
 };
 
 
+export type SubscriptionOnUpdateSupportedChainArgs = {
+  filter?: InputMaybe<ModelSubscriptionSupportedChainFilterInput>;
+};
+
+
 export type SubscriptionOnUpdateTokenArgs = {
   filter?: InputMaybe<ModelSubscriptionTokenFilterInput>;
 };
@@ -9506,6 +9601,16 @@ export type SubscriptionOnUpdateUserTokensArgs = {
 
 export type SubscriptionOnUpdateVoterRewardsHistoryArgs = {
   filter?: InputMaybe<ModelSubscriptionVoterRewardsHistoryFilterInput>;
+};
+
+export type SupportedChain = {
+  __typename?: 'SupportedChain';
+  createdAt: Scalars['AWSDateTime'];
+  /** The chainId of the supported chain */
+  id: Scalars['ID'];
+  /** A flag that tells us if the supported chain is active or not */
+  isActive?: Maybe<Scalars['Boolean']>;
+  updatedAt: Scalars['AWSDateTime'];
 };
 
 /** Represents the currencies/tokens that users' balances can be converted to (for display purposes) */
@@ -10230,6 +10335,11 @@ export type UpdateStreamingPaymentMetadataInput = {
   limitAmount?: InputMaybe<Scalars['String']>;
 };
 
+export type UpdateSupportedChainInput = {
+  id: Scalars['ID'];
+  isActive?: InputMaybe<Scalars['Boolean']>;
+};
+
 export type UpdateTokenExchangeRateInput = {
   date?: InputMaybe<Scalars['AWSDateTime']>;
   id: Scalars['ID'];
@@ -10625,6 +10735,8 @@ export type ExtensionDisplayFragmentFragment = { __typename?: 'ColonyExtension',
 export type LiquidationAddressFragment = { __typename?: 'LiquidationAddress', id: string, chainId: number, userAddress: string, liquidationAddress: string, user?: { __typename?: 'User', bridgeCustomerId?: string | null, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, displayNameChanged?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null, preferredCurrency?: SupportedCurrencies | null, isAutoOfframpEnabled?: boolean | null, meta?: { __typename?: 'ProfileMetadata', metatransactionsEnabled?: boolean | null, decentralizedModeEnabled?: boolean | null, customRpc?: string | null } | null } | null, privateBetaInviteCode?: { __typename?: 'PrivateBetaInviteCode', id: string, shareableInvites?: number | null } | null, notificationsData?: { __typename?: 'NotificationsData', magicbellUserId: string, notificationsDisabled: boolean, mutedColonyAddresses: Array<string>, paymentNotificationsDisabled: boolean, mentionNotificationsDisabled: boolean, adminNotificationsDisabled: boolean } | null } | null };
 
 export type ProxyColonyFragment = { __typename?: 'ProxyColony', id: string, colonyAddress: string, chainId: string, isActive: boolean };
+
+export type SupportedChainFragment = { __typename?: 'SupportedChain', id: string, isActive?: boolean | null };
 
 export type ColonyUserRoleFragment = { __typename?: 'ColonyRole', id: string, targetAddress: string, role_1?: boolean | null, role_2?: boolean | null, role_3?: boolean | null, role_5?: boolean | null, role_6?: boolean | null, targetUser?: { __typename?: 'User', bridgeCustomerId?: string | null, walletAddress: string, profile?: { __typename?: 'Profile', avatar?: string | null, bio?: string | null, displayName?: string | null, displayNameChanged?: string | null, email?: string | null, location?: string | null, thumbnail?: string | null, website?: string | null, preferredCurrency?: SupportedCurrencies | null, isAutoOfframpEnabled?: boolean | null, meta?: { __typename?: 'ProfileMetadata', metatransactionsEnabled?: boolean | null, decentralizedModeEnabled?: boolean | null, customRpc?: string | null } | null } | null, privateBetaInviteCode?: { __typename?: 'PrivateBetaInviteCode', id: string, shareableInvites?: number | null } | null, notificationsData?: { __typename?: 'NotificationsData', magicbellUserId: string, notificationsDisabled: boolean, mutedColonyAddresses: Array<string>, paymentNotificationsDisabled: boolean, mentionNotificationsDisabled: boolean, adminNotificationsDisabled: boolean } | null } | null };
 
@@ -11210,6 +11322,11 @@ export type GetProxyColoniesQueryVariables = Exact<{
 
 
 export type GetProxyColoniesQuery = { __typename?: 'Query', getProxyColoniesByColonyAddress?: { __typename?: 'ModelProxyColonyConnection', items: Array<{ __typename?: 'ProxyColony', id: string, colonyAddress: string, chainId: string, isActive: boolean } | null> } | null };
+
+export type GetSupportedChainsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetSupportedChainsQuery = { __typename?: 'Query', listSupportedChains?: { __typename?: 'ModelSupportedChainConnection', items: Array<{ __typename?: 'SupportedChain', id: string, isActive?: boolean | null } | null> } | null };
 
 export type GetColonyHistoricRoleRolesQueryVariables = Exact<{
   id: Scalars['ID'];
@@ -12005,6 +12122,12 @@ export const ProxyColonyFragmentDoc = gql`
   id
   colonyAddress
   chainId
+  isActive
+}
+    `;
+export const SupportedChainFragmentDoc = gql`
+    fragment SupportedChain on SupportedChain {
+  id
   isActive
 }
     `;
@@ -15464,6 +15587,42 @@ export function useGetProxyColoniesLazyQuery(baseOptions?: Apollo.LazyQueryHookO
 export type GetProxyColoniesQueryHookResult = ReturnType<typeof useGetProxyColoniesQuery>;
 export type GetProxyColoniesLazyQueryHookResult = ReturnType<typeof useGetProxyColoniesLazyQuery>;
 export type GetProxyColoniesQueryResult = Apollo.QueryResult<GetProxyColoniesQuery, GetProxyColoniesQueryVariables>;
+export const GetSupportedChainsDocument = gql`
+    query GetSupportedChains {
+  listSupportedChains {
+    items {
+      ...SupportedChain
+    }
+  }
+}
+    ${SupportedChainFragmentDoc}`;
+
+/**
+ * __useGetSupportedChainsQuery__
+ *
+ * To run a query within a React component, call `useGetSupportedChainsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetSupportedChainsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetSupportedChainsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetSupportedChainsQuery(baseOptions?: Apollo.QueryHookOptions<GetSupportedChainsQuery, GetSupportedChainsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetSupportedChainsQuery, GetSupportedChainsQueryVariables>(GetSupportedChainsDocument, options);
+      }
+export function useGetSupportedChainsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetSupportedChainsQuery, GetSupportedChainsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetSupportedChainsQuery, GetSupportedChainsQueryVariables>(GetSupportedChainsDocument, options);
+        }
+export type GetSupportedChainsQueryHookResult = ReturnType<typeof useGetSupportedChainsQuery>;
+export type GetSupportedChainsLazyQueryHookResult = ReturnType<typeof useGetSupportedChainsLazyQuery>;
+export type GetSupportedChainsQueryResult = Apollo.QueryResult<GetSupportedChainsQuery, GetSupportedChainsQueryVariables>;
 export const GetColonyHistoricRoleRolesDocument = gql`
     query GetColonyHistoricRoleRoles($id: ID!) {
   getColonyHistoricRole(id: $id) {

--- a/src/graphql/queries/proxyColonies.graphql
+++ b/src/graphql/queries/proxyColonies.graphql
@@ -5,3 +5,11 @@ query GetProxyColonies($colonyAddress: ID!) {
     }
   }
 }
+
+query GetSupportedChains {
+  listSupportedChains {
+    items {
+      ...SupportedChain
+    }
+  }
+}

--- a/src/utils/proxyColonies.ts
+++ b/src/utils/proxyColonies.ts
@@ -7,6 +7,6 @@ export const findSupportedChain = (chainId: number | undefined | null) => {
     return null;
   }
   return SUPPORTED_CHAINS.find(
-    (supportedChain) => supportedChain.chainId === chainId,
+    (supportedChain) => supportedChain.chainId === chainId.toString(),
   );
 };


### PR DESCRIPTION
## Description

This PR introduces lookup of supported proxy chains from the database.
We still need to keep them in a local config, due to all the titles and lookups.
[Block ingestor PR](https://github.com/JoinColony/block-ingestor/pull/319)

## Testing

1. Run your dev env and check that we got supported chains in the database by running the following query
```
query MyQuery {
  listSupportedChains {
    items {
      id
      isActive
    }
  }
}
```
![image](https://github.com/user-attachments/assets/5f59819a-e02c-49db-8240-173eac6ef577)

2. Run the create-data script and go to `planex`. Try to create a `Manage supported chains` action and verify that you only get "Local proxy chain 1" and "Local proxy chain 2" in the dropdown.
![image](https://github.com/user-attachments/assets/c27753d5-48a2-4b45-912f-dae76b868ee8)
> [!IMPORTANT]
> Unfortunately when stopping a docker container the `SIGTERM` event doesn't get properly propagated to the child process which in our case would be the process started with `pnpm --filter @joincolony/proxy-chain run start`
> So the next steps require you to stop the proxy block ingestor container and run the `block-ingestor` locally (branch `feat/dynamically-add-supported-proxy-chain`)

3. Stop the proxy chain ingestor 1 with docker and run it locally via `pnpm run dev:proxy-chain` with the block ingestor changes above (sorry, it's a bit janky :sweat_smile: ) Verify that you get these logs and that the proxy is still active
![image](https://github.com/user-attachments/assets/ddae1313-fe4f-4720-9429-f67d457ca580)

4. Stop the running instance and run the query above, verify that it's inactive. Reload the app and check that "Local proxy chain 1" is disabled.
![image](https://github.com/user-attachments/assets/985215af-d81c-48ec-8e7e-465ec70e02ba)
![image](https://github.com/user-attachments/assets/0698109c-1fcc-40cd-8d38-e43fbebb502d)
![image](https://github.com/user-attachments/assets/c4c7f316-1716-4f22-9039-ac2e426ed8ad)

5. Restart it and check that everything is reenabled :D 
![image](https://github.com/user-attachments/assets/0a8469f4-1245-41e4-b8e8-f4a8491d6ade)
![image](https://github.com/user-attachments/assets/88483d9a-3ec8-465c-a54f-01b04891bab8)



## Diffs

**New stuff** ✨

* New entity in the DB called `SupportedChains`
* New constants for the local proxy chains

**Changes** 🏗

* All the proxies are in a single supported chains array which we filter according to the ones active in the database
* The proxy block ingestor adds a new supported chain entry when it's first started
* The proxy ingestors also mark the supported chain as inactive when it's stopped
