### PR TITLE
Add rate limited notifications queue

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=87073303a0369e97cf439baf572809f238f923ed
+ENV BLOCK_INGESTOR_HASH=beeb66bc18b2a353a8b961cc1f98d229e73bf7b8
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=beeb66bc18b2a353a8b961cc1f98d229e73bf7b8
+ENV BLOCK_INGESTOR_HASH=77acd2cb6ed86877a19807bee2a902a6e846bdbf
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/context/Notifications/NotificationsDataContext/NotificationsDataContextProvider.tsx
+++ b/src/context/Notifications/NotificationsDataContext/NotificationsDataContextProvider.tsx
@@ -10,6 +10,28 @@ import {
   type NotificationsDataContextValues,
 } from './NotificationsDataContext.ts';
 
+const STORES =
+  isDev && !!import.meta.env.MAGICBELL_DEV_KEY
+    ? [
+        {
+          id: 'dev-store',
+          defaultQueryParams: {
+            topic: import.meta.env.MAGICBELL_DEV_KEY,
+            // eslint-disable-next-line camelcase
+            per_page: 10,
+          },
+        },
+      ]
+    : [
+        {
+          id: 'store',
+          // eslint-disable-next-line camelcase
+          defaultQueryParams: { per_page: 10 },
+        },
+      ];
+
+const USE_BELL_OPTS = { storeId: isDev ? 'dev-store' : 'store' };
+
 const NotificationsDataContextProvider = ({
   children,
 }: {
@@ -25,7 +47,7 @@ const NotificationsDataContextProvider = ({
     notifications,
     totalPages,
     unreadCount,
-  } = useBell({ storeId: isDev ? 'dev-store' : 'store' }) || {
+  } = useBell(USE_BELL_OPTS) || {
     currentPage: 1,
     fetchNextPage: () => Promise.resolve(),
     markAllAsRead: () => null,
@@ -70,26 +92,7 @@ const NotificationsDataContextProvider = ({
       apiKey={import.meta.env.MAGICBELL_API_KEY}
       userExternalId={user.notificationsData.magicbellUserId}
       userKey={data?.getUserNotificationsHMAC || ''}
-      stores={
-        isDev && !!import.meta.env.MAGICBELL_DEV_KEY
-          ? [
-              {
-                id: 'dev-store',
-                defaultQueryParams: {
-                  topic: import.meta.env.MAGICBELL_DEV_KEY,
-                  // eslint-disable-next-line camelcase
-                  per_page: 10,
-                },
-              },
-            ]
-          : [
-              {
-                id: 'store',
-                // eslint-disable-next-line camelcase
-                defaultQueryParams: { per_page: 10 },
-              },
-            ]
-      }
+      stores={STORES}
     >
       <NotificationsDataContext.Provider value={value}>
         {children}


### PR DESCRIPTION
## Description

- Since this is really a block ingestor change, the description is here: https://github.com/JoinColony/block-ingestor/pull/320

## Testing

* ⚠️  You'll need to restart your dev environment and make sure you run `npm run dev --notifications` to enable notifications locally.
* Once it's up and running, stop the block ingestor in docker. Open `.env` of the CDapp and copy the auto generated MAGICBELL_DEV_KEY, and add it to the `.env` of your block ingestor. Now run the block ingestor locally with `npm run dev`.
* Now you need a way to trigger more than 60 notifications inside a minute. The easiest way is probably to open `src/handlers/actions/mintTokens.ts` in the block ingestor, and go to line 35 where it calls `sendPermissionsActionNotifications`. Just add a for loop around this call to fire it like 80 times when a mint token action happens.
```ts
for (let index = 0; index < 80; index++) {
      sendPermissionsActionNotifications({
        creator: initiatorAddress,
        colonyAddress,
        transactionHash,
        notificationCategory: NotificationCategory.Payment,
      });
    }
```
* Open localhost, and mint some tokens. You should see 30 notifications come in pretty quickly, and after waiting a minute, more should come through.
* Check the block ingestor logs, there should be no errors about API rate limits being hit.

## Diffs

**Changes** 🏗

* Block ingestor changes: https://github.com/JoinColony/block-ingestor/pull/320
