### PR TITLE
Fix: Ensure minimum dimension of 120x120px for file uploads

### DIFF
--- a/playwright/e2e/manage-account-avatar.spec.ts
+++ b/playwright/e2e/manage-account-avatar.spec.ts
@@ -80,7 +80,7 @@ test.describe('Avatar Uploader on Manage Account page', () => {
     ).toBeHidden();
   });
   // NOTE: enable this test once we have fixed issue #3858 with the avatar uploader
-  test.skip('rejects file smaller than 250x250px', async ({ page }) => {
+  test.skip('rejects file smaller than 120x120px', async ({ page }) => {
     const smallImage = path.join(
       __dirname,
       '../fixtures/images/small-avatar-200x200.png',
@@ -91,7 +91,7 @@ test.describe('Avatar Uploader on Manage Account page', () => {
 
     await expect(
       // The error message to be confirmed
-      page.getByText(/Image must be at least 250x250px/i),
+      page.getByText(/Image must be at least 120x120px/i),
     ).toBeVisible({ timeout: 10000 });
   });
 

--- a/src/components/common/Onboarding/wizardSteps/CreateColony/StepCreateTokenInputs.tsx
+++ b/src/components/common/Onboarding/wizardSteps/CreateColony/StepCreateTokenInputs.tsx
@@ -140,7 +140,7 @@ const StepCreateTokenInputs = ({
         }
         fileOptions={{
           fileFormat: ['.PNG', '.JPG', '.SVG'],
-          fileDimension: '250x250px',
+          fileDimension: '120x120px',
           fileSize: '1MB',
         }}
         updateFn={updateFn}

--- a/src/components/frame/v5/pages/UserProfilePage/partials/consts.ts
+++ b/src/components/frame/v5/pages/UserProfilePage/partials/consts.ts
@@ -1,6 +1,6 @@
 export const profileFileOptions = {
   fileFormat: ['.PNG', '.JPG', '.SVG'],
-  fileDimension: '250x250px',
+  fileDimension: '120x120px',
   fileSize: '1MB',
 };
 

--- a/src/components/v5/common/ActionSidebar/partials/ColonyDetailsFields/ColonyDetailsFields.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/ColonyDetailsFields/ColonyDetailsFields.tsx
@@ -62,7 +62,7 @@ const ColonyDetailsFields: FC = () => {
             name="avatar"
             fileOptions={{
               fileFormat: ['.PNG', '.JPG', '.SVG'],
-              fileDimension: '250x250px',
+              fileDimension: '120x120px',
               fileSize: '1MB',
             }}
             disabled={hasNoDecisionMethods}

--- a/src/components/v5/common/AvatarUploader/partials/ErrorContent.tsx
+++ b/src/components/v5/common/AvatarUploader/partials/ErrorContent.tsx
@@ -13,7 +13,7 @@ const ErrorContent: FC<ErrorContentProps> = ({
   errorCode,
   handleFileRemove,
   open,
-  fileRejections,
+  processedFile,
 }) => {
   const { formatMessage } = useIntl();
 
@@ -46,7 +46,7 @@ const ErrorContent: FC<ErrorContentProps> = ({
           </button>
         </div>
         <span className="break-all text-left text-sm text-gray-600">
-          {fileRejections}
+          {processedFile}
         </span>
         <TextButton
           onClick={open}

--- a/src/components/v5/common/AvatarUploader/partials/FileUpload.tsx
+++ b/src/components/v5/common/AvatarUploader/partials/FileUpload.tsx
@@ -27,7 +27,7 @@ const FileUpload: FC<FileUploadProps> = ({
     getRootProps,
     open,
     isDragReject,
-    fileRejections,
+    processedFiles,
     isDragAccept,
   } = useDropzoneWithFileReader({
     dropzoneOptions: {
@@ -70,7 +70,7 @@ const FileUpload: FC<FileUploadProps> = ({
       errorCode={errorCode}
       handleFileRemove={handleFileRemove}
       open={open}
-      fileRejections={fileRejections?.[0]?.file?.name}
+      processedFile={processedFiles?.[0]?.name}
     />
   );
 

--- a/src/components/v5/common/AvatarUploader/types.ts
+++ b/src/components/v5/common/AvatarUploader/types.ts
@@ -17,7 +17,7 @@ export type HandleFileAccept = (file: FileReaderFile) => void;
 
 export interface ErrorContentProps
   extends Pick<FileUploadProps, 'handleFileRemove' | 'errorCode'> {
-  fileRejections?: string;
+  processedFile?: string;
   open: () => void;
 }
 

--- a/src/hooks/useDropzoneWithFileReader.ts
+++ b/src/hooks/useDropzoneWithFileReader.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import {
   type DropzoneOptions,
   type DropzoneProps,
@@ -51,7 +52,13 @@ const useDropzoneWithFileReader = ({
     ...restDropzoneOptions,
   });
 
-  return dropzoneState;
+  const processedFiles = useMemo(() => {
+    const { fileRejections, acceptedFiles } = dropzoneState;
+
+    return { ...fileRejections.map(({ file }) => file), ...acceptedFiles };
+  }, [dropzoneState]);
+
+  return { ...dropzoneState, processedFiles };
 };
 
 export default useDropzoneWithFileReader;

--- a/src/stories/common/FileUpload.stories.tsx
+++ b/src/stories/common/FileUpload.stories.tsx
@@ -25,7 +25,7 @@ export const Base: StoryObj<typeof FileUpload> = {
   args: {
     fileOptions: {
       fileFormat: ['.csv', '.jpg', '.png'],
-      fileDimension: '250x250px',
+      fileDimension: '120x120px',
       fileSize: '1MB',
     },
   },
@@ -36,7 +36,7 @@ export const WithSimplifiedUploader: StoryObj<typeof FileUpload> = {
     isSimplified: true,
     fileOptions: {
       fileFormat: ['.csv'],
-      fileDimension: '250x250px',
+      fileDimension: '120x120px',
       fileSize: '1MB',
     },
   },


### PR DESCRIPTION
## Description

As discussed with Product, files being uploaded should have a dimension of at least 120x120px.

![min-120x120px](https://github.com/user-attachments/assets/98ae92a3-6061-4858-beb3-7820433591d1)

## Testing

**Pika**

![pikachu-119x119](https://github.com/user-attachments/assets/c0399855-5312-48e1-8bbf-816030432be3)

1. Generate a create colony URL: node scripts/create-colony-url.js
2. On the token creation page, upload Pikachu
3. Verify that:
 - the error message says: "Image dimensions should be at least 120x120px"
 - you hear an audio clip of an angry Pikachu (of course I'm kidding, don't request changes because of this)
4. Visit the Planex colony: http://localhost:9091/planex/
5. Bring up the Edit colony details form
6. Upload Pikachu as the Colony logo
7. Verify that the error message says: "Image dimensions should be at least 120x120px"

Resolves #3858 