### PR TITLE
Fix (?) intermittent error in create-data script

### DIFF
--- a/scripts/create-data.js
+++ b/scripts/create-data.js
@@ -1275,7 +1275,7 @@ const userPayments = async (
             users[userIndex] ===
             utils.getAddress(Object.keys(ganacheAddresses)[0])
           ) {
-            amount = BigNumber.from(`50000000000000000000`);
+            amount = BigNumber.from(`30000000000000000000`);
           }
 
           const params = [


### PR DESCRIPTION
<p align="center">
<img width="300" src="https://github.com/user-attachments/assets/af6a62d6-46a4-4b6f-ba97-81d2abd5e8ce" />
</p>

In #4150, I saw @mmioana had experienced one of my most hated things while trying to run the `create-data` script: _an intermittent error_

<img width="1186" alt="Screenshot 2025-01-23 at 10 24 36" src="https://github.com/user-attachments/assets/d57fb571-9117-4324-9c46-cc2d4b4b9c33" />

so I went hunting and think I've arrived at a simple fix. 

Currently, when the script is run:

* Colonies get between 1 and 100 million of a token
* Domains get between 100 and 500 of a token

So far, so good.

Individual users are then paid out from each domain by calling [`userPayments`](https://github.com/JoinColony/colonyCDapp/blob/0f0e20ee01635902183852292d09e85d0dac5616/scripts/create-data.js#L1626) with the three `walletUsers` (which are the first three ganache accounts) and a random contributor address.

Users are paid out a random amount between [1 and 3 tokens](https://github.com/JoinColony/colonyCDapp/blob/0f0e20ee01635902183852292d09e85d0dac5616/scripts/create-data.js#L1272)... unless we are considering the [first 'ganache' address](https://github.com/JoinColony/colonyCDapp/blob/0f0e20ee01635902183852292d09e85d0dac5616/scripts/create-data.js#L1278), which gets 50 tokens, a fixed amount.

So, how does this result in a (rare) error when running the script? When paying out from a domain, the random contributor selected can be the first ganache address (if the domain is not the first in the colony to be considered). In that case, we will pay out to the first ganache address twice, resuling in somewhere between 102 and 106 tokens trying to leave the domain - but there is a chance that the domain only received as low as 100 tokens, and will not have enough to pay out.

In that scenario, the transaction will fail with the overflow message seen in the original error - but to occur, the domain must have received a sufficiently low number of tokens (less than 1% chance) and the first ganache account must have been randomly selected as a contributor (haven't properly understood how this is generated, but must be less than 33%), explaining why it is so rare to occur, anecdotally.

To fix the issue, the 'constant' amount we pay out to the first ganache address has been reduced to 30 tokens, which means that the most we can pay out from a domain is 66 tokens, which is less than the smallest amount that can be given to a domain.

For anyone paying _particularly_ close attention, the last non-error log in the screenshot was paying out address `0x27fF0C145E191C22C75cD123C679C3e1F58a4469`, which is `ganacheAccounts[2]`, not `ganacheAccounts[0]`. However, the log occurs in the script [after the payout succeeds](https://github.com/JoinColony/colonyCDapp/blob/0f0e20ee01635902183852292d09e85d0dac5616/scripts/create-data.js#L1335), and so the error will have occurred when paying out the _next_ address, which you can see in the failed transaction blob is `0xb77D57F4959eAfA0339424b83FcFaf9c15407461`, as would be the case in the situation I've described here.

I've checked with Raul and this 50 tokens isn't a magic value anywhere, so shouldn't break anything. Obviously the issue with an intermittent error is that it's tough to be sure that it's fixed, especially one with such a low recurrence rate, but I hope that the above case is compelling.

If/when this is merged, if you see a similar error in the future, please let me know - I really detest intermittent errors, which make it incredibly hard to debug _actual_ issues, and try to extinguish them with extreme prejudice!