### PR TITLE
Feat/16237056 uninstall streaming payments

### DIFF
--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
@@ -119,7 +119,7 @@ const MSG = {
     },
     uninstallConfirmation: {
       id: `${displayName}.${Extension.StreamingPayments}.uninstallConfirmation`,
-      defaultMessage: "I understand that deleted accounts aren't recoverable",
+      defaultMessage: 'I understand the risk of uninstalling this extension.',
     },
   }),
 };

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
@@ -147,7 +147,7 @@ const UninstallButton = ({
 
   const canRemoveExtension =
     !isStreamingPaymentsExtension ||
-    (isStreamingPaymentsExtension && (!hasActiveStream || !hasUnclaimedFunds));
+    (isStreamingPaymentsExtension && !hasActiveStream && !hasUnclaimedFunds);
 
   return (
     <>

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/UninstallButton.tsx
@@ -11,7 +11,7 @@ import Checkbox from '~v5/common/Checkbox/Checkbox.tsx';
 import Button from '~v5/shared/Button/Button.tsx';
 import Modal from '~v5/shared/Modal/Modal.tsx';
 
-import { useGetActiveAndUnclaimedStreams, useUninstall } from './hooks.tsx';
+import { useGetUninstallExtensionInfo, useUninstall } from './hooks.tsx';
 
 const displayName = 'pages.ExtensionDetailsPage.UninstallButton';
 
@@ -139,15 +139,10 @@ const UninstallButton = ({
   const [isCheckboxChecked, setIsCheckboxChecked] = useState(false);
   const { handleUninstall, isLoading } = useUninstall(extensionId);
   const { waitingForActionConfirmation } = useExtensionDetailsPageContext();
-  const { hasActiveStream, hasUnclaimedFunds } =
-    useGetActiveAndUnclaimedStreams();
 
-  const isStreamingPaymentsExtension =
-    extensionId === Extension.StreamingPayments;
+  const { canRemoveExtension } = useGetUninstallExtensionInfo();
 
-  const canRemoveExtension =
-    !isStreamingPaymentsExtension ||
-    (isStreamingPaymentsExtension && !hasActiveStream && !hasUnclaimedFunds);
+  const isExtensionRemovable = canRemoveExtension(extensionId);
 
   return (
     <>
@@ -189,11 +184,11 @@ const UninstallButton = ({
             values={{
               ul: ListChunks,
               li: ListItemChunks,
-              hasActiveStream: hasActiveStream || hasUnclaimedFunds,
+              hasActiveStream: !isExtensionRemovable,
             }}
           />
         </div>
-        {canRemoveExtension && (
+        {isExtensionRemovable && (
           <Checkbox
             name="uninstall"
             id="uninstall"

--- a/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/hooks.tsx
+++ b/src/components/frame/Extensions/pages/ExtensionDetailsPage/partials/ExtensionDetailsSidePanel/hooks.tsx
@@ -14,10 +14,7 @@ import { ActionTypes } from '~redux/index.ts';
 import Toast from '~shared/Extensions/Toast/index.ts';
 import { type StreamingPaymentItems } from '~shared/StreamingPayments/types.ts';
 import { StreamingPaymentStatus } from '~types/streamingPayments.ts';
-import {
-  getStreamingPaymentAmountsLeft,
-  getStreamingPaymentStatus,
-} from '~utils/streamingPayments.ts';
+import { getStreamingPaymentStatus } from '~utils/streamingPayments.ts';
 
 export const useUninstall = (extensionId: Extension) => {
   const {
@@ -144,16 +141,10 @@ export const useGetActiveAndUnclaimedStreams = () => {
 
   const getTotalActiveStreamingPayments = (items: StreamingPaymentItems) => {
     const activeStreams = items.filter((item) => {
-      const { amountAvailableToClaim } = getStreamingPaymentAmountsLeft(
-        item,
-        Math.floor(blockTime ?? Date.now() / 1000),
-      );
-
       return (
         getStreamingPaymentStatus({
           streamingPayment: item,
           currentTimestamp: Math.floor(blockTime ?? Date.now() / 1000),
-          amountAvailableToClaim,
         }) === StreamingPaymentStatus.Active
       );
     });

--- a/src/hooks/useColonyStreamingPayments.ts
+++ b/src/hooks/useColonyStreamingPayments.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import {
   type GetStreamingPaymentsByColonyQueryVariables,
@@ -38,27 +38,6 @@ export const useColonyStreamingPayments = (
       }
     },
   });
-
-  useEffect(() => {
-    fetchMore({
-      variables,
-      updateQuery: (prev, { fetchMoreResult }) => {
-        if (!fetchMoreResult) return prev;
-
-        return {
-          ...prev,
-          getStreamingPaymentsByColony: {
-            ...prev.getStreamingPaymentsByColony,
-            items: [
-              ...(prev?.getStreamingPaymentsByColony?.items || []),
-              ...(fetchMoreResult?.getStreamingPaymentsByColony?.items || []),
-            ],
-            nextToken: fetchMoreResult?.getStreamingPaymentsByColony?.nextToken,
-          },
-        };
-      },
-    });
-  }, [fetchMore, variables]);
 
   const streamingPayments = useMemo(
     () => data?.getStreamingPaymentsByColony?.items?.filter(notNull) || [],

--- a/src/hooks/useColonyStreamingPayments.ts
+++ b/src/hooks/useColonyStreamingPayments.ts
@@ -1,0 +1,69 @@
+import { useEffect, useMemo } from 'react';
+
+import {
+  type GetStreamingPaymentsByColonyQueryVariables,
+  useGetStreamingPaymentsByColonyQuery,
+} from '~gql';
+import { notNull } from '~utils/arrays/index.ts';
+
+export const useColonyStreamingPayments = (
+  variables: GetStreamingPaymentsByColonyQueryVariables,
+) => {
+  const { data, fetchMore, loading } = useGetStreamingPaymentsByColonyQuery({
+    variables,
+    onCompleted: (receivedData) => {
+      if (receivedData?.getStreamingPaymentsByColony?.nextToken) {
+        fetchMore({
+          variables: {
+            nextToken: receivedData.getStreamingPaymentsByColony.nextToken,
+          },
+          updateQuery: (prev, { fetchMoreResult }) => {
+            if (!fetchMoreResult) return prev;
+
+            return {
+              ...prev,
+              getStreamingPaymentsByColony: {
+                ...prev.getStreamingPaymentsByColony,
+                items: [
+                  ...(prev?.getStreamingPaymentsByColony?.items || []),
+                  ...(fetchMoreResult?.getStreamingPaymentsByColony?.items ||
+                    []),
+                ],
+                nextToken:
+                  fetchMoreResult?.getStreamingPaymentsByColony?.nextToken,
+              },
+            };
+          },
+        });
+      }
+    },
+  });
+
+  useEffect(() => {
+    fetchMore({
+      variables,
+      updateQuery: (prev, { fetchMoreResult }) => {
+        if (!fetchMoreResult) return prev;
+
+        return {
+          ...prev,
+          getStreamingPaymentsByColony: {
+            ...prev.getStreamingPaymentsByColony,
+            items: [
+              ...(prev?.getStreamingPaymentsByColony?.items || []),
+              ...(fetchMoreResult?.getStreamingPaymentsByColony?.items || []),
+            ],
+            nextToken: fetchMoreResult?.getStreamingPaymentsByColony?.nextToken,
+          },
+        };
+      },
+    });
+  }, [fetchMore, variables]);
+
+  const streamingPayments = useMemo(
+    () => data?.getStreamingPaymentsByColony?.items?.filter(notNull) || [],
+    [data?.getStreamingPaymentsByColony?.items],
+  );
+
+  return { streamingPayments, loading, fetchMore };
+};


### PR DESCRIPTION
## Description

handle uninstall streaming payments extension

## Testing

### Install Streaming payments extension

Allow uninstall:
- make sure you have no active or unclaimed streaming payment

Block uninstall:
- Create active streaming payment or create streaming payment with unclaimed funds

## Diffs

**New stuff** ✨

Allow unintall:
![Screenshot 2025-01-23 at 14 27 59](https://github.com/user-attachments/assets/d6775b87-89d9-448e-a6ce-d0d36530ff07)

Block uninstall:
![Screenshot 2025-01-23 at 14 27 41](https://github.com/user-attachments/assets/adb3c2b0-710c-4a98-abd3-dfeb18d40b8c)

Resolves https://github.com/JoinColony/colonyCDapp/issues/4099#event-15928147406
