### PR TITLE
fix: add keys to avoid console keys error

### DIFF
--- a/src/components/v5/shared/CardWithCallout/CardWithCallout.tsx
+++ b/src/components/v5/shared/CardWithCallout/CardWithCallout.tsx
@@ -28,7 +28,7 @@ const CardWithCallout: FC<PropsWithChildren<CardWithCalloutProps>> = ({
       <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3 md:flex-nowrap md:gap-y-0">
         <div>
           {subtitle && <h2 className="mb-1 text-md font-medium">{subtitle}</h2>}
-          {children && <p className="text-sm text-gray-600">{children}</p>}
+          {children && <div className="text-sm text-gray-600">{children}</div>}
         </div>
         {button}
       </div>

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -124,7 +124,7 @@ const Routes = () => {
           // Allow in use colony names
           .filter((route) => !['/meta', '/beta'].includes(route))
           .map((route) => (
-            <Route path={route} element={<NotFoundRoute />} />
+            <Route path={route} key={route} element={<NotFoundRoute />} />
           ))}
 
         {/* Colony routes */}


### PR DESCRIPTION
## Description
- This is a small fix to remove console error about react keys and div inside p.
<img width="717" alt="image" src="https://github.com/user-attachments/assets/e698e726-872d-45a4-beff-044c75995ef8" />


## Testing
Step 1. Open http://localhost:9091/planex
Step 2. Open dev tools and check that there is no error regading keys
Step 3. Disconnect wallet
Step 4. Verify that there is no error regarding div inside p at page http://localhost:9091/go/planex
