### PR TITLE
Fix: Ensure you can reclaim your stakes even if you staked the losing side

### DIFF
--- a/src/redux/sagas/motions/claimMotionRewards.ts
+++ b/src/redux/sagas/motions/claimMotionRewards.ts
@@ -64,22 +64,22 @@ function* claimMotionRewards({
       throw new Error('Could not retrieve motion from database');
     }
 
-    const userRewards = motionData.stakerRewards.find(
+    const userStakes = motionData.usersStakes.find(
       ({ address }) => address === userAddress,
     );
 
-    if (!userRewards) {
-      throw new Error('Could not find rewards for given user address');
+    if (!userStakes) {
+      throw new Error('Could not find stakes for given user address');
     }
 
-    const {
-      rewards: { yay, nay },
-    } = userRewards;
+    const { stakes } = userStakes ?? {};
+    const yayStake = stakes?.raw.yay;
+    const nayStake = stakes?.raw.nay;
 
-    const hasYayClaim = !BigNumber.from(yay).isZero();
-    const hasNayClaim = !BigNumber.from(nay).isZero();
+    const hasYayStake = !BigNumber.from(yayStake).isZero();
+    const hasNayStake = !BigNumber.from(nayStake).isZero();
 
-    if (!hasYayClaim && !hasNayClaim) {
+    if (!hasYayStake && !hasNayStake) {
       throw new Error('A motion with claims needs to be provided');
     }
 
@@ -89,7 +89,7 @@ function* claimMotionRewards({
     const channels: { [id: string]: ChannelDefinition } = yield call(
       createTransactionChannels,
       meta.id,
-      [...(hasYayClaim ? [YAY_ID] : []), ...(hasNayClaim ? [NAY_ID] : [])],
+      [...(hasYayStake ? [YAY_ID] : []), ...(hasNayStake ? [NAY_ID] : [])],
     );
 
     const BATCH_KEY = 'claimMotionRewards';


### PR DESCRIPTION
## Description

Thanks to @jakubcolony for helping me with the painful debugging process... which turned out to require a very straightforward fix 😅 

We had this logic in the saga that incorrectly prevents you from claiming your stakes. A little tweak was needed in order to allow all stakers to reclaim their tokens.

![reclaim](https://github.com/user-attachments/assets/18490150-db7c-4b24-906d-40aa2528ada8)

## Testing

1. Install the Reputation extension
2. As leela, create a Simple Payment motion using the Reputation decision method
3. As leela, during the Staking phase, Oppose and fully stake it
4. Copy the URL
5. Open an incognito window and connect amy's wallet
6. As amy, visit the URL you just copied
7. As amy, Support and fully stake it
8. Go back to leela's window
9. Reload the page
10. During the Voting phase, submit a Support vote
11. Reveal your vote
12. Finalise the motion
13. Reclaim your stakes
14. It could take a while but verify that the reclaim action successfully finishes

Resolves #4158 