### PR TITLE
Feat: Add script for deploying colony native token on chain

### DIFF
--- a/amplify/backend/api/colonycdapp/schema/proxyColonies.graphql
+++ b/amplify/backend/api/colonycdapp/schema/proxyColonies.graphql
@@ -9,7 +9,8 @@ type ProxyColony @model {
   """
   Address of the colony on the blockchain
   """
-  colonyAddress: ID! @index(
+  colonyAddress: ID!
+    @index(
       name: "byColonyAddress"
       queryField: "getProxyColoniesByColonyAddress"
     )

--- a/amplify/backend/api/colonycdapp/schema/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema/schema.graphql
@@ -899,10 +899,6 @@ enum ColonyActionType {
   MANAGE_TOKENS_MOTION
   MANAGE_TOKENS_MULTISIG
   """
-  An action related to arbitrary transaction
-  """
-  ARBITRARY_TX
-  """
   An action related to creating a proxy colony
   """
   ADD_PROXY_COLONY

--- a/scripts/deploy-token-to-chain.js
+++ b/scripts/deploy-token-to-chain.js
@@ -5,7 +5,6 @@ const {
 const { providers, ContractFactory } = require('ethers');
 const readline = require('readline');
 const { graphqlRequest } = require('./utils/graphqlRequest');
-const { unlockMintTokens } = require('./utils/unlockMintTokens');
 
 const API_KEY = 'da2-fakeApiId123456';
 const GRAPHQL_URI =
@@ -164,8 +163,6 @@ const deployNativeTokenToChain = async (
     console.log(
       `Proxy token with address ${foreignToken.address} successfully deployed for colony with address ${colonyAddress}.`,
     );
-
-    return foreignToken;
   } catch (error) {
     console.error(
       `Error deploying proxy token for ${colonyAddress}: ${error.message}`,
@@ -210,34 +207,6 @@ const getArgumentsFromConsole = async () => {
   };
 };
 
-const furtherActionsOnToken = async (colonyAddress, foreignToken) => {
-  const unlockMintTokensAction = await promptQuestion(
-    'Do you want to unlock and mint tokens now? Y/N',
-  );
-
-  if (unlockMintTokensAction.toUpperCase() !== 'Y') {
-    console.log(
-      'Skipping token unlock and minting. If you change your mind, please use the mint-tokens-on-chain script.',
-    );
-    return;
-  }
-
-  const tokenAmount = await promptQuestion(
-    'Please provide a numeric tokenAmount. Press enter to default to 100',
-  );
-
-  if (tokenAmount && (isNaN(tokenAmount) || Number(tokenAmount) <= 0)) {
-    console.error('Error: Please enter a valid number greater than 0.');
-    process.exit(1);
-  }
-
-  await unlockMintTokens(
-    colonyAddress,
-    foreignToken,
-    !tokenAmount ? 100 : Number(tokenAmount),
-  );
-};
-
 const start = async () => {
   try {
     const { foreignChainId, foreignChainRpcUrl, colonyAddress } =
@@ -250,14 +219,12 @@ const start = async () => {
     );
 
     const { nativeToken: colonyNativeToken } = deployedColony;
-    const foreignToken = await deployNativeTokenToChain(
+    await deployNativeTokenToChain(
       tokenFactory,
       foreignChainId,
       colonyNativeToken,
       colonyAddress,
     );
-
-    await furtherActionsOnToken(colonyAddress, foreignToken);
   } catch (error) {
     console.error(
       `There was an error executing the deploy-token-to-chain script. Error: ${error.message}`,

--- a/scripts/deploy-token-to-chain.js
+++ b/scripts/deploy-token-to-chain.js
@@ -1,0 +1,270 @@
+const {
+  abi: metaTxAbi,
+  bytecode: metaTxBytecode,
+} = require('@colony/abis/versions/hmwss/MetaTxToken');
+const { providers, ContractFactory } = require('ethers');
+const readline = require('readline');
+const { graphqlRequest } = require('./utils/graphqlRequest');
+const { unlockMintTokens } = require('./utils/unlockMintTokens');
+
+const API_KEY = 'da2-fakeApiId123456';
+const GRAPHQL_URI =
+  process.env.AWS_APPSYNC_GRAPHQL_URL || 'http://localhost:20002/graphql';
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+// Function to prompt for any input
+function promptQuestion(question) {
+  return new Promise((resolve) => {
+    rl.question(`${question}: `, (answer) => {
+      resolve(answer.trim());
+    });
+  });
+}
+
+/*
+ * Queries
+ */
+
+const getColony = /* GraphQL */ `
+  query GetColony($id: ID!) {
+    getColony(id: $id) {
+      colonyAddress: id
+      nativeToken {
+        tokenAddress: id
+        name
+        symbol
+        decimals
+        avatar
+        thumbnail
+        type
+      }
+    }
+  }
+`;
+
+const getProxyColony = /* GraphQL */ `
+  query GetProxyColony($id: ID!) {
+    getProxyColony(id: $id) {
+      id
+    }
+  }
+`;
+
+/*
+ * Mutations
+ */
+const createForeignToken = /* GraphQL */ `
+  mutation CreateToken($input: CreateTokenInput!) {
+    createToken(input: $input) {
+      id
+    }
+  }
+`;
+
+const graphqlRequestPreconfigured = async (queryOrMutation, variables) =>
+  graphqlRequest(queryOrMutation, variables, GRAPHQL_URI, API_KEY);
+
+const TokenFactoryConfig = (() => {
+  let tokenFactory = null;
+
+  const createTokenFactory = (abi, bytecode, rpcUrl) => {
+    // Initialize the foreign provider using the provided RPC URL
+    const foreignProvider = new providers.JsonRpcProvider(rpcUrl);
+
+    // Get the signer from the provider
+    const foreignSigner = foreignProvider.getSigner();
+
+    // Create the contract factory using the signer and bytecode
+    return new ContractFactory(abi, bytecode, foreignSigner);
+  };
+
+  return {
+    getTokenFactory: (rpcUrl) => {
+      if (!tokenFactory) {
+        tokenFactory = createTokenFactory(metaTxAbi, metaTxBytecode, rpcUrl);
+      }
+
+      return tokenFactory;
+    },
+  };
+})();
+
+const getDeployedColonyToChain = async (chainId, colonyAddress) => {
+  const colonyQuery = await graphqlRequestPreconfigured(getColony, {
+    id: colonyAddress,
+  });
+
+  if (colonyQuery?.errors) {
+    throw Error(JSON.stringify(colonyQuery?.errors));
+  }
+
+  const colony = colonyQuery?.data?.getColony;
+
+  const proxyColonyQuery = await graphqlRequestPreconfigured(getProxyColony, {
+    id: `${colony.colonyAddress}_${chainId}`,
+  });
+
+  const hasErrors = !!proxyColonyQuery?.errors;
+  const isProxyColonyExisting = !!proxyColonyQuery?.data?.getProxyColony?.id;
+
+  if (!hasErrors && isProxyColonyExisting) {
+    return colony;
+  }
+};
+
+const deployNativeTokenToChain = async (
+  tokenFactory,
+  chainId,
+  colonyNativeToken,
+  colonyAddress,
+) => {
+  try {
+    if (!colonyNativeToken) {
+      throw new Error(
+        `No native token setup for colony with address ${colonyAddress}.`,
+      );
+    }
+
+    const foreignToken = await tokenFactory.deploy(
+      colonyNativeToken.name,
+      colonyNativeToken.symbol,
+      colonyNativeToken.decimals,
+    );
+
+    await foreignToken.deployTransaction.wait();
+
+    const createForeignTokenMutationResult = await graphqlRequestPreconfigured(
+      createForeignToken,
+      {
+        input: {
+          id: foreignToken.address,
+          name: `${colonyNativeToken.name} ${chainId}`,
+          symbol: colonyNativeToken.symbol,
+          decimals: colonyNativeToken.decimals,
+          avatar: colonyNativeToken.avatar,
+          thumbnail: colonyNativeToken.thumbnail,
+          type: colonyNativeToken.type,
+          chainMetadata: {
+            chainId,
+          },
+        },
+      },
+    );
+
+    if (createForeignTokenMutationResult.errors) {
+      throw new Error(
+        `Error creating token for ${chainId} and ${colonyAddress}: ${JSON.stringify(createForeignTokenMutationResult.errors)}`,
+      );
+    }
+
+    console.log(
+      `Proxy token with address ${foreignToken.address} successfully deployed for colony with address ${colonyAddress}.`,
+    );
+
+    return foreignToken;
+  } catch (error) {
+    console.error(
+      `Error deploying proxy token for ${colonyAddress}: ${error.message}`,
+    );
+  }
+};
+
+const getArgumentsFromConsole = async () => {
+  const foreignChainId = await promptQuestion(
+    'Please provide the foreignChainId',
+  );
+
+  if (isNaN(foreignChainId) || Number.isInteger(foreignChainId)) {
+    console.error(
+      'Error: The foreignChainId cannot be empty and must be a number.',
+    );
+    process.exit(1);
+  }
+
+  const foreignChainRpcUrl = await promptQuestion(
+    'Please provide the foreignChainRpcUrl',
+  );
+
+  if (!foreignChainRpcUrl) {
+    console.error('Error: The foreignChainRpcUrl cannot be empty.');
+    process.exit(1);
+  }
+
+  const colonyAddress = await promptQuestion(
+    'Please provide the colonyAddress',
+  );
+
+  if (!colonyAddress) {
+    console.error('Error: The colonyAddress cannot be empty.');
+    process.exit(1);
+  }
+
+  return {
+    colonyAddress,
+    foreignChainId,
+    foreignChainRpcUrl,
+  };
+};
+
+const furtherActionsOnToken = async (colonyAddress, foreignToken) => {
+  const unlockMintTokensAction = await promptQuestion(
+    'Do you want to unlock and mint tokens now? Y/N',
+  );
+
+  if (unlockMintTokensAction.toUpperCase() !== 'Y') {
+    console.log(
+      'Skipping token unlock and minting. If you change your mind, please use the mint-tokens-on-chain script.',
+    );
+    return;
+  }
+
+  const tokenAmount = await promptQuestion(
+    'Please provide a numeric tokenAmount. Press enter to default to 100',
+  );
+
+  if (tokenAmount && (isNaN(tokenAmount) || Number(tokenAmount) <= 0)) {
+    console.error('Error: Please enter a valid number greater than 0.');
+    process.exit(1);
+  }
+
+  await unlockMintTokens(
+    colonyAddress,
+    foreignToken,
+    !tokenAmount ? 100 : Number(tokenAmount),
+  );
+};
+
+const start = async () => {
+  try {
+    const { foreignChainId, foreignChainRpcUrl, colonyAddress } =
+      await getArgumentsFromConsole();
+
+    const tokenFactory = TokenFactoryConfig.getTokenFactory(foreignChainRpcUrl);
+    const deployedColony = await getDeployedColonyToChain(
+      foreignChainId,
+      colonyAddress,
+    );
+
+    const { nativeToken: colonyNativeToken } = deployedColony;
+    const foreignToken = await deployNativeTokenToChain(
+      tokenFactory,
+      foreignChainId,
+      colonyNativeToken,
+      colonyAddress,
+    );
+
+    await furtherActionsOnToken(colonyAddress, foreignToken);
+  } catch (error) {
+    console.error(
+      `There was an error executing the deploy-token-to-chain script. Error: ${error.message}`,
+    );
+  } finally {
+    rl.close();
+  }
+};
+
+start();

--- a/scripts/mint-tokens-on-chain.js
+++ b/scripts/mint-tokens-on-chain.js
@@ -1,0 +1,108 @@
+const { abi: metaTxAbi } = require('@colony/abis/versions/hmwss/MetaTxToken');
+const { utils, providers, Contract } = require('ethers');
+const readline = require('readline');
+
+const { unlockMintTokens } = require('./utils/unlockMintTokens');
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+// Function to prompt for any input
+function promptQuestion(question) {
+  return new Promise((resolve) => {
+    rl.question(`${question}: `, (answer) => {
+      resolve(answer.trim());
+    });
+  });
+}
+
+const TokenConfig = (() => {
+  let token = null;
+
+  const getTokenContract = (tokenAddress, abi, rpcUrl) => {
+    // Initialize the foreign provider using the provided RPC URL
+    const foreignProvider = new providers.JsonRpcProvider(rpcUrl);
+
+    // Get the signer from the provider
+    const foreignSigner = foreignProvider.getSigner();
+
+    const checksummedAddress = utils.getAddress(tokenAddress);
+
+    // Create the contract factory using the signer and bytecode
+    return new Contract(checksummedAddress, abi, foreignSigner);
+  };
+
+  return {
+    getToken: (tokenAddress, rpcUrl) => {
+      if (!token) {
+        token = getTokenContract(tokenAddress, metaTxAbi, rpcUrl);
+      }
+
+      return token;
+    },
+  };
+})();
+
+const getArgumentsFromConsole = async () => {
+  const foreignChainRpcUrl = await promptQuestion(
+    'Please provide the foreignChainRpcUrl',
+  );
+
+  if (!foreignChainRpcUrl) {
+    console.error('Error: The foreignChainRpcUrl cannot be empty.');
+    process.exit(1);
+  }
+
+  const colonyAddress = await promptQuestion(
+    'Please provide the colonyAddress',
+  );
+
+  if (!colonyAddress) {
+    console.error('Error: The colonyAddress cannot be empty.');
+    process.exit(1);
+  }
+
+  const tokenAddress = await promptQuestion('Please provide the tokenAddress');
+
+  if (!tokenAddress) {
+    console.error('Error: The tokenAddress cannot be empty.');
+    process.exit(1);
+  }
+
+  const tokenAmount = await promptQuestion(
+    'Please provide a numeric tokenAmount. Press enter to default to 100',
+  );
+
+  if (tokenAmount && (isNaN(tokenAmount) || Number(tokenAmount) <= 0)) {
+    console.error('Error: Please enter a valid number greater than 0.');
+    process.exit(1);
+  }
+
+  return {
+    foreignChainRpcUrl,
+    colonyAddress,
+    tokenAddress,
+    tokenAmount: !tokenAmount ? 100 : Number(tokenAmount),
+  };
+};
+
+async function start() {
+  try {
+    const { foreignChainRpcUrl, colonyAddress, tokenAddress, tokenAmount } =
+      await getArgumentsFromConsole();
+
+    const token = TokenConfig.getToken(tokenAddress, foreignChainRpcUrl);
+
+    await unlockMintTokens(colonyAddress, token, tokenAmount);
+  } catch (error) {
+    console.error(
+      `There was an error executing the deploy-token-to-chain script. Error: ${error.message}`,
+    );
+  } finally {
+    rl.close();
+  }
+}
+
+start();

--- a/scripts/utils/unlockMintTokens.js
+++ b/scripts/utils/unlockMintTokens.js
@@ -1,0 +1,32 @@
+/**
+ * Unlocks a token and mints a specified amount of tokens to the colony address.
+ *
+ * @async
+ * @function unlockMintTokens
+ * @param {string} colonyAddress - The address of the colony where the tokens will be minted.
+ * @param {Object} token - The token contract representing the token to be unlocked and minted.
+ * @param {number|string|BigNumber} tokenAmount - The amount of tokens to mint.
+ * @returns {Promise<void>} A promise that resolves when the token has been successfully unlocked and minted.
+ * @throws Will log an error message if unlocking or minting the token fails.
+ */
+const unlockMintTokens = async (colonyAddress, token, tokenAmount) => {
+  const tokenAddress = token.address;
+  try {
+    await token.unlock();
+
+    // The proxy colony address is the same as the main colony address
+    await token['mint(address,uint256)'](colonyAddress, tokenAmount);
+
+    console.log(
+      `Proxy token with address ${tokenAddress} successfully unlocked and ${tokenAmount} tokens were minted.`,
+    );
+  } catch {
+    console.error(
+      `Error while unlocking and minting foreign token with address ${tokenAddress}.`,
+    );
+  }
+};
+
+module.exports = {
+  unlockMintTokens,
+};

--- a/scripts/utils/unlockMintTokens.js
+++ b/scripts/utils/unlockMintTokens.js
@@ -1,24 +1,40 @@
 /**
- * Unlocks a token and mints a specified amount of tokens to the colony address.
+ * Unlocks a token.
  *
  * @async
- * @function unlockMintTokens
- * @param {string} colonyAddress - The address of the colony where the tokens will be minted.
- * @param {Object} token - The token contract representing the token to be unlocked and minted.
+ * @function unlockToken
+ * @param {Object} token - The token contract representing the token to be unlocked.
  * @param {number|string|BigNumber} tokenAmount - The amount of tokens to mint.
- * @returns {Promise<void>} A promise that resolves when the token has been successfully unlocked and minted.
- * @throws Will log an error message if unlocking or minting the token fails.
+ * @returns {Promise<void>} A promise that resolves when the token has been successfully unlocked.
+ * @throws Will log an error message if unlocking the token fails.
  */
-const unlockMintTokens = async (colonyAddress, token, tokenAmount) => {
+const unlockToken = async (token) => {
   const tokenAddress = token.address;
   try {
     await token.unlock();
+    console.log(`Token with address ${tokenAddress} successfully unlocked.`);
+  } catch {
+    console.error(`Error while unlocking token with address ${tokenAddress}.`);
+  }
+};
 
-    // The proxy colony address is the same as the main colony address
+/**
+ * Mints a specified amount of tokens to the colony address.
+ *
+ * @async
+ * @function mintTokens
+ * @param {string} colonyAddress - The address of the colony where the tokens will be minted.
+ * @param {Object} token - The token contract representing the token to be minted.
+ * @param {number|string|BigNumber} tokenAmount - The amount of tokens to mint.
+ * @returns {Promise<void>} A promise that resolves when the token has been successfully minted.
+ * @throws Will log an error message if minting the token fails.
+ */
+const mintTokens = async (colonyAddress, token, tokenAmount) => {
+  const tokenAddress = token.address;
+  try {
     await token['mint(address,uint256)'](colonyAddress, tokenAmount);
-
     console.log(
-      `Proxy token with address ${tokenAddress} successfully unlocked and ${tokenAmount} tokens were minted.`,
+      `Successfully minted ${tokenAmount} tokens for token with address ${tokenAddress} to colony with address ${colonyAddress}.`,
     );
   } catch {
     console.error(
@@ -28,5 +44,6 @@ const unlockMintTokens = async (colonyAddress, token, tokenAmount) => {
 };
 
 module.exports = {
-  unlockMintTokens,
+  unlockToken,
+  mintTokens,
 };

--- a/src/redux/sagas/proxyColonies/createProxyColony.ts
+++ b/src/redux/sagas/proxyColonies/createProxyColony.ts
@@ -33,8 +33,6 @@ export type CreateProxyColonyPayload =
   Action<ActionTypes.PROXY_COLONY_CREATE>['payload'];
 
 // @TODO if metatx are enabled sent a metaTx instead of tx
-// @TODO we need to add the annotationMessage and the customActionTitle
-// @TODO we need to add re-enable logic if the proxy colony was already deployed
 function* createProxyColony({
   payload: {
     colonyAddress,


### PR DESCRIPTION
## Description

- This PR addresses the fact that once a proxy colony gets deployed, on the `DEV` env we'll need to deploy the associated native token on the respective chain in order to have some data to work with. 
- Also this PR adds a script for supporting unlocking and minting tokens
Thank you @iamsamgibbs and @bassgeta for all the help

## Testing

TODO: Let's test the colony native token gets deployed on a new chain and we actually store that information.

* Step 1. Go to http://localhost:9091/planex
* Step 2. Create a `Manage supported chains` action/motion for chain `Local Proxy Chain 1`

![Screenshot 2025-01-24 at 20 20 31](https://github.com/user-attachments/assets/e48493c8-4f2e-4234-b2ac-437bfe3825fe)

* Step 3. Close the action sidebar and copy the colony address.

* Step 4. Once the action is completed, please run `node scripts/deploy-token-to-chain.js`
Please use the following values for the input
foreignChainId `265669101`
foreignChainRpcUrl `http://localhost:8546`
colonyAddress `<COLONY_ADDRESS_HERE>`

You should get a similar output to the one below
<img width="1116" alt="Screenshot 2025-01-27 at 21 17 21" src="https://github.com/user-attachments/assets/4d0e1bd2-8a6c-42f9-9909-aa2bbfd191b9" />

* Step 5. Run the following query 
```
query MyQuery {
  listTokens {
    items {
      id
      name
      chainMetadata {
        chainId
      }
    }
  }
}
```
You should see a new entry for `Space Creds` on chain with id `265669101`
![Screenshot 2025-01-27 at 21 18 14](https://github.com/user-attachments/assets/0b476cd9-30a2-4c60-942e-f52dc71b2f7c)

* Step 6. Copy the token id from the `265669101` chain

* Step 7. Now let's test the script for unlocking and minting tokens, please run `node scripts/unlock-mint-tokens-on-chain.js`
Please use the following values for the input
foreignChainRpcUrl `http://localhost:8546`
colonyAddress `<COLONY_ADDRESS_HERE>`
tokenAddress `<TOKEN_ADDRESS_FROM_OTHER_CHAIN_HERE>`
tokenAmount `100`
<img width="1160" alt="Screenshot 2025-01-27 at 21 25 38" src="https://github.com/user-attachments/assets/f91e0ade-c986-4ae3-b368-5b771c841b13" />

* Step 8. Test the token was actually minted by running `npm run hardhat`. Then paste the following, but make sure to replace the colony and token addresses.
```
p = await new ethers.providers.StaticJsonRpcProvider("http://network-contracts-remote:8545")

erc20Abi = ["function balanceOf(address owner) view returns (uint256)", "function decimals() view returns (uint8)"]

t = new ethers.Contract("<TOKEN_ADDRESS_FROM_OTHER_CHAIN_HERE>", erc20Abi, p)

await t.balanceOf("<COLONY_ADDRESS_HERE>")
```
<img width="477" alt="Screenshot 2025-01-27 at 21 29 40" src="https://github.com/user-attachments/assets/607b4d6a-09c7-4897-af3a-3b0e9e69c16a" />


> [!IMPORTANT]
> Running the script above multiple times will create each time a new entry on the given chain, which actually simulates a real situation when a token can have multiple addresses on a single chain

## Diffs

**New stuff** ✨

* `deploy-token-to-chain` script
* `unlock-mint-tokens-on-chain` script
