### PR TITLE
Fix: Button with icon bug

### DIFF
--- a/src/components/frame/v5/pages/FundsPage/partials/FundsTable/FundsTable.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/FundsTable/FundsTable.tsx
@@ -10,6 +10,7 @@ import { IncomingFundsLoadingContextProvider } from '~frame/v5/pages/FundsPage/c
 import { useMobile } from '~hooks';
 import useColonyFundsClaims from '~hooks/useColonyFundsClaims.ts';
 import { formatText } from '~utils/intl.ts';
+import { formatMessage } from '~utils/yup/tests/helpers.ts';
 import EmptyContent from '~v5/common/EmptyContent/index.ts';
 import { Table } from '~v5/common/Table/Table.tsx';
 import TableHeader from '~v5/common/TableHeader/TableHeader.tsx';
@@ -78,6 +79,7 @@ const FundsTable: FC = () => {
             unclaimedClaims={allUnclaimedClaims}
             isButtonDisabled={!searchedTokens.length}
             shouldShowButton={unclaimedClaims.length > 0}
+            buttonText={formatMessage({ id: 'allFilters' })}
           />
         </div>
       </TableHeader>

--- a/src/components/v5/common/ActionSidebar/partials/SaveDraftButton/SaveDraftButton.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/SaveDraftButton/SaveDraftButton.tsx
@@ -71,7 +71,7 @@ const SaveDraftButton: FC = () => {
       isFullSize={isMobile}
       disabled={formState.isValidating || isDraftSaved || hasNoDecisionMethods}
     >
-      {!isDraftSaved && <FileDashed size={18} className="mr-2" />}
+      {!isDraftSaved && <FileDashed size={18} />}
       {formatText({
         id: isDraftSaved ? 'button.draftSaved' : 'button.saveDraft',
       })}

--- a/src/components/v5/shared/Filter/FilterButton.tsx
+++ b/src/components/v5/shared/Filter/FilterButton.tsx
@@ -32,10 +32,10 @@ const FilterButton: FC<FilterButtonProps> = ({
       mode="tertiary"
       size={size}
     >
-      <FunnelSimple size={18} className="mr-2 flex-shrink-0" />
+      <FunnelSimple size={18} className="flex-shrink-0" />
       {customLabel || formatMessage({ id: 'filter' })}
       {!!numberSelectedFilters && (
-        <span className="ml-2 inline-flex h-[.8125rem] min-w-[.75rem] items-center rounded-sm bg-blue-100 px-1 py-0.5 text-[.5rem] font-bold leading-none text-blue-400">
+        <span className="inline-flex h-[.8125rem] min-w-[.75rem] items-center rounded-sm bg-blue-100 px-1 py-0.5 text-[.5rem] font-bold leading-none text-blue-400">
           {numberSelectedFilters}
         </span>
       )}


### PR DESCRIPTION
## Description

This PR resolves an issue where the "save draft" button and "filters" button had too much big of a gap between the icon and the text.

## Testing

Check all instances of the filters buttons.

Check the filter button on the incoming funds page reads "All filters".

Check the "Save draft" button for creating agreements has the correct spacing.

![Screenshot 2025-01-27 at 14 48 19](https://github.com/user-attachments/assets/ed708102-7159-4fcc-8ada-36e940124405)

![Screenshot 2025-01-27 at 14 48 32](https://github.com/user-attachments/assets/83749150-54bf-4710-9328-df07dde830f1)

![Screenshot 2025-01-27 at 14 48 41](https://github.com/user-attachments/assets/bbb26e79-9c40-46e1-9d34-2349f50e37cf)

## Diffs

**Changes** 🏗

* Updated filter text to "All filters"

**Deletions** ⚰️

* Removed additional padding around save draft and filter button icons.

Resolves #3351