### PR TITLE
[Proxy colonies M1] feat: handle cases where the main chain ingestor is slower than the proxy one

### DIFF
--- a/amplify/backend/api/colonycdapp/schema/schema.graphql
+++ b/amplify/backend/api/colonycdapp/schema/schema.graphql
@@ -3580,9 +3580,13 @@ type ColonyAction @model @searchable {
   expenditureSlotIds: [Int!]
   arbitraryTransactions: [ColonyActionArbitraryTransaction!]
   """
+  The id of the multichain info entry
+  """
+  multiChainInfoId: ID
+  """
   Multichain info if the action is bridged
   """
-  multiChainInfo: MultiChainInfo
+  multiChainInfo: MultiChainInfo @hasOne(fields: ["multiChainInfoId"])
   """
   Target chain id if the action is on a proxy colony chain
   """
@@ -3597,8 +3601,13 @@ type ColonyAction @model @searchable {
   finalizedActionData: ColonyAction @hasOne(fields: ["finalizedActionId"])
 }
 
-type MultiChainInfo {
-  completed: Boolean!
+type MultiChainInfo @model {
+  """
+  The format is txHash_chainId
+  """
+  id: ID!
+  completedOnMainChain: Boolean!
+  completedOnProxyChain: Boolean!
   wormholeInfo: ActionWormholeInfo
 }
 

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=4ac06d5744f8ada7b80047afd586da4d82898436
+ENV BLOCK_INGESTOR_HASH=1b39cf385254c2117dff2e0e8a0c9578c549ed6e
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/docker/colony-cdapp-dev-env-proxy-block-ingestor
+++ b/docker/colony-cdapp-dev-env-proxy-block-ingestor
@@ -1,7 +1,7 @@
 FROM colony-cdapp-dev-env/base:latest
 
 # @TODO maybe add a PROXY_BLOCK_INGESTOR_HASH and fallback to BLOCK_INGESTOR_HASH
-ENV BLOCK_INGESTOR_HASH=4ac06d5744f8ada7b80047afd586da4d82898436
+ENV BLOCK_INGESTOR_HASH=1b39cf385254c2117dff2e0e8a0c9578c549ed6e
 
 ENV CHAIN_RPC_ENDPOINTS='["http://network-contracts-remote:8545", "http://network-contracts-remote-2:8545"]'
 ENV STATS_PORTS='["10002", "10003"]'

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -514,6 +514,8 @@ export type ColonyAction = {
   motionId?: Maybe<Scalars['ID']>;
   /** Multichain info if the action is bridged */
   multiChainInfo?: Maybe<MultiChainInfo>;
+  /** The id of the multichain info entry */
+  multiChainInfoId?: Maybe<Scalars['ID']>;
   /** Expanded `ColonyMultiSig` for the corresponding `multiSigId` */
   multiSigData?: Maybe<ColonyMultiSig>;
   /** The internal database id of the multiSig */
@@ -638,6 +640,8 @@ export enum ColonyActionType {
   AddVerifiedMembers = 'ADD_VERIFIED_MEMBERS',
   AddVerifiedMembersMotion = 'ADD_VERIFIED_MEMBERS_MOTION',
   AddVerifiedMembersMultisig = 'ADD_VERIFIED_MEMBERS_MULTISIG',
+  /** An action related to arbitrary transaction */
+  ArbitraryTx = 'ARBITRARY_TX',
   /** An action related to canceling an expenditure */
   CancelExpenditure = 'CANCEL_EXPENDITURE',
   /** An action related to a motion to cancel an expenditure */
@@ -1513,7 +1517,7 @@ export type CreateColonyActionInput = {
   members?: InputMaybe<Array<Scalars['ID']>>;
   motionDomainId?: InputMaybe<Scalars['Int']>;
   motionId?: InputMaybe<Scalars['ID']>;
-  multiChainInfo?: InputMaybe<MultiChainInfoInput>;
+  multiChainInfoId?: InputMaybe<Scalars['ID']>;
   multiSigId?: InputMaybe<Scalars['ID']>;
   networkFee?: InputMaybe<Scalars['String']>;
   newColonyVersion?: InputMaybe<Scalars['Int']>;
@@ -1853,6 +1857,13 @@ export type CreateMotionMessageInput = {
   vote?: InputMaybe<Scalars['String']>;
 };
 
+export type CreateMultiChainInfoInput = {
+  completedOnMainChain: Scalars['Boolean'];
+  completedOnProxyChain: Scalars['Boolean'];
+  id?: InputMaybe<Scalars['ID']>;
+  wormholeInfo?: InputMaybe<ActionWormholeInfoInput>;
+};
+
 export type CreateMultiSigUserSignatureInput = {
   colonyAddress: Scalars['ID'];
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
@@ -2186,6 +2197,10 @@ export type DeleteLiquidationAddressInput = {
 };
 
 export type DeleteMotionMessageInput = {
+  id: Scalars['ID'];
+};
+
+export type DeleteMultiChainInfoInput = {
   id: Scalars['ID'];
 };
 
@@ -2992,6 +3007,7 @@ export type ModelColonyActionConditionInput = {
   members?: InputMaybe<ModelIdInput>;
   motionDomainId?: InputMaybe<ModelIntInput>;
   motionId?: InputMaybe<ModelIdInput>;
+  multiChainInfoId?: InputMaybe<ModelIdInput>;
   multiSigId?: InputMaybe<ModelIdInput>;
   networkFee?: InputMaybe<ModelStringInput>;
   newColonyVersion?: InputMaybe<ModelIntInput>;
@@ -3040,6 +3056,7 @@ export type ModelColonyActionFilterInput = {
   members?: InputMaybe<ModelIdInput>;
   motionDomainId?: InputMaybe<ModelIntInput>;
   motionId?: InputMaybe<ModelIdInput>;
+  multiChainInfoId?: InputMaybe<ModelIdInput>;
   multiSigId?: InputMaybe<ModelIdInput>;
   networkFee?: InputMaybe<ModelStringInput>;
   newColonyVersion?: InputMaybe<ModelIntInput>;
@@ -3973,6 +3990,29 @@ export type ModelMotionMessageFilterInput = {
   vote?: InputMaybe<ModelStringInput>;
 };
 
+export type ModelMultiChainInfoConditionInput = {
+  and?: InputMaybe<Array<InputMaybe<ModelMultiChainInfoConditionInput>>>;
+  completedOnMainChain?: InputMaybe<ModelBooleanInput>;
+  completedOnProxyChain?: InputMaybe<ModelBooleanInput>;
+  not?: InputMaybe<ModelMultiChainInfoConditionInput>;
+  or?: InputMaybe<Array<InputMaybe<ModelMultiChainInfoConditionInput>>>;
+};
+
+export type ModelMultiChainInfoConnection = {
+  __typename?: 'ModelMultiChainInfoConnection';
+  items: Array<Maybe<MultiChainInfo>>;
+  nextToken?: Maybe<Scalars['String']>;
+};
+
+export type ModelMultiChainInfoFilterInput = {
+  and?: InputMaybe<Array<InputMaybe<ModelMultiChainInfoFilterInput>>>;
+  completedOnMainChain?: InputMaybe<ModelBooleanInput>;
+  completedOnProxyChain?: InputMaybe<ModelBooleanInput>;
+  id?: InputMaybe<ModelIdInput>;
+  not?: InputMaybe<ModelMultiChainInfoFilterInput>;
+  or?: InputMaybe<Array<InputMaybe<ModelMultiChainInfoFilterInput>>>;
+};
+
 export type ModelMultiSigUserSignatureConditionInput = {
   and?: InputMaybe<Array<InputMaybe<ModelMultiSigUserSignatureConditionInput>>>;
   colonyAddress?: InputMaybe<ModelIdInput>;
@@ -4366,6 +4406,7 @@ export type ModelSubscriptionColonyActionFilterInput = {
   members?: InputMaybe<ModelSubscriptionIdInput>;
   motionDomainId?: InputMaybe<ModelSubscriptionIntInput>;
   motionId?: InputMaybe<ModelSubscriptionIdInput>;
+  multiChainInfoId?: InputMaybe<ModelSubscriptionIdInput>;
   multiSigId?: InputMaybe<ModelSubscriptionIdInput>;
   networkFee?: InputMaybe<ModelSubscriptionStringInput>;
   newColonyVersion?: InputMaybe<ModelSubscriptionIntInput>;
@@ -4735,6 +4776,14 @@ export type ModelSubscriptionMotionMessageFilterInput = {
   name?: InputMaybe<ModelSubscriptionStringInput>;
   or?: InputMaybe<Array<InputMaybe<ModelSubscriptionMotionMessageFilterInput>>>;
   vote?: InputMaybe<ModelSubscriptionStringInput>;
+};
+
+export type ModelSubscriptionMultiChainInfoFilterInput = {
+  and?: InputMaybe<Array<InputMaybe<ModelSubscriptionMultiChainInfoFilterInput>>>;
+  completedOnMainChain?: InputMaybe<ModelSubscriptionBooleanInput>;
+  completedOnProxyChain?: InputMaybe<ModelSubscriptionBooleanInput>;
+  id?: InputMaybe<ModelSubscriptionIdInput>;
+  or?: InputMaybe<Array<InputMaybe<ModelSubscriptionMultiChainInfoFilterInput>>>;
 };
 
 export type ModelSubscriptionMultiSigUserSignatureFilterInput = {
@@ -5371,13 +5420,13 @@ export type MotionStateHistoryInput = {
 
 export type MultiChainInfo = {
   __typename?: 'MultiChainInfo';
-  completed: Scalars['Boolean'];
+  completedOnMainChain: Scalars['Boolean'];
+  completedOnProxyChain: Scalars['Boolean'];
+  createdAt: Scalars['AWSDateTime'];
+  /** The format is txHash_chainId */
+  id: Scalars['ID'];
+  updatedAt: Scalars['AWSDateTime'];
   wormholeInfo?: Maybe<ActionWormholeInfo>;
-};
-
-export type MultiChainInfoInput = {
-  completed: Scalars['Boolean'];
-  wormholeInfo?: InputMaybe<ActionWormholeInfoInput>;
 };
 
 export type MultiSigDomainConfig = {
@@ -5460,6 +5509,7 @@ export type Mutation = {
   createIngestorStats?: Maybe<IngestorStats>;
   createLiquidationAddress?: Maybe<LiquidationAddress>;
   createMotionMessage?: Maybe<MotionMessage>;
+  createMultiChainInfo?: Maybe<MultiChainInfo>;
   createMultiSigUserSignature?: Maybe<MultiSigUserSignature>;
   createNotificationsData?: Maybe<NotificationsData>;
   createPrivateBetaInviteCode?: Maybe<PrivateBetaInviteCode>;
@@ -5510,6 +5560,7 @@ export type Mutation = {
   deleteIngestorStats?: Maybe<IngestorStats>;
   deleteLiquidationAddress?: Maybe<LiquidationAddress>;
   deleteMotionMessage?: Maybe<MotionMessage>;
+  deleteMultiChainInfo?: Maybe<MultiChainInfo>;
   deleteMultiSigUserSignature?: Maybe<MultiSigUserSignature>;
   deleteNotificationsData?: Maybe<NotificationsData>;
   deletePrivateBetaInviteCode?: Maybe<PrivateBetaInviteCode>;
@@ -5560,6 +5611,7 @@ export type Mutation = {
   updateIngestorStats?: Maybe<IngestorStats>;
   updateLiquidationAddress?: Maybe<LiquidationAddress>;
   updateMotionMessage?: Maybe<MotionMessage>;
+  updateMultiChainInfo?: Maybe<MultiChainInfo>;
   updateMultiSigUserSignature?: Maybe<MultiSigUserSignature>;
   updateNotificationsData?: Maybe<NotificationsData>;
   updatePrivateBetaInviteCode?: Maybe<PrivateBetaInviteCode>;
@@ -5800,6 +5852,13 @@ export type MutationCreateLiquidationAddressArgs = {
 export type MutationCreateMotionMessageArgs = {
   condition?: InputMaybe<ModelMotionMessageConditionInput>;
   input: CreateMotionMessageInput;
+};
+
+
+/** Root mutation type */
+export type MutationCreateMultiChainInfoArgs = {
+  condition?: InputMaybe<ModelMultiChainInfoConditionInput>;
+  input: CreateMultiChainInfoInput;
 };
 
 
@@ -6138,6 +6197,13 @@ export type MutationDeleteMotionMessageArgs = {
 
 
 /** Root mutation type */
+export type MutationDeleteMultiChainInfoArgs = {
+  condition?: InputMaybe<ModelMultiChainInfoConditionInput>;
+  input: DeleteMultiChainInfoInput;
+};
+
+
+/** Root mutation type */
 export type MutationDeleteMultiSigUserSignatureArgs = {
   condition?: InputMaybe<ModelMultiSigUserSignatureConditionInput>;
   input: DeleteMultiSigUserSignatureInput;
@@ -6468,6 +6534,13 @@ export type MutationUpdateLiquidationAddressArgs = {
 export type MutationUpdateMotionMessageArgs = {
   condition?: InputMaybe<ModelMotionMessageConditionInput>;
   input: UpdateMotionMessageInput;
+};
+
+
+/** Root mutation type */
+export type MutationUpdateMultiChainInfoArgs = {
+  condition?: InputMaybe<ModelMultiChainInfoConditionInput>;
+  input: UpdateMultiChainInfoInput;
 };
 
 
@@ -6944,6 +7017,7 @@ export type Query = {
   /** Get the timeout for the current period of a motion */
   getMotionTimeoutPeriods?: Maybe<GetMotionTimeoutPeriodsReturn>;
   getMotionVoterRewards?: Maybe<ModelVoterRewardsHistoryConnection>;
+  getMultiChainInfo?: Maybe<MultiChainInfo>;
   getMultiSigByColonyAddress?: Maybe<ModelColonyMultiSigConnection>;
   getMultiSigByExpenditureId?: Maybe<ModelColonyMultiSigConnection>;
   getMultiSigByTransactionHash?: Maybe<ModelColonyMultiSigConnection>;
@@ -7021,6 +7095,7 @@ export type Query = {
   listIngestorStats?: Maybe<ModelIngestorStatsConnection>;
   listLiquidationAddresses?: Maybe<ModelLiquidationAddressConnection>;
   listMotionMessages?: Maybe<ModelMotionMessageConnection>;
+  listMultiChainInfos?: Maybe<ModelMultiChainInfoConnection>;
   listMultiSigUserSignatures?: Maybe<ModelMultiSigUserSignatureConnection>;
   listNotificationsData?: Maybe<ModelNotificationsDataConnection>;
   listPrivateBetaInviteCodes?: Maybe<ModelPrivateBetaInviteCodeConnection>;
@@ -7548,6 +7623,12 @@ export type QueryGetMotionVoterRewardsArgs = {
   motionId: Scalars['ID'];
   nextToken?: InputMaybe<Scalars['String']>;
   sortDirection?: InputMaybe<ModelSortDirection>;
+};
+
+
+/** Root query type */
+export type QueryGetMultiChainInfoArgs = {
+  id: Scalars['ID'];
 };
 
 
@@ -8122,6 +8203,14 @@ export type QueryListMotionMessagesArgs = {
 
 
 /** Root query type */
+export type QueryListMultiChainInfosArgs = {
+  filter?: InputMaybe<ModelMultiChainInfoFilterInput>;
+  limit?: InputMaybe<Scalars['Int']>;
+  nextToken?: InputMaybe<Scalars['String']>;
+};
+
+
+/** Root query type */
 export type QueryListMultiSigUserSignaturesArgs = {
   filter?: InputMaybe<ModelMultiSigUserSignatureFilterInput>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -8428,6 +8517,7 @@ export enum SearchableColonyActionAggregateField {
   Members = 'members',
   MotionDomainId = 'motionDomainId',
   MotionId = 'motionId',
+  MultiChainInfoId = 'multiChainInfoId',
   MultiSigId = 'multiSigId',
   NetworkFee = 'networkFee',
   NewColonyVersion = 'newColonyVersion',
@@ -8483,6 +8573,7 @@ export type SearchableColonyActionFilterInput = {
   members?: InputMaybe<SearchableIdFilterInput>;
   motionDomainId?: InputMaybe<SearchableIntFilterInput>;
   motionId?: InputMaybe<SearchableIdFilterInput>;
+  multiChainInfoId?: InputMaybe<SearchableIdFilterInput>;
   multiSigId?: InputMaybe<SearchableIdFilterInput>;
   networkFee?: InputMaybe<SearchableStringFilterInput>;
   newColonyVersion?: InputMaybe<SearchableIntFilterInput>;
@@ -8530,6 +8621,7 @@ export enum SearchableColonyActionSortableFields {
   Members = 'members',
   MotionDomainId = 'motionDomainId',
   MotionId = 'motionId',
+  MultiChainInfoId = 'multiChainInfoId',
   MultiSigId = 'multiSigId',
   NetworkFee = 'networkFee',
   NewColonyVersion = 'newColonyVersion',
@@ -8801,6 +8893,7 @@ export type Subscription = {
   onCreateIngestorStats?: Maybe<IngestorStats>;
   onCreateLiquidationAddress?: Maybe<LiquidationAddress>;
   onCreateMotionMessage?: Maybe<MotionMessage>;
+  onCreateMultiChainInfo?: Maybe<MultiChainInfo>;
   onCreateMultiSigUserSignature?: Maybe<MultiSigUserSignature>;
   onCreateNotificationsData?: Maybe<NotificationsData>;
   onCreatePrivateBetaInviteCode?: Maybe<PrivateBetaInviteCode>;
@@ -8847,6 +8940,7 @@ export type Subscription = {
   onDeleteIngestorStats?: Maybe<IngestorStats>;
   onDeleteLiquidationAddress?: Maybe<LiquidationAddress>;
   onDeleteMotionMessage?: Maybe<MotionMessage>;
+  onDeleteMultiChainInfo?: Maybe<MultiChainInfo>;
   onDeleteMultiSigUserSignature?: Maybe<MultiSigUserSignature>;
   onDeleteNotificationsData?: Maybe<NotificationsData>;
   onDeletePrivateBetaInviteCode?: Maybe<PrivateBetaInviteCode>;
@@ -8893,6 +8987,7 @@ export type Subscription = {
   onUpdateIngestorStats?: Maybe<IngestorStats>;
   onUpdateLiquidationAddress?: Maybe<LiquidationAddress>;
   onUpdateMotionMessage?: Maybe<MotionMessage>;
+  onUpdateMultiChainInfo?: Maybe<MultiChainInfo>;
   onUpdateMultiSigUserSignature?: Maybe<MultiSigUserSignature>;
   onUpdateNotificationsData?: Maybe<NotificationsData>;
   onUpdatePrivateBetaInviteCode?: Maybe<PrivateBetaInviteCode>;
@@ -9051,6 +9146,11 @@ export type SubscriptionOnCreateLiquidationAddressArgs = {
 
 export type SubscriptionOnCreateMotionMessageArgs = {
   filter?: InputMaybe<ModelSubscriptionMotionMessageFilterInput>;
+};
+
+
+export type SubscriptionOnCreateMultiChainInfoArgs = {
+  filter?: InputMaybe<ModelSubscriptionMultiChainInfoFilterInput>;
 };
 
 
@@ -9284,6 +9384,11 @@ export type SubscriptionOnDeleteMotionMessageArgs = {
 };
 
 
+export type SubscriptionOnDeleteMultiChainInfoArgs = {
+  filter?: InputMaybe<ModelSubscriptionMultiChainInfoFilterInput>;
+};
+
+
 export type SubscriptionOnDeleteMultiSigUserSignatureArgs = {
   filter?: InputMaybe<ModelSubscriptionMultiSigUserSignatureFilterInput>;
 };
@@ -9511,6 +9616,11 @@ export type SubscriptionOnUpdateLiquidationAddressArgs = {
 
 export type SubscriptionOnUpdateMotionMessageArgs = {
   filter?: InputMaybe<ModelSubscriptionMotionMessageFilterInput>;
+};
+
+
+export type SubscriptionOnUpdateMultiChainInfoArgs = {
+  filter?: InputMaybe<ModelSubscriptionMultiChainInfoFilterInput>;
 };
 
 
@@ -9895,7 +10005,7 @@ export type UpdateColonyActionInput = {
   members?: InputMaybe<Array<Scalars['ID']>>;
   motionDomainId?: InputMaybe<Scalars['Int']>;
   motionId?: InputMaybe<Scalars['ID']>;
-  multiChainInfo?: InputMaybe<MultiChainInfoInput>;
+  multiChainInfoId?: InputMaybe<Scalars['ID']>;
   multiSigId?: InputMaybe<Scalars['ID']>;
   networkFee?: InputMaybe<Scalars['String']>;
   newColonyVersion?: InputMaybe<Scalars['Int']>;
@@ -10239,6 +10349,13 @@ export type UpdateMotionMessageInput = {
   motionId?: InputMaybe<Scalars['ID']>;
   name?: InputMaybe<Scalars['String']>;
   vote?: InputMaybe<Scalars['String']>;
+};
+
+export type UpdateMultiChainInfoInput = {
+  completedOnMainChain?: InputMaybe<Scalars['Boolean']>;
+  completedOnProxyChain?: InputMaybe<Scalars['Boolean']>;
+  id: Scalars['ID'];
+  wormholeInfo?: InputMaybe<ActionWormholeInfoInput>;
 };
 
 export type UpdateMultiSigUserSignatureInput = {


### PR DESCRIPTION
## Description

This PR changes how our multiChainInfo works. It's now a new entity so we can modify it from anywhere, and it has 2 flags for cross-chain completion, so it's more granular too!
[Block ingestor PR](https://github.com/JoinColony/block-ingestor/pull/323)


## Testing

Let's make sure all of our deploy proxy colony actions still work :crossed_fingers: 

Queries we'll be using

**Get permissions action**
```
getColonyAction(
    id: "<YOUR_TX_HASH>"
  ) {
    multiChainInfo {
      completedOnMainChain
      completedOnProxyChain
      id
      wormholeInfo {
        emitterAddress
        emitterChainId
        sequence
      }
    }
    type
    id
  }
```

**List proxy colonies**
```
listProxyColonies(
    filter: {colonyAddress: {eq: "<YOUR_COLONY_ADDRESS>"}}
  ) {
    items {
      chainId
      colonyAddress
      id
      isActive
    }
  }
```

**List multichain info(s)**
```
listMultiChainInfos {
    items {
      completedOnMainChain
      completedOnProxyChain
      id
      wormholeInfo {
        emitterAddress
        emitterChainId
        sequence
      }
      updatedAt
      createdAt
    }
  }
```

**Get multisig with finalization data**
```
getColonyMultiSig: getColonyAction(
    id: "<YOUR_TX_HASH>"
  ) {
    id
    type
    multiSigData {
      finalizationActionId
      id
      transactionHash
      finalizationActionData {
        id
        type
        isMotionFinalization     
        targetChainId
        multiChainInfo {
          completedOnMainChain
          completedOnProxyChain
          wormholeInfo {
            emitterAddress
            emitterChainId
            sequence
          }
        }
      }
    }
  }
```

**Get motion with finalization data**
```
getColonyMotion: getColonyAction(
    id: "<YOUR_TX_HASH>"
  ) {
    id
    type
    motionData {
      finalizationActionId
      id
      transactionHash
      finalizationActionData {
        id
        type
        isMotionFinalization
        targetChainId
        multiChainInfo {
          completedOnMainChain
          completedOnProxyChain
          wormholeInfo {
            emitterAddress
            emitterChainId
            sequence
          }
        }
      }
    }
  }
```


1. Run your dev env and the create-data script with more colonies than the default 2, something like `node ./scripts/create-data.js --yes --coloniesCount 6` just in case 
2. Let's check our ordinary deploying via permissions still works. Go to `planex`, `Manage supported chains` and choose `Local proxy 1`. 
![image](https://github.com/user-attachments/assets/d590d18f-0585-4595-a249-d3d91649d305)
![image](https://github.com/user-attachments/assets/e380883b-097b-4c8e-b3ee-e2528ae00874)
and list the proxy colonies:
![image](https://github.com/user-attachments/assets/5c5101c0-d2ad-4602-8ee5-106c2c01a068)
and check that the action has correct multiChainInfo by getting the action and listing the multiChainInfos
![image](https://github.com/user-attachments/assets/448eaca3-e711-4851-98e8-af8069e2441e)
3. Now for the fun part, go to `wayne` and fill out the `Manage supported chains` form, but don't submit it yet!
![image](https://github.com/user-attachments/assets/a46fa58a-6ec5-4176-9ce6-f00bbc141458)
4. Stop the main-chain block ingestor (either via the UI or `docker ps` > `docker stop <the id>`
![image](https://github.com/user-attachments/assets/4caa2664-653a-4a0b-9925-257e4ffabea8)
5. Submit the action and check the logs if the proxy-ingestor-1 caught some logs
![image](https://github.com/user-attachments/assets/a1ff4eaf-94cc-442f-9450-a37ebcab6b04)
![image](https://github.com/user-attachments/assets/f52b49e7-328d-4335-a494-7aa7371622bd)
6. Verify by running the `List multiChainInfos query` - the multichain info is available, but the action isn't created yet
![image](https://github.com/user-attachments/assets/3fbf9922-4e4f-484e-b85f-d2be2164cb98)
7. Resume the main chain block-ingestor, wait for some time and rerun the `List multichain infos` query, verify that it's completed on both chains. Copy the `id` and just take the value until `_`, so `0x8442409f224e81ae165c7d9bcdbee99b35590e620ac021a62d7974334c5125f2_265669101` -> `0x8442409f224e81ae165c7d9bcdbee99b35590e620ac021a62d7974334c5125f2`. Paste it into the `Get colony action` query and run it. Make sure it's an action and that the multichain info is linked up!
![image](https://github.com/user-attachments/assets/9df0e782-3c82-4873-97a0-8969aa85f7ba)
![image](https://github.com/user-attachments/assets/c97ac7b3-525c-44ca-9d9e-d20711311a42)

Normally this would be it, but let's check motions and multisig too!

1. Go to `stark` and install the Multi-Sig extension. Give `leela` the Multi-Sig owner role in `General`
![image](https://github.com/user-attachments/assets/a5131401-8e9b-4a60-963d-48556b49e4ff)
2.  Create a Multi-Sig motion to add a new proxy colony but don't finalize it yet
![image](https://github.com/user-attachments/assets/851cb549-f1da-4efa-928a-a0f69a25b00d)
![image](https://github.com/user-attachments/assets/c34b899a-0eab-4e20-89db-c5244a90748e)
3. Copy its `txHash` and run the `Get multisig query`, verify we have no finalization data yet
![image](https://github.com/user-attachments/assets/ba361909-333e-448d-8c01-be88c73badce)
4. Stop the main chain block ingestor again and finalize the motion. Verify that we got a new entry when running the `list multiChainInfos` query
![image](https://github.com/user-attachments/assets/49d06aa0-2cf5-4a12-b75b-fae7eba6f9c5)
5. Rerun the main chain ingestor, rerun the `Get multisig` and `List motionActionInfo` queries. verify that the info is finalized on both chains and the `finalizationAction` is filled in with the multiChainInfo
![image](https://github.com/user-attachments/assets/52f2c686-8d85-422a-9518-bcf9f299f800)
![image](https://github.com/user-attachments/assets/f8791d29-d2b1-43b9-8fe3-4efc9384b9ad)


Alright now for voting reputation motions
1. Go to `oscorp` and install the voting reputation extension.
2. Create a motion to add a new proxy colony - `Local proxy colony 1`
![image](https://github.com/user-attachments/assets/27e9dc11-3521-4cd0-8358-5c50b7c0f6eb)
3. Fully support it and get to the finalization step (either by forwarding the time or opposing and then voting for it). DOn't finalize it yet!
![image](https://github.com/user-attachments/assets/8538d4ba-5727-4852-ab14-255b6cb5694a)
4. Stop the main chain block ingestor and then click `Finalize`. Run the `List multiChainInfos` query and verify that there is one that hasn't been confirmed on the main chain yet
![image](https://github.com/user-attachments/assets/d7b4654f-0484-43a4-ada6-a58ac9d5d707)
5. Rerun the main ingestor. Run the `Get colony motion` query and the `List multiChainInfos` query to verify that the multiChainInfo has been completed on both chains and that the motion's finalization data has that info
![image](https://github.com/user-attachments/assets/b83c17ce-5595-4d49-9d0b-1f09d343f389)




## Diffs

Most of the changes are in the block ingestor so do check it out.
**New stuff** ✨

* `MultiChainInfo` is now a model referenced by the `ColonyAction`
* `upsertEntry` helper on the block ingestor we can reuse for such cases
* new utils that use `upsertEntry` to upsert new multichain info for a given `txHash`

**Deletions** ⚰️

* Motions no longer use `multiChainInfo` since motions don't go across chains, the finalization actions do

Resolves #4060 
