### PR TITLE
Fix: changing distribution type should show accurate percentage

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/hooks.ts
@@ -25,7 +25,10 @@ import useActionFormBaseHook from '~v5/common/ActionSidebar/hooks/useActionFormB
 import { useShowCreateStakedExpenditureModal } from '~v5/common/ActionSidebar/partials/CreateStakedExpenditureModal/hooks.tsx';
 import { type ActionFormBaseProps } from '~v5/common/ActionSidebar/types.ts';
 
-import { getSplitPaymentPayload } from './utils.ts';
+import {
+  getSplitPaymentPayload,
+  getUnevenSplitPaymentTotalPercentage,
+} from './utils.ts';
 
 export const useValidationSchema = () => {
   const { colony } = useColonyContext();
@@ -209,12 +212,12 @@ export const useValidationSchema = () => {
                 return true;
               }
 
-              const sum = value.reduce(
-                (acc, curr) => acc + (curr?.percent || 0),
-                0,
+              const percentage = getUnevenSplitPaymentTotalPercentage(
+                Number(parent?.amount || 0),
+                value,
               );
 
-              return sum === 100;
+              return percentage === 100;
             },
           )
           .test(

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/hooks.tsx
@@ -19,6 +19,7 @@ import useWrapWithRef from '~hooks/useWrapWithRef.ts';
 import { type ColonyContributor, type Token } from '~types/graphql.ts';
 import { formatText } from '~utils/intl.ts';
 import { getSelectedToken } from '~utils/tokens.ts';
+import { getUnevenSplitPaymentTotalPercentage } from '~v5/common/ActionSidebar/partials/forms/SplitPaymentForm/utils.ts';
 import UserSelect, {
   type UserSearchSelectOption,
 } from '~v5/common/ActionSidebar/partials/UserSelect/index.ts';
@@ -156,16 +157,10 @@ export const useRecipientsFieldTableColumns = ({
               />
               {isTablet && (
                 <span className="text-md font-medium text-gray-900">
-                  {parseFloat(
-                    (
-                      dataRef.current?.reduce(
-                        (acc, _, index) =>
-                          Number(acc) + Number(getPercentValue(index)),
-                        0,
-                      ) || 0
-                    ).toFixed(4),
-                  )}
-                  %
+                  {distributionMethodRef?.current ===
+                  SplitPaymentDistributionType.Equal
+                    ? '100%'
+                    : `${getUnevenSplitPaymentTotalPercentage(Number(amount || 0), dataRef.current)}%`}
                 </span>
               )}
             </div>
@@ -219,15 +214,7 @@ export const useRecipientsFieldTableColumns = ({
                     {distributionMethodRef?.current ===
                     SplitPaymentDistributionType.Equal
                       ? '100%'
-                      : `${Number(
-                          dataRef.current
-                            ?.reduce(
-                              (acc, _, index) =>
-                                Number(acc) + Number(getPercentValue(index)),
-                              0,
-                            )
-                            .toFixed(4) || 0,
-                        )}%`}
+                      : `${getUnevenSplitPaymentTotalPercentage(Number(amount || 0), dataRef.current)}%`}
                   </span>
                 );
               }

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/utils.ts
@@ -11,6 +11,7 @@ import { findDomainByNativeId } from '~utils/domains.ts';
 import { getEnumValueFromKey } from '~utils/getEnumValueFromKey.ts';
 
 import { type SplitPaymentFormValues } from './hooks.ts';
+import { type SplitPaymentRecipientsFieldModel } from './partials/SplitPaymentRecipientsField/types.ts';
 
 export const getSplitPaymentPayload = (
   colony: Colony,
@@ -61,4 +62,22 @@ export const getSplitPaymentPayload = (
         tokenDecimals,
       })) || [],
   };
+};
+
+export const getUnevenSplitPaymentTotalPercentage = (
+  amount: number,
+  recipients: SplitPaymentRecipientsFieldModel[],
+) => {
+  if (!amount) {
+    return 0;
+  }
+
+  const total =
+    recipients?.reduce((acc, recipient) => {
+      return acc + Number(recipient.amount);
+    }, 0) || 0;
+
+  const percentage = (100 * total) / amount;
+
+  return Number(percentage.toFixed(4));
 };


### PR DESCRIPTION
## Description

- Change the way the total percentage is being calculated to not do any rounding until the final step, increasing accuracy.
- This also fixes a bug where switching from distribution type `equal` (which will always be 100%) to unequal suddenly makes the percentage not 100%.

## Testing

* Step 1. Make a split payment using equal as the distribution type. Have an awkward number of recipients compared to the total amount so that the percentages have a number of decimals.
<img width="672" alt="Screenshot 2025-01-28 at 17 08 48" src="https://github.com/user-attachments/assets/0075f313-47f8-4eb3-981f-980ddc6ee235" />

* Step 2. Change the distribution type to unequal. The total percentage should still say 100%, and you should be able to submit the form.
<img width="674" alt="Screenshot 2025-01-28 at 17 09 08" src="https://github.com/user-attachments/assets/474984ea-4cf1-4abf-bf5c-ddf818b06de6" />

* Step 3. Play around with different amounts / recipients with an uneven distribution type. The percentage should always be correct.
<img width="678" alt="Screenshot 2025-01-28 at 17 09 49" src="https://github.com/user-attachments/assets/543e53dd-28ef-4a7c-8b37-af420c7f7285" />
<img width="680" alt="Screenshot 2025-01-28 at 17 10 03" src="https://github.com/user-attachments/assets/ae3fd91f-5b51-4bca-8416-2aeeb4cc496c" />


## Diffs

**Changes** 🏗

* Change the way the total percentage is calculated for split payments

Resolves #3856
