### PR TITLE
Fix: modal toggle should only happen on left click

### DIFF
--- a/src/hooks/useToggle/index.ts
+++ b/src/hooks/useToggle/index.ts
@@ -22,6 +22,10 @@ const getHtmlElement = (): HTMLElement | null => {
 };
 
 const documentMousedownHandler = (event: MouseEvent): void => {
+  // Only toggle on 'main button' (left mouse click) events.
+  if (event.button !== 0) {
+    return;
+  }
   refsRegistry.forEach(
     ({ element, toggleOff, toggleState, onBeforeCloseCallbacksRef }) => {
       if (!(event.target instanceof Element)) {


### PR DESCRIPTION
## Description

- Change the useToggle hook to only toggle modals on a left click.
- This comes from this bug: https://github.com/JoinColony/colonyCDapp/issues/3888 where right clicking on a dropdown menu item _inside_ a modal was accidentally closing the modal (since the useToggle hook didn't recognise the menu item as a descendant of the modal) and it was causing all kinds of weird behaviours.
- I've checked this change in toggle behaviour with design and received approval

## Testing

* Start an advanced payment and proceed to the Funding step.
* In the Fund Payment modal, open the decision method dropdown.
* Right-click on the 'Permissions' option inside the Select component within the funding modal. It should _not_ close the modal. 
* Try right clicking outside the modal - it should also not close the modal. A left click outside should however.
* Open any action form, and right click outside the sidepanel. The sidepanel should _not_ be closed until you left click outside of it.

https://github.com/user-attachments/assets/35eb54cc-584f-42db-87c1-b24702ed1480

## Diffs

**Changes** 🏗

* useToggle should only close modals on a left click

Resolves #3888
