### PR TITLE
[Dashboard] Fix: Broken dashboard layout on mobile 

### DIFF
--- a/src/components/common/Extensions/UserHub/UserHub.tsx
+++ b/src/components/common/Extensions/UserHub/UserHub.tsx
@@ -80,15 +80,16 @@ const UserHub: FC<Props> = ({
 
   useLockBodyScroll(isMobile);
 
+  const shouldHaveAutoHeight =
+    selectedTab === UserHubTab.Balance ||
+    selectedTab === UserHubTab.CryptoToFiat;
   return (
     <div
       className={clsx(
-        'mt-5.5 flex h-dynamic-screen flex-col sm:mt-0 sm:h-auto sm:w-[42.625rem] sm:flex-row',
+        'mt-5.5 flex h-dynamic-screen flex-col sm:mt-0 sm:min-h-[27.75rem] sm:w-[42.625rem] sm:flex-row',
         {
-          'sm:h-[27.75rem]':
-            selectedTab !== UserHubTab.Balance &&
-            selectedTab !== UserHubTab.CryptoToFiat,
-          'sm:min-h-[27.75rem]': selectedTab === UserHubTab.Balance,
+          'sm:h-[27.75rem]': !shouldHaveAutoHeight,
+          'sm:h-auto': shouldHaveAutoHeight,
         },
       )}
     >

--- a/src/components/common/Extensions/UserNavigation/partials/UserMenu/UserMenu.tsx
+++ b/src/components/common/Extensions/UserNavigation/partials/UserMenu/UserMenu.tsx
@@ -70,7 +70,7 @@ const UserMenu: FC<UserMenuProps> = ({
       tooltipProps={tooltipProps}
       withTooltipStyles={!isTablet}
       className={clsx(
-        '!h-dynamic-screen w-full overflow-auto bg-base-white p-6 sm:h-auto md:w-80 md:rounded-lg md:border md:border-gray-100 md:shadow-default',
+        'h-dynamic-screen w-full overflow-auto bg-base-white p-6 sm:h-auto md:w-80 md:rounded-lg md:border md:border-gray-100 md:shadow-default',
         {
           '!top-[calc(var(--header-nav-section-height))] !translate-y-0':
             isTablet && isActionSidebarOpen,

--- a/src/components/frame/Extensions/layouts/LandingPageLayout.tsx
+++ b/src/components/frame/Extensions/layouts/LandingPageLayout.tsx
@@ -3,6 +3,7 @@ import React, { type PropsWithChildren } from 'react';
 import { usePageThemeContext } from '~context/PageThemeContext/PageThemeContext.ts';
 import { light } from '~frame/Extensions/themes/consts.ts';
 import LandingPageCarousel from '~frame/LandingPage/partials/LandingPageCarousel/LandingPageCarousel.tsx';
+import { useTablet } from '~hooks';
 import ColonyLogo from '~icons/ColonyLogoLandingPage.tsx';
 import PageHeader from '~v5/frame/PageLayout/partials/PageHeader/PageHeader.tsx';
 import { BasicPageSidebar } from '~v5/shared/Navigation/Sidebar/sidebars/BasicPageSidebar.tsx';
@@ -19,12 +20,22 @@ export const LandingPageLayout = ({
   bottomComponent,
 }: LandingPageLayoutProps) => {
   const { isDarkMode } = usePageThemeContext();
+  const isTablet = useTablet();
 
   return (
     <div className="flex h-screen w-screen flex-col justify-between md:py-4 md:pl-4">
-      <div className="block md:hidden">
-        <PageHeader userNavigation={<UserNavigationWrapper />} />
-      </div>
+      {/* 
+        Using conditional rendering with isTablet instead of CSS display classes
+        because PageHeader uses a ResizeObserver to set a CSS custom variable.
+        If we used CSS classes to hide/show headers, both would exist in the DOM
+        and their ResizeObservers would conflict, causing incorrect variable values.
+        This ensures only one header (and thus one observer) is active at a time.
+      */}
+      {isTablet && (
+        <div className="block">
+          <PageHeader userNavigation={<UserNavigationWrapper />} />
+        </div>
+      )}
       <div className="overflow-auto md:flex md:h-full md:flex-row">
         <section>
           <BasicPageSidebar />
@@ -36,9 +47,11 @@ export const LandingPageLayout = ({
                 color={isDarkMode ? light.baseWhite : light.gray900}
               />
             </div>
-            <div className="hidden w-full md:block">
-              <PageHeader userNavigation={<UserNavigationWrapper />} />
-            </div>
+            {!isTablet && (
+              <div className="block w-full">
+                <PageHeader userNavigation={<UserNavigationWrapper />} />
+              </div>
+            )}
           </div>
           <div className="flex h-full w-full flex-col-reverse overflow-hidden md:flex-row md:bg-transparent">
             <div className="flex h-full w-full flex-1 justify-center md:justify-end">

--- a/src/components/v5/common/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/v5/common/DropdownMenu/DropdownMenu.tsx
@@ -63,7 +63,7 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
             hasShadow: true,
             className: 'py-4 px-0',
           }}
-          className="w-full overflow-hidden px-6 sm:w-auto sm:px-0"
+          className="z-dropdown w-dvw overflow-hidden px-6 sm:w-auto sm:px-0"
         >
           <ul
             className={clsx('w-full px-6 sm:w-[14.625rem]', {

--- a/src/components/v5/common/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/v5/common/DropdownMenu/DropdownMenu.tsx
@@ -1,8 +1,9 @@
 import { CaretLeft, CaretRight } from '@phosphor-icons/react';
 import clsx from 'clsx';
-import React, { type FC, useEffect, useState } from 'react';
+import React, { type FC, useEffect, useRef, useState } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
 
+import { usePopperCustomPositioning } from '~hooks/usePopperCustomPositioning.ts';
 import KebapMenu from '~v5/shared/KebapMenu/index.ts';
 import PopoverBase from '~v5/shared/PopoverBase/index.ts';
 
@@ -14,6 +15,23 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
   className,
   showSubMenuInPopover,
 }) => {
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const menuRef = useRef<HTMLElement | null>(null);
+
+  const { menuClassName, menuStyle } = usePopperCustomPositioning({
+    triggerRef,
+    menuRef,
+    config: {
+      skipDesktop: true,
+      keepInitialBottomPlacement: true,
+      useTriggerAsTranslateDefault: true,
+      offset: {
+        left: 0.25,
+        top: 0.25,
+      },
+    },
+  });
+
   const { getTooltipProps, setTooltipRef, setTriggerRef, visible } =
     usePopperTooltip({
       delayShow: 200,
@@ -22,6 +40,7 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
       trigger: ['click'],
       interactive: true,
       closeOnOutsideClick: true,
+      offset: [0, 8],
     });
   const [activeGroupIndex, setActiveGroupIndex] = useState<number | undefined>(
     undefined,
@@ -47,7 +66,10 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
     <div className={className}>
       <KebapMenu
         isVertical
-        setTriggerRef={setTriggerRef}
+        setTriggerRef={(ref: HTMLElement | null) => {
+          setTriggerRef(ref);
+          triggerRef.current = ref;
+        }}
         className={clsx('!duration-0', {
           '!text-blue-400': visible,
           'text-gray-900': !visible,
@@ -55,7 +77,10 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
       />
       {visible && !!groups.length && (
         <PopoverBase
-          setTooltipRef={setTooltipRef}
+          setTooltipRef={(ref: HTMLElement | null) => {
+            setTooltipRef(ref);
+            menuRef.current = ref;
+          }}
           tooltipProps={getTooltipProps}
           withTooltipStyles={false}
           cardProps={{
@@ -63,7 +88,11 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
             hasShadow: true,
             className: 'py-4 px-0',
           }}
-          className="z-dropdown w-dvw overflow-hidden px-6 sm:w-auto sm:px-0"
+          className={clsx(
+            menuClassName,
+            'z-dropdown overflow-hidden px-6 sm:px-0',
+          )}
+          style={menuStyle}
         >
           <ul
             className={clsx('w-full px-6 sm:w-[14.625rem]', {

--- a/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useHeaderLinks.ts
+++ b/src/components/v5/frame/ColonyHome/partials/DashboardHeader/partials/ColonyLinks/useHeaderLinks.ts
@@ -146,6 +146,7 @@ export const useHeaderLinks = (): { dropdownMenuProps: DropdownMenuProps } => {
     dropdownMenuProps: {
       groups: menuItems,
       showSubMenuInPopover: !isMobile,
+      className: 'relative',
     },
   };
 };

--- a/src/components/v5/frame/ColonyHome/partials/ReputationChart/ReputationChart.tsx
+++ b/src/components/v5/frame/ColonyHome/partials/ReputationChart/ReputationChart.tsx
@@ -91,7 +91,7 @@ const ReputationChart = () => {
 
   return (
     <div className="flex w-full flex-col items-start rounded-lg border px-5 py-6">
-      <div className="flex w-full justify-between">
+      <div className="relative flex w-full justify-between">
         <LoadingSkeleton
           className="h-6 w-[120px] rounded"
           isLoading={isDataLoading}

--- a/src/components/v5/frame/PageLayout/PageLayout.tsx
+++ b/src/components/v5/frame/PageLayout/PageLayout.tsx
@@ -67,7 +67,7 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
             <section
               id="main-content-container"
               className={clsx(
-                'modal-blur h-full w-full overflow-auto px-6 scrollbar-gutter-stable md:p-8 md:pb-0 md:pt-2',
+                'modal-blur h-full w-full overflow-y-auto overflow-x-hidden px-6 scrollbar-gutter-stable md:p-8 md:pb-0 md:pt-2',
                 {
                   'md:!pt-[1.125rem]': !pageTitle,
                 },

--- a/src/components/v5/frame/PageLayout/PageLayout.tsx
+++ b/src/components/v5/frame/PageLayout/PageLayout.tsx
@@ -67,7 +67,7 @@ const PageLayout: FC<PropsWithChildren<PageLayoutProps>> = ({
             <section
               id="main-content-container"
               className={clsx(
-                'modal-blur h-full w-full overflow-y-auto overflow-x-hidden px-6 scrollbar-gutter-stable md:p-8 md:pb-0 md:pt-2',
+                'modal-blur h-full w-full overflow-auto px-6 scrollbar-gutter-stable md:p-8 md:pb-0 md:pt-2',
                 {
                   'md:!pt-[1.125rem]': !pageTitle,
                 },

--- a/src/components/v5/shared/Dropdown/DropdownMenu.tsx
+++ b/src/components/v5/shared/Dropdown/DropdownMenu.tsx
@@ -35,7 +35,7 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
         <div
           ref={setTooltipRef}
           {...getTooltipProps()}
-          className="z-dropdown w-full px-6 sm:w-auto sm:px-0"
+          className="z-dropdown w-dvw px-6 sm:w-auto sm:px-0"
         >
           <div className="flex w-full flex-col rounded-lg border border-gray-200 bg-base-white px-3 py-4 shadow-default sm:w-[14.25rem]">
             {children}

--- a/src/components/v5/shared/Dropdown/DropdownMenu.tsx
+++ b/src/components/v5/shared/Dropdown/DropdownMenu.tsx
@@ -1,12 +1,15 @@
 import { DotsThreeVertical } from '@phosphor-icons/react';
 import clsx from 'clsx';
-import React, { type FC, type PropsWithChildren } from 'react';
+import React, { useRef, type FC, type PropsWithChildren } from 'react';
+import { type PropsGetterArgs } from 'react-popper-tooltip';
+
+import { usePopperCustomPositioning } from '~hooks/usePopperCustomPositioning.ts';
 
 interface DropdownMenuProps extends PropsWithChildren {
   isDisabled?: boolean;
   setTriggerRef: (node: HTMLElement | null) => void;
   setTooltipRef: (node: HTMLElement | null) => void;
-  getTooltipProps: () => Record<string, any>;
+  getTooltipProps: (args?: PropsGetterArgs) => Record<string, any>;
   visible: boolean;
 }
 
@@ -18,11 +21,31 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
   getTooltipProps,
   visible,
 }) => {
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  const { menuClassName, menuStyle } = usePopperCustomPositioning({
+    triggerRef,
+    menuRef,
+    config: {
+      skipDesktop: true,
+      keepInitialBottomPlacement: true,
+      useTriggerAsTranslateDefault: true,
+      offset: {
+        left: 0.25,
+        top: 0.25,
+      },
+    },
+  });
+
   return (
     <>
       <button
         type="button"
-        ref={setTriggerRef}
+        ref={(ref) => {
+          setTriggerRef(ref);
+          triggerRef.current = ref;
+        }}
         className={clsx('hover:text-blue-400', {
           'text-gray-400': !visible,
           'text-blue-400': visible,
@@ -33,9 +56,14 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
       </button>
       {visible && (
         <div
-          ref={setTooltipRef}
-          {...getTooltipProps()}
-          className="z-dropdown w-dvw px-6 sm:w-auto sm:px-0"
+          ref={(ref) => {
+            setTooltipRef(ref);
+            menuRef.current = ref;
+          }}
+          {...getTooltipProps({
+            style: menuStyle,
+          })}
+          className={clsx(menuClassName, 'z-dropdown px-6 sm:px-0')}
         >
           <div className="flex w-full flex-col rounded-lg border border-gray-200 bg-base-white px-3 py-4 shadow-default sm:w-[14.25rem]">
             {children}

--- a/src/components/v5/shared/PopoverBase/PopoverBase.tsx
+++ b/src/components/v5/shared/PopoverBase/PopoverBase.tsx
@@ -15,6 +15,7 @@ const PopoverBase: FC<PropsWithChildren<PopoverBaseProps>> = ({
   cardProps,
   withTooltipStyles = true,
   isTopSectionWithBackground,
+  style,
 }) => (
   <div
     ref={setTooltipRef}
@@ -22,6 +23,7 @@ const PopoverBase: FC<PropsWithChildren<PopoverBaseProps>> = ({
       className: clsx(className, 'z-header', {
         'tooltip-container': withTooltipStyles,
       }),
+      style,
     })}
   >
     {cardProps ? (

--- a/src/components/v5/shared/PopoverBase/types.ts
+++ b/src/components/v5/shared/PopoverBase/types.ts
@@ -12,4 +12,5 @@ export interface PopoverBaseProps {
   cardProps?: CardProps;
   withTooltipStyles?: boolean;
   isTopSectionWithBackground?: boolean;
+  style?: any;
 }

--- a/src/components/v5/shared/TeamFilter/partials/DesktopTeamFilter/DesktopTeamFilter.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/DesktopTeamFilter/DesktopTeamFilter.tsx
@@ -93,7 +93,7 @@ const DesktopTeamFilter = ({ allDomains }: { allDomains: Domain[] }) => {
   );
 
   return (
-    <div className="mt-[-2px] flex h-[38px] w-fit overflow-hidden whitespace-nowrap p-[2px]">
+    <div className="relative mt-[-2px] flex h-[38px] w-fit whitespace-nowrap p-[2px]">
       <AllTeamsItem
         selected={isAllTeamsFilterActive}
         // The item should have a delimiter only if it is not the first one before the selected team

--- a/src/components/v5/shared/TeamFilter/partials/TeamsDropdown/TeamsDropdown.tsx
+++ b/src/components/v5/shared/TeamFilter/partials/TeamsDropdown/TeamsDropdown.tsx
@@ -49,7 +49,7 @@ const TeamsDropdown: FC<TeamsDropdownProps> = ({ domains }) => {
         <div
           ref={setTooltipRef}
           {...getTooltipProps()}
-          className="z-aboveBase flex flex-col gap-2 rounded-b-lg border-b border-l border-r border-gray-200 bg-base-white py-2"
+          className="z-dropdown flex flex-col gap-2 rounded-b-lg border-b border-l border-r border-gray-200 bg-base-white py-2"
         >
           {domains.map((domain) => (
             <button

--- a/src/hooks/useHeightResizeObserver.ts
+++ b/src/hooks/useHeightResizeObserver.ts
@@ -7,22 +7,17 @@ export const useHeightResizeObserver = <T extends HTMLElement | null>(
   cssVar: CSSCustomVariable,
 ) => {
   useEffect(() => {
-    if (!ref?.current) {
-      return undefined;
-    }
+    const element = ref.current;
+    if (!element) return undefined;
 
-    const observer = new ResizeObserver(([topContainer]) => {
-      const {
-        contentRect: { height },
-      } = topContainer;
-
+    const updateHeight = ([entry]: ResizeObserverEntry[]) => {
+      const { height } = entry.contentRect;
       document.body.style.setProperty(cssVar, `${height}px`);
-    });
-
-    observer.observe(ref.current);
-
-    return () => {
-      observer.disconnect();
     };
-  }, [cssVar, ref]);
+
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [ref, cssVar]);
 };

--- a/src/hooks/usePopperCustomPositioning.ts
+++ b/src/hooks/usePopperCustomPositioning.ts
@@ -1,0 +1,92 @@
+import { useCallback } from 'react';
+
+import { useMobile } from '~hooks';
+
+import { useResize } from './useResize.ts';
+
+interface PopperCustomPositioningProps<T, K> {
+  triggerRef: React.RefObject<T>;
+  menuRef: React.RefObject<K>;
+  config: {
+    skipDesktop?: boolean;
+    keepInitialBottomPlacement?: boolean;
+    offset?: {
+      top: number;
+      left: number;
+    };
+    useTriggerAsTranslateDefault?: boolean;
+    hasLeftAlignment?: boolean;
+  };
+}
+
+// @Note: this can be used also for MeatBallMenu component, but will require some testing and refactoring
+export const usePopperCustomPositioning = <
+  T extends HTMLElement,
+  K extends HTMLElement,
+>({
+  triggerRef,
+  menuRef,
+  config: {
+    skipDesktop,
+    keepInitialBottomPlacement,
+    offset = {
+      top: 1.2,
+      left: 1.2,
+    },
+    useTriggerAsTranslateDefault,
+    hasLeftAlignment,
+  },
+}: PopperCustomPositioningProps<T, K>) => {
+  const isMobile = useMobile();
+
+  const trigger = triggerRef.current;
+  const menu = menuRef.current;
+
+  const adjustMenuPosition = useCallback(() => {
+    if (!trigger || !menu) return;
+
+    if (!isMobile && skipDesktop) return;
+
+    const triggerPlacement = trigger.getBoundingClientRect();
+    const leftOffset = window.innerWidth - triggerPlacement.x;
+    const bottomOffset = window.innerHeight - triggerPlacement.y;
+    let translateX = useTriggerAsTranslateDefault ? triggerPlacement.x : '0';
+    let translateY = useTriggerAsTranslateDefault ? triggerPlacement.y : '0';
+
+    if (!isMobile) {
+      if (leftOffset < menu.clientWidth || hasLeftAlignment) {
+        translateX = `calc(-100% + ${offset.left}rem)`;
+      }
+    } else {
+      translateX = `calc(-100% + ${leftOffset}px - ${offset.left}rem)`;
+    }
+
+    if (bottomOffset < menu.clientHeight && !keepInitialBottomPlacement) {
+      translateY = `calc(-100% - ${offset.top}rem)`;
+    }
+
+    menu.style.transform = `translate(${translateX}, ${translateY})`;
+  }, [
+    isMobile,
+    trigger,
+    menu,
+    skipDesktop,
+    offset,
+    hasLeftAlignment,
+    keepInitialBottomPlacement,
+    useTriggerAsTranslateDefault,
+  ]);
+
+  useResize(adjustMenuPosition);
+
+  // Separate dynamic styles and classes since tailwind doesn't support runtime values
+  return {
+    menuClassName: `left-0 sm:w-auto sm:min-w-fit`,
+    menuStyle: isMobile
+      ? {
+          width: `calc(100vw - ${2 * offset.left}rem)`,
+          minWidth: `calc(100vw - ${2 * offset.left}rem)`,
+        }
+      : {},
+  };
+};


### PR DESCRIPTION
## Description

- This PR aims to fix the popper dropdown menus present on the dashboard that were overflowing over the page navigation header when scrolling on `mobile`. The same issue was present also for the team filter dots menu on `tablet`. However I did not manage to reproduce the other layout breaking mentioned in the original issue.
- While solving this, I encountered some issues with the user navigation which on `desktop` was occupying the whole screen height due to `!h-dynamic-screen` overridding the `md:h-auto`. Also, on the landing page, once opening the user navigation, the page header was no longer visible due to having 2 instances of the `PageHeader`, their visibility being manipulated through `css` classes. This wouldn't have been a problem, if the `PageHeader` wouldn't have set a css variable `CSSCustomVariable.HeaderNavSectionContainer` under the scenes. The solution was to conditional render the `PageHeader` based on the device size, so the custom css variable doesn't get overridden with a wrong value.
- The initial reported issue was having the charts scroll with the content when the colony links dropdown is open on `mobile`. This was reproduced by @olgapod only using a `iPhone 13 Pro Max` real device, but in the simulator, I couldn't, so hoping the css fixes in this PR address that as well

## Testing

TODO: Let's test everything works as expected ✨. 

* Step 1. Let's start testing the original issue, so make sure your dev env is running, you have data and visit http://localhost:9091/planex 
* Step 2. Switch to a `mobile` screen size and reload the page. 
* Step 3. Check opening the colony links doesn't go over the page navigation header nor does it break the layout
![Screenshot 2025-01-31 at 09 32 15](https://github.com/user-attachments/assets/08ce3ad8-2cb3-4195-8383-a766708aa31b)
* Step 4. Try the same for the reputation chart dots menu

https://github.com/user-attachments/assets/2e1dc3fc-7e6c-4207-a319-13f25a41cfeb

* Step 5. Now switch to a `tablet` screen size and check the dots entry in the team filter doesn't go over the page navigation header on scroll

https://github.com/user-attachments/assets/65923069-bc31-499f-b869-1f3f76bb8ad6

* Step 6. Now let us test also the user navigation. So please switch to a `desktop` screen size. Try opening the user menu and check it doesn't occupy the whole screen height. You can also test this on the landing page or the user account pages.

https://github.com/user-attachments/assets/b4f117f6-8aac-4105-9dac-fdddb4a9f789

* Step 7. Now go to the landing page http://localhost:9091 and set your screen to a `mobile` size. Try opening the user menu up and check the page navigation header is still visible. 


https://github.com/user-attachments/assets/c638d57c-13e4-4aaa-a1d2-acc0c236822b


## Diffs

**Changes** 🏗

* Added and removed some css classes
* Refactored the `useEffect` in the `useHeightResizeObserver` to make use of the `updateHeight` function and not have the function directly in the `ResizeObserver`
* Make use of `isTablet` for conditionally rendering the `PageHeader` in `LandingPageLayout`

**New stuff** ✨ 
* `usePopperCustomPositioning` hook

Resolves #3982 
