### PR TITLE
Fix: Dont show failed expenditures in actions list

### DIFF
--- a/docker/colony-cdapp-dev-env-auth-proxy
+++ b/docker/colony-cdapp-dev-env-auth-proxy
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV AUTH_PROXY_HASH=7c767ecd75c681be0250f07056103a4468c5c556
+ENV AUTH_PROXY_HASH=7c5824fbb4ce444a9563d4cc4012f66db214f036
 
 # Add dependencies from the host
 # Note: these are listed individually so that if they change, they won't affect

--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=77acd2cb6ed86877a19807bee2a902a6e846bdbf
+ENV BLOCK_INGESTOR_HASH=34c7828238a24872029bf9f026307a858ecbd28b
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]

--- a/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/utils.ts
@@ -1,5 +1,7 @@
 import { Id } from '@colony/colony-js';
 
+import { type CreateExpenditurePayload } from '~redux/sagas/expenditures/createExpenditure.ts';
+import { type CreateStakedExpenditurePayload } from '~redux/sagas/expenditures/createStakedExpenditure.ts';
 import { type Colony } from '~types/graphql.ts';
 import { notNull } from '~utils/arrays/index.ts';
 import { findDomainByNativeId } from '~utils/domains.ts';
@@ -11,7 +13,7 @@ export const getStagedPaymentPayload = (
   colony: Colony,
   values: StagedPaymentFormValues,
   networkInverseFee: string,
-) => {
+): CreateExpenditurePayload | CreateStakedExpenditurePayload | null => {
   const colonyTokens = colony.tokens?.items.filter(notNull);
   const rootDomain = findDomainByNativeId(Id.RootDomain, colony);
   const createdInDomain =

--- a/src/components/v5/common/CompletedAction/partials/CompletedExpenditureContent/CompletedExpenditureContent.tsx
+++ b/src/components/v5/common/CompletedAction/partials/CompletedExpenditureContent/CompletedExpenditureContent.tsx
@@ -75,7 +75,7 @@ const CompletedExpenditureContent: FC<CompletedExpenditureContentProps> = ({
 
     return {
       milestone: stage.name,
-      amount: currentSlot?.payouts?.[0].amount,
+      amount: currentSlot?.payouts?.[0].amount || 0,
       tokenAddress: currentSlot?.payouts?.[0].tokenAddress,
     };
   });

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -10390,6 +10390,13 @@ export type CreateColonyActionMetadataMutationVariables = Exact<{
 
 export type CreateColonyActionMetadataMutation = { __typename?: 'Mutation', createColonyActionMetadata?: { __typename?: 'ColonyActionMetadata', id: string } | null };
 
+export type UpdateColonyActionMutationVariables = Exact<{
+  input: UpdateColonyActionInput;
+}>;
+
+
+export type UpdateColonyActionMutation = { __typename?: 'Mutation', updateColonyAction?: { __typename?: 'ColonyAction', id: string } | null };
+
 export type CreateAnnotationMutationVariables = Exact<{
   input: CreateAnnotationInput;
 }>;
@@ -12307,6 +12314,39 @@ export function useCreateColonyActionMetadataMutation(baseOptions?: Apollo.Mutat
 export type CreateColonyActionMetadataMutationHookResult = ReturnType<typeof useCreateColonyActionMetadataMutation>;
 export type CreateColonyActionMetadataMutationResult = Apollo.MutationResult<CreateColonyActionMetadataMutation>;
 export type CreateColonyActionMetadataMutationOptions = Apollo.BaseMutationOptions<CreateColonyActionMetadataMutation, CreateColonyActionMetadataMutationVariables>;
+export const UpdateColonyActionDocument = gql`
+    mutation UpdateColonyAction($input: UpdateColonyActionInput!) {
+  updateColonyAction(input: $input) {
+    id
+  }
+}
+    `;
+export type UpdateColonyActionMutationFn = Apollo.MutationFunction<UpdateColonyActionMutation, UpdateColonyActionMutationVariables>;
+
+/**
+ * __useUpdateColonyActionMutation__
+ *
+ * To run a mutation, you first call `useUpdateColonyActionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateColonyActionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateColonyActionMutation, { data, loading, error }] = useUpdateColonyActionMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUpdateColonyActionMutation(baseOptions?: Apollo.MutationHookOptions<UpdateColonyActionMutation, UpdateColonyActionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateColonyActionMutation, UpdateColonyActionMutationVariables>(UpdateColonyActionDocument, options);
+      }
+export type UpdateColonyActionMutationHookResult = ReturnType<typeof useUpdateColonyActionMutation>;
+export type UpdateColonyActionMutationResult = Apollo.MutationResult<UpdateColonyActionMutation>;
+export type UpdateColonyActionMutationOptions = Apollo.BaseMutationOptions<UpdateColonyActionMutation, UpdateColonyActionMutationVariables>;
 export const CreateAnnotationDocument = gql`
     mutation CreateAnnotation($input: CreateAnnotationInput!) {
   createAnnotation(input: $input) {

--- a/src/graphql/mutations/actions.graphql
+++ b/src/graphql/mutations/actions.graphql
@@ -3,3 +3,9 @@ mutation CreateColonyActionMetadata($input: CreateColonyActionMetadataInput!) {
     id
   }
 }
+
+mutation UpdateColonyAction($input: UpdateColonyActionInput!) {
+  updateColonyAction(input: $input) {
+    id
+  }
+}


### PR DESCRIPTION
## Description

- So this was a bit of a tricky bug (original ticket: https://github.com/JoinColony/colonyCDapp/issues/4033) which is basically caused by the action being created and put in the actions list a little prematurely. If a user cancels the final transaction in metamask, or if the final transaction just fails, then the action is not properly created and gets into a weird state where it is technically created but shouldn't really be seen by the user or show in the lists.

- This PR aims to fix this by not setting showInActionsList by default to true for createExpenditure actions. The saga will instead set it to true once it has finished all of the necessary transactions. There's also a couple of very small cleanup things tacked on.

There's also a couple of changes in PRs in other repos so please also review them:
- [block ingestor](https://github.com/JoinColony/block-ingestor/pull/326/commits)
- [auth proxy](https://github.com/JoinColony/colonyCDappAuthProxy/pull/36)

## Testing

⚠️  You'll need to restart your dev env to use the correct block ingestor and auth proxy ⚠️ 

* Install the staged expenditure extension.
* Log in as Leela **using metamask** (if you run into issues with this give me a shout and I can help you).
* Create a staged payment, and complete it as usual, accepting all the metamask transactions. You should see it show up in the actions list.
<img width="1231" alt="Screenshot 2025-01-30 at 17 27 41" src="https://github.com/user-attachments/assets/827d7e5e-5f30-4744-9c20-29ffefa838d3" />
<img width="1584" alt="Screenshot 2025-01-30 at 17 28 02" src="https://github.com/user-attachments/assets/624d0d5d-ce85-4494-a450-4df5d509d795" />
* Create another staged payment, and this time accept the first metamask transaction, but cancel the second one. The expenditure creation should show as failed, and the action shouldn't show in the actions list.
<img width="1583" alt="Screenshot 2025-01-30 at 17 28 52" src="https://github.com/user-attachments/assets/4f2b9d73-e57f-46e5-bca0-2e82b1693210" />
<img width="677" alt="Screenshot 2025-01-30 at 17 30 42" src="https://github.com/user-attachments/assets/57284b69-b48e-4c45-89db-15df754cb539" />
* Repeat the previous step, but this time accept the first two transactions before cancelling the third one. Again, it should fail and not show in the actions list.
<img width="1572" alt="Screenshot 2025-01-30 at 17 29 11" src="https://github.com/user-attachments/assets/62c8277f-4630-4876-8f05-1c5370fb379b" />
* To be sure, it's probably worth checking some other advanced payment types to make sure they still work and show as expected.

## Diffs

**Changes** 🏗

* Changes to the way expenditure actions are created and shown in the actions list

Resolves #4033
