### PR TITLE
Fix: Extension notifications should show the username when using metatransactions

### DIFF
--- a/docker/colony-cdapp-dev-env-block-ingestor
+++ b/docker/colony-cdapp-dev-env-block-ingestor
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV BLOCK_INGESTOR_HASH=34c7828238a24872029bf9f026307a858ecbd28b
+ENV BLOCK_INGESTOR_HASH=844f5a387f7d2bb22c47bbc1b26d8eba4daf10e3
 
 # Declare volumes to set up metadata
 VOLUME [ "/colonyCDapp/amplify/mock-data" ]


### PR DESCRIPTION
## Description

[See block-ingestor PR](https://github.com/JoinColony/block-ingestor/pull/328)

This PR makes a change to how the `creator` name is set for extension related actions.

Previously the block-ingestor used `receipt.from` as the creator for all extension related actions as the extension event does not emit the msg_sender. This works fine when metatransactions are disabled, but when they are enabled the metatransaction address in place of the original creator.

This PR adds a new `getTransactionSignerAddress` function to the block-ingestor (courtesy of @bassgeta 's implementation on the proxy colony PRs!) and replaces uses of `receipt.from` to get the address of the user who actually installed the extension.

This means the correct user now shows in both notifications and the extension details.

> [!WARNING]  
> If anyone knows of a reason why replacing the metatransactions address with the user address is a bad idea, please let me know!

## Testing

* Step 1: Run the dev environment with the notifications flag to enable notifications `npm run dev --notifications`
* Step 2: Login with dev wallet 1 and enable metatransactions in the user profile

![Screenshot 2025-01-31 at 10 42 57](https://github.com/user-attachments/assets/e7cce6fa-7a97-4829-9e14-bb291106c342)

* Step 3: Install an extension and check the notifications.

![Screenshot 2025-01-31 at 10 43 24](https://github.com/user-attachments/assets/2d11478a-c2e9-4ee3-8b34-94135801f13d)

![Screenshot 2025-01-31 at 10 43 30](https://github.com/user-attachments/assets/0afe3bd8-4f8e-4b63-8562-010f9091757f)

## Diffs

**New stuff** ✨

* `getTransactionSignerAddress` function added

**Changes** 🏗

* `receipt.from` replaced with `getTransactionSignerAddress`

Resolves #3913
