### PR TITLE
Fix: Hide accept all funds button after claiming funds

### DIFF
--- a/src/components/frame/v5/pages/FundsPage/partials/FundsTable/FundsTable.tsx
+++ b/src/components/frame/v5/pages/FundsPage/partials/FundsTable/FundsTable.tsx
@@ -28,7 +28,9 @@ const FundsTable: FC = () => {
   const isMobile = useMobile();
   const { filters, searchedTokens, activeFilters } = useFundsTable();
   const claims = useColonyFundsClaims();
-  const unclaimedClaims = claims.filter((claim) => !claim.isClaimed);
+  const unclaimedClaims = claims.filter(
+    (claim) => !claim.isClaimed && claim.amount !== '0',
+  );
   const allUnclaimedClaims = Array.from(
     new Set(unclaimedClaims.map((claim) => claim.token?.tokenAddress || '')),
   );


### PR DESCRIPTION
## Description

This PR fixes a bug with the "Accept all funds" button where it would stay enabled even after claiming all funds.

This was caused by checking if the length of the unclaimed array is longer than 0, however we always insert an unclaimed native token chain claim so that the token appears on the page. The fix is to also filter claims with a balance of 0.

Note: The original issue also shows an issue with claims not working at all on QA. I've not been able to recreate this at all locally.

## Testing

On a fresh dev environment, navigate to the incoming funds page. (If not on a fresh environment just send some tokens to the colony).

Accept all available funds and after the transactions process the button should disappear.

## Diffs

**Changes** 🏗

* Unclaimed funds with a balance of 0 are now filtered out.

Resolves #3918 
