### PR TITLE
Fix: App crashes when split payment total is small

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/hooks.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/partials/SplitPaymentRecipientsField/hooks.tsx
@@ -187,7 +187,7 @@ export const useRecipientsFieldTableColumns = ({
                         .toDecimalPlaces(
                           token.decimals || DEFAULT_TOKEN_DECIMALS,
                         )
-                        .toString();
+                        .toFixed();
 
                       if (
                         dataRef.current?.[row.index].amount === amountCalculated

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderTable/partials/AmountField/AmountField.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderTable/partials/AmountField/AmountField.tsx
@@ -23,7 +23,7 @@ const AmountField: FC<AmountFieldProps> = ({
   return (
     <LoadingSkeleton isLoading={isLoading} className="h-4 w-[11.25rem] rounded">
       <div className="flex items-center gap-3 text-md text-gray-900">
-        {formattedAmount}
+        <span>{formattedAmount}</span>
         {tokenData && (
           <div className="flex items-center gap-1">
             <TokenAvatar

--- a/src/components/v5/common/CompletedAction/partials/rows/Amount.tsx
+++ b/src/components/v5/common/CompletedAction/partials/rows/Amount.tsx
@@ -27,7 +27,7 @@ const AmountRow = ({ amount, token }: AmountRowProps) => {
       RowIcon={Coins}
       rowContent={
         <div className="flex items-center gap-3">
-          {formattedAmount}
+          <span>{formattedAmount}</span>
           {token && (
             <div className="flex gap-1">
               <TokenAvatar


### PR DESCRIPTION
## Description

- Fix an issue with the app crashing when the split payment type is too small.
- Took a while to figure out the actual root cause of this, since the crash was caused by an invalid input to BigNumber, but I had to actually trace it back about 6 steps to find out why it was ending up in that format.
- Long story short, when the user changes the percentage of a payout in a split payment, there is a function run to calculate the amount. When this amount is set, we need to use the `toFixed` instead of `toString` method from `decimal.js`, because otherwise when the amount is small it will be in scientific notation, which down the line (after trying to move the decimal point and convert to wei and then pass to BigNumber) causes the crash 😥 

- Small side note: I also fixed some awkward padding / styling for scientific notation amounts by wrapping the amounts in span tags in the completed action.

## Testing

* Open the Split Payment form
* Set the Total Amount to 0.000001 (1*10 pow -6) or smaller
* Change the Percentage Value of a recipient to anything less than 100%
* The app shouldn't crash 🤞 

<img width="687" alt="Screenshot 2025-02-03 at 12 00 59" src="https://github.com/user-attachments/assets/9e409d06-972d-407d-bef3-989096f2d519" />

* Just to be sure, you could also try if you wish to create a few other split payments just to ensure nothing broke

## Diffs

**Changes** 🏗

* use `toFixed` instead of `toString` when calculating split payment amounts

Resolves #4031
