### PR TITLE
Fix: Expenditure createdIn domain should use fundedIn domain

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/CreateStakedExpenditureModal/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/CreateStakedExpenditureModal/utils.ts
@@ -11,6 +11,35 @@ import { getPaymentBuilderPayload } from '../forms/PaymentBuilderForm/utils.ts';
 import { getSplitPaymentPayload } from '../forms/SplitPaymentForm/utils.ts';
 import { getStagedPaymentPayload } from '../forms/StagedPaymentForm/utils.ts';
 
+// Always create staked expenditures in the domain they are funded from
+export const getCreatedInDomain = ({
+  actionType,
+  colony,
+  formValues,
+}: {
+  actionType: Action;
+  colony: Colony;
+  formValues: any;
+}) => {
+  const rootDomain = findDomainByNativeId(Id.RootDomain, colony);
+
+  switch (actionType) {
+    case Action.PaymentBuilder:
+    case Action.StagedPayment: {
+      return (
+        findDomainByNativeId(Number(formValues.from), colony) || rootDomain
+      );
+    }
+    case Action.SplitPayment: {
+      return (
+        findDomainByNativeId(Number(formValues.team), colony) || rootDomain
+      );
+    }
+    default:
+      return null;
+  }
+};
+
 export const getActionPayload = ({
   actionType,
   colony,
@@ -57,10 +86,11 @@ export const getCreateStakedExpenditurePayload = ({
     stakedExpenditureAddress,
   } = options;
 
-  const rootDomain = findDomainByNativeId(Id.RootDomain, colony);
-  const createdInDomain =
-    findDomainByNativeId(Number(values.createdInDomainId), colony) ||
-    rootDomain;
+  const createdInDomain = getCreatedInDomain({
+    actionType,
+    colony,
+    formValues: values,
+  });
 
   if (!createdInDomain) {
     return null;

--- a/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/PaymentBuilderForm/utils.ts
@@ -26,7 +26,7 @@ export const getPaymentBuilderPayload = (
   const createdInDomain =
     values.decisionMethod === DecisionMethod.Permissions
       ? undefined
-      : findDomainByNativeId(values.createdIn, colony) || rootDomain;
+      : findDomainByNativeId(values.from, colony) || rootDomain;
 
   return {
     colonyAddress: colony.colonyAddress,

--- a/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/SplitPaymentForm/utils.ts
@@ -22,7 +22,6 @@ export const getSplitPaymentPayload = (
   const {
     tokenAddress,
     distributionMethod,
-    createdIn,
     team,
     description,
     payments,
@@ -32,7 +31,7 @@ export const getSplitPaymentPayload = (
   const createdInDomain =
     decisionMethod === DecisionMethod.Permissions
       ? undefined
-      : findDomainByNativeId(createdIn, colony) || rootDomain;
+      : findDomainByNativeId(team, colony) || rootDomain;
 
   if (!payments.length) {
     return null;

--- a/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/utils.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/StagedPaymentForm/utils.ts
@@ -15,7 +15,7 @@ export const getStagedPaymentPayload = (
   const colonyTokens = colony.tokens?.items.filter(notNull);
   const rootDomain = findDomainByNativeId(Id.RootDomain, colony);
   const createdInDomain =
-    findDomainByNativeId(values.createdIn, colony) || rootDomain;
+    findDomainByNativeId(values.from, colony) || rootDomain;
 
   if (!createdInDomain) {
     return null;
@@ -24,7 +24,7 @@ export const getStagedPaymentPayload = (
   return {
     colonyAddress: colony.colonyAddress,
     createdInDomain,
-    fundFromDomainId: 1,
+    fundFromDomainId: values.from,
     payouts: values.stages.map((stage) => ({
       recipientAddress: values.recipient,
       tokenAddress: stage.tokenAddress,


### PR DESCRIPTION
## Description

This PR resolves an issue where it was impossible to fund a staked advanced payment via multi-sig if you had MS permissions in the sub-domain the payment was being funded from. This was due to a bug with how staked expenditures were created which were always being created in the root domain.

This PR ensures staked expenditures are created in the same domain they are funded from, which resolves the MS funding issue.

## Testing

* Step 1 - Install the multi-sig extension and assign Leela "Payer" multi-sig permissions in Andromeda.
* Step 2 - Create an advanced payment using the staked decision method. Make sure you are funding from Andromeda.
* Step 3 - Proceed through to the funding stage.
* Step 4 - Fund the expenditure by selecting multi-sig from the select menu. The multi-sig motion should be created without issue.

## Diffs

**Changes** 🏗

* `createdIn` field for staked expenditures now uses from / team value

Resolves #4165
