### PR TITLE
Fix: Disable payment buttons for staged payments when release is in progress

### DIFF
--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/PaymentBuilderWidget.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/PaymentBuilderWidget.tsx
@@ -296,7 +296,6 @@ const PaymentBuilderWidget: FC<PaymentBuilderWidgetProps> = ({ action }) => {
             releaseActions={sortedReleaseActions}
             expenditure={expenditure}
             expectedStepKey={expectedStepKey}
-            previousReleaseActionsCount={previousReleaseActionsCount}
           />
         ),
       }

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/types.ts
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/types.ts
@@ -1,5 +1,3 @@
-import { type Dispatch, type SetStateAction } from 'react';
-
 import { type Expenditure } from '~types/graphql.ts';
 import { type ModalProps } from '~v5/shared/Modal/types.ts';
 
@@ -15,7 +13,6 @@ export interface MilestoneReleaseModalProps extends ModalProps {
   hasAllMilestonesReleased: boolean;
   expenditure: Expenditure;
   slotsWithActiveMotions: number[];
-  setIsWaitingForStagesRelease: Dispatch<SetStateAction<boolean>>;
 }
 
 export type MilestoneModalContentProps = Pick<

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentTable/partials/ReleaseAllButton/ReleaseAllButton.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentTable/partials/ReleaseAllButton/ReleaseAllButton.tsx
@@ -1,9 +1,9 @@
 import React, { type FC } from 'react';
 import { defineMessages } from 'react-intl';
 
-import { usePaymentBuilderContext } from '~context/PaymentBuilderContext/PaymentBuilderContext.ts';
-import { formatText } from '~utils/intl.ts';
 import { type MilestoneItem } from '~v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/types.ts';
+
+import ReleaseButton from '../ReleaseButton/ReleaseButton.tsx';
 
 const displayName =
   'v5.common.CompletedAction.partials.StagedPaymentTable.partials.ReleaseAllButton';
@@ -19,23 +19,12 @@ interface ReleaseAllButtonProps {
   items: MilestoneItem[];
 }
 
-const ReleaseAllButton: FC<ReleaseAllButtonProps> = ({ items }) => {
-  const { toggleOnMilestoneModal: showModal, setSelectedMilestones } =
-    usePaymentBuilderContext();
-  const notReleasedMilestones = items.filter((item) => !item.isClaimed);
-
-  return (
-    <button
-      type="button"
-      className="w-full text-end text-gray-900 underline transition-colors text-3 hover:text-blue-400"
-      onClick={() => {
-        setSelectedMilestones(notReleasedMilestones);
-        showModal();
-      }}
-    >
-      {formatText(MSG.payAll)}
-    </button>
-  );
-};
+const ReleaseAllButton: FC<ReleaseAllButtonProps> = ({ items }) => (
+  <ReleaseButton
+    description={MSG.payAll}
+    items={items.filter((item) => !item.isClaimed)}
+    className="w-full text-end"
+  />
+);
 
 export default ReleaseAllButton;

--- a/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentTable/partials/ReleaseButton/ReleaseButton.tsx
+++ b/src/components/v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentTable/partials/ReleaseButton/ReleaseButton.tsx
@@ -1,0 +1,60 @@
+import clsx from 'clsx';
+import React, { type FC } from 'react';
+import { type MessageDescriptor } from 'react-intl';
+
+import { useStagedPaymentContext } from '~context/StagedPaymentContext/StagedPaymentContext.ts';
+import { formatText } from '~utils/intl.ts';
+import { type MilestoneItem } from '~v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/types.ts';
+
+const displayName =
+  'v5.common.CompletedAction.partials.StagedPaymentTable.partials.ReleaseButton';
+
+interface ReleaseButtonProps {
+  items: MilestoneItem[];
+  description: MessageDescriptor;
+  className?: string;
+}
+
+const ReleaseButton: FC<ReleaseButtonProps> = ({
+  items,
+  description,
+  className,
+}) => {
+  const {
+    toggleOnMilestoneModal: showModal,
+    setCurrentMilestonesAwaitingRelease,
+    allMilestonesSlotIdsAwaitingRelease,
+    isPendingStagesRelease,
+  } = useStagedPaymentContext();
+
+  const disabledSlotsMap = new Map(
+    allMilestonesSlotIdsAwaitingRelease.map((id) => [id, true]),
+  );
+
+  const notReleasedMilestones = items.filter(
+    (item) => !disabledSlotsMap.get(item.slotId),
+  );
+
+  const isDisabled = isPendingStagesRelease && !notReleasedMilestones.length;
+
+  return (
+    <button
+      type="button"
+      disabled={isDisabled}
+      className={clsx(
+        className,
+        'text-gray-900 underline transition-colors text-3 hover:text-blue-400 disabled:text-gray-300',
+      )}
+      onClick={() => {
+        setCurrentMilestonesAwaitingRelease(notReleasedMilestones);
+        showModal();
+      }}
+    >
+      {formatText(description)}
+    </button>
+  );
+};
+
+ReleaseButton.displayName = displayName;
+
+export default ReleaseButton;

--- a/src/context/PaymentBuilderContext/PaymentBuilderContext.ts
+++ b/src/context/PaymentBuilderContext/PaymentBuilderContext.ts
@@ -4,7 +4,6 @@ import { ExpenditureType } from '~gql';
 import { type ExpenditureAction } from '~types/graphql.ts';
 import noop from '~utils/noop.ts';
 import { type ExpenditureStep } from '~v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/types.ts';
-import { type MilestoneItem } from '~v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/types.ts';
 
 export const PaymentBuilderContext = createContext<{
   expectedExpenditureType: ExpenditureType | undefined;
@@ -17,9 +16,6 @@ export const PaymentBuilderContext = createContext<{
   toggleOnCancelModal: () => void;
   toggleOffCancelModal: () => void;
   isCancelModalOpen: boolean;
-  toggleOnMilestoneModal: () => void;
-  toggleOffMilestoneModal: () => void;
-  isMilestoneModalOpen: boolean;
   toggleOnReleaseModal: () => void;
   toggleOffReleaseModal: () => void;
   isReleaseModalOpen: boolean;
@@ -28,8 +24,6 @@ export const PaymentBuilderContext = createContext<{
   isFinalizeModalOpen: boolean;
   selectedFundingAction: ExpenditureAction | null;
   setSelectedFundingAction: (action: ExpenditureAction | null) => void;
-  selectedMilestones: MilestoneItem[];
-  setSelectedMilestones: (transaction: MilestoneItem[]) => void;
   selectedReleaseAction: ExpenditureAction | null;
   setSelectedReleaseAction: (action: ExpenditureAction | null) => void;
   selectedFinalizeAction: ExpenditureAction | null;
@@ -44,9 +38,6 @@ export const PaymentBuilderContext = createContext<{
   toggleOnFinalizeModal: noop,
   toggleOffFinalizeModal: noop,
   isFinalizeModalOpen: false,
-  toggleOnMilestoneModal: noop,
-  toggleOffMilestoneModal: noop,
-  isMilestoneModalOpen: false,
   toggleOnReleaseModal: noop,
   toggleOffReleaseModal: noop,
   expectedExpenditureType: ExpenditureType.PaymentBuilder,
@@ -60,8 +51,6 @@ export const PaymentBuilderContext = createContext<{
   selectedFinalizeAction: null,
   setSelectedFinalizeAction: noop,
   setSelectedReleaseAction: noop,
-  selectedMilestones: [],
-  setSelectedMilestones: noop,
 });
 
 export const usePaymentBuilderContext = () => useContext(PaymentBuilderContext);

--- a/src/context/PaymentBuilderContext/PaymentBuilderContextProvider.tsx
+++ b/src/context/PaymentBuilderContext/PaymentBuilderContextProvider.tsx
@@ -9,7 +9,6 @@ import { type ExpenditureType } from '~gql';
 import useToggle from '~hooks/useToggle/index.ts';
 import { type ExpenditureAction } from '~types/graphql.ts';
 import { type ExpenditureStep } from '~v5/common/CompletedAction/partials/PaymentBuilder/partials/PaymentBuilderWidget/types.ts';
-import { type MilestoneItem } from '~v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/types.ts';
 
 import { PaymentBuilderContext } from './PaymentBuilderContext.ts';
 
@@ -37,11 +36,6 @@ const PaymentBuilderContextProvider: FC<PropsWithChildren> = ({ children }) => {
     { toggleOn: toggleOnFinalizeModal, toggleOff: toggleOffFinalizeModal },
   ] = useToggle();
 
-  const [
-    isMilestoneModalOpen,
-    { toggleOn: toggleOnMilestoneModal, toggleOff: toggleOffMilestoneModal },
-  ] = useToggle();
-
   const [selectedFundingAction, setSelectedFundingAction] =
     useState<ExpenditureAction | null>(null);
   const [selectedFinalizeAction, setSelectedFinalizeAction] =
@@ -53,10 +47,6 @@ const PaymentBuilderContextProvider: FC<PropsWithChildren> = ({ children }) => {
     ExpenditureType | undefined
   >(undefined);
 
-  const [selectedMilestones, setSelectedMilestones] = useState<MilestoneItem[]>(
-    [],
-  );
-
   const value = useMemo(
     () => ({
       toggleOnFundingModal,
@@ -65,9 +55,6 @@ const PaymentBuilderContextProvider: FC<PropsWithChildren> = ({ children }) => {
       toggleOnCancelModal,
       toggleOffCancelModal,
       isCancelModalOpen,
-      toggleOnMilestoneModal,
-      toggleOffMilestoneModal,
-      isMilestoneModalOpen,
       toggleOnReleaseModal,
       toggleOffReleaseModal,
       expectedExpenditureType,
@@ -78,8 +65,6 @@ const PaymentBuilderContextProvider: FC<PropsWithChildren> = ({ children }) => {
       selectedExpenditureMotion: null,
       expectedStepKey,
       setExpectedStepKey,
-      selectedMilestones,
-      setSelectedMilestones,
       selectedFundingAction,
       setSelectedFundingAction,
       selectedReleaseAction,
@@ -97,15 +82,11 @@ const PaymentBuilderContextProvider: FC<PropsWithChildren> = ({ children }) => {
       toggleOnCancelModal,
       toggleOffCancelModal,
       isCancelModalOpen,
-      toggleOnMilestoneModal,
-      toggleOffMilestoneModal,
-      isMilestoneModalOpen,
       toggleOnReleaseModal,
       toggleOffReleaseModal,
       expectedExpenditureType,
       isReleaseModalOpen,
       expectedStepKey,
-      selectedMilestones,
       selectedFundingAction,
       selectedReleaseAction,
       setSelectedReleaseAction,

--- a/src/context/StagedPaymentContext/StagedPaymentContext.ts
+++ b/src/context/StagedPaymentContext/StagedPaymentContext.ts
@@ -1,0 +1,30 @@
+import { createContext, useContext } from 'react';
+
+import noop from '~utils/noop.ts';
+import { type MilestoneItem } from '~v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/types.ts';
+
+export const StagedPaymentContext = createContext<{
+  allMilestonesSlotIdsAwaitingRelease: number[];
+  currentMilestonesAwaitingRelease: MilestoneItem[];
+  setCurrentMilestonesAwaitingRelease: (milestones: MilestoneItem[]) => void;
+  isPendingStagesRelease: boolean;
+  setPendingState: (isPending: boolean) => void;
+  removeSlotIdsFromPending: (slotIds: number[]) => void;
+  resetMilestonesState: VoidFunction;
+  toggleOnMilestoneModal: VoidFunction;
+  toggleOffMilestoneModal: VoidFunction;
+  isMilestoneModalOpen: boolean;
+}>({
+  allMilestonesSlotIdsAwaitingRelease: [],
+  currentMilestonesAwaitingRelease: [],
+  setCurrentMilestonesAwaitingRelease: noop,
+  isPendingStagesRelease: false,
+  setPendingState: noop,
+  removeSlotIdsFromPending: noop,
+  resetMilestonesState: noop,
+  toggleOnMilestoneModal: noop,
+  toggleOffMilestoneModal: noop,
+  isMilestoneModalOpen: false,
+});
+
+export const useStagedPaymentContext = () => useContext(StagedPaymentContext);

--- a/src/context/StagedPaymentContext/StagedPaymentContextProvider.tsx
+++ b/src/context/StagedPaymentContext/StagedPaymentContextProvider.tsx
@@ -1,0 +1,160 @@
+import React, {
+  type FC,
+  type PropsWithChildren,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import useToggle from '~hooks/useToggle/index.ts';
+import { TX_SEARCH_PARAM } from '~routes';
+import { type MilestoneItem } from '~v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/types.ts';
+
+import { StagedPaymentContext } from './StagedPaymentContext.ts';
+import { type MilestoneState } from './types.ts';
+import { getMilestoneStateWithFallback } from './utils.ts';
+
+const StagedPaymentContextProvider: FC<PropsWithChildren> = ({ children }) => {
+  const [
+    isMilestoneModalOpen,
+    { toggleOn: toggleOnMilestoneModal, toggleOff: toggleOffMilestoneModal },
+  ] = useToggle();
+  const [milestonesState, setMilestonesState] = useState<
+    Record<string, MilestoneState>
+  >({});
+  const [searchParams] = useSearchParams();
+  const transactionId = searchParams?.get(TX_SEARCH_PARAM) || '';
+
+  // The current state for the given transactionId
+  const {
+    allMilestonesSlotIdsAwaitingRelease,
+    currentMilestonesAwaitingRelease,
+    isPendingStagesRelease,
+  } = getMilestoneStateWithFallback(milestonesState[transactionId]);
+
+  const setCurrentMilestonesAwaitingRelease = useCallback(
+    (milestones: MilestoneItem[]) => {
+      if (transactionId) {
+        setMilestonesState((previousState) => {
+          const previousStateForTransaction = getMilestoneStateWithFallback(
+            previousState[transactionId],
+          );
+
+          return {
+            ...previousState,
+            [transactionId]: {
+              ...previousStateForTransaction,
+              currentMilestonesAwaitingRelease: milestones,
+            },
+          };
+        });
+      }
+    },
+    [transactionId],
+  );
+
+  const setPendingState = useCallback(
+    (isPending: boolean) => {
+      if (transactionId) {
+        setMilestonesState((previousState) => {
+          const previousStateForTransaction = getMilestoneStateWithFallback(
+            previousState[transactionId],
+          );
+
+          const allMilestones = isPending
+            ? [
+                ...new Set([
+                  ...previousStateForTransaction.allMilestonesSlotIdsAwaitingRelease,
+                  ...previousStateForTransaction.currentMilestonesAwaitingRelease.map(
+                    (milestone) => milestone.slotId,
+                  ),
+                ]),
+              ]
+            : previousStateForTransaction.allMilestonesSlotIdsAwaitingRelease;
+
+          return {
+            ...previousState,
+            [transactionId]: {
+              ...previousStateForTransaction,
+              isPendingStagesRelease: isPending,
+              allMilestonesSlotIdsAwaitingRelease: allMilestones,
+            },
+          };
+        });
+      }
+    },
+    [transactionId],
+  );
+
+  const removeSlotIdsFromPending = useCallback(
+    (slotIds: number[]) => {
+      if (transactionId) {
+        setMilestonesState((previousState) => {
+          const previousStateForTransaction = getMilestoneStateWithFallback(
+            previousState[transactionId],
+          );
+
+          const updatedAllMilestones =
+            previousStateForTransaction.allMilestonesSlotIdsAwaitingRelease.filter(
+              (slotId) => !slotIds.includes(slotId),
+            );
+
+          return {
+            ...previousState,
+            [transactionId]: {
+              ...previousStateForTransaction,
+              allMilestonesSlotIdsAwaitingRelease: updatedAllMilestones,
+            },
+          };
+        });
+      }
+    },
+    [transactionId],
+  );
+
+  const resetMilestonesState = useCallback(() => {
+    if (transactionId) {
+      setMilestonesState((previousState) => {
+        const updatedState = { ...previousState };
+        delete updatedState[transactionId];
+        return updatedState;
+      });
+    }
+  }, [transactionId]);
+
+  const value = useMemo(
+    () => ({
+      currentMilestonesAwaitingRelease,
+      allMilestonesSlotIdsAwaitingRelease,
+      setCurrentMilestonesAwaitingRelease,
+      isPendingStagesRelease,
+      setPendingState,
+      isMilestoneModalOpen,
+      toggleOffMilestoneModal,
+      toggleOnMilestoneModal,
+      resetMilestonesState,
+      removeSlotIdsFromPending,
+    }),
+    [
+      allMilestonesSlotIdsAwaitingRelease,
+      currentMilestonesAwaitingRelease,
+      setCurrentMilestonesAwaitingRelease,
+      isPendingStagesRelease,
+      setPendingState,
+      isMilestoneModalOpen,
+      toggleOffMilestoneModal,
+      toggleOnMilestoneModal,
+      resetMilestonesState,
+      removeSlotIdsFromPending,
+    ],
+  );
+
+  return (
+    <StagedPaymentContext.Provider value={value}>
+      {children}
+    </StagedPaymentContext.Provider>
+  );
+};
+
+export default StagedPaymentContextProvider;

--- a/src/context/StagedPaymentContext/types.ts
+++ b/src/context/StagedPaymentContext/types.ts
@@ -1,0 +1,7 @@
+import { type MilestoneItem } from '~v5/common/CompletedAction/partials/PaymentBuilder/partials/StagedPaymentStep/partials/MilestoneReleaseModal/types.ts';
+
+export interface MilestoneState {
+  allMilestonesSlotIdsAwaitingRelease: number[];
+  currentMilestonesAwaitingRelease: MilestoneItem[];
+  isPendingStagesRelease: boolean;
+}

--- a/src/context/StagedPaymentContext/utils.ts
+++ b/src/context/StagedPaymentContext/utils.ts
@@ -1,0 +1,8 @@
+import { type MilestoneState } from './types.ts';
+
+export const getMilestoneStateWithFallback = (state?: MilestoneState) =>
+  state || {
+    allMilestonesSlotIdsAwaitingRelease: [],
+    currentMilestonesAwaitingRelease: [],
+    isPendingStagesRelease: false,
+  };

--- a/src/routes/ColonyRoute.tsx
+++ b/src/routes/ColonyRoute.tsx
@@ -13,6 +13,7 @@ import ColonyTriggersContextProvider from '~context/GlobalTriggersContext/Colony
 import MemberContextProvider from '~context/MemberContext/MemberContextProviderWithSearchAndFilter.tsx';
 import MemberModalProvider from '~context/MemberModalContext/MemberModalContextProvider.tsx';
 import PaymentBuilderContextProvider from '~context/PaymentBuilderContext/PaymentBuilderContextProvider.tsx';
+import StagedPaymentContextProvider from '~context/StagedPaymentContext/StagedPaymentContextProvider.tsx';
 import TokensModalContextProvider from '~context/TokensModalContext/TokensModalContextProvider.tsx';
 import TourContextProvider from '~context/TourContext/TourContextProvider.tsx';
 import UserTokenBalanceProvider from '~context/UserTokenBalanceContext/UserTokenBalanceContextProvider.tsx';
@@ -113,11 +114,13 @@ const ColonyRoute = () => {
                     <TokensModalContextProvider>
                       <TourContextProvider>
                         <PaymentBuilderContextProvider>
-                          <ActionContextProvider>
-                            <ColonyLayout>
-                              <Outlet />
-                            </ColonyLayout>
-                          </ActionContextProvider>
+                          <StagedPaymentContextProvider>
+                            <ActionContextProvider>
+                              <ColonyLayout>
+                                <Outlet />
+                              </ColonyLayout>
+                            </ActionContextProvider>
+                          </StagedPaymentContextProvider>
                         </PaymentBuilderContextProvider>
                       </TourContextProvider>
                     </TokensModalContextProvider>


### PR DESCRIPTION
## Description

- This PR addresses an issue in the `Staged payment` action where the `Pay now` and `Pay all` buttons remained enabled until payments were successfully claimed in case of actions. 
To resolve this, I introduced a context dedicated specifically for the `Staged payments` (and refactored everything related to this type of action that was unnecessarily polluting the `PaymentBuilderContext`). The context stores the current milestones for release, all the milestones awaiting release, and a flag for the pending release. Based on the last two props, we can easily decide the `enabled`/`disabled` state of the buttons, the first prop being used only for the release modal and the saga. In case of using motions to release a payment, once the motion got created, the button will be re-enabled in order to allow using a different decision method.
Moreover, the context state is scoped by `txHash`, given we can switch between `Staged payment` actions and we still want to keep the state until all the payments are released.

> [!IMPORTANT]
> If we are using motions (aka Reputation) to release the payments, after discussing with Prod and Network teams, we should still be able to use another method to release those payments. If the payments got released in the meantime using a different decision method, the motions will still pass, but no amount will be transferred.

> [!NOTE]
> Even though the context looses its state upon page refresh, it's highly unlikely to refresh the page and the payment to not get in a claimed state, thus making it possible for someone to re-trigger the claim process. However, I'm open to more opinions.

## Testing

TODO: Ok, enough talking, now let's make sure we get our desired state. 

* Step 1. First make sure to install the `Staged payments` and `Reputation` extensions.
* Step 2. Now, please create a staged payments with about 4 milestones and go trough all the steps until `Payment` stage
![Screenshot 2025-02-03 at 20 09 58](https://github.com/user-attachments/assets/816bb12b-ff93-4e19-81c9-d6bacc3aeada)

* Step 3. Create another one and reach the `Payment` stage
![Screenshot 2025-02-03 at 20 10 52](https://github.com/user-attachments/assets/bfd6c46c-dba3-4ee0-9f8b-181edbdec11d)

* Step 4. Now please use `Permissions` and `Payment creator` to release different milestones. Switch between the `Staged payment` actions you previously created and make sure the `Pay now`/`Pay all` buttons remain disabled until the `Released` pill is shown
 
https://github.com/user-attachments/assets/ef58af67-5a13-4d24-b1c7-6c1d308b619e

* Step 5. Create another `Staged payments` action with 2 milestones and go through all steps until the `Payment` step 
* Step 6. Now try using `Reputation` to release the milestone. The button should be disabled until the motion got created.
* Step 7. Once the button is re-enabled try to release the milestone using `Reputation` again. This should not be possible.
* Step 8. Try to use a different decision method to release the milestone. The button should be disabled until the milestone's payment gets `claimed`.


https://github.com/user-attachments/assets/1c30102e-0415-4993-9030-a078175cd2c4

* Step 9. Try releasing the second milestone using `Reputation`.
* Step 10. You should see a single status for the completed action status pill. 
![Screenshot 2025-02-04 at 13 53 19](https://github.com/user-attachments/assets/c0349e19-fb6a-4092-88c3-0e634a0802b5)
I haven't done any change for the last step, but it's worth to double-check this issue is no longer happening.

## Diffs

**New stuff** ✨

* `StagedPaymentContext`
* `ReleaseButton`

**Deletions** ⚰️

* All props related to staged payments were removed from `PaymentBuilderContext`

Resolves #4049 
