### PR TITLE
[Proxy Colonies] Fix: Pending Button gets stuck on createProxy action

### DIFF
--- a/src/redux/sagas/proxyColonies/createProxyColony.ts
+++ b/src/redux/sagas/proxyColonies/createProxyColony.ts
@@ -105,13 +105,13 @@ function* createProxyColony({
         gasLimit: BigInt(10_000_000),
       });
 
-    put(transactionSent(metaId));
+    yield put(transactionSent(metaId));
 
     if (!transaction || !transaction.blockHash || !transaction.blockNumber) {
       throw new Error('Invalid transaction'); // @TODO add more info
     }
 
-    put(
+    yield put(
       transactionHashReceived(metaId, {
         hash: transaction.hash,
         blockNumber: transaction.blockNumber,
@@ -124,8 +124,8 @@ function* createProxyColony({
 
     const [eventData, receipt] = yield waitForMined();
 
-    put(transactionReceiptReceived(metaId, { params, receipt }));
-    put(transactionSucceeded(metaId, { eventData, receipt, params }));
+    yield put(transactionReceiptReceived(metaId, { params, receipt }));
+    yield put(transactionSucceeded(metaId, { eventData, receipt, params }));
 
     if (annotationMessage) {
       yield takeFrom(


### PR DESCRIPTION
## Description

This PR gets the Pending button unstuck on create proxy colony actions. I also checked other actions and could not recreate the issue.

## Testing

Nice and straightforward to test. Create a "Manage Supported Chains" action and add "Proxy Chain 1" as a supported chain. Check the "Pending" button in the header does not get stuck at any point.

https://github.com/user-attachments/assets/a31d3489-e7ab-45aa-a93d-83b528f71f18

## Diffs

**Changes** 🏗

* `createProxyColony` saga now yields puts

Resolves #4232
