### PR TITLE
fix: update link to funding and releasing action, fix advanced paymen…

### DIFF
--- a/src/components/common/ColonyActions/helpers/getActionTitleValues.ts
+++ b/src/components/common/ColonyActions/helpers/getActionTitleValues.ts
@@ -116,6 +116,7 @@ const getMessageDescriptorKeys = (actionType: AnyActionType) => {
         ActionTitleMessageKeys.TokensNumber,
       ];
     case actionType.includes(ColonyActionType.FundExpenditureMotion):
+    case actionType.includes(ColonyActionType.FinalizeExpenditureMotion):
       return [
         ActionTitleMessageKeys.Initiator,
         ActionTitleMessageKeys.RecipientsNumber,

--- a/src/components/common/Extensions/UserHub/partials/StakesTab/partials/StakeItem.tsx
+++ b/src/components/common/Extensions/UserHub/partials/StakesTab/partials/StakeItem.tsx
@@ -1,8 +1,10 @@
-import React, { useMemo, type FC } from 'react';
+import React, { useMemo, type FC, useState } from 'react';
+import { useEffect } from 'react';
 import { FormattedDate, useIntl } from 'react-intl';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { useGetActionTitleValues } from '~common/ColonyActions/index.ts';
+import { UserStakeType } from '~gql';
 import useNetworkInverseFee from '~hooks/useNetworkInverseFee.ts';
 import { TX_SEARCH_PARAM } from '~routes';
 import Numeral from '~shared/Numeral/index.ts';
@@ -16,6 +18,9 @@ const displayName =
   'common.Extensions.UserHub.partials.StakesTab.partials.StakeItem';
 
 const StakeItem: FC<StakeItemProps> = ({ stake }) => {
+  const [stakeTxParam, setStakeTxParam] = useState(
+    stake.action?.transactionHash,
+  );
   const { formatMessage } = useIntl();
   const navigate = useNavigate();
   const { expenditure } = useGetExpenditureData(stake.action?.expenditureId);
@@ -62,6 +67,18 @@ const StakeItem: FC<StakeItemProps> = ({ stake }) => {
     networkInverseFee,
   });
 
+  useEffect(() => {
+    if (stake.type === UserStakeType.Motion) {
+      setStakeTxParam(
+        stake.action?.expenditure?.creatingActions?.items[0]?.transactionHash,
+      );
+    }
+  }, [
+    stake.type,
+    setStakeTxParam,
+    stake.action?.expenditure?.creatingActions?.items,
+  ]);
+
   return (
     <li className="flex flex-col border-b border-gray-100 first:pt-2 last:pb-6 sm:first:pt-0 sm:last:border-none sm:last:pb-1.5">
       <button
@@ -71,7 +88,7 @@ const StakeItem: FC<StakeItemProps> = ({ stake }) => {
             setQueryParamOnUrl({
               path: navigatePath,
               params: {
-                [TX_SEARCH_PARAM]: stake.action?.transactionHash,
+                [TX_SEARCH_PARAM]: stakeTxParam,
               },
             }),
             {

--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -57,6 +57,7 @@ const actionsMessageDescriptors = {
       ${ColonyActionType.ManageTokensMotion} {Manage tokens by {initiator}}
       ${ColonyActionType.ManageTokensMultisig} {Manage tokens by {initiator}}
       ${ColonyActionType.FundExpenditureMotion} {Payment to {recipientsNumber} {recipientsNumber, plural, one {recipient} other {recipients}} with {tokensNumber} {tokensNumber, plural, one {token} other {tokens}} by {initiator}}
+      ${ColonyActionType.FinalizeExpenditureMotion} {Payment to {recipientsNumber} {recipientsNumber, plural, one {recipient} other {recipients}} with {tokensNumber} {tokensNumber, plural, one {token} other {tokens}} by {initiator}}
 
       ${ColonyActionType.MakeArbitraryTransaction} {{arbitraryTransactionsLength, select,
         0 {Arbitrary transaction by {initiator}}


### PR DESCRIPTION
## Description
The link in User Hub for expenditures actions led to the "Not implemented" page. The task was to change this link into an expenditure link instead of an action link. 

## Testing
1. Install "Voting reputation" extension
2. Create Advanced payment
3. Fund it with the "Reputation" decision method
<img width="586" alt="image" src="https://github.com/user-attachments/assets/070a0179-bcac-4318-bc25-96a835f8d6b0" />

4. Fully support and fully oppose, support and submit your vote, then reveal your vote
5. Open User Hub -> Stakes
6. Verify that you can see 2 actions from Advanced payments (one is Parent expenditure action, second one is Funding action)
<img width="683" alt="image" src="https://github.com/user-attachments/assets/01a21bc9-3a78-46a2-af4f-6215286b11d3" />

7. Verify that by clicking either one of them you were redirected to the correct expenditure action
8. Finalize motion
9. Release it with the "Reputation" decision method
10. Fully support and fully oppose, support and submit your vote, then reveal your vote
11. Open User Hub -> Stakes
12. Verify that you can see 3 actions from Advanced payments (one is Parent expenditure action, second one is Funding action, third one is Release action)
<img width="684" alt="image" src="https://github.com/user-attachments/assets/88dbc0af-4291-4542-8e8d-d7d5c9d11561" />

13. Verify that by clicking either one of them you were redirected to the correct expenditure action
14. Verify that second action has a correct subtitle instead of "Generic action"
<img width="689" alt="Screenshot 2025-02-04 at 17 41 01" src="https://github.com/user-attachments/assets/ff1f5523-ab2c-407c-a786-61327ff08654" />

15. Repeat Step 2-14 with Staged payments and Split payments
<img width="687" alt="image" src="https://github.com/user-attachments/assets/d4849020-ed81-4866-86dc-69b7f1387ac2" />
<img width="683" alt="image" src="https://github.com/user-attachments/assets/7dcab64a-7c96-4862-a125-f2b5ed4e60ec" />



Resolves #4143
