### PR TITLE
Fix: Use contributorAddress when no user wallet address found

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/hooks.ts
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/hooks.ts
@@ -53,7 +53,7 @@ export const useUserSelect = ({
             thumbnail: profile?.thumbnail || undefined,
             id: result.length,
             showAvatar: true,
-            walletAddress,
+            walletAddress: walletAddress || member.contributorAddress,
             isVerified: member.isVerified,
             userReputation,
           },


### PR DESCRIPTION
## Description

This PR fixes an issue where blockies were not being properly generated for colony members who no longer had user accounts.

## Testing

* Step 1 - We need to delete some user accounts to replicate the production scenario. Go to [http://localhost:9091/planex/members/followers](http://localhost:9091/planex/members/followers).

* Step 2 - Ignore our dev wallet pals, but copy the wallet address of the first non-dev wallet follower.

* Step 3 - Run the following mutation in graphiql to delete the user.

```
mutation MyMutation {
  deleteUser(input: {id: "<USER_ADDRESS>"}) {
    id
  }
}
```

* Step 4 - Repeat for the first few users.
* Step 5 - Refresh and create a simple payment action.
* Step 6 - Open the recipient list, each user should have a unique blockie.

![Screenshot 2025-02-05 at 12 09 14](https://github.com/user-attachments/assets/d89d472a-4847-47ac-8a59-3427c87a46c3)

Compared to master:

![Screenshot 2025-02-05 at 12 09 04](https://github.com/user-attachments/assets/2a4819b5-6c81-456b-ac9c-09458baa3057)

## Diffs

**Changes** 🏗

* Fallback to member.contributorAddress is no user wallet address found.

Resolves #3969 
