### PR TITLE
Fix: Team name max length should not be enforced on input

### DIFF
--- a/src/components/v5/common/Fields/InputBase/InputBase.tsx
+++ b/src/components/v5/common/Fields/InputBase/InputBase.tsx
@@ -80,7 +80,6 @@ const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
         id={id}
         value={value}
         onBlur={onBlur}
-        maxLength={maxLength}
         {...rest}
       />
     );


### PR DESCRIPTION
## Description

This PR removes the max length restriction from the input in the `InputBase` component. The component should instead show `currentLength / maxLength` in the UI next to the input and not restrict the max length on the input itself. The form validation still restricts submitting a name which exceeds the max length.

I could not find any other places where this component is consumed that uses the maxLength property so do not believe it breaks anything elsewhere, but please do check.

## Testing

Create an "Edit team" or "Create team" action and enter a team name that exceeds the 20 character limit. You should be able to keep typing past the character limit and the `currentLength / maxLength` UI should display.

![Screenshot 2025-02-05 at 12 42 10](https://github.com/user-attachments/assets/70740734-d03c-47cc-b096-28c2f595527d)

![Screenshot 2025-02-05 at 12 42 21](https://github.com/user-attachments/assets/743450ad-101b-492a-bee8-b721f43a4476)


## Diffs

**Deletions** ⚰️

* Removed the max length restriction from the input in the `InputBase` component. 

Resolves #3993 
