### PR TITLE
fix: dont show staking errors if the motion is completed

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/Motions/MotionStep/StakingStep/StakingStep.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Motions/MotionStep/StakingStep/StakingStep.tsx
@@ -41,6 +41,7 @@ const StakingStep: FC<StakingStepProps> = ({ className, isActive }) => {
     motionStakes,
     requiredStake,
     motionDomain: { metadata },
+    isFinalized,
   } = motionData;
 
   const { nativeToken } = colony;
@@ -78,6 +79,14 @@ const StakingStep: FC<StakingStepProps> = ({ className, isActive }) => {
     return 'motion.staking.status.text';
   })();
 
+  const canUserStake = canInteract && !isFinalized;
+  const shouldShowNotEnoughReputation =
+    !enoughReputationToStakeMinimum && canUserStake;
+  const shouldShowNotEnoughTokens =
+    !enoughTokensToStakeMinimum &&
+    enoughReputationToStakeMinimum &&
+    canUserStake;
+
   return isLoading ? (
     <SpinnerLoader />
   ) : (
@@ -110,7 +119,7 @@ const StakingStep: FC<StakingStepProps> = ({ className, isActive }) => {
           </StatusText>
         }
         sections={[
-          ...(!enoughReputationToStakeMinimum && canInteract
+          ...(shouldShowNotEnoughReputation
             ? [
                 {
                   key: '1',
@@ -128,9 +137,7 @@ const StakingStep: FC<StakingStepProps> = ({ className, isActive }) => {
                 },
               ]
             : []),
-          ...(!enoughTokensToStakeMinimum &&
-          enoughReputationToStakeMinimum &&
-          canInteract
+          ...(shouldShowNotEnoughTokens
             ? [
                 {
                   key: '2',


### PR DESCRIPTION
## Description

This PR just cleans up the booleans a bit and makes sure that when a motion is completed, the errors don't show up.

## Testing

1. Run your dev env and the create-data script, install the voting reputation extension in planex
2. Open up 2 more browsers (trust me, it's gonna be the fastest). 
3. Be logged in as `leela` in browser 1. In browser 2, go to `http://localhost:9091/go/planex` with `Dev wallet 4`. Name the user "has-nothing" or something
![image](https://github.com/user-attachments/assets/40f7bb81-12b8-4185-8268-9f83f0fd7546)
4. In browser 2, go to `http://localhost:9091/go/planex` with `Dev wallet 5`. Name the user "has-no-coins"
![image](https://github.com/user-attachments/assets/806abef5-7807-4406-b517-344267938a73)
5. Run the following query and copy the invite code.
```
query MyQuery {
  getColony(id: "<planex_address>") {
    colonyMemberInviteCode
  }
}
```
![image](https://github.com/user-attachments/assets/590424dd-3ade-4302-8a22-6ce82b78d13f)
6. Open up the URL `http://localhost:9091/invite/planex/<that_code>` as `has-nothing` and `has-no-coins` and join the colony
7. As `leela` give `has-no-coins` some reputation in `General`. Go to `http://localhost:3001/reputation/monitor/toggle` and run `npm run forward-time 1` in the terminal
![image](https://github.com/user-attachments/assets/c8873e89-877c-4971-ad9c-d985ec59fc79)
8. Create a mint tokens motion and fully stake it as `leela`. Don't finalize it!
![image](https://github.com/user-attachments/assets/44006712-a10a-4fdd-9559-3143e901b676)
9. As `has-nothing` open up the motion and verify that you get the no reputation error.
![image](https://github.com/user-attachments/assets/c8f7083a-7081-43ad-8480-4746c6d99859)
10. As `has-no-coins` open up the motion and verify that you get the not enough tokens error.
![image](https://github.com/user-attachments/assets/d534d42f-d150-435a-b9c6-ef55bc7d87dc)
11. Finalize the motion and open it as `has-nothing` and `has-no-coins` and verify that there is no error
![image](https://github.com/user-attachments/assets/ab9001a8-ce1f-45ca-8a37-7b33db3aee4d)
![image](https://github.com/user-attachments/assets/5867753a-f53f-480c-a32f-aa913b9e7bea)


## Diffs

**Changes** 🏗

* Tidied up the boolean flags in `StakingStep`

Resolves #3909
