### PR TITLE
Fix: CompletedAction should be height fit content on mobile

### DIFF
--- a/src/components/v5/common/CompletedAction/CompletedAction.tsx
+++ b/src/components/v5/common/CompletedAction/CompletedAction.tsx
@@ -171,7 +171,7 @@ const CompletedAction = ({ action }: ICompletedAction) => {
   return (
     <div
       data-testid="completed-action"
-      className="flex flex-grow flex-col-reverse justify-end overflow-auto sm:flex-row sm:justify-start"
+      className="flex h-fit w-full flex-col-reverse overflow-auto sm:h-full sm:flex-row sm:justify-start"
     >
       <div
         className={clsx('w-full overflow-y-auto px-6 pb-6 pt-8', {


### PR DESCRIPTION
## Description

This PR resolves an issue where the motion timeline was stuck at the top of the page on mobile making it difficult to see the motion details.

## Testing

* Step 1 - Install the reputation extension
* Step 2 - Create any motion
* Step 3 - Switch to a mobile width and scroll! The motion timeline should scroll letting you fully view the details.

![Screenshot 2025-02-05 at 13 54 29](https://github.com/user-attachments/assets/511c2b09-9750-4336-86b9-0a75bceca7fe)

## Diffs

**Changes** 🏗

* `CompletedAction` is height fit-content

Resolves #3878
