### PR TITLE
Arbitrary txs: show warning instead of error if contract address is not verified

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/AddTransactionModal/AddTransactionForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/AddTransactionModal/AddTransactionForm.tsx
@@ -1,8 +1,11 @@
 import React, { useState } from 'react';
 
+import { formatText } from '~utils/intl.ts';
+
 import { ContractAddressInput } from './ContractAddressInput.tsx';
 import { DynamicInputs } from './DynamicInputs.tsx';
 import { JsonAbiInput } from './JsonAbiInput.tsx';
+import { MSG } from './translation.ts';
 import { useGenerateABI } from './useGenerateABI.ts';
 
 export const AddTransactionForm = () => {
@@ -19,7 +22,12 @@ export const AddTransactionForm = () => {
     <>
       {contractAddressServerError && (
         <div className="flex rounded-md border border-warning-400 bg-warning-100 px-4 py-4.5 text-warning-400 break-word">
-          <span className="text-sm">{contractAddressServerError}</span>
+          <span className="text-sm">
+            <span className="font-medium">
+              {formatText(MSG.contractAddressServerErrorNote)}{' '}
+            </span>
+            {contractAddressServerError}
+          </span>
         </div>
       )}
       <ContractAddressInput contractAbiLoading={contractAbiLoading} />

--- a/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/AddTransactionModal/AddTransactionForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/AddTransactionModal/AddTransactionForm.tsx
@@ -9,7 +9,7 @@ export const AddTransactionForm = () => {
   const [contractAbiLoading, setContractAbiLoading] = useState(false);
 
   const {
-    serverError,
+    contractAddressServerError,
     isJsonAbiFormatted,
     showJsonAbiEditWarning,
     toggleJsonFormat,
@@ -17,10 +17,12 @@ export const AddTransactionForm = () => {
   } = useGenerateABI({ setContractAbiLoading });
   return (
     <>
-      <ContractAddressInput
-        contractAbiLoading={contractAbiLoading}
-        serverError={serverError}
-      />
+      {contractAddressServerError && (
+        <div className="flex rounded-md border border-warning-400 bg-warning-100 px-4 py-4.5 text-warning-400 break-word">
+          <span className="text-sm">{contractAddressServerError}</span>
+        </div>
+      )}
+      <ContractAddressInput contractAbiLoading={contractAbiLoading} />
       <JsonAbiInput
         loading={contractAbiLoading}
         toggleJsonFormat={toggleJsonFormat}

--- a/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/AddTransactionModal/ContractAddressInput.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/AddTransactionModal/ContractAddressInput.tsx
@@ -8,10 +8,8 @@ import { MSG } from './translation.ts';
 
 interface ContractAddressInputProps {
   contractAbiLoading?: boolean;
-  serverError?: string;
 }
 export const ContractAddressInput: FC<ContractAddressInputProps> = ({
-  serverError,
   contractAbiLoading,
 }) => {
   return (
@@ -20,7 +18,6 @@ export const ContractAddressInput: FC<ContractAddressInputProps> = ({
         name="contractAddress"
         label={formatText(MSG.contractAddressField)}
         placeholder={formatText(MSG.contractAddressPlaceholder)}
-        error={serverError || undefined}
         loading={contractAbiLoading}
         registerOptions={{
           validate: validateContractAddress,

--- a/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/AddTransactionModal/translation.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/AddTransactionModal/translation.ts
@@ -32,7 +32,11 @@ export const MSG = defineMessages({
   contractAddressServerError: {
     id: `${displayName}.contractAddressServerError`,
     defaultMessage:
-      'Note: We were unable to verify this contract. Please proceed only if you fully understand its functionality and trust its source.',
+      'We were unable to verify this contract. Please proceed only if you fully understand its functionality and trust its source.',
+  },
+  contractAddressServerErrorNote: {
+    id: `${displayName}.contractAddressServerErrorNote`,
+    defaultMessage: 'Note:',
   },
   jsonAbiField: {
     id: `${displayName}.jsonAbiField`,

--- a/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/AddTransactionModal/translation.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/AddTransactionModal/translation.ts
@@ -29,6 +29,11 @@ export const MSG = defineMessages({
     id: `${displayName}.contractAddressError`,
     defaultMessage: 'Please enter a valid contract address.',
   },
+  contractAddressServerError: {
+    id: `${displayName}.contractAddressServerError`,
+    defaultMessage:
+      'Note: We were unable to verify this contract. Please proceed only if you fully understand its functionality and trust its source.',
+  },
   jsonAbiField: {
     id: `${displayName}.jsonAbiField`,
     defaultMessage: 'ABI/JSON',

--- a/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/AddTransactionModal/useGenerateABI.ts
+++ b/src/components/v5/common/ActionSidebar/partials/forms/ArbitraryTxsForm/partials/AddTransactionModal/useGenerateABI.ts
@@ -6,10 +6,13 @@ import useGetCurrentNetwork from '~hooks/useGetCurrentNetwork.ts';
 import { formatText } from '~utils/intl.ts';
 import { fetchContractABI } from '~utils/safes/index.ts';
 
+import { MSG } from './translation.ts';
+
 export const useGenerateABI = ({ setContractAbiLoading }) => {
   const { watch, setValue, trigger } = useFormContext();
 
-  const [serverError, setServerError] = useState('');
+  const [contractAddressServerError, setContractAddressServerError] =
+    useState('');
   const networkInfo = useGetCurrentNetwork();
 
   const [isJsonAbiFormatted, setIsJsonAbiFormatted] = useState(false);
@@ -29,18 +32,27 @@ export const useGenerateABI = ({ setContractAbiLoading }) => {
 
         setContractAbiLoading(false);
         if (response.status === '1') {
-          setServerError('');
+          setContractAddressServerError('');
           setValue('jsonAbi', response.result);
           trigger('jsonAbi'); // Trigger validation to clear previous errors
           setShowJsonAbiEditWarning(true);
         } else {
-          setServerError(
-            response?.result ?? formatText({ id: 'error.message' }),
-          );
+          const errorMessage = response?.result;
+          if (errorMessage) {
+            if (errorMessage.toLowerCase().includes('not verified')) {
+              setContractAddressServerError(
+                formatText(MSG.contractAddressServerError),
+              );
+            } else {
+              setContractAddressServerError(errorMessage);
+            }
+          } else {
+            setContractAddressServerError(formatText({ id: 'error.message' }));
+          }
         }
       } catch (e) {
         setContractAbiLoading(false);
-        setServerError(e.message);
+        setContractAddressServerError(e.message);
         // eslint-disable-next-line no-console
         console.log(e);
       }
@@ -110,7 +122,7 @@ export const useGenerateABI = ({ setContractAbiLoading }) => {
   };
 
   return {
-    serverError,
+    contractAddressServerError,
     isJsonAbiFormatted,
     showJsonAbiEditWarning,
     toggleJsonFormat,


### PR DESCRIPTION
## Description
The Target Address input won't be an error, because there is nothing wrong with the input content. But we'll show the orange 'Alert' box above it to warn the user.
Figma: https://www.figma.com/design/5V8pr7iMwXsT9L3VAZsmUt/Actions-%26-Motions?node-id=29345-217753&t=4Px73UQMsihEvSqf-4

## Testing
Step 1. Open Custom transaction action ("Manage Colony" -> "Custom transactions")
Step 2. Add transaction and insert a Contract address `0xeF841fe1611ce41bFCf0265097EFaf50486F5111`
Step 3. Verify that Warning is shown according to the figma design https://www.figma.com/design/5V8pr7iMwXsT9L3VAZsmUt/Actions-%26-Motions?node-id=29345-217753&t=4Px73UQMsihEvSqf-4

<img width="485" alt="image" src="https://github.com/user-attachments/assets/f0a1669f-ea5a-4927-a7a1-9429ce812ab7" />

Step 4. Insert Verified Contract address `0xeeeafa86903cf2cb5c74a61d3e67844e226730c0 `
Step 5. Verify that Warning disappear and ABI is loaded
<img width="495" alt="image" src="https://github.com/user-attachments/assets/14da9a84-6fc4-4267-a53e-9809cd572502" />


Contributes to #4245
