### PR TITLE
Fix: Token balances not showing in amount field

### DIFF
--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -22,11 +22,11 @@ import { convertToDecimal } from './convertToDecimal.ts';
 export const getBalanceForTokenAndDomain = (
   balances: ColonyBalances | null | undefined,
   tokenAddress: Address,
-  domainId: number = COLONY_TOTAL_BALANCE_DOMAIN_ID,
+  domainId: number | '' = COLONY_TOTAL_BALANCE_DOMAIN_ID,
 ) => {
   const currentDomainBalance = balances?.items
     ?.filter((domainBalance) =>
-      domainId === COLONY_TOTAL_BALANCE_DOMAIN_ID
+      domainId === COLONY_TOTAL_BALANCE_DOMAIN_ID || domainId === ''
         ? domainBalance?.domain === null
         : domainBalance?.domain?.nativeId === domainId,
     )


### PR DESCRIPTION
## Description

This PR fixes an issue where token balances were failing to load in the amount field.

## Testing

* Step 1 - Create any action with an amount field (simple payment)
* Step 2 - Check the tokens have the expected balances

![Screenshot 2025-02-06 at 12 23 51](https://github.com/user-attachments/assets/0b68ff02-2d6d-4a42-a8c7-610708f2b3fc)


## Diffs

**Changes** 🏗

* Check domainId is not `''`
