### PR TITLE
fix: UserSelect now shows empty content when no user was found

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/UserSelect/UserSelect.tsx
@@ -233,6 +233,7 @@ const UserSelect: FC<UserSelectProps> = ({
               isLoading={usersOptions.isLoading}
               className="z-sidebar"
               shouldReturnAddresses
+              showEmptyContent
             />
           )}
         </>


### PR DESCRIPTION
## Description

Well turns out that all the places where we use `UserSelect` it's applicable to show empty content if user was not found :shrug: 

## Testing

Basically test out that the user select works as it should in all possible payment actions!

![image](https://github.com/user-attachments/assets/c2e3c392-c70a-40f5-888d-12089a93e6c7)
![image](https://github.com/user-attachments/assets/e1ed4f03-fe75-4806-8593-9df53c0917e4)
![image](https://github.com/user-attachments/assets/977df0aa-6c33-46a5-92aa-7b926dde2b7b)



## Diffs


**Changes** 🏗

* `UserSelect` now by default shows empty content if the user was not found

Resolves #3738
