### PR TITLE
fix: remove the description form row tooltip

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/Description/Description.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/Description/Description.tsx
@@ -24,14 +24,6 @@ const Description: FC<DescriptionProps> = ({
     <ActionFormRow
       icon={Pencil}
       fieldName={DESCRIPTION_FIELD_NAME}
-      tooltips={{
-        label: {
-          placement: 'bottom-start',
-          tooltipContent: formatText({
-            id: 'actionSidebar.tooltip.description',
-          }),
-        },
-      }}
       title={formatText({ id: 'actionSidebar.description' })}
       isExpandable={!(disabled || hasNoDecisionMethods)}
       isDisabled={disabled || hasNoDecisionMethods}

--- a/src/components/v5/common/CompletedAction/partials/rows/Description.tsx
+++ b/src/components/v5/common/CompletedAction/partials/rows/Description.tsx
@@ -2,9 +2,7 @@ import { CaretRight, Pencil } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import DOMPurify from 'dompurify';
 import React, { useState } from 'react';
-import { defineMessages } from 'react-intl';
 
-import Tooltip from '~shared/Extensions/Tooltip/index.ts';
 import { formatText } from '~utils/intl.ts';
 import { ICON_SIZE } from '~v5/common/CompletedAction/consts.ts';
 import RichTextDisplay from '~v5/shared/RichTextDisplay/index.ts';
@@ -17,14 +15,6 @@ interface DescriptionRowProps {
 }
 
 const SHORT_DESCRIPTION_CHAR_LIMIT = 180;
-
-const MSG = defineMessages({
-  descriptionTooltip: {
-    id: `${displayName}.descriptionTooltip`,
-    defaultMessage:
-      'The description for why this action is being performed including any relevant details.',
-  },
-});
 
 // @NOTE this is pretty hacky with the arbitrary limit and DOMPurify sanitization
 // it's also outside the grid, since it changes from a row to a column
@@ -54,34 +44,29 @@ const DescriptionRow = ({
         'flex-col': isExpanded,
       })}
     >
-      <Tooltip
-        placement="bottom-start"
-        tooltipContent={formatText(MSG.descriptionTooltip)}
-      >
-        <div className="w-40 flex-shrink-0 sm:w-[12.5rem]">
-          <button
-            className="flex items-center hover:text-blue-400"
-            type="button"
-            onClick={() => {
-              setIsExpanded((previousExpanded) => !previousExpanded);
-            }}
-          >
-            <Pencil size={ICON_SIZE} />
-            <span className="ml-2 mr-1">
-              {formatText({ id: 'actionSidebar.description' })}
-            </span>
-            <CaretRight
-              size={12}
-              className={clsx(
-                'rotate-0 transition-transform duration-300 ease-in-out',
-                {
-                  'rotate-90': isExpanded,
-                },
-              )}
-            />
-          </button>
-        </div>
-      </Tooltip>
+      <div className="w-40 flex-shrink-0 sm:w-[12.5rem]">
+        <button
+          className="flex items-center hover:text-blue-400"
+          type="button"
+          onClick={() => {
+            setIsExpanded((previousExpanded) => !previousExpanded);
+          }}
+        >
+          <Pencil size={ICON_SIZE} />
+          <span className="ml-2 mr-1">
+            {formatText({ id: 'actionSidebar.description' })}
+          </span>
+          <CaretRight
+            size={12}
+            className={clsx(
+              'rotate-0 transition-transform duration-300 ease-in-out',
+              {
+                'rotate-90': isExpanded,
+              },
+            )}
+          />
+        </button>
+      </div>
       <div
         className={clsx('flex items-start', {
           'h-10 flex-1 cursor-pointer': !isExpanded,


### PR DESCRIPTION
## Description

It's only fitting that I remove it after I've mistakenly added it back in.

## Testing

1. Start creating any action, verify that on hover, the description row doesn't have a tooltip (can't see my cursor here :') )
![image](https://github.com/user-attachments/assets/b0de56bc-327a-4cc3-8043-71323911756f)
2. Create the action and verify that the tooltip doesn't appear on the completed action view
![image](https://github.com/user-attachments/assets/f446e23f-948e-4ccd-aef8-2d855681df7f)


## Diffs

**Changes** 🏗

* Removed the tooltip from the form row and completed action row

Resolves #4104 
