### PR TITLE
fix: advanced payment status

### DIFF
--- a/src/components/v5/common/ActionSidebar/hooks/useGetStreamingPaymentData.ts
+++ b/src/components/v5/common/ActionSidebar/hooks/useGetStreamingPaymentData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import { FAILED_LOADING_DURATION as POLLING_TIMEOUT } from '~frame/LoadingTemplate/index.ts';
 import { useGetStreamingPaymentQuery } from '~gql';
@@ -22,14 +22,8 @@ export const useGetStreamingPaymentData = (
 
   const streamingPayment = data?.getStreamingPayment;
 
-  const [isPolling, setIsPolling] = useState(
-    streamingPaymentId && !streamingPayment,
-  );
-
   useEffect(() => {
     const shouldPoll = streamingPaymentId && !streamingPayment;
-
-    setIsPolling(shouldPoll);
 
     if (!shouldPoll) {
       return noop;
@@ -54,11 +48,9 @@ export const useGetStreamingPaymentData = (
     pollInterval,
   ]);
 
-  const isLoading = loading || !!isPolling;
-
   return {
     streamingPaymentData: streamingPayment,
-    loadingStreamingPayment: isLoading,
+    loadingStreamingPayment: loading,
     refetchStreamingPayment: refetch,
     startPolling,
     stopPolling,


### PR DESCRIPTION
## Description

Fix displaying status for advanced payments

## Testing

- Go to `feat/streaming-payments-ui` branch
- Create advanced payment
- Display the advanced payment in activity feed

## Diffs

Status badge is displaying correctly
![Screenshot 2025-02-20 at 15 48 34](https://github.com/user-attachments/assets/c36cb733-b6f6-4741-89a6-b063039ba998)


Resolves https://github.com/JoinColony/colonyCDapp/issues/4210
