### PR TITLE
fix: big number error during redo action

### DIFF
--- a/src/components/v5/common/ActionSidebar/partials/forms/StreamingPaymentForm/StreamingPaymentForm.tsx
+++ b/src/components/v5/common/ActionSidebar/partials/forms/StreamingPaymentForm/StreamingPaymentForm.tsx
@@ -1,7 +1,7 @@
 import { HandPalm, UserFocus, UsersThree } from '@phosphor-icons/react';
 import isDate from 'date-fns/isDate';
-import React, { type FC } from 'react';
-import { useWatch } from 'react-hook-form';
+import React, { useEffect, type FC } from 'react';
+import { useWatch, useFormContext } from 'react-hook-form';
 
 import { StreamingPaymentEndCondition } from '~gql';
 import { formatText } from '~utils/intl.ts';
@@ -29,6 +29,21 @@ const StreamingPaymentForm: FC<ActionFormBaseProps> = ({ getFormOptions }) => {
   const selectedTeam = useWatch({ name: 'from' });
   const startsCondition = useWatch({ name: 'starts' });
   const endsCondition = useWatch({ name: 'ends' });
+  const amountValue = useWatch({ name: 'amount' });
+  const limitValue = useWatch({ name: 'limit' });
+
+  const { setValue } = useFormContext();
+
+  useEffect(() => {
+    if (typeof amountValue === 'string' && amountValue.includes(',')) {
+      const newValue = amountValue.replace(/,/g, '');
+      setValue('amount', newValue);
+    }
+    if (typeof limitValue === 'string' && limitValue.includes(',')) {
+      const newValue = limitValue.replace(/,/g, '');
+      setValue('limit', newValue);
+    }
+  }, [limitValue, amountValue, setValue]);
 
   return (
     <>


### PR DESCRIPTION
## Description

Fix BigNumber error after redo action

## Testing

- Create streaming payment with `Limit reached` end condition
- Input some number that is longer than 3 characters
- Create streaming payment
- Click `Redo action`
- Click `Create stream`

## Diffs

**Changes** 🏗

The error is no longer visible

Resolves https://github.com/JoinColony/colonyCDapp/issues/4223
