### PR TITLE
Accommodate stricter SIWE in devstack

### DIFF
--- a/docker/colony-cdapp-dev-env-auth-proxy
+++ b/docker/colony-cdapp-dev-env-auth-proxy
@@ -1,6 +1,6 @@
 FROM colony-cdapp-dev-env/base:latest
 
-ENV AUTH_PROXY_HASH=7c5824fbb4ce444a9563d4cc4012f66db214f036
+ENV AUTH_PROXY_HASH=9a64b6bdc7d993ed2da89d707fb4f1cc8468b8fe
 
 # Add dependencies from the host
 # Note: these are listed individually so that if they change, they won't affect

--- a/docker/colony-cdapp-dev-env-orchestration.yaml
+++ b/docker/colony-cdapp-dev-env-orchestration.yaml
@@ -82,6 +82,8 @@ services:
     depends_on:
       amplify:
         condition: service_healthy
+    environment:
+      AUTH_DOMAIN: 'localhost:9091'
 
   network-files:
     container_name: 'network-files'


### PR DESCRIPTION
Allows devstack to still work with changes in https://github.com/JoinColony/colonyCDappAuthProxy/pull/37 